### PR TITLE
Update selenium-webdriver

### DIFF
--- a/selenium-public/Gemfile.lock
+++ b/selenium-public/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    childprocess (0.3.9)
+    childprocess (0.5.0)
       ffi (~> 1.0, >= 1.0.11)
     diff-lcs (1.1.3)
     ffi (1.7.0-java)
@@ -15,8 +15,8 @@ GEM
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.12.0)
     rubyzip (1.0.0)
-    selenium-webdriver (2.37.0)
-      childprocess (>= 0.2.5)
+    selenium-webdriver (2.41.0)
+      childprocess (>= 0.5.0)
       multi_json (~> 1.0)
       rubyzip (~> 1.0.0)
       websocket (~> 1.0.4)

--- a/selenium/Gemfile.lock
+++ b/selenium/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    childprocess (0.3.9)
+    childprocess (0.5.0)
       ffi (~> 1.0, >= 1.0.11)
     diff-lcs (1.1.3)
     ffi (1.9.3-java)
@@ -15,8 +15,8 @@ GEM
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.12.0)
     rubyzip (1.0.0)
-    selenium-webdriver (2.37.0)
-      childprocess (>= 0.2.5)
+    selenium-webdriver (2.41.0)
+      childprocess (>= 0.5.0)
       multi_json (~> 1.0)
       rubyzip (~> 1.0.0)
       websocket (~> 1.0.4)


### PR DESCRIPTION
Bump selenium-webdriver version to 2.41.0 to support Firefox 28.
Version 2.41.0 requires childprocess 0.5.0 which is also updated.
