### PR TITLE
Add rights_transferred to locales enums

### DIFF
--- a/common/locales/enums/en.yml
+++ b/common/locales/enums/en.yml
@@ -325,6 +325,7 @@ en:
       processed: Processed
       publication: Publication
       replication: Replication
+      rights_transferred: Rights Transferred
       validation: Validation
       virus_check: Virus Check
     resource_resource_type:


### PR DESCRIPTION
Has been identified as missing, with the familiar error message: "translation missing" ... 
