### PR TITLE
Add support for external Solr instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,10 @@ customize ArchivesSpace, please see the README in the `plugins` directory.
 
 [Instructions for running under Tomcat](https://github.com/archivesspace/archivesspace/blob/master/README_TOMCAT.md).
 
+# Running ArchivesSpace with an external Solr instance
+
+[Instructions for using an external Solr server](https://github.com/archivesspace/archivesspace/blob/master/README_SOLR.md)
+
 # Running ArchivesSpace under a prefix
 
 [Instructions for running under a prefix](https://github.com/archivesspace/archivesspace/blob/master/README_PREFIX.md).

--- a/README_SOLR.md
+++ b/README_SOLR.md
@@ -1,0 +1,40 @@
+Running ArchivesSpace with external Solr
+-------------------------------------------------------------
+
+Assuming you've unzipped a fresh new release there are a couple of steps to take:
+
+*Setup a Solr core*
+
+On the Solr server make a core available for ArchivesSpace. Copy the solr files from the ArchivesSpace source into the core's conf directory and enable it:
+
+https://github.com/archivesspace/archivesspace/tree/master/solr
+
+*Disable the embedded server Solr instance*
+
+Edit the ArchivesSpace config.rb file:
+
+```
+AppConfig[:enable_solr] = false
+```
+
+Note that doing this means that you will have to backup Solr manually.
+
+*Set the Solr url*
+
+This config setting should point to your Solr instance:
+
+```
+AppConfig[:solr_url] = "http://solr.somewhere.org:8983"
+```
+
+Include path if required:
+
+```
+AppConfig[:solr_url] = "http://solr.somewhere.org:8983/solr/archivesspace"
+```
+
+---
+
+You should monitor the ArchivesSpace logs and Solr to ensure that the indexer application is connecting to the external Solr instance.
+
+---

--- a/backend/app/main.rb
+++ b/backend/app/main.rb
@@ -140,7 +140,7 @@ class ArchivesSpaceService < Sinatra::Base
           end
         end
 
-        if AppConfig[:solr_backup_schedule] && AppConfig[:solr_backup_number_to_keep] > 0
+        if AppConfig[:enable_solr] && AppConfig[:solr_backup_schedule] && AppConfig[:solr_backup_number_to_keep] > 0
           settings.scheduler.cron(AppConfig[:solr_backup_schedule],
                                   :tags => 'solr_backup') do
             Log.info("Creating snapshot of Solr index and indexer state")

--- a/backend/app/model/solr.rb
+++ b/backend/app/model/solr.rb
@@ -222,7 +222,8 @@ class Solr
       end
 
       url = @solr_url
-      url.path = "/select"
+      # retain path if present i.e. "solr/aspace/select" when using an external Solr with path required
+      url.path += "/select"
       url.query = URI.encode_www_form([[:q, @query_string],
                                        [:wt, @writer_type],
                                        [:start, (@pagination[:page] - 1) * @pagination[:page_size]],

--- a/build/build.xml
+++ b/build/build.xml
@@ -20,7 +20,7 @@
 
   <property environment="env"/>
   <property name="env.JAVA_OPTS" value="-XX:MaxPermSize=196m -Xmx300m -Xss2m" />
-  <property name="default_java_options" value="-Daspace.config.data_directory=${aspace.data_directory} -Dfile.encoding=UTF-8 -Daspace.config.search_user_secret=devserver -Daspace.config.public_user_secret=devserver -Daspace.config.staff_user_secret=devserver -Daspace.devserver=true -Daspace.config.frontend_cookie_secret=devserver -Daspace.config.public_cookie_secret=devserver -Daspace.config.solr_url=http://localhost:${aspace.solr.port}/" />
+  <property name="default_java_options" value="-Daspace.config.data_directory=${aspace.data_directory} -Dfile.encoding=UTF-8 -Daspace.config.search_user_secret=devserver -Daspace.config.public_user_secret=devserver -Daspace.config.staff_user_secret=devserver -Daspace.devserver=true -Daspace.config.frontend_cookie_secret=devserver -Daspace.config.public_cookie_secret=devserver -Daspace.config.solr_url=http://localhost:${aspace.solr.port}" />
 
 
   <target name="help" description="This help">

--- a/clustering/README.md
+++ b/clustering/README.md
@@ -303,6 +303,7 @@ Here's our `config/instance_apps1.example.com.rb`:
        :backend_url => "http://apps1.example.com:8089",
        :frontend_url => "http://apps1.example.com:8080",
        :solr_url => "http://apps1.example.com:8090",
+       :indexer_url => "http://apps1.example.com:8091",
        :public_url => "http://apps1.example.com:8081",
      }
 

--- a/clustering/files/archivesspace/tenants/_template/archivesspace/config/instance_hostname.rb.example
+++ b/clustering/files/archivesspace/tenants/_template/archivesspace/config/instance_hostname.rb.example
@@ -2,5 +2,6 @@
   :backend_url => "http://yourhostname:8089",
   :frontend_url => "http://yourhostname:8080",
   :solr_url => "http://yourhostname:8090",
+  :indexer_url => "http://yourhostname:8091",
   :public_url => "http://yourhostname:8081",
 }

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -47,6 +47,7 @@ AppConfig[:backend_url] = "http://localhost:8089"
 AppConfig[:frontend_url] = "http://localhost:8080"
 AppConfig[:frontend_prefix] = proc { "#{URI(AppConfig[:frontend_url]).path}/".gsub(%r{/+$}, "/") }
 AppConfig[:solr_url] = "http://localhost:8090"
+AppConfig[:indexer_url] = "http://localhost:8091"
 AppConfig[:public_url] = "http://localhost:8081"
 AppConfig[:public_prefix] = proc { "#{URI(AppConfig[:public_url]).path}/".gsub(%r{/+$}, "/") }
 
@@ -58,6 +59,7 @@ AppConfig[:public_prefix] = proc { "#{URI(AppConfig[:public_url]).path}/".gsub(%
 AppConfig[:enable_backend] = true
 AppConfig[:enable_frontend] = true
 AppConfig[:enable_public] = true
+AppConfig[:enable_solr] = true
 AppConfig[:enable_indexer] = true
 
 # Some use cases want the ability to shutdown the Jetty service using Jetty's 

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -405,7 +405,7 @@ class CommonIndexer
   def delete_records(records)
     return if records.empty?
 
-    req = Net::HTTP::Post.new("/update")
+    req = Net::HTTP::Post.new("#{solr_url.path}/update")
     req['Content-Type'] = 'application/json'
 
     # Delete the ID plus any documents that were the child of that ID
@@ -519,14 +519,14 @@ class CommonIndexer
       }.compact
 
       if !records_with_children.empty?
-        req = Net::HTTP::Post.new("/update")
+        req = Net::HTTP::Post.new("#{solr_url.path}/update")
         req['Content-Type'] = 'application/json'
         req.body = {:delete => {'query' => "parent_id:(" + records_with_children.join(" OR ") + ")"}}.to_json
         response = do_http_request(solr_url, req)
       end
 
       # Now apply the updates
-      req = Net::HTTP::Post.new("/update")
+      req = Net::HTTP::Post.new("#{solr_url.path}/update")
       req['Content-Type'] = 'application/json'
 
       stream = batch.to_json_stream
@@ -548,7 +548,7 @@ class CommonIndexer
 
 
   def send_commit(type = :hard)
-    req = Net::HTTP::Post.new("/update")
+    req = Net::HTTP::Post.new("#{solr_url.path}/update")
     req['Content-Type'] = 'application/json'
     req.body = {:commit => {"softCommit" => (type == :soft) }}.to_json
 

--- a/indexer/app/lib/periodic_indexer.rb
+++ b/indexer/app/lib/periodic_indexer.rb
@@ -107,7 +107,7 @@ class PeriodicIndexer < CommonIndexer
     return if resource_uris.empty?
 
     resource_uris.each_slice(512) do |resource_uris|
-      req = Net::HTTP::Post.new("/update")
+      req = Net::HTTP::Post.new("#{solr_url.path}/update")
       req['Content-Type'] = 'application/json'
 
       escaped = resource_uris.map {|s| "\"#{s}\""}

--- a/launcher/backup/lib/backup.rb
+++ b/launcher/backup/lib/backup.rb
@@ -97,7 +97,7 @@ class ArchivesSpaceBackup
 
     solr_snapshot_id = "backup-#{$$}-#{Time.now.to_i}"
     begin
-      SolrSnapshotter.snapshot(solr_snapshot_id)
+      SolrSnapshotter.snapshot(solr_snapshot_id) if AppConfig[:enable_solr]
     rescue
       puts "Solr snapshot failed (#{$!}).  Aborting!"
       return 1
@@ -112,7 +112,7 @@ class ArchivesSpaceBackup
       create_demodb_snapshot
 
       Zip::ZipFile.open(output_file, Zip::ZipFile::CREATE) do |zipfile|
-        add_whole_directory(solr_snapshot, zipfile)
+        add_whole_directory(solr_snapshot, zipfile) if AppConfig[:enable_solr]
         add_whole_directory(demo_db_backups, zipfile) if Dir.exists?(demo_db_backups)
         add_whole_directory(config_dir, zipfile) if config_dir
         zipfile.add("mysqldump.sql", mysql_dump) if mysql_dump
@@ -121,7 +121,7 @@ class ArchivesSpaceBackup
       mysql_tempfile.close
       mysql_tempfile.delete
       FileUtils.rm_rf(File.join(AppConfig[:solr_backup_directory],
-                                "solr.#{solr_snapshot_id}"))
+                                "solr.#{solr_snapshot_id}")) if AppConfig[:enable_solr]
     end
 
     0

--- a/launcher/launcher.rb
+++ b/launcher/launcher.rb
@@ -124,8 +124,10 @@ def main
   FileUtils.mkdir_p(tempdir)
 
   java.lang.System.set_property("java.io.tmpdir", tempdir)
-  java.lang.System.set_property("solr.data.dir", AppConfig[:solr_index_directory])
-  java.lang.System.set_property("solr.solr.home", AppConfig[:solr_home_directory])
+  if AppConfig[:enable_solr]
+    java.lang.System.set_property("solr.data.dir", AppConfig[:solr_index_directory])
+    java.lang.System.set_property("solr.solr.home", AppConfig[:solr_home_directory])
+  end
 
   [:search_user_secret, :public_user_secret, :staff_user_secret].each do |property|
     if !AppConfig.has_key?(property)
@@ -143,9 +145,13 @@ def main
   begin
 	  aspace_base = java.lang.System.get_property("ASPACE_LAUNCHER_BASE")
     start_server(URI(AppConfig[:backend_url]).port, {:war => File.join(aspace_base, 'wars', 'backend.war'), :path => '/'}) if AppConfig[:enable_backend]
+
     start_server(URI(AppConfig[:solr_url]).port,
-                 {:war => File.join(aspace_base,'wars', 'solr.war'), :path => '/'},
+                 {:war => File.join(aspace_base,'wars', 'solr.war'), :path => '/'}) if AppConfig[:enable_solr]
+
+    start_server(URI(AppConfig[:indexer_url]).port,
                  {:war => File.join(aspace_base,'wars', 'indexer.war'), :path => '/aspace-indexer'}) if AppConfig[:enable_indexer]
+
     start_server(URI(AppConfig[:frontend_url]).port,
                  {:war => File.join(aspace_base,'wars', 'frontend.war'), :path => '/'},
                  {:static_dirs => ASUtils.find_local_directories("frontend/assets"),
@@ -193,7 +199,8 @@ end
 def stop
   if AppConfig[:use_jetty_shutdown_handler]  
     stop_server(URI(AppConfig[:backend_url])) if AppConfig[:enable_backend]
-    stop_server(URI(AppConfig[:solr_url])) if AppConfig[:enable_indexer]
+    stop_server(URI(AppConfig[:solr_url])) if AppConfig[:enable_solr]
+    stop_server(URI(AppConfig[:indexer_url])) if AppConfig[:enable_indexer]
     stop_server(URI(AppConfig[:frontend_url])) if AppConfig[:enable_frontend]
     stop_server(URI(AppConfig[:public_url])) if AppConfig[:enable_public]
     pid_file = File.join(AppConfig[:data_directory], ".archivesspace.pid" ) 


### PR DESCRIPTION
This is experimental, although important for certain deployment types
(larger installations, vendor installations, or where there is an
existing Solr infrastructure in place) and therefore would be great
to have for the next release.

The modularity of ArchivesSpace is compromised by how the indexer
and Solr are coupled together in the launcher script. The indexer
can run from anywhere it can access the backend and Solr over http
so it's limiting to have them instantiated together (and somewhat
misleading to have the indexer tucked away behind solr_url).

By starting the indexer and Solr separately, and making it possible
to disable the provided Solr an external instance can be used with
minimal configuration changes (provided Solr is configured
appropriately). For example:

```
AppConfig[:enable_solr] = false
AppConfig[:solr_url] = "http://solr.somewhere.org:8983/solr/archivesspace"
```

To make this work Solr requests in ArchivesSpace have been modified to
retain the URI path of the solr url (so in the above example
"solr/archivesspace" is appended or concatenated before the handler,
such as "/select").

A build for anyone interested is available at:

https://dl.dropboxusercontent.com/u/870845/apps/archivesspace-external-solr.zip

Also there is an Ansible playbook for testing:

https://github.com/mark-cooper/archivesspace-solr-playbook
