### PR TITLE
tag image_url in ead export

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -615,7 +615,7 @@ class EADSerializer < ASpaceExport::Serializer
           xml.publisher { sanitize_mixed_content(data.repo.name,xml, fragments) } 
 
           if data.repo.image_url
-            xml.p {
+            xml.p ( { "id" => "logostmt" } ) {
               xml.extref ({"xlink:href" => data.repo.image_url,
                           "xlink:actuate" => "onLoad",
                           "xlink:show" => "embed",


### PR DESCRIPTION

When exporting EAD, tag repository image_url with an @id so it has a unique xpath.

see: http://lyralists.lyrasis.org/pipermail/archivesspace_users_group/2015-February/001113.html