### PR TITLE
Support filter_term parameters in the linker widget typeahead and browse URLs

### DIFF
--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -13,8 +13,8 @@ $(function() {
       $this.addClass("initialised");
 
       var config = {
-        url: $this.data("url"),
-        browse_url: $this.data("browse-url"),
+        url: decodeURIComponent($this.data("url")),
+        browse_url: decodeURIComponent($this.data("browse-url")),
         format_template: $this.data("format_template"),
         format_template_id: $this.data("format_template_id"),
         format_property: $this.data("format_property"),


### PR DESCRIPTION
Hi @cfitz, 

We're just working on a few plugins with one that requires a scoped search within a linker widget's typeahead search.

Currently the linker allows us to define a `data-url` and `data-browse-url` for the typeahead and browse search URLs.  When trying to add a `filter_term` to these URLs, we noticed that the JSON string was being double escaped and this results in an error in the backend as the JSON string cannot be parsed successfully.  I think the url_for escapes it once and then again when we perform the AJAX request.  The safest place to put the unescaping seems to be in the linker's javascript. 

So, this is a pretty simple patch that unescapes the `data-url` and `data-browse-url` as the widget is initialised; simple URLs will be untouched and any URLs with filter_term JSON string values will now come through unescaped and friendly.

Thanks, I hope things are all going well!

Payten
