### PR TITLE
Pass content as string to MixedContentParser

### DIFF
--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -230,7 +230,7 @@ module ApplicationHelper
   
   def clean_mixed_content(content)
     return content if content.blank? 
-    MixedContentParser::parse(content, url_for(:root), { :wrap_blocks => false } )
+    MixedContentParser::parse(content.to_s, url_for(:root), { :wrap_blocks => false } )
   end
 
 end


### PR DESCRIPTION
FYI -- testing master ran into EAD import errors when Fixnum was
passed to MixedContentParser::parse. Casting the content to string
overcame the issue to allow me to continue testing elsewhere.
