### PR TITLE
Modify the plugin_helper to handle zero_to_one record types.

### DIFF
--- a/frontend/app/helpers/plugin_helper.rb
+++ b/frontend/app/helpers/plugin_helper.rb
@@ -5,7 +5,7 @@ module PluginHelper
     jsonmodel_type = record['jsonmodel_type']
     Plugins.plugins_for(jsonmodel_type).each do |plugin|
       name = Plugins.parent_for(plugin, jsonmodel_type)['name']
-      if not controller.action_name === "show" or record.send(name).length > 0
+      if not controller.action_name === "show" or Array(record.send(name)).length > 0
         result << '<li>'
         result << "<a href='##{jsonmodel_type}_#{name}_'>"
         result << I18n.t("plugins.#{plugin}._plural")
@@ -21,7 +21,7 @@ module PluginHelper
     jsonmodel_type = record['jsonmodel_type']
     Plugins.plugins_for(jsonmodel_type).each do |plugin|
       name = Plugins.parent_for(plugin, jsonmodel_type)['name']
-      if record.send(name).length > 0
+      if Array(record.send(name)).length > 0
         result << render_aspace_partial(:partial => "#{name}/show",
                          :locals => { name.intern => record.send(name),
                            :context => context, :section_id => "#{jsonmodel_type}_#{name}_" })


### PR DESCRIPTION
Hi Chris,

Just another little fix I found we needed when developing plugins.  This plugin helper code was assuming that all added subrecords would be one-to-many (and therefore an array), but we want to support zero_or_one records as well.

Thanks,
Mark
