### PR TITLE
Set `use_after_commit_rollback` to false on Sequel::Model classes.

### DIFF
--- a/backend/app/model/ASModel.rb
+++ b/backend/app/model/ASModel.rb
@@ -23,6 +23,14 @@ module ASModel
       plugin :validation_helpers
     end
 
+    # Turn off the 'after_commit' and 'after_rollback' hooks on Sequel::Model.
+    # We don't use them anywhere, and they would otherwise cause a pair of
+    # blocks to be stored in memory every time we call '.save' (which in turn
+    # capture the record being saved and stop it being GC'd until the
+    # transaction finally commits).  When we're doing large batch imports (and
+    # committing at the end) that's a lot of memory!
+    base.use_after_commit_rollback = false
+
     base.extend(JSONModel)
 
     base.include(CRUD)


### PR DESCRIPTION
Hi there,

I've been running a migration from AT and watching the memory usage as it runs, and I noticed memory filling up when importing large trees of records.

After some searching I eventually worked out that the leak was in Sequel itself. There are two model hooks we've never used: `after_commit` and `after_rollback`. You can define them on your `Sequel::Model` subclasses and they'll be called when an object you call `.save` on has been committed by the underlying transaction.

Even if you don't use those hooks, Sequel pushes some empty `after_commit` and `after_rollback` proc objects onto the transaction's own "after" hook. And although those proc objects won't do anything, they create closures that capture the current lexical scope, and that lexical scope includes all of the values that are being written to the database. So it ends up leaking the record!

Sequel provides an option to turn this behavior off, so I've disabled it in the ASModel module, and that made a big difference to the memory consumption.  My migration was previously topping out at 600GB of oldgen used, and now I never see it get above 300GB.  And if a particular model ever needed these hooks, it could always turn them back on just for one model.  Free lunch! :hamburger: