### PR TITLE
Dump routines in backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,9 @@ recover.
 If you are running MySQL, the `mysqldump` utility can dump the database
 schema and data to a file.  It's a good idea to run this with the
 `--single-transaction` option to avoid locking your database tables
-while your backups run.
+while your backups run. It is also essential to use the `--routines`
+flag, which will include functions and stored procedures in the
+backup (which ArchivesSpace uses at least for Jasper reports).
 
 If you are running with the demo database, you can create periodic
 database snapshots using the following configuration settings:

--- a/launcher/backup/lib/backup.rb
+++ b/launcher/backup/lib/backup.rb
@@ -45,6 +45,7 @@ class ArchivesSpaceBackup
         "--port=#{port}",
         "--user=#{username}",
         "--password=#{password}",
+        "--routines",
         "--single-transaction",
         "--quick",
       ]


### PR DESCRIPTION
Add flag to include stored procedures and functions in backup.
This is needed since migration 055 (without it if you dump and
restore then the functions will be missing).

Add to docs for admins managing their own backups.