### PR TITLE
quick fix to catch hashed errors that choke the template

### DIFF
--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -138,7 +138,7 @@ class ApplicationController < ActionController::Base
       resolver = Resolver.new(target_uri)
       redirect_to(resolver.view_uri)
     rescue ValidationException => e
-      flash[:error] = e.errors
+      flash[:error] = e.errors.to_s
       redirect_to({:action => :show, :id => params[:id]}.merge(extra_params))
     rescue RecordNotFound => e
       flash[:error] = I18n.t("errors.error_404")


### PR DESCRIPTION
there's probably a better solution for this but for now this will do it. resource merge errors are causing the templates to break.