### PR TITLE
Allow frontend PluginHelper to append to Location and Event records + Events.external_ids bug fix

### DIFF
--- a/backend/app/model/event.rb
+++ b/backend/app/model/event.rb
@@ -8,6 +8,7 @@ class Event < Sequel::Model(:event)
   include Relationships
   include Agents
   include ExternalDocuments
+  include ExternalIDs
 
   agent_role_enum("linked_agent_event_roles")
 

--- a/frontend/app/views/events/_form.html.erb
+++ b/frontend/app/views/events/_form.html.erb
@@ -89,3 +89,5 @@
 <% end %>
 
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents"} %>
+
+<%= form_plugins_for("event", form) %>

--- a/frontend/app/views/locations/_form.html.erb
+++ b/frontend/app/views/locations/_form.html.erb
@@ -25,3 +25,5 @@
 <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:object => @location, :form => form} %>
 <% form.emit_template("location") %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_ids", :hidden => true} %>
+
+<%= form_plugins_for("location", form) %>

--- a/frontend/app/views/locations/show.html.erb
+++ b/frontend/app/views/locations/show.html.erb
@@ -14,6 +14,10 @@
       <%= read_only_view(@location.to_hash) %>
 
       <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @location, :filter_term => {"location_uris" => @location.uri}.to_json, :heading_text => I18n.t("location._frontend.section.search_embedded")} %>
+
+      <%= readonly_context :location, @location do |readonly| %>
+        <%= show_plugins_for(@location, readonly) %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/frontend/app/views/subjects/show.html.erb
+++ b/frontend/app/views/subjects/show.html.erb
@@ -31,9 +31,9 @@
         <%= render_aspace_partial :partial => "external_documents/show", :locals => { :external_documents => @subject.external_documents, :section_id => "subject_external_documents_" } %>
       <% end %>
 
-      <%= show_plugins_for(@subject, readonly) %>
-
       <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @subject, :filter_term => {"subjects" => @subject.title}.to_json, :heading_text => I18n.t("subject._frontend.section.search_embedded")} %>
+
+      <%= show_plugins_for(@subject, readonly) %>
     <% end %>
    </div>
   </div>


### PR DESCRIPTION
Hi guys,

In working through some plugins I've noticed that Locations and Events were missing the frontend hooks to allow nested records to be inserted by the PluginHelper mechanisms.  I've added those to the respective templates.

I’ve also rearranged the PluginHelper hook for Subjects, as the sidebar expects any plugin inserted subrecords to be included at the end of the page.

And one more little bug fix.. I noticed that External IDs were not being returned on Events. So I’ve included the missing ExternalIds module to the Event model to save the day.

Hope you’re all doing well,

Thanks,
Payten