### PR TITLE
Rename and cleanup groups

### DIFF
--- a/backend/app/model/repository.rb
+++ b/backend/app/model/repository.rb
@@ -36,15 +36,15 @@ class Repository < Sequel::Model(:repository)
     end
 
     standard_groups = [{
-                         :group_code => "repository-managers",
-                         :description => "Managers of the #{repo_code} repository",
+                         :group_code => "repository-repository-managers",
+                         :description => "Repository managers of the #{repo_code} repository",
                          :grants_permissions => ["manage_repository", "update_location_record", "update_subject_record",
                                                  "update_agent_record", "update_archival_record", "update_event_record", "view_repository",
                                                  "delete_archival_record", "suppress_archival_record"]
                        },
                        {
-                         :group_code => "repository-archivists",
-                         :description => "Archivists of the #{repo_code} repository",
+                         :group_code => "repository-advanced-data-entry",
+                         :description => "Advanced Data Entry users of the #{repo_code} repository",
                          :grants_permissions => ["update_subject_record", "update_agent_record", "update_archival_record", "update_event_record", "view_repository"]
                        },
                        {
@@ -53,11 +53,6 @@ class Repository < Sequel::Model(:repository)
                          :grants_permissions => ["view_repository", "update_archival_record", "update_event_record", "update_subject_record", "update_agent_record",
                                                  "delete_archival_record", "suppress_archival_record",
                                                  'merge_agents_and_subjects']
-                       },
-                       {
-                         :group_code => "repository-advanced-data-entry",
-                         :description => "Advanced Data Entry users of the #{repo_code} repository",
-                         :grants_permissions => ["view_repository", "update_archival_record", "update_event_record", "update_subject_record", "update_agent_record"]
                        },
                        {
                          :group_code => "repository-basic-data-entry",

--- a/backend/spec/controller_accession_spec.rb
+++ b/backend/spec/controller_accession_spec.rb
@@ -225,7 +225,7 @@ describe 'Accession controller' do
     test_accession = create(:json_accession)
 
     create_nobody_user
-    archivists = JSONModel(:group).all(:group_code => "repository-archivists").first
+    archivists = JSONModel(:group).all(:group_code => "repository-advanced-data-entry").first
     archivists.member_usernames = ['nobody']
     archivists.save
 

--- a/backend/spec/controller_group_spec.rb
+++ b/backend/spec/controller_group_spec.rb
@@ -93,9 +93,9 @@ describe 'Group controller' do
   end
 
 
-  it "restricts group-related activities to repository-managers" do
+  it "restricts group-related activities to repository-repository-managers" do
     create(:user, {:username => 'archivist'})
-    archivists = JSONModel(:group).all(:group_code => "repository-archivists").first
+    archivists = JSONModel(:group).all(:group_code => "repository-advanced-data-entry").first
     archivists.member_usernames = ["archivist"]
     archivists.save
 
@@ -138,7 +138,7 @@ describe 'Group controller' do
     create(:user, {:username => 'newmanager'})
     create(:user, {:username => 'underling'})
     
-    managers = JSONModel(:group).all(:group_code => "repository-managers").first
+    managers = JSONModel(:group).all(:group_code => "repository-repository-managers").first
     managers.member_usernames = ["newmanager"]
     managers.save
 

--- a/backend/spec/controller_repo_transfers_spec.rb
+++ b/backend/spec/controller_repo_transfers_spec.rb
@@ -23,7 +23,7 @@ describe 'Record transfers' do
 
     it "ensures that the requesting user has the right permissions in both repositories" do
       archivist = make_test_user("archivist")
-      Group[:group_code => 'repository-archivists', :repo_id => $repo_id].add_user(archivist)
+      Group[:group_code => 'repository-advanced-data-entry', :repo_id => $repo_id].add_user(archivist)
 
       as_test_user('archivist') do
         # No permission in @target_repo
@@ -33,7 +33,7 @@ describe 'Record transfers' do
 
       # Grant permission
       RequestContext.open(:repo_id => @target_repo.id) do
-        Group[:group_code => 'repository-archivists', :repo_id => @target_repo.id].add_user(archivist)
+        Group[:group_code => 'repository-advanced-data-entry', :repo_id => @target_repo.id].add_user(archivist)
       end
 
       as_test_user('archivist') do
@@ -66,7 +66,7 @@ describe 'Record transfers' do
       end
 
       # Grant transfer permission in the source repo but not the target one
-      Group[:group_code => 'repository-archivists', :repo_id => $repo_id].tap do |group|
+      Group[:group_code => 'repository-advanced-data-entry', :repo_id => $repo_id].tap do |group|
         group.add_user(archivist)
         group.grant('transfer_repository')
       end
@@ -79,7 +79,7 @@ describe 'Record transfers' do
 
 
       RequestContext.open(:repo_id => @target_repo.id) do
-        Group[:group_code => 'repository-archivists', :repo_id => @target_repo.id].tap do |group|
+        Group[:group_code => 'repository-advanced-data-entry', :repo_id => @target_repo.id].tap do |group|
           group.add_user(archivist)
           group.grant('transfer_repository')
         end

--- a/backend/spec/controller_repository_spec.rb
+++ b/backend/spec/controller_repository_spec.rb
@@ -51,8 +51,8 @@ describe 'Repository controller' do
   it "creating a repository automatically creates the standard set of groups" do
     groups = JSONModel(:group).all.map {|group| group.group_code}
 
-    groups.include?("repository-managers").should be_true
-    groups.include?("repository-archivists").should be_true
+    groups.include?("repository-repository-managers").should be_true
+    groups.include?("repository-advanced-data-entry").should be_true
     groups.include?("repository-viewers").should be_true
   end
 

--- a/backend/spec/controller_rest_spec.rb
+++ b/backend/spec/controller_rest_spec.rb
@@ -12,7 +12,7 @@ describe 'REST interface' do
     create(:user, :username => 'mrkrabs')
 
     viewers = JSONModel(:group).all(:group_code => "repository-viewers").first
-    archivists = JSONModel(:group).all(:group_code => "repository-archivists").first
+    archivists = JSONModel(:group).all(:group_code => "repository-advanced-data-entry").first
 
     viewers.member_usernames = ["spongebob"]
     archivists.member_usernames = ["mrkrabs"]

--- a/selenium/common.rb
+++ b/selenium/common.rb
@@ -442,12 +442,12 @@ end
 
 
 def add_user_to_archivists(user, repo)
-  add_user_to_group(user, repo, 'repository-archivists')
+  add_user_to_group(user, repo, 'repository-advanced-data-entry')
 end
 
 
 def add_user_to_managers(user, repo)
-  add_user_to_group(user, repo, 'repository-managers')
+  add_user_to_group(user, repo, 'repository-repository-managers')
 end
 
 

--- a/selenium/spec/selenium_spec.rb
+++ b/selenium/spec/selenium_spec.rb
@@ -161,7 +161,7 @@ describe "ArchivesSpace user interface" do
       $driver.find_element(:css, '.repo-container .btn.dropdown-toggle').click
       $driver.find_element(:link, "Manage Groups").click
 
-      row = $driver.find_element_with_text('//tr', /repository-archivists/)
+      row = $driver.find_element_with_text('//tr', /repository-advanced-data-entry/)
       row.find_element(:css, '.btn').click
 
       $driver.clear_and_send_keys([:id, 'new-member'],(@user))


### PR DESCRIPTION
"Managers" should be "Repository Managers", and "Archivists" is duplicative of "Advanced Data Entry"
