### PR TITLE
Update Tomcat setup to decouple solr / indexer

### DIFF
--- a/README_TOMCAT.md
+++ b/README_TOMCAT.md
@@ -17,6 +17,11 @@ However, if you have a burning desire to use Tomcat, the steps are:
 
       AppConfig[:db_url] = "jdbc:mysql://localhost:3306/archivesspace?user=as&password=as123&useUnicode=true&characterEncoding=UTF-8"
 
+  * Also in config/config.rb disable embedded solr and set solr url if you want to use an [external Solr instance](README_SOLR.md)
+
+      AppConfig[:enable_solr] = false
+      AppConfig[:solr_url] = "http://some.solr.org:8983/solr/archivesspace"
+
   * Unpack the Tomcat distribution
 
   * From your 'archivesspace' directory, use the 'configure-tomcat.sh'

--- a/launcher/tomcat/files/server.xml
+++ b/launcher/tomcat/files/server.xml
@@ -98,4 +98,20 @@
   </Service>
 
 
+  <Service name="ArchivesSpaceIndexer">
+
+    <Connector port="%INDEXER_PORT%" protocol="HTTP/1.1" connectionTimeout="20000" />
+
+    <Engine name="ArchivesSpaceIndexer" defaultHost="localhost">
+      <Host name="localhost" appBase="webapps-indexer" unpackWARs="true" autoDeploy="false">
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="indexer_access_log." suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+
+  </Service>
+
+
 </Server>

--- a/launcher/tomcat/lib/configure-tomcat.rb
+++ b/launcher/tomcat/lib/configure-tomcat.rb
@@ -41,7 +41,9 @@ class TomcatSetup
     [{:service => 'backend', :root_war => 'backend'},
      {:service => 'frontend', :root_war => 'frontend'},
      {:service => 'public', :root_war => 'public'},
-     {:service => 'solr', :root_war => 'solr', :extra_wars => ['indexer']}].each do |service|
+     {:service => 'solr', :root_war => 'solr'},
+     {:service => 'indexer', :root_war => 'indexer'}].each do |service|
+      next if service[:service] == "solr" and not AppConfig[:enable_solr]
 
       webapps = File.join(@tomcat_dir, "webapps-#{service[:service]}")
       FileUtils.mkdir_p(webapps)
@@ -102,7 +104,7 @@ class TomcatSetup
 
     server_xml = File.read(File.join(@base_dir, "launcher", "tomcat", "files", "server.xml"))
 
-    ['backend', 'frontend', 'public', 'solr'].each do |service|
+    ['backend', 'frontend', 'public', 'solr', 'indexer'].each do |service|
       server_xml = server_xml.gsub(/%#{service.upcase}_PORT%/,
                                    port_for(service).to_s)
     end


### PR DESCRIPTION
Tomcat setup wasn't brought in line with recent updates to
enable external Solr instance. This makes Tomcat setup equivalent
to standard install with the indexer using a dedicated port.

Note: a future improvement would be to better handle external Solr
with Tomcat. The embedded Solr war file will not be transferred
but the Solr entry in server.xml is present. This produces an
error on startup in the logs but does not appear to otherwise
impact the system.
