### PR TITLE
Nil passed to clean_mixed_content will error in view

### DIFF
--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -229,8 +229,9 @@ module ApplicationHelper
   end
   
   def clean_mixed_content(content)
+    content = content.to_s
     return content if content.blank? 
-    MixedContentParser::parse(content.to_s, url_for(:root), { :wrap_blocks => false } )
+    MixedContentParser::parse(content, url_for(:root), { :wrap_blocks => false } )
   end
 
   def proxy_localhost?


### PR DESCRIPTION
Cast value to string will prevent display error in search results
when value is nil. This comes up in the context of events as those
do not have a title or display string currently.
