### PR TITLE
When resolving note_index linkages, don't waste time looking up NULL records

### DIFF
--- a/backend/app/model/mixins/notes.rb
+++ b/backend/app/model/mixins/notes.rb
@@ -162,10 +162,12 @@ module Notes
                                                [proc {|hash, schema|
                                                   if hash['jsonmodel_type'] == 'note_index'
                                                     hash["items"].each do |item|
-                                                      referenced_record = klass.filter(:root_record_id => root_id,
-                                                                                       :ref_id => item["reference"]).first
-                                                      if !referenced_record.nil?
-                                                        item["reference_ref"] = {"ref" => referenced_record.uri}
+                                                      if item["reference"]
+                                                        referenced_record = klass.filter(:root_record_id => root_id,
+                                                                                         :ref_id => item["reference"]).first
+                                                        if !referenced_record.nil?
+                                                          item["reference_ref"] = {"ref" => referenced_record.uri}
+                                                        end
                                                       end
                                                     end
                                                   end
@@ -183,20 +185,22 @@ module Notes
                                              [proc {|hash, schema|
                                                 if hash['jsonmodel_type'] == 'note_index'
                                                   hash["items"].each do |item|
-                                                    (parent_id, parent_type) = obj.persistent_id_context
-                                                    persistent_id_record = NotePersistentId.filter(:parent_id => parent_id,
-                                                                                                   :parent_type => parent_type,
-                                                                                                   :persistent_id => item["reference"]).first
-                                                    if !persistent_id_record.nil?
-                                                      note = Note[persistent_id_record[:note_id]]
+                                                    if item["reference"]
+                                                      (parent_id, parent_type) = obj.persistent_id_context
+                                                      persistent_id_record = NotePersistentId.filter(:parent_id => parent_id,
+                                                                                                     :parent_type => parent_type,
+                                                                                                     :persistent_id => item["reference"]).first
+                                                      if !persistent_id_record.nil?
+                                                        note = Note[persistent_id_record[:note_id]]
 
-                                                      referenced_record = Note.associations.map {|association|
-                                                        next if association == :note_persistent_id
-                                                        note.send(association)
-                                                      }.compact.first
+                                                        referenced_record = Note.associations.map {|association|
+                                                          next if association == :note_persistent_id
+                                                          note.send(association)
+                                                        }.compact.first
 
-                                                      if referenced_record
-                                                        item["reference_ref"] = {"ref" => referenced_record.uri}
+                                                        if referenced_record
+                                                          item["reference_ref"] = {"ref" => referenced_record.uri}
+                                                        end
                                                       end
                                                     end
                                                   end


### PR DESCRIPTION
Hi there,

Just a small change arising from talking to an institution who noticed slow performance when loading one particular record.

When we try to resolve the references in `note_index` records, we do the DB lookup even when the reference hasn't been filled in.  As a result, we're doing an awful lot of pointless queries in cases where there are a large number of `note_index` notes without references.