### PR TITLE
Update backup.rb

### DIFF
--- a/launcher/backup/lib/backup.rb
+++ b/launcher/backup/lib/backup.rb
@@ -9,7 +9,7 @@ require 'zip/zip'
 require 'tempfile'
 require 'uri'
 require 'net/http'
-
+require 'asutils'
 
 class ArchivesSpaceBackup
 


### PR DESCRIPTION
Since 1.0.4 running the backup script:

Loading ArchivesSpace configuration file from path: /home/sandbox/archivesspace/config/config.rb
2014-01-17 17:42:34 -0600: Writing backup to /home/sandbox/backups/aspace-staff_sandbox_2014-01-17.zip
INFO: Previous snapshot status: {"startTime"=>"Fri Jan 17 17:40:08 CST 2014", "fileCount"=>146, "status"=>"success", "snapshotCompletedAt"=>"Fri Jan 17 17:40:08 CST 2014"}; snapshot: 
NameError: uninitialized constant ArchivesSpaceBackup::ASUtils
  const_missing at org/jruby/RubyModule.java:2684
         backup at ../launcher/backup/lib/backup.rb:105
           main at ../launcher/backup/lib/backup.rb:146
         (root) at ../launcher/backup/lib/backup.rb:150

Requiring 'asutils' fixes this error.
