### PR TITLE
Small fix for public UI display of file versions

### DIFF
--- a/public/app/views/records/_file_versions.html.erb
+++ b/public/app/views/records/_file_versions.html.erb
@@ -6,7 +6,7 @@
         <li class="result">
           <% if file.embed %>
             <%= render_aspace_partial :partial => "file_version_embed/#{file.embed_type}", :locals => {:file => file} %>
-          <% elsif  file.uri && file.uri.scheme.match(/^http/) %>
+          <% elsif  file.uri && file.uri.scheme && file.uri.scheme.match(/^http/) %>
             <%= link_to file.uri.to_s, file.uri.to_s %>
           <% else %>
             <%= file['file_uri'] %>


### PR DESCRIPTION
Not all URI parsable stings will have a defined scheme i.e.

/path/to/file.txt

In this case the scheme is nil so the interface will "crash".
Therefore check for the scheme as well when looking to add the
the file_uri link.
