### PR TITLE
Tree ordering fixes

### DIFF
--- a/backend/app/controllers/component_add_children.rb
+++ b/backend/app/controllers/component_add_children.rb
@@ -166,13 +166,27 @@ class ArchivesSpaceService < Sinatra::Base
   def accept_children_response(target_class, child_class)
     target = target_class.get_or_die(params[:id])
 
-    position = params[:position]
-    parent_id = (target_class == child_class) ? params[:id] : nil
+    unless params[:children].empty?
+      position = params[:position]
+      parent_id = (target_class == child_class) ? params[:id] : nil
+
+      # We need to be careful about the order these get processed in.  If we're
+      # moving from low to high, we need to work backwards to make sure the
+      # final ordering ends up right.
+      first_uri = params[:children][0]
+      first_obj = child_class.get_or_die(child_class.my_jsonmodel.id_for(first_uri))
+      ordered = if first_obj.absolute_position < position
+                  params[:children].each_with_index.to_a.reverse
+                else
+                  params[:children].each_with_index
+                end
 
 
-    params[:children].each_with_index do |uri, i|
-      child = child_class.get_or_die(child_class.my_jsonmodel.id_for(uri))
-      child.update_position_only(parent_id, position + i)
+      ordered.each do |uri, i|
+        child = child_class.get_or_die(child_class.my_jsonmodel.id_for(uri))
+        child.update_position_only(parent_id, position + i)
+      end
+
     end
 
     updated_response(target)

--- a/backend/app/controllers/component_add_children.rb
+++ b/backend/app/controllers/component_add_children.rb
@@ -175,7 +175,7 @@ class ArchivesSpaceService < Sinatra::Base
       # final ordering ends up right.
       first_uri = params[:children][0]
       first_obj = child_class.get_or_die(child_class.my_jsonmodel.id_for(first_uri))
-      ordered = if first_obj.absolute_position < position
+      ordered = if target.id == first_obj.parent_id && first_obj.absolute_position < position
                   params[:children].each_with_index.to_a.reverse
                 else
                   params[:children].each_with_index

--- a/backend/app/model/mixins/tree_nodes.rb
+++ b/backend/app/model/mixins/tree_nodes.rb
@@ -279,6 +279,17 @@ module TreeNodes
           if obj.parent_id
             json.parent = {'ref' => uri_for(node_record_type, obj.parent_id)}
           end
+
+          if obj.parent_name
+            # Calculate the absolute (gapless) position of this node.  This
+            # bridges the gap between the DB's view of position, which only
+            # cares that the positions order correctly, with the API's view,
+            # which speaks in absolute numbering (i.e. the first position is 0,
+            # the second position is 1, etc.)
+
+            json.position = obj.class.dataset.filter(:parent_name => obj.parent_name).where { position < obj.position }.count
+          end
+
         end
 
         if node_model.publishable?

--- a/backend/app/model/mixins/tree_nodes.rb
+++ b/backend/app/model/mixins/tree_nodes.rb
@@ -83,6 +83,12 @@ module TreeNodes
   end
 
 
+  def absolute_position
+    relative_position = self.position
+    self.class.dataset.filter(:parent_name => self.parent_name).where { position < relative_position }.count
+  end
+
+
   def update_from_json(json, opts = {}, apply_nested_records = true)
     sequence = self.class.sequence_for(json)
 
@@ -287,7 +293,7 @@ module TreeNodes
             # which speaks in absolute numbering (i.e. the first position is 0,
             # the second position is 1, etc.)
 
-            json.position = obj.class.dataset.filter(:parent_name => obj.parent_name).where { position < obj.position }.count
+            json.position = obj.absolute_position
           end
 
         end

