### PR TITLE
Add a larger timeout when talking to Solr (the default was 60 seconds)

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -26,6 +26,7 @@ AppConfig[:cookie_prefix] = "archivesspace"
 # cores and/or more records per thread means more memory used).
 AppConfig[:indexer_records_per_thread] = 25
 AppConfig[:indexer_thread_count] = 4
+AppConfig[:indexer_solr_timeout_seconds] = 300
 
 AppConfig[:allow_other_unmapped] = false
 

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -378,6 +378,7 @@ class CommonIndexer
     req['X-ArchivesSpace-Session'] = @current_session
 
     Net::HTTP.start(url.host, url.port) do |http|
+      http.read_timeout = AppConfig[:indexer_solr_timeout_seconds].to_i
       http.request(req)
     end
   end


### PR DESCRIPTION
Hi there,

A small change here to ensure that the indexer doesn't timeout prematurely when Solr is busy.  Default the timeout to 5 minutes and made it configurable through config.rb too.