### PR TITLE
Do not enforce available locales in exporter

### DIFF
--- a/backend/app/exporters/lib/exporter.rb
+++ b/backend/app/exporters/lib/exporter.rb
@@ -17,6 +17,7 @@ module ASpaceExport
     Dir.glob(File.dirname(__FILE__) + '/../serializers/*.rb', &method(:require))
     Dir.glob(File.dirname(__FILE__) + '/../models/*.rb', &method(:require))
 
+    I18n.enforce_available_locales = false # do not require locale to be in available_locales for export
     I18n.load_path += ASUtils.find_locales_directories(File.join("enums", "#{AppConfig[:locale]}.yml"))
     @@initialized = true
   end

--- a/backend/spec/export_spec_helper.rb
+++ b/backend/spec/export_spec_helper.rb
@@ -9,6 +9,7 @@ require 'factory_girl'
 if ENV['ASPACE_BACKEND_URL']
 
   include FactoryGirl::Syntax::Methods
+  I18n.enforce_available_locales = false # do not require locale to be in available_locales for export
   I18n.load_path += ASUtils.find_locales_directories(File.join("enums", "#{AppConfig[:locale]}.yml"))
 
   JSONModel::init(:client_mode => true, :strict_mode => true,


### PR DESCRIPTION
If a site supplies their own locale files and sets AppConfig[:locale]
to something other than :en exports will fail with an error such as:

(InvalidLocale) :en is not a valid locale

Setting enforce_available_locales to false is an expedient way to not
trip up over any arbitrary user added / configured locales in the exporter.