### PR TITLE
Make container fluid for main wrapper div

### DIFF
--- a/frontend/app/views/layouts/application.html.erb
+++ b/frontend/app/views/layouts/application.html.erb
@@ -43,7 +43,7 @@
 </head>
 <body data-spy="scroll" data-target="#archivesSpaceSidebar" data-offset="20" class="action-<%= controller.action_name %>">
 
-  <div class="container center-block">
+  <div class="container-fluid center-block">
     <header>
       <%= render "shared/browser_support" %>
       <%= render "shared/header_global" %>


### PR DESCRIPTION
This aligns the content centrally and provides a more flexible base
to build on without having to override application.html.erb in a
plugin.