### PR TITLE
Small fix for related agents display / linking

### DIFF
--- a/public/app/views/records/agent.html.erb
+++ b/public/app/views/records/agent.html.erb
@@ -17,7 +17,7 @@
                      {:property => 'contacts', :subrecord_type => 'note', :anchor => 'notes'},
                      {:property => 'published_external_documents', :subrecord_type => 'external_document', :anchor => 'external_documents'},
 
-                     {:property => 'published_agents', :subrecord_type => 'related_collection', :anchor => 'related_collection'},
+                     {:property => 'published_agents', :subrecord_type => 'related_agent', :anchor => 'linked_agents'},
 
                      {:property => 'published_notes', :subrecord_type => 'note', :anchor => 'notes'},
                      {:property => 'related_resources', :subrecord_type => 'related_resource', :anchor => 'related_resources'},


### PR DESCRIPTION
For linked agents currently displays: translation missing: en.related_collection._plural
