### PR TITLE
Fix exception when visiting accession in public app

### DIFF
--- a/public/app/controllers/records_controller.rb
+++ b/public/app/controllers/records_controller.rb
@@ -101,7 +101,7 @@ class RecordsController < ApplicationController
       [@repository['repo_code'], url_for(:controller => :search, :action => :repository, :id => @repository.id), "repository"]
     ]
 
-    @breadcrumbs.push([@accession.title, "#", "accession"])
+    @breadcrumbs.push([@accession.display_string, "#", "accession"])
   end
 
 


### PR DESCRIPTION
To replicate:

1) in the staff interface create an accession without a title (so only with a four-part-id).
2) check the publish checkbox so it is delivered to the public app
3) in the public app, search and navigate to that accession
4) throws an exception `undefined method`length' for nil:NilClass`

Fixed by using the accession `display_string` rather than the `title` in the breadcrumb trail.
