### PR TITLE
Fix pdf export "image not found"

### DIFF
--- a/backend/app/lib/AS_fop.rb
+++ b/backend/app/lib/AS_fop.rb
@@ -27,6 +27,14 @@ class ASFop
    # WHAT A HACK! but you can't pass in a URI as a variable? jeezus.  
    filepath =  File.join(ASUtils.find_base_directory, 'stylesheets', 'as-helper-functions.xsl').gsub("\\", "/" )
    @xslt.gsub!('<xsl:include href="as-helper-functions.xsl"/>', "<xsl:include href='#{filepath}'/>" ) 
+
+   # ... ALSO UPDATE PATH TO ICON
+   stylesheets = File.dirname(filepath)
+   icon = @xslt.match("<fo:external-graphic src=\"(.*)\"")
+   if icon
+     icon = icon[1] # the match
+     @xslt.gsub!("<fo:external-graphic src=\"#{icon}\"", "<fo:external-graphic src=\"#{stylesheets}/#{icon}\"")
+   end
   end
 
 

--- a/stylesheets/as-ead-pdf.xsl
+++ b/stylesheets/as-ead-pdf.xsl
@@ -265,7 +265,12 @@
         -->
         <xsl:apply-templates select="local:parseDate(.)"/>
     </xsl:template>
-    <!-- This template can be modified to include repository specific icons, use the template as a example.  -->
+    <!--
+        This template can be modified to include repository specific icons,
+        use the template as an example. PDF exports only support this single
+        icon template for an image in this directory specified by filename
+        i.e. src="myicon.png"
+    -->
     <xsl:template name="icon">
         <fo:block text-align="left" margin-left="-.75in" margin-top="-.5in">
             <fo:external-graphic src="archivesspace.small.png" content-height="75%" content-width="75%"/>


### PR DESCRIPTION
After recently being asked about custom branding for pdf exports I've
tested a number of instances including the ArchivesSpace Sandbox and in
every case I'm seeing, for example:

```
Completed 200 OK in 62.0ms (Views: 0.0ms)
Jul 15, 2015 12:08:13 PM org.apache.fop.events.LoggingEventListener
processEvent
SEVERE: Image not found. URI: archivesspace.small.png. (See position
71:-1)
...
```

Looking at `AS_fop.rb` a workaround was implemented to pickup
`as-helper-functions.xsl`. Applying that same approach for the "icon"
(logo) works around the issue for this as well. Supports user supplied
files / filenames in the stylesheets directory for the icon.