### PR TITLE
Bump ffi version to 1.9.5

### DIFF
--- a/selenium-public/Gemfile.lock
+++ b/selenium-public/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     childprocess (0.5.3)
       ffi (~> 1.0, >= 1.0.11)
     diff-lcs (1.1.3)
-    ffi (1.9.3-java)
+    ffi (1.9.5-java)
     multi_json (1.10.0)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)

--- a/selenium/Gemfile.lock
+++ b/selenium/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     childprocess (0.5.3)
       ffi (~> 1.0, >= 1.0.11)
     diff-lcs (1.1.3)
-    ffi (1.9.4-java)
+    ffi (1.9.5-java)
     multi_json (1.10.0)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)


### PR DESCRIPTION
1.9.4 was yanked:

https://rubygems.org/gems/ffi/versions

1.9.3 is ~ 1 yr old. So suggest moving forward. Tests pass.
