### PR TITLE
Configurable facets limit for solr queries

### DIFF
--- a/backend/app/model/solr.rb
+++ b/backend/app/model/solr.rb
@@ -229,6 +229,7 @@ class Solr
       add_solr_param(:facet, "true")
       unless @facet_fields.empty?
         add_solr_param(:"facet.field", @facet_fields)
+        add_solr_param(:"facet.limit", AppConfig[:solr_facet_limit])
       end
 
       if @query_type == :edismax

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -4,6 +4,7 @@ AppConfig[:backup_directory] = proc { File.join(AppConfig[:data_directory], "dem
 AppConfig[:solr_index_directory] = proc { File.join(AppConfig[:data_directory], "solr_index") }
 AppConfig[:solr_home_directory] = proc { File.join(AppConfig[:data_directory], "solr_home") }
 AppConfig[:solr_indexing_frequency_seconds] = 30
+AppConfig[:solr_facet_limit] = 100
 
 AppConfig[:default_page_size] = 10
 AppConfig[:max_page_size] = 250


### PR DESCRIPTION
Retain the default value for `facet.limit` but allow it to be configured according to preference / to combat facet sprawl.

Related to: https://archivesspace.atlassian.net/browse/AR-1146
