### PR TITLE
Add missing key, value for default 'none' to enum locales

### DIFF
--- a/common/locales/enums/en.yml
+++ b/common/locales/enums/en.yml
@@ -313,10 +313,12 @@ en:
       terabytes: Terabytes
       volumes: Volumes
     collection_management_processing_priority:
+      none: Not specified
       high: High
       medium: Medium
       low: Low
     collection_management_processing_status:
+      none: Not specified
       new: New
       in_progress: In Progress
       completed: Completed


### PR DESCRIPTION
For collection management processing priority and status.
Issue is viewable at (08/26):

http://sandbox.archivesspace.org/digital_objects/8#tree::digital_object_8