### PR TITLE
Implement support for repository selection stickiness

### DIFF
--- a/frontend/app/controllers/repositories_controller.rb
+++ b/frontend/app/controllers/repositories_controller.rb
@@ -85,6 +85,7 @@ class RepositoriesController < ApplicationController
   def select
     selected = @repositories.find {|r| r.id.to_s == params[:id]}
     self.class.session_repo(session, selected.uri)
+    set_user_repository_cookie selected.uri
 
     flash[:success] = I18n.t("repository._frontend.messages.changed", JSONModelI18nWrapper.new(:repository => selected))
 

--- a/selenium/spec/selenium_spec.rb
+++ b/selenium/spec/selenium_spec.rb
@@ -95,6 +95,9 @@ describe "ArchivesSpace user interface" do
       assert(5) { $driver.find_element(:css, 'span.current-repository-id').text.should eq @test_repo_code_2 }
     end
 
+    it "will persist repository selection" do
+      assert(5) { $driver.find_element(:css, 'span.current-repository-id').text.should eq @test_repo_code_2 }
+    end
 
     it "automatically refreshes the repository list when a new repo gets added" do
       new_repo_code = "notificationtest1#{Time.now.to_i}_#{$$}"


### PR DESCRIPTION
The current behavior of selecting the first created repository
(available to a user) each time a user logs in is frustrating
and unintuitive.

This is particularly a problem for sites with multiple
repositories where the "primary" repository is not listed first
in the repository selection dropdown menu.

Use a cookie that includes the session username to track the
currently selected repository so that the selection persists
between logins.

By including the username in the cookie maintaining the selection
for different users from the same browser will be handled correctly.
