### PR TITLE
Set auth subject source via leader / 008

### DIFF
--- a/backend/app/converters/lib/marcxml_base_map.rb
+++ b/backend/app/converters/lib/marcxml_base_map.rb
@@ -1,5 +1,42 @@
 
 module MarcXMLBaseMap
+
+  AUTH_SUBJECT_SOURCE = {
+    'a'=>"Library of Congress Subject Headings",
+    'b'=>"LC subject headings for children's literature",
+    'c'=>"Medical Subject Headings",
+    'd'=>"National Agricultural Library subject authority file",
+    'k'=>"Canadian Subject Headings",
+    'n'=>"Not applicable",
+    'r'=>"Art and Architecture Thesaurus",
+    's'=>"Sears List of Subject Headings",
+    'v'=>"R\u00E9pertoire de vedettes-matic\u00E8re",
+    'z'=>"Other"
+  }
+
+  BIB_SUBJECT_SOURCE = {
+    '0'=>"Library of Congress Subject Headings",
+    '1'=>"LC subject headings for children's literature",
+    '2'=>"Medical Subject Headings",
+    '3'=>"National Agricultural Library subject authority file",
+    '4'=>"Source not specified",
+    '5'=>"Canadian Subject Headings",
+    '6'=>"R\u00E9pertoire de vedettes-matic\u00E8re"
+  }
+
+  def record_type(type_of_record = nil, subject_source = nil)
+    @type ||= { type: :bibliographic, subject_source: nil }
+    if type_of_record
+      @type[:type] = type_of_record == 'z' ? :authority : :bibliographic
+    end
+    if subject_source
+      @type[:subject_source] = subject_source and @type[:type] == :authority ? subject_source : nil
+    end
+    @type
+  end
+
+  alias_method :set_record_type, :record_type
+
   def subject_template(getterms, getsrc)
     {
       :obj => :subject,
@@ -24,15 +61,11 @@ module MarcXMLBaseMap
 
   def sets_subject_source
     -> node {
-      {
-        '0'=>"Library of Congress Subject Headings",
-        '1'=>"LC subject headings for children's literature",
-        '2'=>"Medical Subject Headings",
-        '3'=>"National Agricultural Library subject authority file",
-        '4'=>"Source not specified",
-        '5'=>"Canadian Subject Headings",
-        '6'=>"R\u00E9pertoire de vedettes-matic\u00E8re"
-      }[node.attr('ind2')] || node.xpath("subfield[@code='2']").inner_text
+      if record_type[:type] == :authority
+        AUTH_SUBJECT_SOURCE[ record_type[:subject_source] ] || 'Source not specified'
+      else
+        BIB_SUBJECT_SOURCE[node.attr('ind2')] || ( !node.at_xpath("subfield[@code='2']").nil? ? node.at_xpath("subfield[@code='2']").inner_text : 'Source not specified' )
+      end
     }
   end
 
@@ -538,11 +571,12 @@ module MarcXMLBaseMap
        :level => 'collection',
       },
       :map => {
-
         #LEADER
         "//leader" =>  -> resource, node { 
-          if resource.respond_to?(:level) 
-            values = node.inner_text.strip
+          values = node.inner_text.strip
+          set_record_type values[6]
+
+          if resource.respond_to?(:level)
             resource.level = "item" if  values[7] == 'm'  
           end 
         }, 
@@ -550,6 +584,7 @@ module MarcXMLBaseMap
         #CONTROLFIELD
         "//controlfield[@tag='008']" => -> resource, node {
           control = node.inner_text.strip
+          set_record_type nil, control[11]
           resource.language = control[35..37]
 
           if %w(i k s).include?(control[6])

--- a/backend/app/exporters/examples/marc/authority_cyberpunk.xml
+++ b/backend/app/exporters/examples/marc/authority_cyberpunk.xml
@@ -1,0 +1,49 @@
+<marcxml:record xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:marcxml="http://www.loc.gov/MARC21/slim" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#" xmlns:ri="http://id.loc.gov/ontologies/RecordInfo#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mets="http://www.loc.gov/METS/">
+      <marcxml:leader>00582nz  a2200205n  4500</marcxml:leader>
+      <marcxml:controlfield tag="001">no2006087900</marcxml:controlfield>
+      <marcxml:controlfield tag="003">DLC</marcxml:controlfield>
+      <marcxml:controlfield tag="005">20060823051957.0</marcxml:controlfield>
+      <marcxml:controlfield tag="008">060822n| acaabaaan          |a ana     c</marcxml:controlfield>
+      <marcxml:datafield tag="010" ind1=" " ind2=" ">
+    <marcxml:subfield code="a">no2006087900</marcxml:subfield>
+  </marcxml:datafield>
+      <marcxml:datafield tag="035" ind1=" " ind2=" ">
+    <marcxml:subfield code="a">(OCoLC)oca07029280</marcxml:subfield>
+  </marcxml:datafield>
+      <marcxml:datafield tag="040" ind1=" " ind2=" ">
+    <marcxml:subfield code="a">NcD</marcxml:subfield>
+    <marcxml:subfield code="b">eng</marcxml:subfield>
+    <marcxml:subfield code="c">NcD</marcxml:subfield>
+  </marcxml:datafield>
+      <marcxml:datafield tag="130" ind1=" " ind2="0">
+    <marcxml:subfield code="a">Cyberpunk</marcxml:subfield>
+  </marcxml:datafield>
+      <marcxml:datafield tag="430" ind1=" " ind2="0">
+    <marcxml:subfield code="a">Badass sci-fi</marcxml:subfield>
+  </marcxml:datafield>
+      <marcxml:datafield tag="643" ind1=" " ind2=" ">
+    <marcxml:subfield code="a">London</marcxml:subfield>
+    <marcxml:subfield code="b">Creation</marcxml:subfield>
+  </marcxml:datafield>
+      <marcxml:datafield tag="644" ind1=" " ind2=" ">
+    <marcxml:subfield code="a">f</marcxml:subfield>
+    <marcxml:subfield code="5">NcD</marcxml:subfield>
+  </marcxml:datafield>
+      <marcxml:datafield tag="645" ind1=" " ind2=" ">
+    <marcxml:subfield code="a">t</marcxml:subfield>
+    <marcxml:subfield code="5">DPCC</marcxml:subfield>
+    <marcxml:subfield code="5">NcD</marcxml:subfield>
+  </marcxml:datafield>
+      <marcxml:datafield tag="646" ind1=" " ind2=" ">
+    <marcxml:subfield code="a">s</marcxml:subfield>
+    <marcxml:subfield code="5">NcD</marcxml:subfield>
+  </marcxml:datafield>
+      <marcxml:datafield tag="670" ind1=" " ind2=" ">
+    <marcxml:subfield code="a">Wired for chaos, 2005:</marcxml:subfield>
+    <marcxml:subfield code="b">cover (Badass sci-fi) back cover (Cyberpunk: Badass sci-fi)</marcxml:subfield>
+  </marcxml:datafield>
+      <marcxml:datafield tag="670" ind1=" " ind2=" ">
+    <marcxml:subfield code="a">Creation Books site via WWW, Aug. 22, 2006</marcxml:subfield>
+    <marcxml:subfield code="b">(series: Cyberpunk)</marcxml:subfield>
+  </marcxml:datafield>
+    </marcxml:record>

--- a/backend/spec/lib_marcxml_converter_spec.rb
+++ b/backend/spec/lib_marcxml_converter_spec.rb
@@ -340,8 +340,8 @@ END
     end
   end
 
-  describe "Importing Authority Files" do
-    it "can import an authority record" do
+  describe "Importing Name Authority Files" do
+    it "can import a name authority record" do
       john_davis = File.expand_path("../app/exporters/examples/marc/authority_john_davis.xml",
                                     File.dirname(__FILE__))
 
@@ -364,6 +364,24 @@ END
     end
   end
 
+  describe "Importing Subject Authority Files" do
+    it "can import a subject authority record" do
+      cyberpunk_file = File.expand_path("../app/exporters/examples/marc/authority_cyberpunk.xml",
+                                    File.dirname(__FILE__))
+
+      converter = MarcXMLConverter.for_subjects_and_agents_only(cyberpunk_file)
+      converter.run
+      json = JSON(IO.read(converter.get_output_path))
+
+      # ensure we get them in a standard order
+      badass, cyberpunk = json.sort_by { |j| j['terms'][0]['term'] }
+      badass['terms'][0]['term'].should eq("Badass sci-fi")
+      badass['source'].should eq("Library of Congress Subject Headings")
+
+      cyberpunk['terms'][0]['term'].should eq("Cyberpunk")
+      cyberpunk['source'].should eq("Library of Congress Subject Headings")
+    end
+  end
 
   describe "008 string handling" do
     let (:test_doc) {


### PR DESCRIPTION
Fix for subject authority records import ("source : Property is required but was missing"). Checks for record type (bibliographic or authority) using leader position 6, and if authority uses 008 position 11 for source as per:

http://www.loc.gov/marc/authority/ad008.html

Sets source to "Source not specified" for bibliographic records without an ind2 or subfield $2 value.
