### PR TITLE
bug fix for browsing collection management records that belong to accessions without titles

### DIFF
--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -310,9 +310,9 @@ class CommonIndexer
         docs << {
           'id' => "#{record['uri']}##{parent_type}_collection_management",
           'parent_id' => record['uri'],
-          'parent_title' => record['record']['title'],
+          'parent_title' => record['record']['title'] || record['record']['display_string'],
           'parent_type' => parent_type,
-          'title' => record['record']['title'],
+          'title' => record['record']['title'] || record['record']['display_string'],
           'types' => ['collection_management'],
           'primary_type' => 'collection_management',
           'json' => cm.to_json(:max_nesting => false),


### PR DESCRIPTION
A quick fix for a small bug I just bumped into.

Collection Management records can belong to Accessions. Accessions do not require a title, but browsing Collection Management records breaks if there is a Collection Management record that belongs to an Accession that has no title.

This is fixed by looking for display_string if there is no title.

There's also a selenium test to exercise the bug.
