### PR TITLE
In the batch importer provide the converter with more context i.e. job's repo and user

### DIFF
--- a/backend/app/lib/batch_import_runner.rb
+++ b/backend/app/lib/batch_import_runner.rb
@@ -69,12 +69,13 @@ class BatchImportRunner < JobRunner
             ticker.log(("=" * 50) + "\n#{filenames[i]}\n" + ("=" * 50)) if filenames[i]
             converter = Converter.for(@json.job['import_type'], input_file.file_path)
             begin
-              converter.run
+              RequestContext.open(:create_enums => true,
+                                  :current_username => @job.owner.username,
+                                  :repo_id => @job.repo_id) do
 
-              File.open(converter.get_output_path, "r") do |fh|
-                RequestContext.open(:create_enums => true,
-                                    :current_username => @job.owner.username,
-                                    :repo_id => @job.repo_id) do
+                converter.run
+
+                File.open(converter.get_output_path, "r") do |fh|
                   batch = StreamingImport.new(fh, ticker, @import_canceled)
                   batch.process
                   log_created_uris(batch)


### PR DESCRIPTION
Hi there,

We've been working on some custom importers where the converter checks for the existence of records before they are imported.  This patch provides the converter with the same context as the importer, namely the job's repository and the user.  Within this context, the converter can now query the correct repository as it builds the JSONModel for import.

Thanks,
Payten