### PR TITLE
New endpoint for logging out a session explicitly

### DIFF
--- a/backend/app/controllers/users.rb
+++ b/backend/app/controllers/users.rb
@@ -232,6 +232,17 @@ class ArchivesSpaceService < Sinatra::Base
   end
 
 
+  Endpoint.post('/logout')
+    .description("Log out the current session")
+    .permissions([])
+    .returns([200, "Session logged out"]) \
+  do
+    if session
+      Session.expire(session.id)
+    end
+  end
+
+
   private
 
   def check_admin_access

--- a/backend/spec/controller_user_spec.rb
+++ b/backend/spec/controller_user_spec.rb
@@ -198,4 +198,22 @@ describe 'User controller' do
     user.name.should eq("A New Name")
   end
 
+
+  it "can log out a session" do
+    post '/users/test1/login', params = { "password" => "password", "expiring" => "false" }
+    last_response.should be_ok
+
+    session_headers = {"HTTP_X_ARCHIVESSPACE_SESSION" => JSON(last_response.body)["session"]}
+
+    get '/', params = {}, session_headers
+    last_response.should be_ok
+
+    # Now log it out
+    post '/logout', params = {}, session_headers
+
+    get '/', params = {}, session_headers
+    last_response.status.should eq(412)
+  end
+
+
 end


### PR DESCRIPTION
Hi there,

While chatting with @helrond about session stuff I noticed that there's currently no endpoint to explicitly log out a session.  For the expiring kind they get cleaned up anyway, but for the non-expiring kind there's currently no way of removing those sessions from the database.

I've added and endpoint so that people writing scripts have the option of logging out once they're finished, and there's a small test to go with it.

Mark