### PR TITLE
Fix show-all button not working for hidden nested subrecords

### DIFF
--- a/frontend/app/assets/javascripts/subrecord.crud.js
+++ b/frontend/app/assets/javascripts/subrecord.crud.js
@@ -135,7 +135,7 @@ $(function() {
 
         // init any existing subforms
          
-        var subformsExisting = $("> .subrecord-form-container .subrecord-form-list > .subrecord-form-wrapper:not(.initialised)", $this) 
+        var subformsExisting = $("> .subrecord-form-container > .subrecord-form-list > .subrecord-form-wrapper:not(.initialised)", $this)
         
         if (subformsExisting.length > 4 ) { 
           $("> .subrecord-form-heading > .btn.show-all", $this).show(); 
@@ -156,7 +156,7 @@ $(function() {
             subformsExisting.slice(5).hide();
           } 
         }  
-          $("> .subrecord-form-container .subrecord-form-list > .subrecord-form-wrapper", $this).each(init_subform);
+          $("> .subrecord-form-container > .subrecord-form-list > .subrecord-form-wrapper", $this).each(init_subform);
 
       }
 


### PR DESCRIPTION
This patch ensures the immediate subrecord-form-list is targeted when initialising the show-all link.

This fixes an issue whereby a nested list within a subrecord has items hidden but the show-all button is disabled and those items cannot be viewed.

To reproduce, add a Rights Statement to an Accession with more than 4 External Documents.  After save, the "Show All" button is displayed on the Rights Statement header and also at the end of the External Documents listing.  The latter causes the page to refresh.

If the subrecord is a one-to-one to the parent record, the Show All button is disabled along with "Add" button (as seen on some plugin specific subrecords - I can't see an example in vanilla ASpace).