### PR TITLE
Show top 10 facets with link for more

### DIFF
--- a/public/app/assets/javascripts/application.js
+++ b/public/app/assets/javascripts/application.js
@@ -8,3 +8,4 @@
 //= require record_tree
 //= require jquery.form
 //= require image_resize
+//= require facet

--- a/public/app/assets/javascripts/facet.js
+++ b/public/app/assets/javascripts/facet.js
@@ -1,0 +1,26 @@
+$(function() {
+
+  // show top 10 facet results with link to display more / fewer
+  $('.facet').each( function() {
+    var list = this;
+    $(list).children('li:gt(9)').hide().last().after(
+      $('<a />').attr('href','#').attr('class', 'show_more').text(FACET_SHOW_MORE).click(function() {
+        if($('.show_fewer:not(:visible)')) $('.show_fewer').show();
+        $(list).children('li:not(:visible):lt(10)').fadeIn(function() {
+          if ($(list).children('li:not(:visible)').length == 0) {
+            $('.show_more').hide();
+            $('span.show_fewer').hide();
+          }
+        }); return false;
+      }),
+      $('<span class="show_fewer"> -- </span>').hide(),
+      $('<a />').attr('href','#').attr('class', 'show_fewer').text(FACET_SHOW_FEWER).click(function() {
+        if ($('.show_more:not(:visible)')) $('.show_more').show();
+        $(list).children('li:visible:gt(9)').fadeOut(function() {
+          if ($(list).children('li:visible').length == 10) $('.show_fewer').hide();
+        }); return false;
+      }).hide()
+    );
+  });
+
+});

--- a/public/app/views/layouts/application.html.erb
+++ b/public/app/views/layouts/application.html.erb
@@ -36,6 +36,8 @@
     FRONTEND_URL = "<%= j(AppConfig[:frontend_proxy_url]) %>";
     PUBLIC_URL = "<%= j(AppConfig[:public_proxy_url]) %>";
     APP_PATH = "<%= j(root_path) %>";
+    FACET_SHOW_FEWER = "<%= I18n.t("search_results.filter.show_fewer") %>";
+    FACET_SHOW_MORE = "<%= I18n.t("search_results.filter.show_more") %>";
   </script>
 
 </head>

--- a/public/app/views/search/_filter.html.erb
+++ b/public/app/views/search/_filter.html.erb
@@ -44,7 +44,7 @@
 
 <% @search_data.facets_for_filter.each do |facet_group, facets| %>
   <h5><%= I18n.t("search_results.filter.#{facet_group}", :default => facet_group) %></h5>
-  <ul>
+  <ul class="facet">
     <% facets.each do |facet, facet_map| %>
       <li>
         <%= link_to facet_map[:label], params_for_search({"add_filter_term" => facet_map[:filter_term]}) %> <span class="badge badge-info"><%= facet_map[:count] %></span>

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -40,6 +40,8 @@ en:
     modified: Modified
     component_switch: Include Components
     filter:
+      show_fewer: Show fewer
+      show_more: Show more
       query: Text
       subjects: Subject
       primary_type: Type


### PR DESCRIPTION
In the public UI (where lengthy facet lists tend to produce a long scroll-y interface i.e. http://sandbox.archivesspace.org:8081/search?type=resource) display up to the first 10 values then offer a "Show more" option (with a subsequent "Show fewer" link).

Related to: https://archivesspace.atlassian.net/browse/AR-1146
