### PR TITLE
Enable documentation by default

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -75,6 +75,6 @@ AppConfig[:plugins] = ['local', 'aspace_feedback']
 AppConfig[:allow_user_registration] = true
 
 # Help Configuration
-AppConfig[:help_enabled] = false
+AppConfig[:help_enabled] = true
 AppConfig[:help_url] = "http://docs.archivesspace.org"
 AppConfig[:help_topic_prefix] = "/Default_CSH.htm#"


### PR DESCRIPTION
**Note: this is a placeholder pull request.** Do not merge until the documentation AuthN system is officially deployed...
