### PR TITLE
Run the ASpaceGems setup procedure to make sure newrelic can find its gem

### DIFF
--- a/plugins/newrelic/Gemfile
+++ b/plugins/newrelic/Gemfile
@@ -1,3 +1,5 @@
+ASpaceGems.setup if defined? ASpaceGems
+
 source 'http://rubygems.org'
 
 gem 'newrelic_rpm', :require => false


### PR DESCRIPTION
Hi there,

Just a tiny fix to the newrelic plugin to make sure it finds its gem when loading after a clean install.  Yale reported getting exceptions like this, which I could confirm locally:

```
 Caused by: 
 org.jruby.exceptions.RaiseException: (GemNotFound) Could not find gem 'newrelic_rpm (>= 0) java' in the gems available on this machine.
         at RUBY.resolve(/mnt/ssd/tmp/aspace/archivesspace/gems/gems/bundler-1.7.12/lib/bundler/resolver.rb:368)
         at RUBY.start(/mnt/ssd/tmp/aspace/archivesspace/gems/gems/bundler-1.7.12/lib/bundler/resolver.rb:166)
         at RUBY.resolve(/mnt/ssd/tmp/aspace/archivesspace/gems/gems/bundler-1.7.12/lib/bundler/resolver.rb:129)
         at RUBY.resolve(/mnt/ssd/tmp/aspace/archivesspace/gems/gems/bundler-1.7.12/lib/bundler/definition.rb:193)
         at RUBY.specs(/mnt/ssd/tmp/aspace/archivesspace/gems/gems/bundler-1.7.12/lib/bundler/definition.rb:132)
```

It's a one-line fix and they've been running with the fix for a while, so I think it's a good one!

Mark
