### PR TITLE
Don't display interface links if proxy address is localhost

### DIFF
--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -233,4 +233,8 @@ module ApplicationHelper
     MixedContentParser::parse(content, url_for(:root), { :wrap_blocks => false } )
   end
 
+  def proxy_localhost?
+    AppConfig[:public_proxy_url] =~ /localhost/
+  end
+
 end

--- a/frontend/app/views/site/_footer.html.erb
+++ b/frontend/app/views/site/_footer.html.erb
@@ -1,7 +1,7 @@
 <div class="container footer">
    <div class="row-fluid">
       <div class="span12">
-         <p><% if AppConfig[:enable_public] %>View <a href="<%= AppConfig[:public_proxy_url] %>">Public Interface</a> | <% end %>Visit <a href="http://archivesspace.org">ArchivesSpace.org</a> | <%= ASConstants.VERSION %></p>
+         <p><% if AppConfig[:enable_public] and not proxy_localhost? %>View <a href="<%= AppConfig[:public_proxy_url] %>">Public Interface</a> | <% end %>Visit <a href="http://archivesspace.org">ArchivesSpace.org</a> | <%= ASConstants.VERSION %></p>
       </div>
    </div>
 </div>

--- a/plugins/aspace_feedback/frontend/views/site/_footer.html.erb
+++ b/plugins/aspace_feedback/frontend/views/site/_footer.html.erb
@@ -3,7 +3,7 @@
 <div class="container footer">
    <div class="row-fluid">
       <div class="span12">
-         <p><% if AppConfig[:enable_public] %>View <a href="<%= AppConfig[:public_proxy_url] %>">Public Interface</a> | <% end %>Visit <a href="http://archivesspace.org">ArchivesSpace.org</a> | Version <%= ASConstants.VERSION %> | <a id="aspaceFeedbackLink" href="javascript:void(0);">Send Feedback</a></p>
+         <p><% if AppConfig[:enable_public] and not proxy_localhost? %>View <a href="<%= AppConfig[:public_proxy_url] %>">Public Interface</a> | <% end %>Visit <a href="http://archivesspace.org">ArchivesSpace.org</a> | Version <%= ASConstants.VERSION %> | <a id="aspaceFeedbackLink" href="javascript:void(0);">Send Feedback</a></p>
       </div>
    </div>
 </div>

--- a/public/app/helpers/application_helper.rb
+++ b/public/app/helpers/application_helper.rb
@@ -120,4 +120,8 @@ module ApplicationHelper
     return render(defaults.merge(args))
   end
 
+  def proxy_localhost?
+    AppConfig[:frontend_proxy_url] =~ /localhost/
+  end
+
 end

--- a/public/app/views/site/_footer.html.erb
+++ b/public/app/views/site/_footer.html.erb
@@ -1,7 +1,7 @@
 <div class="container footer">
   <div class="row-fluid">
     <div class="span12">
-             <p><% if AppConfig[:enable_frontend] %>View <a href="<%= AppConfig[:frontend_proxy_url] %>">Staff Interface</a> | <% end %>Visit <a href="http://archivesspace.org">ArchivesSpace.org</a> | <%= ASConstants.VERSION %></p>
+             <p><% if AppConfig[:enable_frontend] and not proxy_localhost? %>View <a href="<%= AppConfig[:frontend_proxy_url] %>">Staff Interface</a> | <% end %>Visit <a href="http://archivesspace.org">ArchivesSpace.org</a> | <%= ASConstants.VERSION %></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The default is localhost and there is no requirement or instruction
to change this value. When ArchivesSpace is being accessed in a non
localhost context the default behavior is unreasonable as the links
will not work (and I've seen this a few places online). 

Therefore only display links between interfaces if
the proxy urls are not localhost (sites can choose to override this
however they like). The fact that this will not display the links when 
localhost would be valid (dev for instance) is a much lesser 
(and arguably insignificant) problem.
