### PR TITLE
Plugin schema extension fix

### DIFF
--- a/common/jsonmodel.rb
+++ b/common/jsonmodel.rb
@@ -196,11 +196,11 @@ module JSONModel
         allow_unmapped_enum_value(entry[:schema]['properties'])
       end
 
-      AppConfig[:plugins].each do |plugin|
-        Dir.glob(File.join('..', 'plugins', plugin, 'schemas', "#{schema_name}_ext.rb")).each do |ext|
-          entry[:schema]['properties'] = ASUtils.deep_merge(entry[:schema]['properties'],
-                                                            eval(File.open(ext).read))
-        end
+      ASUtils.find_local_directories("schemas/#{schema_name}_ext.rb").
+              select {|path| File.exists?(path)}.
+              each do |schema_extension|
+        entry[:schema]['properties'] = ASUtils.deep_merge(entry[:schema]['properties'],
+                                                          eval(File.open(schema_extension).read))
       end
 
       self.create_model_for(schema_name, entry[:schema])


### PR DESCRIPTION
Hey there Chris,

I noticed that the facility that's supposed to allow plugins to add fields to JSON schemas isn't quite working correctly.  It's using a relative path, but when running from the .zip distribution, that path ends up being relative to the jetty directory.  It works by accident for plugins that come bundled with ArchivesSpace, but breaks if it tries to find a plugin from the 'plugins' directory.

Here's a fix!

Thanks,
Mark
