### PR TITLE
Session expired during edit poll redirect

### DIFF
--- a/frontend/app/assets/javascripts/update_monitor.js
+++ b/frontend/app/assets/javascripts/update_monitor.js
@@ -98,7 +98,11 @@ $(function() {
             clearAnyMonitorErrors()
           }
         },
-        "json")
+        "json").fail(function(jqXHR, textStatus, errorThrown) {
+          if (jqXHR.status === 500) {
+            window.location.replace(FRONTEND_URL);
+          }
+        });
     };
 
     poll();

--- a/frontend/app/views/layouts/application.html.erb
+++ b/frontend/app/views/layouts/application.html.erb
@@ -24,6 +24,7 @@
   <script>
     APP_PATH = "<%= j(AppConfig[:frontend_prefix]) %>";
     COOKIE_PREFIX = "<%= j(AppConfig[:cookie_prefix]) %>";
+    FRONTEND_URL = "<%= j(AppConfig[:frontend_proxy_url]) %>";
   </script>
 
   <%= javascript_include_tag "application" %>


### PR DESCRIPTION
Trigger a redirect to the welcome index action when the user
session has expired during polling. This suppresses the
potentially massive amounts of AccessDeniedException spam
that comes from an expired session in edit mode (which we
see a lot).

If the user had no changes they will be redirected. If the user
had unsaved changes the confirmation navigation alert is
activated. This gives the user a chance to "stay" and attempt
to save their changes after reauthenticating. The alert blocks
polling so it also prevents spam AccessDeniedException messages.