### PR TITLE
fix a key mistyped for a value

### DIFF
--- a/backend/app/converters/lib/xml_sax.rb
+++ b/backend/app/converters/lib/xml_sax.rb
@@ -206,7 +206,7 @@ module ASpaceImport
         return unless property_type[0].match(/string/) && value.is_a?(String)
         filtered_value = ASpaceImport::Utils.value_filter(property_type[0]).call(value)
         if obj.send(property)
-          obj.send(property).send(:<<, property)
+          obj.send(property).send(:<<, filtered_value)
         else
           obj.send("#{property}=", filtered_value)
         end


### PR DESCRIPTION
Looks like this error has been hiding here for a while. The converter will blow up if it tries to append to a field that already has string data. 
