### PR TITLE
Change AppConfig :report_page_size to :report_page_layout

### DIFF
--- a/backend/app/model/reports/abstract_report.rb
+++ b/backend/app/model/reports/abstract_report.rb
@@ -15,8 +15,8 @@ class AbstractReport
     :'reports/_listing'
   end
 
-  def orientation
-    'landscape'
+  def layout
+    AppConfig[:report_page_layout]
   end
 
   def processor

--- a/backend/app/views/reports/_styles.erb
+++ b/backend/app/views/reports/_styles.erb
@@ -50,7 +50,7 @@
   }
 
   @page {
-    size: <%= report.orientation %>;
+    size: <%= report.layout %>;
     -fs-flow-bottom: "footer";
   }
 

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -61,11 +61,14 @@ AppConfig[:demodb_snapshot_flag] = proc { File.join(AppConfig[:data_directory], 
 AppConfig[:locale] = :en
 
 # Report Configuration
-AppConfig[:report_page_size] = "A4"
+# :report_page_layout uses valid values for the  CSS3 @page directive's
+# size property: http://www.w3.org/TR/css3-page/#page-size-prop
+AppConfig[:report_page_layout] = "letter landscape"
 
 # Plug-ins to load. They will load in the order specified
 AppConfig[:plugins] = ['local']
 
+# Allow an unauthenticated user to create an account
 AppConfig[:allow_user_registration] = true
 
 # Help Configuration


### PR DESCRIPTION
- The AppConfig[:report_page_size] config variable was not used.
- Change AbstractReport#orientation method to AbstractReport#layout.
- AbstractReport#layout now returns AppConfig[:report_page_layout]
- Add a few extra comments to config-defaults.rb for info.
