### PR TITLE
Add links in footer to frontend and public interfaces

### DIFF
--- a/frontend/app/views/site/_footer.html.erb
+++ b/frontend/app/views/site/_footer.html.erb
@@ -1,7 +1,7 @@
 <div class="container footer">
    <div class="row-fluid">
       <div class="span12">
-         <p>Visit <a href="http://archivesspace.org">ArchivesSpace.org</a> | <%= ASConstants.VERSION %></p>
+         <p><% if AppConfig[:enable_public] %>View <a href="<%= AppConfig[:public_proxy_url] %>">Public Interface</a> | <% end %>Visit <a href="http://archivesspace.org">ArchivesSpace.org</a> | <%= ASConstants.VERSION %></p>
       </div>
    </div>
 </div>

--- a/plugins/aspace_feedback/frontend/views/site/_footer.html.erb
+++ b/plugins/aspace_feedback/frontend/views/site/_footer.html.erb
@@ -3,7 +3,7 @@
 <div class="container footer">
    <div class="row-fluid">
       <div class="span12">
-         <p>Visit <a href="http://archivesspace.org">ArchivesSpace.org</a> | Version <%= ASConstants.VERSION %> | <a id="aspaceFeedbackLink" href="javascript:void(0);">Send Feedback</a></p>
+         <p><% if AppConfig[:enable_public] %>View <a href="<%= AppConfig[:public_proxy_url] %>">Public Interface</a> | <% end %>Visit <a href="http://archivesspace.org">ArchivesSpace.org</a> | Version <%= ASConstants.VERSION %> | <a id="aspaceFeedbackLink" href="javascript:void(0);">Send Feedback</a></p>
       </div>
    </div>
 </div>

--- a/public/app/views/site/_footer.html.erb
+++ b/public/app/views/site/_footer.html.erb
@@ -1,7 +1,7 @@
 <div class="container footer">
   <div class="row-fluid">
     <div class="span12">
-             <p>Visit <a href="http://archivesspace.org">ArchivesSpace.org</a> | <%= ASConstants.VERSION %></p>
+             <p><% if AppConfig[:enable_frontend] %>View <a href="<%= AppConfig[:frontend_proxy_url] %>">Staff Interface</a> | <% end %>Visit <a href="http://archivesspace.org">ArchivesSpace.org</a> | <%= ASConstants.VERSION %></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
From the frontend if the public interface is enabled add a link
to it in the footer. Do the same for the public interface if the
frontend is enabled (add frontend footer link).

The feedback plugin overrides the footer so that is updated also.
