### PR TITLE
Make sure our breadcrumb trail label is always a string.

### DIFF
--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -41,7 +41,7 @@ module ApplicationHelper
       type = options[:type] || object["jsonmodel_type"]
       controller = options[:controller] || type.to_s.pluralize
 
-      title = options[:title] || object["title"] || object["username"]
+      title = (options[:title] || object["title"] || object["username"]).to_s
 
       breadcrumb_trail.push(["#{I18n.t("#{controller.to_s.singularize}._plural")}", {:controller => controller, :action => :index}])
 


### PR DESCRIPTION
The batch import endpoint seemed to pass through an object ID for its
breadcrumb label, which failed when the HTML sanitizer got called on a
Fixnum.  Coerce the title into a string before sending it along.