### PR TITLE
Disable use_after_commit_rollback globally, not just for ASModel.

### DIFF
--- a/backend/app/lib/bootstrap.rb
+++ b/backend/app/lib/bootstrap.rb
@@ -5,6 +5,16 @@ require 'sequel/plugins/optimistic_locking'
 Sequel.extension :pagination
 Sequel.extension :core_extensions
 
+
+# Turn off the 'after_commit' and 'after_rollback' hooks on Sequel::Model.
+# We don't use them anywhere, and they would otherwise cause a pair of
+# blocks to be stored in memory every time we call '.save' (which in turn
+# capture the record being saved and stop it being GC'd until the
+# transaction finally commits).  When we're doing large batch imports (and
+# committing at the end) that's a lot of memory!
+Sequel::Model.use_after_commit_rollback = false
+
+
 require "db/db_migrator"
 
 require 'fileutils'

--- a/backend/app/model/ASModel.rb
+++ b/backend/app/model/ASModel.rb
@@ -24,14 +24,6 @@ module ASModel
       plugin :after_initialize
     end
 
-    # Turn off the 'after_commit' and 'after_rollback' hooks on Sequel::Model.
-    # We don't use them anywhere, and they would otherwise cause a pair of
-    # blocks to be stored in memory every time we call '.save' (which in turn
-    # capture the record being saved and stop it being GC'd until the
-    # transaction finally commits).  When we're doing large batch imports (and
-    # committing at the end) that's a lot of memory!
-    base.use_after_commit_rollback = false
-
     base.extend(JSONModel)
 
     base.include(CRUD)


### PR DESCRIPTION
This relates to the fix for issue #143 

It turns out that during very large imports, relationships, agents and other non-ASModel classes get hit heavily enough for this to still cause problems.  I've moved the fix into `bootstrap.rb` to make sure it gets applied everywhere, and that fixes the case I'm seeing.