### PR TITLE
Escape log data when appending to the spool

### DIFF
--- a/frontend/app/assets/javascripts/jobs.show.js
+++ b/frontend/app/assets/javascripts/jobs.show.js
@@ -40,7 +40,7 @@ $(function() {
           var dataLength = data.length;
           $(".alert", $logSection).remove();
           $logSpool.slideDown();
-          $logSpool.append(data);
+          $logSpool.append($("<div>").text(data));
           offset +=dataLength;
 
           if (dataLength === 0) {


### PR DESCRIPTION
When hitting an error in an import job, the error message has some angle brackets in there and they are misinterpreted as an element:

![Error in Job Log](http://paytengiles.com/aspace/job_log.png)

This little patch adds the log data to a &lt;div&gt; as text so the angle brackets (and other bits and pieces) are escaped accordingly.