### PR TITLE
Fix exception when more than 2 fields entered into advanced search

### DIFF
--- a/public/app/controllers/search_controller.rb
+++ b/public/app/controllers/search_controller.rb
@@ -113,13 +113,21 @@ class SearchController < ApplicationController
 
         stack.push(JSONModel(:boolean_query).from_hash({
                                                          :op => b[:op],
-                                                         :subqueries => [JSONModel(:field_query).from_hash(a), JSONModel(:field_query).from_hash(b)]
+                                                         :subqueries => [as_subquery(a), as_subquery(b)]
                                                        }))
       end
 
       stack.pop
     else
       JSONModel(:field_query).from_hash(terms[0])
+    end
+  end
+
+  def as_subquery(query_data)
+    if query_data.kind_of? JSONModelType
+      query_data
+    else
+      JSONModel(:field_query).from_hash(query_data)
     end
   end
 


### PR DESCRIPTION
To replicate:
1) Go to the public interface homepage
2) Click `Show Advanced Search`
3) Enter a value in all 3 advanced search text fields
4) Click `Search`

Results in an exception: `JSONModel::ValidationException in SearchController#advanced_search`
