### PR TITLE
Update solr_snapshotter.rb

### DIFF
--- a/common/solr_snapshotter.rb
+++ b/common/solr_snapshotter.rb
@@ -60,7 +60,7 @@ class SolrSnapshotter
 
     retries.times do |i|
       begin
-        SolrSnapshotter.do_snapshot
+        SolrSnapshotter.do_snapshot(identifier)
         break
       rescue
         log(:error, "Solr snapshot failed (#{$!}) - attempt #{i}")


### PR DESCRIPTION
do_snapshot is not receiving an argument from self.snapshot. This most clearly impacts the backup.rb script which is not adding the solr backups to the output zip file by default.