--- a/backend/spec/tree_position_spec.rb
+++ b/backend/spec/tree_position_spec.rb
@@ -1,0 +1,126 @@
+require 'spec_helper'
+
+describe 'Tree positioning' do
+
+  before(:each) do
+    @resource = create(:json_resource)
+
+    @parent = create(:json_archival_object,
+                     :resource => {'ref' => @resource.uri},
+                     :title => "Parent")
+
+    @child1 = create(:json_archival_object,
+                     :resource => {'ref' => @resource.uri},
+                     :parent => {'ref' => @parent.uri},
+                     :title => "Child 1")
+
+    @child2 = create(:json_archival_object,
+                     :resource => {'ref' => @resource.uri},
+                     :parent => {'ref' => @parent.uri},
+                     :title => "Child 2")
+
+    @child3 = create(:json_archival_object,
+                     :resource => {'ref' => @resource.uri},
+                     :parent => {'ref' => @parent.uri},
+                     :title => "Child 3")
+  end
+
+
+  def refresh!
+    [:@parent, :@child1, :@child2, :@child3].each do |var|
+      new_obj = ArchivalObject.to_jsonmodel(instance_variable_get(var).id)
+      instance_variable_set(var, new_obj)
+    end
+  end
+
+
+  it "gives a sensible initial ordering" do
+    @parent.position.should eq(0)
+
+    [@child1, @child2, @child3].map {|record| record.position}.should eq([0, 1, 2])
+  end
+
+
+
+  it "updates an object without affecting its position" do
+    ArchivalObject[@child1.id].update_from_json(@child1)
+
+    refresh!
+
+    [@child1, @child2, @child3].sort_by(&:position).should eq([@child1, @child2, @child3])
+  end
+
+
+  it "can change the position of an object by updating it" do
+    @child1.position = 2
+
+    ArchivalObject[@child1.id].update_from_json(@child1)
+
+    refresh!
+
+    [@child1, @child2, @child3].sort_by(&:position).should eq([@child2, @child3, @child1])
+  end
+
+
+  it "leaves us where we started if we repeatedly move the first to the last" do
+    @child1.position = 2; ArchivalObject[@child1.id].update_from_json(@child1)
+    @child2.position = 2; ArchivalObject[@child2.id].update_from_json(@child2)
+    @child3.position = 2; ArchivalObject[@child3.id].update_from_json(@child3)
+
+    refresh!
+
+    [@child1, @child2, @child3].sort_by(&:position).should eq([@child1, @child2, @child3])
+
+  end
+
+
+  it "can swap two elements after some shuffling around" do
+    # I think this is where things are currently going wrong...
+
+    @child1.position = 2; ArchivalObject[@child1.id].update_from_json(@child1)
+    @child2.position = 2; ArchivalObject[@child2.id].update_from_json(@child2)
+    @child3.position = 2; ArchivalObject[@child3.id].update_from_json(@child3)
+
+    refresh!
+
+    # Swap child1 and child3 by assigning their positions.
+    #
+    # Previously this case could fail because the positions in the database
+    # might contain gaps.  For example, at the end of the first shuffle, the
+    # positions of our three records could be something like:
+    #
+    #  [3, 5, 10]
+    #
+    # That's all fine as far as the database schema is concerned, since it only
+    # cares that these numbers will result in the correct ordering when sorted.
+    #
+    # However, things go wrong when we take this position, load it into a
+    # JSONModel and expose it through the API.  The API and frontend work with
+    # absolute positions, where setting a record to position = 2 always means
+    # "this is the third item in the list".  If the frontend takes the second
+    # record (with a position of '5' in the DB) and updates it, it passes
+    # 'position = 5' back through to the backend.  The backend then assumes this
+    # '5' is an absolute '5', so it adjusts it to be relative to the other
+    # numbers it has.  Since it appears that the frontend wanted the second
+    # record to be moved to position 5, and since there are only three records,
+    # it moves the record to the end of the list.
+    #
+    # So in short, it's a confusion between two different numbering systems.  Or
+    # if you like Dr Seuss, it's the Goose drinking Moose Juice and vice versa.
+
+
+    tmp = @child1.position
+    @child1.position = @child3.position
+    @child3.position = tmp
+
+    ArchivalObject[@child1.id].update_from_json(@child1)
+    ArchivalObject[@child3.id].update_from_json(@child3)
+
+    refresh!
+
+    [@child1, @child2, @child3].sort_by(&:position).should eq([@child3, @child2, @child1])
+  end
+
+
+
+end

--- a/frontend/app/assets/javascripts/tree.js.erb
+++ b/frontend/app/assets/javascripts/tree.js.erb
@@ -583,7 +583,7 @@ $(function() {
           // list will shift up as the node is plucked out, we need to
           // adjust the target index for this.
 
-          index--;
+          index -= jstreeMoveData.rslt.o.length;
       }
 
       var data_for_post = {

--- a/frontend/app/assets/javascripts/tree.js.erb
+++ b/frontend/app/assets/javascripts/tree.js.erb
@@ -576,9 +576,19 @@ $(function() {
 
       var urisOfNodesToMove = $.makeArray(jstreeMoveData.rslt.o.map(function(i, moved) {return $(moved).data("uri");}));
 
+      var index = jstreeMoveData.rslt.cp;
+
+      if (jstreeMoveData.rslt.cop < jstreeMoveData.rslt.cp) {
+          // We have moved a node downwards in the list.  Since the
+          // list will shift up as the node is plucked out, we need to
+          // adjust the target index for this.
+
+          index--;
+      }
+
       var data_for_post = {
         children: urisOfNodesToMove,
-        index: jstreeMoveData.rslt.cp
+        index: index
       };
 
       $.ajax({

--- a/frontend/app/assets/javascripts/tree.js.erb
+++ b/frontend/app/assets/javascripts/tree.js.erb
@@ -578,12 +578,13 @@ $(function() {
 
       var index = jstreeMoveData.rslt.cp;
 
-      if (jstreeMoveData.rslt.cop < jstreeMoveData.rslt.cp) {
-          // We have moved a node downwards in the list.  Since the
-          // list will shift up as the node is plucked out, we need to
-          // adjust the target index for this.
+      if ((jstreeMoveData.rslt.op == jstreeMoveData.rslt.np) &&
+          (jstreeMoveData.rslt.cop < jstreeMoveData.rslt.cp)) {
+        // We have moved a node downwards in the list.  Since the
+        // list will shift up as the node is plucked out, we need to
+        // adjust the target index for this.
 
-          index -= jstreeMoveData.rslt.o.length;
+        index -= jstreeMoveData.rslt.o.length;
       }
 
       var data_for_post = {


### PR DESCRIPTION
After reviewing the drag/drop code for reordering trees, I noticed a few issues that can cause the ordering to end up a little crazy.  There are a few fixes here:

  * When the user selects multiple nodes and drag/drops them, the backend needs to be careful to interpret the target position correctly.  If moving nodes from top to bottom, it needs to apply the moves backwards to get the final ordering right.  Yep.

  * The tree_node.rb code was incorrectly sending out the DB's view of the "position" property, which was not the same as the absolute position the frontend was expecting.  Big comment on this and some test cases added.

  * The drag/drop code in the JS needs to compensate for the case when one or more nodes is dragged from top to bottom (i.e. where the target index is below the nodes being moved).

After a fair bit of dragging and dropping of single and multiple nodes, things seem more predictable now.
