### PR TITLE
Fix for digital object file versions

### DIFF
--- a/frontend/app/helpers/file_embed_helper.rb
+++ b/frontend/app/helpers/file_embed_helper.rb
@@ -1,15 +1,18 @@
 module FileEmbedHelper
 
   def can_embed?(file_version)
-    uri = URI(file_version['file_uri'])
-
-    if %w(jpeg gif).include?(file_version['file_format_name']) && 
+    begin
+      uri = URI(file_version['file_uri'])
+      if %w(jpeg gif).include?(file_version['file_format_name']) &&
         uri.scheme =~ /http/ &&
         file_version['file_size_bytes'].to_i < 512001
-
-      true
-    else
+        true
+      else
+        false
+      end
+    rescue Exception => ex
       false
     end
   end
+
 end

--- a/frontend/app/views/file_versions/_file_uri.html.erb
+++ b/frontend/app/views/file_versions/_file_uri.html.erb
@@ -1,7 +1,7 @@
 <div class="control-group">
   <div class="control-label"><%= I18n.t("file_version.file_uri") %></div>
   <div class="controls label-only">
-    <% if file_uri.scheme && file_uri.scheme.match(/^http/) %>
+    <% if file_uri.respond_to?(:scheme) && file_uri.scheme.match(/^http/) %>
   	<%= link_to file_uri.to_s, file_uri.to_s %>
     <% else %>
   	<%= file_uri.to_s %>

--- a/frontend/app/views/file_versions/_show.html.erb
+++ b/frontend/app/views/file_versions/_show.html.erb
@@ -22,8 +22,9 @@
           <div class="form-horizontal">
             <% if can_embed?(file_version) %>
               <%= render_aspace_partial :partial => "file_versions/image", :locals => {:file => file_version} %>
+              <%= render_aspace_partial :partial => "file_versions/file_uri", :locals => {:file_uri => URI(file_version['file_uri'])} %>
             <% end %>
-            <%= render_aspace_partial :partial => "file_versions/file_uri", :locals => {:file_uri => URI(file_version['file_uri'])} %>
+            <%= render_aspace_partial :partial => "file_versions/file_uri", :locals => {:file_uri => file_version['file_uri']} %>
           </div>
           <%= read_only_view(file_version) %>
         </div>

--- a/selenium/spec/selenium_spec.rb
+++ b/selenium/spec/selenium_spec.rb
@@ -1951,6 +1951,21 @@ describe "ArchivesSpace user interface" do
       assert(5) { $driver.find_element(:css => "a.jstree-clicked").text.strip.should match(/#{digital_object_title}/) }
     end
 
+    it "can handle multiple file versions and file system and network path types" do
+      [
+        '/root/top_secret.txt',
+        'C:\Program Files\windows.exe',
+        '\\\\SomeAwesome\Network\location.bat',
+      ].each_with_index do |uri, idx|
+        i = idx + 1
+        $driver.find_element(:css => "section#digital_object_file_versions_ > h3 > .btn").click
+        $driver.clear_and_send_keys([:id, "digital_object_file_versions__#{i}__file_uri_"], uri)
+        $driver.find_element(:css => ".form-actions button[type='submit']").click
+      end
+      $driver.find_element(:link, "Close Record").click
+      $driver.find_element_with_text('//h3', /File Versions/)
+      $driver.find_element(:link, "Edit").click
+    end
 
     it "reports errors if adding an empty child to a Digital Object" do
       $driver.find_element(:link, "Add Child").click


### PR DESCRIPTION
File versions with non parsable URI's cannot display in View mode.
Instead a server error (URI::InvalidURIError) is returned:

ActionView::Template::Error (bad URI(is not URI?)

Examples:

C:\Program Files\windows.exe
\SomeAwesome\Network\location.bat
http://www.yr.no/sted/Finland/Västra_Finland/Askainen/varsel.xml

This patch acts defensively by catching the exception and displaying
the file_uri string if it does not parse as a URI.
