### PR TITLE
Use matching bundler version for plugins

### DIFF
--- a/launcher/plugin_gems/initialize-plugin.sh
+++ b/launcher/plugin_gems/initialize-plugin.sh
@@ -4,6 +4,9 @@ plugin="$1"
 
 export ASPACE_LAUNCHER_BASE="$("`dirname $0`"/find-base.sh)"
 
+cd "$ASPACE_LAUNCHER_BASE/gems/gems"
+BUNDLER_VERSION=$(ls | grep bundler | cut -d'-' -f 2)
+
 cd "$ASPACE_LAUNCHER_BASE/plugins/$plugin"
 
 if [ "$plugin" = "" ]; then
@@ -23,7 +26,7 @@ done
 
 export GEM_HOME=gems
 
-java $JAVA_OPTS -cp "../../lib/*$JRUBY" org.jruby.Main --1.9 -S gem install bundler
+java $JAVA_OPTS -cp "../../lib/*$JRUBY" org.jruby.Main --1.9 -S gem install bundler -v "$BUNDLER_VERSION"
 java $JAVA_OPTS -cp "../../lib/*$JRUBY" org.jruby.Main --1.9 ../../gems/bin/bundle install --gemfile=Gemfile
 
 


### PR DESCRIPTION
If the version of bundler that gets installed in a plugins gems
directory does not match the version shipped with ArchivesSpace
then ArchivesSpace fails to start.

Explicitly setting the bundler version in initialize-plugin.sh to
match the version in the archivesspace gems directory resolves
the issue.

This will also to need to be done for initialize-plugin.bat
