### PR TITLE
Add AccessDeniedException to newrelic ignore list

### DIFF
--- a/plugins/newrelic/frontend/newrelic.yml
+++ b/plugins/newrelic/frontend/newrelic.yml
@@ -168,7 +168,7 @@ common: &default_settings
     # To stop specific errors from reporting to New Relic, set this property
     # to comma-separated values.  Default is to ignore routing errors,
     # which are how 404's get triggered.
-    ignore_errors: "ActionController::RoutingError,Sinatra::NotFound"
+    ignore_errors: "ActionController::RoutingError,Sinatra::NotFound,AccessDeniedException"
 
   # If you're interested in capturing memcache keys as though they
   # were SQL uncomment this flag. Note that this does increase

--- a/plugins/newrelic/public/newrelic.yml
+++ b/plugins/newrelic/public/newrelic.yml
@@ -168,7 +168,7 @@ common: &default_settings
     # To stop specific errors from reporting to New Relic, set this property
     # to comma-separated values.  Default is to ignore routing errors,
     # which are how 404's get triggered.
-    ignore_errors: "ActionController::RoutingError,Sinatra::NotFound"
+    ignore_errors: "ActionController::RoutingError,Sinatra::NotFound,AccessDeniedException"
 
   # If you're interested in capturing memcache keys as though they
   # were SQL uncomment this flag. Note that this does increase


### PR DESCRIPTION
These exceptions are typically user error. However in the case
that a user session has gone stale while in edit mode in the
staff interface the update monitor polling will generate a lot of
AccessDeniedException messages which are a "false alarm" from a
monitoring point of view.
