### PR TITLE
drop fk and constraint before dropping the column to make mysql happy

### DIFF
--- a/common/db/migrations/047_add_rights_statements_to_agents.rb
+++ b/common/db/migrations/047_add_rights_statements_to_agents.rb
@@ -14,6 +14,9 @@ Sequel.migration do
       add_foreign_key([:agent_family_id], :agent_family, :key => :id)
       add_foreign_key([:agent_corporate_entity_id], :agent_corporate_entity, :key => :id)
       add_foreign_key([:agent_software_id], :agent_software, :key => :id)
+
+      drop_foreign_key [:repo_id]
+      drop_constraint( :rights_unique_identifier, :type => :unique )
       drop_column( :repo_id ) 
     end
 


### PR DESCRIPTION
Migration 047 was making MySQL unhappy by dropping a column used as an FK and as a member of a uniqueness constraint. This drops the constraints before removing the column.