### PR TITLE
Ordered batch imports

### DIFF
--- a/backend/app/lib/streaming_import.rb
+++ b/backend/app/lib/streaming_import.rb
@@ -80,7 +80,7 @@ class StreamingImport
 
     with_status("Evaluating record relationships") do
 
-      @dependencies = load_dependencies
+      @dependencies, @position_offsets = load_dependencies
     end
 
     @limbs_for_reattaching = {}
@@ -174,6 +174,7 @@ class StreamingImport
 
   def load_dependencies
     dependencies = {}
+    position_offsets = {}
 
     @ticker.tick_estimate = @jstream.count
 
@@ -188,7 +189,8 @@ class StreamingImport
 
         set_key = (rec['parent'] || rec['resource'] || rec['digital_object'])['ref']
         position_maps[set_key] ||= []
-        position_maps[set_key][pos] = rec['uri']
+        position_maps[set_key][pos] ||= []
+        position_maps[set_key][pos] << rec['uri']
 
       end
 
@@ -196,14 +198,25 @@ class StreamingImport
     end
 
     position_maps.each do |set_key, positions|
+      offset = 0
       positions.compact!
       while !positions.empty?
-        last = positions.pop
-        dependencies[last] << positions[-1] unless positions.empty?
+        first = positions.shift
+        while first.length > 1
+          offset += 1
+          first_last = first.pop
+          position_offsets[first_last] = offset
+          dependencies[first_last] << first[0]
+        end
+
+        unless positions.empty?
+          dependencies[positions[0][0]] << first[0] 
+          position_offsets[positions[0][0]] = offset
+        end
       end
     end
 
-    dependencies
+    return dependencies, position_offsets
   end
 
 
@@ -214,7 +227,12 @@ class StreamingImport
 
   def do_create(record, noerror = false)
     begin
+      if record['position'] && @position_offsets[record['uri']]
+        record['position'] += @position_offsets[record['uri']]
+      end
+
       json = to_jsonmodel(record, true)
+
       model = model_for(record['jsonmodel_type'])
 
       obj = if model.respond_to?(:ensure_exists)

--- a/backend/spec/controller_batch_import_spec.rb
+++ b/backend/spec/controller_batch_import_spec.rb
@@ -236,4 +236,54 @@ describe "Batch Import Controller" do
 
     children.map {|child| child['title']}.should eq [a1, a2, a3].map {|a| a.title}
   end
+
+
+  it "manages repeated position numbers in batch" do
+    resource = build(:json_resource)
+    resource.uri = resource.class.uri_for(rand(100000), {:repo_id => $repo_id})
+    archival_objects = []
+    (0..10).each do  |i|
+      a = build(:json_archival_object)
+      a.title = "AO #{i}"
+      a.uri = a.class.uri_for(rand(100000), {:repo_id => $repo_id})
+      a.resource = {:ref => resource.uri}
+      a.position = i
+      archival_objects[i] = a
+    end
+
+    correct_order = archival_objects.map{ |a| a['title'] }
+
+    # simulate a double entry
+    archival_objects[-3..-1].each do |a|
+      a.position = a.position - 1
+    end
+
+    # add a gap
+    archival_objects[2..-1].each do |a|
+      a.position = a.position + 1
+    end
+    
+    batch_array = [resource.to_hash(:raw)]
+    archival_objects.shuffle.each do |ao|
+      batch_array << ao.to_hash(:raw)
+    end
+
+    uri = "/repositories/#{$repo_id}/batch_imports"
+    url = URI("#{JSONModel::HTTP.backend_url}#{uri}")
+    url.query = URI.encode_www_form({:use_transaction => true})
+
+    response = JSONModel::HTTP.post_json(url, batch_array.to_json)
+    response.code.should eq('200')
+
+    results = ASUtils.json_parse(response.body)
+    r_id = results.last['saved'][resource.uri][1]
+
+    r = JSONModel.JSONModel(:resource).find(r_id, "resolve[]" => ['tree'])
+    children = r['tree']['_resolved']['children']
+
+    result_order = children.map {|child| child['title']}
+
+    result_order[0..-5].should eq(correct_order[0..-5])
+    result_order[-2..-1].should eq(correct_order[-2..-1])
+  end
 end


### PR DESCRIPTION
The batch import does not use the 'position' attribute of incoming component records to correctly set the order of siblings in the component tree. This PR addresses that. It should probably be reviewed by someone else.
