### PR TITLE
Incorporate results of Hudson Molonglo performance analysis of Yale's ArchivesSpace Instance

### DIFF
--- a/backend/app/model/ASModel_crud.rb
+++ b/backend/app/model/ASModel_crud.rb
@@ -270,6 +270,11 @@ module ASModel
         break if object_graph.models.length == successfully_deleted_models.length
 
         unless progressed
+          if last_error && DB.is_retriable_exception(last_error)
+            # Give us a chance to retry after a deadlock
+            raise last_error
+          end
+
           raise ConflictException.new("Record deletion failed: #{last_error}")
         end
       end

--- a/backend/app/model/db.rb
+++ b/backend/app/model/db.rb
@@ -6,6 +6,12 @@ class DB
   Sequel.database_timezone = :utc
   Sequel.typecast_timezone = :utc
 
+  # When performing a query like ds.filter(:col => []), don't turn it into
+  # SELECT ... WHERE col != col.  MySQL doesn't optimize this at all and
+  # performs a full table scan.
+  Sequel.extension :empty_array_ignore_nulls
+
+
   SUPPORTED_DATABASES = [
                          {
                            :pattern => /jdbc:mysql/,
@@ -335,6 +341,11 @@ eof
 
 
   def self.supports_mvcc?
+    ![:derby, :h2].include?(@pool.database_type)
+  end
+
+
+  def self.supports_join_updates?
     ![:derby, :h2].include?(@pool.database_type)
   end
 

--- a/backend/app/model/mixins/relationships.rb
+++ b/backend/app/model/mixins/relationships.rb
@@ -699,7 +699,7 @@ module Relationships
       relationship.transfer(target, victims)
     end
 
-   	# This notifies the current model that an instance of a related model has
+    # This notifies the current model that an instance of a related model has
     # been changed.  We respond by finding any of our own instances that refer
     # to the updated instance and update their mtime.
     def touch_mtime_of_anyone_related_to(obj)
@@ -707,19 +707,54 @@ module Relationships
 
       relationships.map do |relationship_defn|
         models = relationship_defn.participating_models
+
         if models.include?(obj.class)
           their_ref_columns = relationship_defn.reference_columns_for(obj.class)
           my_ref_columns = relationship_defn.reference_columns_for(self)
           their_ref_columns.each do |their_col|
             my_ref_columns.each do |my_col|
-              ids_to_touch = relationship_defn.filter(their_col => obj.id).
-                             select(my_col)
-              self.filter(:id => ids_to_touch).
-                   update(:system_mtime => now)
+
+              # Example: if we're updating a subject record and want to update
+              # the timestamps of any linked archival object records:
+              #
+              #  * self = ArchivalObject
+              #  * relationship_defn is subject_rlshp
+              #  * obj = #<Subject instance that was updated>
+              #  * their_col = subject_rlshp.subject_id
+              #  * my_col = subject_rlshp.archival_object_id
+
+              if DB.supports_join_updates?
+
+                if self.table_name == :agent_software && relationship_defn.table_name == :linked_agents_rlshp
+                  # Terrible to have to do this, but the MySQL optimizer refuses
+                  # to use the primary key on agent_software because it (often)
+                  # only has one row.
+                  DB.open do |db|
+                    id_str = Integer(obj.id).to_s
+
+                    db.run("UPDATE `agent_software` FORCE INDEX (PRIMARY) " +
+                           " INNER JOIN `linked_agents_rlshp` " +
+                           "ON (`linked_agents_rlshp`.`agent_software_id` = `agent_software`.`id`) " +
+                           "SET `agent_software`.`system_mtime` = NOW() " +
+                           "WHERE (`linked_agents_rlshp`.`archival_object_id` = #{id_str})")
+                  end
+                else
+                  # MySQL will optimize this much more aggressively
+                  self.join(relationship_defn, Sequel.qualify(relationship_defn.table_name, my_col) => Sequel.qualify(self.table_name, :id)).
+                    filter(Sequel.qualify(relationship_defn.table_name, their_col) => obj.id).
+                    update(Sequel.qualify(self.table_name, :system_mtime) => now)
+                end
+
+              else
+                ids_to_touch = relationship_defn.filter(their_col => obj.id).
+                               select(my_col)
+                self.filter(:id => ids_to_touch).
+                  update(:system_mtime => now)
+              end
             end
           end
         end
       end
-                                                                                                                                                                                                  end
+    end
   end
 end

--- a/common/db/migrations/057_add_db_indexes.rb
+++ b/common/db/migrations/057_add_db_indexes.rb
@@ -1,0 +1,33 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+
+    begin
+      alter_table(:archival_object) do
+        add_index([:parent_id, :root_record_id], :name => "ao_parent_root_idx")
+      end
+    rescue Sequel::DatabaseError => e
+      raise e unless e.to_s =~ /Duplicate key name/
+    end
+
+    begin
+      alter_table(:sequence) do
+        add_index([:sequence_name, :value], :name => "sequence_namevalue_idx")
+      end
+    rescue Sequel::DatabaseError => e
+      raise e unless e.to_s =~ /Duplicate key name/
+    end
+
+    begin
+      alter_table(:job) do
+        add_index([:status], :name => "job_status_idx")
+      end
+    rescue Sequel::DatabaseError => e
+      raise e unless e.to_s =~ /Duplicate key name/
+    end
+
+  end
+
+end


### PR DESCRIPTION
Hey @cfitz,

Here's a bundled up version of the changes we made after reviewing Yale's logs and configuration (in addition to the InnoDB tuning changes).  Give me a yell if I can clarify anything.

:wave:,
Mark

------

Several changes around database performance and error handling:

  * Use Sequel's empty_array_ignore_nulls extension to avoid turning
    .filter(:somecol => []) into 'WHERE somecol != somecol`.  MySQL does
    a full table scan when it sees one of these.

  * If a delete request catches a retriable deadlock exception, make
    sure we retry the request.

  * Force the join on the agent_software table to use the primary key
    index.  Since agent_software usually only has one row, the MySQL
    optimizer was skipping the index by default.  But when joining
    agent_software to the (often very large) linked_agents_rlshp table,
    that was becoming prohibitively slow.

  * When updating mtimes in the relationship code, use an INNER JOIN
    instead of a subquery.  MySQL will optimize the former but not the
    latter.

  * Add an index to archival_object.{parent_id, root_record_id}.  When
    viewing a very large resource record (with 40,000+ Archival
    Objects), MySQL was having to resort to a strategy where it would
    use an index to find all top-level Archival Objects in any record, then
    do a scan to find the ones belonging to the Resource of interest.

  * Add indexes to job & sequence columns that get hit pretty heavily.