### PR TITLE
add repo.url to addresslines

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -633,6 +633,16 @@ class EADSerializer < ASpaceExport::Serializer
               data.addresslines.each do |line|
                 xml.addressline { sanitize_mixed_content( line, xml, fragments) }  
               end
+              if data.repo.url 
+              	xml.addressline ( "URL: " ) { 
+              	  xml.extptr ( { 
+              	  				"xlink:href" => data.repo.url,
+              	  				"xlink:title" => data.repo.url,
+              	  				"xlink:type" => "simple",
+              	  				"xlink:show" => "new"
+              	  				} )
+              	 }
+              end
             }
           end
         }


### PR DESCRIPTION
This one might not be as uncontroversial as the last, but I'll suggest it anyway. 
Export the repo.url as a exptr link in addresslines. 
( Is there any better place to put it ? ) 