### PR TITLE
Increase the number of allowed DB connections and have it grow automatically with the number of indexer threads

### DIFF
--- a/backend/app/model/db.rb
+++ b/backend/app/model/db.rb
@@ -25,7 +25,7 @@ class DB
       end
 
       begin
-        Log.info("Connecting to database: #{AppConfig[:db_url]}")
+        Log.info("Connecting to database: #{AppConfig[:db_url]}. Max connections: #{AppConfig[:db_max_connections]}")
         pool = Sequel.connect(AppConfig[:db_url],
                               :max_connections => AppConfig[:db_max_connections],
                               :test => true,

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -30,7 +30,7 @@ AppConfig[:indexer_thread_count] = 4
 AppConfig[:allow_other_unmapped] = false
 
 AppConfig[:db_url] = proc { AppConfig.demo_db_url }
-AppConfig[:db_max_connections] = 10
+AppConfig[:db_max_connections] = proc { 20 + (AppConfig[:indexer_thread_count] * 2) }
 
 # Set to true to log all SQL statements.  Note that this will have a performance
 # impact!


### PR DESCRIPTION
Hi there,

Just a little change to fix an issue that bit us recently.  If you increase the number of indexer threads, it's easy to overwhelm the DB connection pool and have it run out of connections.

The old value of 10 was probably too conservative anyway, so I've doubled it and made the default setting allow an extra two connections for each indexer thread.  Totally unscientific, but I don't think there's any harm in increasing the limit anyway. :microscope: 