### PR TITLE
move telephone_ext to telephone if the latter is nil

### DIFF
--- a/common/db/migrations/043_add_phone_numbers_to_agent_contact.rb
+++ b/common/db/migrations/043_add_phone_numbers_to_agent_contact.rb
@@ -4,33 +4,39 @@ Sequel.migration do
 
   up do
 
-      create_table(:telephone) do
-        primary_key :id
-        Integer :agent_contact_id 
-        TextField :number, :null => false
-        TextField :ext, :null => true
-        apply_mtime_columns
+    create_table(:telephone) do
+      primary_key :id
+      Integer :agent_contact_id
+      TextField :number, :null => false
+      TextField :ext, :null => true
+      apply_mtime_columns
+    end
+
+    alter_table(:telephone) do
+      add_foreign_key([:agent_contact_id], :agent_contact, :key => :id)
+    end
+
+    self[:agent_contact].filter( Sequel.~(:telephone => nil)).or( Sequel.~( :telephone_ext => nil )).each do |row|
+      number = row[:telephone]
+      ext = row[:telephone_ext]
+
+      if number.nil? && ext
+        number = ext
+        ext = nil
       end
 
-      alter_table(:telephone) do
-        add_foreign_key([:agent_contact_id], :agent_contact, :key => :id)
-      end
-    
-      self[:agent_contact].filter( Sequel.~(:telephone => nil)).or( Sequel.~( :telephone_ext => nil )).each do |row|
-        self[:telephone].insert( :agent_contact_id => row[:id], :number => row[:telephone], :ext => row[:telephone_ext],
-                                  :last_modified_by => row[:last_modified_by],
-                                  :create_time => row[:create_time],
-                                  :system_mtime => row[:system_mtime],
-                                  :user_mtime => row[:user_mtime]
+      self[:telephone].insert( :agent_contact_id => row[:id], :number => number, :ext => ext,
+                               :last_modified_by => row[:last_modified_by],
+                               :create_time => row[:create_time],
+                               :system_mtime => row[:system_mtime],
+                               :user_mtime => row[:user_mtime]
                                )
-      end
-      
-      alter_table(:agent_contact) do
-        drop_column(:telephone)
-        drop_column(:telephone_ext)
-      end
+    end
 
-
+    alter_table(:agent_contact) do
+      drop_column(:telephone)
+      drop_column(:telephone_ext)
+    end
 
   end
 


### PR DESCRIPTION
I think the addresses the issue KU had migrating from 1.2 to 1.3. I chose to just move the extension data into the main telephone field if the former has data and the latter doesn't. ¯_(ツ)_/¯