### PR TITLE
#finish turn on Sequel core_extensions

### DIFF
--- a/backend/app/lib/bootstrap.rb
+++ b/backend/app/lib/bootstrap.rb
@@ -3,6 +3,7 @@ require 'java'
 require 'sequel'
 require 'sequel/plugins/optimistic_locking'
 Sequel.extension :pagination
+Sequel.extension :core_extensions
 
 require "db/db_migrator"
 

--- a/common/db/migrations/037_generalized_job_table.rb
+++ b/common/db/migrations/037_generalized_job_table.rb
@@ -38,9 +38,6 @@ Sequel.migration do
 
       job_type_id = self[:enumeration_value].filter(:value => 'import_job').first[:id]
 
-      puts row.inspect
-      puts job_type_id
-
       self[:job].insert(:repo_id => row[:repo_id],
                         :lock_version => row[:lock_version],
                         :json_schema_version => row[:json_schema_version],


### PR DESCRIPTION
Sequel 4.x ships with core_extensions turned off by default, so we lost String.to_sequel_blob and thus broke migrations/utils.rb#blobify