### PR TITLE
Cope with records that don't have titles (but do have display_strings)

### DIFF
--- a/frontend/app/views/events/_form.html.erb
+++ b/frontend/app/views/events/_form.html.erb
@@ -75,7 +75,7 @@
       <div class="controls token-list col-sm-4">
         <% form['linked_records'].each do |linked_record| %>
           <%= render_token :object => linked_record['_resolved'],
-                           :label => linked_record['_resolved']['title'],
+                           :label => (linked_record['_resolved']['display_string'] || linked_record['_resolved']['title']),
                            :type => "location",
                            :uri => linked_record["ref"],
                            :placement => "top" %>

--- a/frontend/app/views/linked_events/_show.html.erb
+++ b/frontend/app/views/linked_events/_show.html.erb
@@ -29,7 +29,7 @@
               <td>
                 <% record['linked_records'].each do |link| %>
                   <div><%= I18n.t("enumerations.linked_event_archival_record_roles.#{link['role']}", :default => link['role']) %>:
-                    <%= link['_resolved']['title'] %>
+                    <%= link['_resolved']['display_string'] || link['_resolved']['title'] %>
                   </div>
                 <% end %>
               </td>


### PR DESCRIPTION
Hi there,

Just a small bugfix that crops up when you link an event to an accession record that doesn't have a title.  The system blows up when it gets back a nil.  Fixed to use the display_string in preference to the title...

Cheers,
Mark