### PR TITLE
Add a default sort to the public interface

### DIFF
--- a/public/app/controllers/search_controller.rb
+++ b/public/app/controllers/search_controller.rb
@@ -59,6 +59,7 @@ class SearchController < ApplicationController
     }
 
     @criteria["page"] ||= 1
+    @criteria["sort"] ||= "title_sort asc"
 
     if @criteria["filter_term"]
       @criteria["filter_term[]"] = Array(@criteria["filter_term"]).reject{|v| v.blank?}

--- a/selenium-public/spec/selenium_spec.rb
+++ b/selenium-public/spec/selenium_spec.rb
@@ -79,7 +79,7 @@ describe "ArchivesSpace Public interface" do
     
     it "shows Title (default)  in the sort pulldown" do
       $driver.find_element(:link, "Repositories").click
-      $driver.find_element(:xpath, "//a[span = 'Select']").click
+      $driver.find_element(:xpath, "//a[span = 'Title Ascending']").click
       $driver.find_element(:link, "Title" )
       $driver.ensure_no_such_element(:link, "Term") 
     end
@@ -254,7 +254,7 @@ describe "ArchivesSpace Public interface" do
 
     it "shows the Agent Name in the sort pulldown" do
       $driver.find_element(:link, "Names").click
-      $driver.find_element(:xpath, "//a[span = 'Select']").click
+      $driver.find_element(:xpath, "//a[span = 'Agent Name Ascending']").click
       $driver.find_element(:link, "Agent Name" )
       $driver.ensure_no_such_element(:link, "Title") 
     end
@@ -289,7 +289,7 @@ describe "ArchivesSpace Public interface" do
     
     it "shows the Term  in the sort pulldown" do
       $driver.find_element(:link, "Subjects").click
-      $driver.find_element(:xpath, "//a[span = 'Select']").click
+      $driver.find_element(:xpath, "//a[span = 'Terms Ascending']").click
       $driver.find_element(:link, "Terms" )
       $driver.ensure_no_such_element(:link, "Title") 
     end


### PR DESCRIPTION
For the greater ArchivesSpace community consideration =)

By popular demand -- the unsorted results aren't useful 
and can be confusing for end users. This is a minimal 
implementation of a default sort that could be enhanced 
in future via config settings, or the ability to set the default 
sort criteria via the staff interface perhaps.
