### PR TITLE
Fix reports with one param not displaying and support an enumeration parameter

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/form.less
+++ b/frontend/app/assets/stylesheets/archivesspace/form.less
@@ -509,6 +509,9 @@ ul.subrecord-form-list {
   .panel-heading {
     #gradient > .vertical(#F3F3F3, #EDEDED);
   }
+  .accordion-inner {
+    padding: 20px;
+  }
 }
 
 .group-member-control-group {

--- a/frontend/app/views/reports/index.html.erb
+++ b/frontend/app/views/reports/index.html.erb
@@ -30,29 +30,36 @@
                     <%
                        report_params = report["params"].reject{|p| ["format", "repo_id"].include?(p[0])}
 
-                       if report_params.length > 1
+                       if report_params.length > 0
                     %>
                       <% report_params.each do | param | %>
                         <div class="form-group <% if @report_errors &&  @report["uri_suffix"] === report["uri_suffix"] && @report_errors['error'].has_key?(param[0]) %>error<% end %>">
-                          <label class="control-label"><%= I18n.t("reports.parameters.#{param[0]}", :default => param[0]) %></label>
-                          <div class="controls">
+                          <label class="col-sm-2 control-label"><%= I18n.t("reports.parameters.#{param[0]}", :default => param[0]) %></label>
+                          <div class="col-sm-9">
                             <% if param[1] === "Date" %>
-                              <%= form.textfield param[0].intern, @report_params[param[0]],  :class => 'date-field', :'data-format' => 'yyyy-mm-dd', :placeholder => 'yyyy-mm-dd' %>
+                              <%= form.textfield param[0].intern, @report_params[param[0]], :class => 'date-field form-control', :'data-format' => 'yyyy-mm-dd', :placeholder => 'yyyy-mm-dd' %>
+                            <% elsif param[1] === "String" && param.length > 3 && param[3].has_key?("enumeration") %>
+                              <%= form.select(param[0].intern,
+                                              options_for_select(
+                                                JSONModel.enum_values(param[3]["enumeration"]).map{|v| [I18n.t("enumerations.#{param[3]["enumeration"]}.#{v}", :default => v), v]},
+                                                @report_params[param[0]]
+                                              )) %>
                             <% else %>
-                              <%= form.textfield param[0].intern, @report_params[param[0]] %>
+                              <%= form.textfield param[0].intern, @report_params[param[0]], :class => 'form-control' %>
                             <% end %>
                           </div>
                         </div>
                       <% end %>
-                      <hr/>
                     <% end %>
                     <div class="form-group">
-                      <label class="control-label">Format</label>
-                      <div class="controls">
-                        <%= form.select("format", options_for_select(@report_data["formats"].map{|format| [I18n.t("reports.formats.#{format}", :default => format), format]}, @report_params["format"])) %>
+                      <label class="col-sm-2 control-label">Format</label>
+                      <div class="col-sm-9">
+                        <%= form.select("format", options_for_select(@report_data["formats"].map{|format| [I18n.t("reports.formats.#{format}", :default => format), format]}, @report_params["format"]), :class => 'form-control') %>
                       </div>
                     </div>
                   <% end %>
+
+                  <hr/>
 
                   <div class="form-actions">
                     <button type="submit" class="btn btn-sm btn-primary">Download Report</button>


### PR DESCRIPTION
Hi guys,

We've been creating a few of the ArchivesSpace reports and ran into a little issue whereby a report needed to define more than 1 parameter for them to be rendered in the frontend.  This patch allows 1 param to now display nicely.

I've also added the ability for a report `String` param to define an optional enumeration setting.  So when a enumeration type is detected in the frontend and a dropdown list is presented instead of a text field.  

I've also poked in a few new bootstrap 3 classes and some extra padding so it renders nicely.

Hope all is well!

Thanks,
Payten