### PR TITLE
Subjects and agents import requires source

### DIFF
--- a/backend/app/converters/lib/marcxml_base_map.rb
+++ b/backend/app/converters/lib/marcxml_base_map.rb
@@ -32,7 +32,7 @@ module MarcXMLBaseMap
         '4'=>"Source not specified",
         '5'=>"Canadian Subject Headings",
         '6'=>"R\u00E9pertoire de vedettes-matic\u00E8re"
-      }[node.attr('ind2')] || node.xpath("subfield[@code='2']").inner_text
+      }[node.attr('ind2')] || ( !node.at_xpath("subfield[@code='2']").nil? ? node.at_xpath("subfield[@code='2']").inner_text : 'Source not specified' )
     }
   end
 


### PR DESCRIPTION
Importing subjects and agents (marcxml) requires that the extracted
field have a source specified in the ind2 or subfield with code 2,
otherwise it will fail with "source : Property is required but was
missing".
