### PR TITLE
Add support for MySQL binary logging in mysqldump

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -11,6 +11,8 @@ AppConfig[:allow_other_unmapped] = false
 
 AppConfig[:db_url] = proc { AppConfig.demo_db_url }
 AppConfig[:db_max_connections] = 10
+# Set to true if you have enabled MySQL binary logging
+AppConfig[:mysql_binlog] = false
 
 AppConfig[:allow_unsupported_database] = false
 

--- a/launcher/backup/lib/backup.rb
+++ b/launcher/backup/lib/backup.rb
@@ -37,14 +37,17 @@ class ArchivesSpaceBackup
       password = params['password'].first
       database = db_uri.path.gsub('/', '')
 
-
+      mysqldump_cmd = [
+        "mysqldump",
+        "--user=#{username}",
+        "--password=#{password}",
+        "--single-transaction",
+        "--quick",
+      ]
+      mysqldump_cmd << "--master-data=2" if AppConfig[:mysql_binlog]
+      mysqldump_cmd << database
       begin
-        IO.popen(["mysqldump",
-                  "--user=#{username}",
-                  "--password=#{password}",
-                  "--single-transaction",
-                  "--quick",
-                  database]) do |io|
+        IO.popen(mysqldump_cmd) do |io|
           while true
             chunk = io.read(4096)
             break if chunk.nil?


### PR DESCRIPTION
If binary logging is enabled in my.cnf it is broadly recommended to
add the "--master-data=2" parameter to mysqldump so that binary log
position information is included in the dump file for PITR.

I tested modifying the files from a v1 release install. I'm speculating that 
config-defaults.rb is the right place to add the new option. Apologies 
if not.
