### PR TITLE
Bundle a version of readlink that handles recursive symlinks.

### DIFF
--- a/launcher/archivesspace.sh
+++ b/launcher/archivesspace.sh
@@ -18,6 +18,43 @@
 # Description:       Start the ArchivesSpace archival management system
 ### END INIT INFO
 
+
+# http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+function readlink_dash_f {
+    max_iterations=32
+
+    target_file=$1
+
+    cd "`dirname "$target_file"`"
+    target_file="`basename "$target_file"`"
+
+    # iterate down a (possible) chain of symlinks
+    i=0
+    while [ -L "$target_file" ]
+    do
+        target_file="`readlink "$target_file"`"
+        cd "`dirname "$target_file"`"
+        target_file="`basename "$target_file"`"
+
+        if [ $i -gt $max_iterations ]; then
+            echo "ERROR: maximum iteration count reached ($max_iterations)" > /dev/stderr
+            return 1
+        fi
+
+        i=$[i + 1]
+    done
+
+    # Compute the canonicalized name by finding the physical path 
+    # for the directory we're in and appending the target file.
+    result="`pwd -P`/$target_file"
+
+    echo $result
+    return 0
+}
+
+
+
+
 cd "`dirname $0`"
 
 # Check for Java
@@ -30,7 +67,7 @@ if [ "$?" != "0" ]; then
 fi
 
 if [ ! -e "scripts/find-base.sh" ]; then
-    cd "$(dirname `readlink $0`)"
+    cd "$(dirname `readlink_dash_f $0`)"
 fi
 
 export ASPACE_LAUNCHER_BASE="$(scripts/find-base.sh)"


### PR DESCRIPTION
On Unix systems, the startup script is intended to be linked into /etc/init.d
and will then be further linked into a particular run-level.  This might result
in a configuration of symlinks like:

  /etc/init.d/archivesspace -> /path/to/archivesspace/archivesspace.sh
  /etc/rc2.d/S99archivesspace -> ../init.d/archivesspace

We need to be able to start with a path like "/etc/rc2.d/S99archivesspace" and
resolve that back to its real "/path/to/archivesspace/archivesspace.sh".  GNU's
readlink has an "-f" option that does this for us, but OSX's version doesn't,
so we implement our own here.
