### PR TITLE
Allow for a linker's Browse form to be delivered as a POST request 

### DIFF
--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -173,8 +173,19 @@ $(function() {
                 event.preventDefault();
 
                 var $form = $(event.target);
+                var method = ($form.attr("method") || "get").toUpperCase();
 
-                $linkerBrowseContainer.load($form.attr("action")+".js?" + $(event.target).serialize(), initBrowseFormInputs);
+
+                if (method == "POST") {
+                  jQuery.post($form.attr("action") + ".js",
+                              $form.serializeArray(),
+                              function(html) {
+                                $linkerBrowseContainer.html(html);
+                                initBrowseFormInputs();
+                              });
+                } else {
+                  $linkerBrowseContainer.load($form.attr("action") + ".js?" + $form.serialize(), initBrowseFormInputs);
+                }
               });
 
               initBrowseFormInputs();


### PR DESCRIPTION
Hi @cfitz, @quoideneuf,

This little patch allows for the linker's Browse form to be delivered as a POST request rather than assuming GET. Due to the default 4kB limit on GET request data (Jetty), there are some cases when the form search data can grow quite large, namely when including other linkers as search filters (these deliver both the record's URI and _resolved json to esnure the linker is kept in sync).

The patch is to the linker.js javascript and allows the target form to define the preferred method (POST || GET).

Thanks! Hope you guys are well.

Payten