### PR TITLE
Add config option to set initial admin password

### DIFF
--- a/backend/app/lib/bootstrap_access_control.rb
+++ b/backend/app/lib/bootstrap_access_control.rb
@@ -59,7 +59,7 @@ class ArchivesSpaceService
 
 
     # Create the admin user
-    self.create_system_user(User.ADMIN_USERNAME, "Administrator", User.ADMIN_USERNAME)
+    self.create_system_user(User.ADMIN_USERNAME, "Administrator", AppConfig[:default_admin_password])
     self.create_group(Group.ADMIN_GROUP_CODE, "Administrators", [User.ADMIN_USERNAME], [])
 
 

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -1,3 +1,4 @@
+AppConfig[:default_admin_password] = "admin"
 AppConfig[:data_directory] = File.join(Dir.home, "ArchivesSpace")
 AppConfig[:backup_directory] = proc { File.join(AppConfig[:data_directory], "demo_db_backups") }
 AppConfig[:solr_index_directory] = proc { File.join(AppConfig[:data_directory], "solr_index") }


### PR DESCRIPTION
There are various contexts in which it would be advantageous to be
able to set the default admin password initially in the config file.
This commit provides that option while retaining the default
behavior of setting the password to "admin".
