### PR TITLE
Updates to selenium and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
   - DB=derby TASK=travis:test
   - DB=mysql TASK=travis:selenium
   - DB=derby TASK=travis:selenium
+  - DB=mysql TASK=travis:selenium:public
+  - DB=derby TASK=travis:selenium:public
   - TASK=dist
 
 before_script:

--- a/build/build.xml
+++ b/build/build.xml
@@ -437,7 +437,12 @@
     <antcall target="db:migrate" />
     <antcall target="selenium:test" />
     <antcall target="travis:db:nuke" />
-    <antcall target="selenium:public:test" />    
+  </target>
+
+  <target name="travis:selenium:public" depends="set-classpath, bootstrap">
+    <antcall target="db:migrate" />
+    <antcall target="selenium:public:test" />
+    <antcall target="travis:db:nuke" />
   </target>
 
   <target name="travis:test" depends="set-classpath, bootstrap">

--- a/selenium-public/Gemfile.lock
+++ b/selenium-public/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    childprocess (0.3.9)
+    childprocess (0.5.0)
       ffi (~> 1.0, >= 1.0.11)
     diff-lcs (1.1.3)
     ffi (1.7.0-java)
@@ -15,8 +15,8 @@ GEM
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.12.0)
     rubyzip (1.0.0)
-    selenium-webdriver (2.37.0)
-      childprocess (>= 0.2.5)
+    selenium-webdriver (2.41.0)
+      childprocess (>= 0.5.0)
       multi_json (~> 1.0)
       rubyzip (~> 1.0.0)
       websocket (~> 1.0.4)

--- a/selenium/Gemfile.lock
+++ b/selenium/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    childprocess (0.3.9)
+    childprocess (0.5.0)
       ffi (~> 1.0, >= 1.0.11)
     diff-lcs (1.1.3)
     ffi (1.9.3-java)
@@ -15,8 +15,8 @@ GEM
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.12.0)
     rubyzip (1.0.0)
-    selenium-webdriver (2.37.0)
-      childprocess (>= 0.2.5)
+    selenium-webdriver (2.41.0)
+      childprocess (>= 0.5.0)
       multi_json (~> 1.0)
       rubyzip (~> 1.0.0)
       websocket (~> 1.0.4)

--- a/selenium/common.rb
+++ b/selenium/common.rb
@@ -365,6 +365,7 @@ def selenium_init(backend_fn, frontend_fn)
 
 
   $driver = Selenium::WebDriver.for :firefox
+  $wait   = Selenium::WebDriver::Wait.new(:timeout => 10)
   $driver.manage.window.maximize
 end
 

--- a/selenium/spec/selenium_spec.rb
+++ b/selenium/spec/selenium_spec.rb
@@ -3060,12 +3060,13 @@ end
       $driver.find_element(:css, '.user-container .btn.dropdown-toggle.last').click
       $driver.find_element(:link, "My Repository Preferences").click
 
-
       $driver.find_element(:id => "preference_defaults__accession_browse_column_1_").select_option_with_text("Acquisition Type")
       $driver.find_element(:css => 'button[type="submit"]').click
+      $wait.until { $driver.find_element(:css => ".alert-success") }
 
       $driver.find_element(:link => 'Browse').click
       $driver.find_element(:link => 'Accessions').click
+      $wait.until { $driver.find_element(:link => "Create Accession") }
 
       cells = $driver.find_elements(:css, "table th")
       cells[1].text.should eq("Title")


### PR DESCRIPTION
Bump selenium for Firefox 28 support.
Add wait in User Preferences test to reduce failure.
Split out travis tasks further for faster build time per job.
