### PR TITLE
Modify the MARC model to cope with missing languages

### DIFF
--- a/backend/app/exporters/models/marc21.rb
+++ b/backend/app/exporters/models/marc21.rb
@@ -117,7 +117,7 @@ class MARCModel < ASpaceExport::ExportModel
     string += date['end'] ? date['end'][0..3] : "    "
     string += "xx"
     18.times { string += ' ' }
-    string += obj.language
+    string += (obj.language || '|||')
     string += ' d'
 
     string


### PR DESCRIPTION
Hi there,

I noticed if a record doesn't have a language set, it throws an exception when you try to export it in MARC format.  Here's a little patch to use the `|||` code to indicate that there's no language coding there.