### PR TITLE
Refinement to default sort for public ui

### DIFF
--- a/public/app/controllers/search_controller.rb
+++ b/public/app/controllers/search_controller.rb
@@ -61,7 +61,7 @@ class SearchController < ApplicationController
     }
 
     @criteria["page"] ||= 1
-    @criteria["sort"] ||= "title_sort asc"
+    @criteria["sort"] = "title_sort asc" unless @criteria["sort"] or @criteria["q"] or params["advanced"].present?
 
     if @criteria["filter_term"]
       @criteria["filter_term[]"] = Array(@criteria["filter_term"]).reject{|v| v.blank?}


### PR DESCRIPTION
For the public interface only apply a default sort if there is no
query (including advanced queries) and no sort specified. This
addresses the problem of meaningless "unsorted" browse views,
but preserves relevancy as the default sort for queries.
