### PR TITLE
Display External IDs in the frontend

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -191,3 +191,6 @@ AppConfig[:resequence_on_startup] = false
 # This is a URL that points to some demo data that can be used for testing,
 # teaching, etc. To use this, set an OS environment variable of ASPACE_DEMO = true
 AppConfig[:demo_data_url] = "https://s3-us-west-2.amazonaws.com/archivesspacedemo/latest-demo-data.zip" 
+
+# Expose external ids in the frontend
+AppConfig[:show_external_ids] = false

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -919,6 +919,13 @@ en:
     _plural: External Documents
     _singular: External Document
 
+  external_id:
+    _plural: External IDs
+    _singular: External ID
+    source: Source
+    external_id: External ID
+
+
   rights_statement: &rights_statement_attributes
     identifier: Identifier
     identifier_tooltip: |

--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -273,4 +273,7 @@ module ApplicationHelper
     end
   end
 
+  def show_external_ids?
+    AppConfig[:show_external_ids] == true
+  end
 end

--- a/frontend/app/helpers/sidebar_helper.rb
+++ b/frontend/app/helpers/sidebar_helper.rb
@@ -41,6 +41,14 @@ module SidebarHelper
     end
 
 
+    def show_external_ids_sidebar_entry?
+      record = @opts[:record]
+
+      @form.controller.action_name == 'show' ||
+        @form.controller.action_name != 'show' && !ASUtils.wrap(record['external_ids']).empty?
+    end
+
+
     private
 
     def render_entry(opts)

--- a/frontend/app/views/accessions/_form.html.erb
+++ b/frontend/app/views/accessions/_form.html.erb
@@ -40,13 +40,14 @@
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "subjects", :template => "subrecord_subject"} %>
 
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents"} %>
-<%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_ids", :hidden => true} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "rights_statements"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "instances", :custom_action_template => "instances/subrecord_form_action"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "deaccessions"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "collection_management", :cardinality => :zero_to_one} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "classifications"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "user_defined", :cardinality => :zero_to_one} %>
+
+<%= render_aspace_partial :partial => "external_ids/edit", :locals => {:form => form, :section_id => "external_ids"} %>
 
 <%= form_plugins_for("accession", form) %>
 

--- a/frontend/app/views/accessions/_sidebar.html.erb
+++ b/frontend/app/views/accessions/_sidebar.html.erb
@@ -18,5 +18,6 @@
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'classification', :property => 'classifications') %>
     <%= sidebar.render_for_view_only(:subrecord_type => 'linked_event', :property => 'linked_events') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'user_defined', :property => 'user_defined') %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_id', :property => 'external_ids') if show_external_ids? && sidebar.show_external_ids_sidebar_entry? %>
 
 <% end %>

--- a/frontend/app/views/accessions/show.html.erb
+++ b/frontend/app/views/accessions/show.html.erb
@@ -97,6 +97,10 @@
            <%= render_aspace_partial :partial => "user_defined/show", :locals => { :user_defined => @accession.user_defined, :context => readonly, :section_id => "accession_user_defined_" } %>
          <% end %>
 
+        <% if @accession.external_ids.length > 0 && show_external_ids? %>
+          <%= render_aspace_partial :partial => "external_ids/show", :locals => { :external_ids => @accession.external_ids, :context => readonly, :section_id => "accession_external_ids_" } %>
+        <% end %>
+
 
          <%= show_plugins_for(@accession, readonly) %>
 

--- a/frontend/app/views/archival_objects/_form_container.html.erb
+++ b/frontend/app/views/archival_objects/_form_container.html.erb
@@ -59,8 +59,9 @@
   <%= render_aspace_partial :partial => "notes/form", :locals => {:form => form, :all_note_types => note_types_for(form['jsonmodel_type'])} %>
 
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents"} %>
-  <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_ids", :hidden => true} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "rights_statements"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "instances", :custom_action_template => "instances/subrecord_form_action"} %>
+
+  <%= render_aspace_partial :partial => "external_ids/edit", :locals => {:form => form, :section_id => "external_ids"} %>
 
   <%= form_plugins_for("archival_object", form) %>

--- a/frontend/app/views/archival_objects/_show_inline.html.erb
+++ b/frontend/app/views/archival_objects/_show_inline.html.erb
@@ -57,6 +57,9 @@
 
         <%= render_aspace_partial :partial => "linked_events/show", :locals => { :linked_events => archival_object.linked_events, :context => readonly, :section_id => "archival_object_linked_events_" } %>
 
+        <% if archival_object.external_ids.length > 0 && show_external_ids? %>
+          <%= render_aspace_partial :partial => "external_ids/show", :locals => { :external_ids => archival_object.external_ids, :context => readonly, :section_id => "archival_object_external_ids_" } %>
+        <% end %>
 
         <%= show_plugins_for(@archival_object, readonly) %>
       <% end %>

--- a/frontend/app/views/archival_objects/_sidebar.html.erb
+++ b/frontend/app/views/archival_objects/_sidebar.html.erb
@@ -14,4 +14,6 @@
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'rights_statement', :property => 'rights_statements') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'instance', :property => 'instances') %>
     <%= sidebar.render_for_view_only(:subrecord_type => 'linked_event', :property => 'linked_events') %>
+
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_id', :property => 'external_ids') if show_external_ids? && sidebar.show_external_ids_sidebar_entry? %>
 <% end %>

--- a/frontend/app/views/collection_management/_show.html.erb
+++ b/frontend/app/views/collection_management/_show.html.erb
@@ -23,6 +23,9 @@
       </div>
       <div id="<%= section_id %>_collection_management" class="accordion-body collapse">
         <%= read_only_view(collection_management) %>
+        <% if ASUtils.wrap(collection_management["external_ids"]).length > 0 && show_external_ids? %>
+          <%= render_aspace_partial :partial => "external_ids/show", :locals => { :external_ids => collection_management["external_ids"], :section_id => "collection_management_external_ids_" } %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/frontend/app/views/collection_management/_template.html.erb
+++ b/frontend/app/views/collection_management/_template.html.erb
@@ -9,6 +9,6 @@
       <%= form.label_and_select "processing_total_extent_type", form.possible_options_for("processing_total_extent_type", true), :required => :conditionally %>
       <%= form.label_and_textfield "processing_hours_total" %>
       <%= form.label_and_textarea "processing_funding_source" %>
-      <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_ids", :hidden => true} %>
+      <%= render_aspace_partial :partial => "external_ids/edit", :locals => {:form => form, :section_id => "external_ids"} %>
     </div>
 <% end %>

--- a/frontend/app/views/digital_object_components/_form_container.html.erb
+++ b/frontend/app/views/digital_object_components/_form_container.html.erb
@@ -50,8 +50,9 @@
   <%= render_aspace_partial :partial => "notes/form", :locals => {:form => form, :all_note_types => note_types_for(form['jsonmodel_type'])} %>
 
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents"} %>
-  <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_ids", :hidden => true} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "rights_statements"} %>
+
+  <%= render_aspace_partial :partial => "external_ids/edit", :locals => {:form => form, :section_id => "external_ids"} %>
 
   <%= form_plugins_for("digital_object_component", form) %>
 

--- a/frontend/app/views/digital_object_components/_show_inline.html.erb
+++ b/frontend/app/views/digital_object_components/_show_inline.html.erb
@@ -56,6 +56,10 @@
 
         <%= render_aspace_partial :partial => "linked_events/show", :locals => { :linked_events => digital_object_component.linked_events, :context => readonly, :section_id => "digital_object_component_linked_events_" } %>
 
+        <% if digital_object_component.external_ids.length > 0 && show_external_ids? %>
+          <%= render_aspace_partial :partial => "external_ids/show", :locals => { :external_ids => digital_object_component.external_ids, :context => readonly, :section_id => "digital_object_component_external_ids_" } %>
+        <% end %>
+
         <%= show_plugins_for(@digital_object_component, readonly) %>
 
       <% end %>

--- a/frontend/app/views/digital_object_components/_sidebar.html.erb
+++ b/frontend/app/views/digital_object_components/_sidebar.html.erb
@@ -14,4 +14,6 @@
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_document', :property => 'external_documents') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'rights_statement', :property => 'rights_statements') %>
     <%= sidebar.render_for_view_only(:subrecord_type => 'linked_event', :property => 'linked_events') %>
+
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_id', :property => 'external_ids') if show_external_ids? && sidebar.show_external_ids_sidebar_entry? %>
 <% end %>

--- a/frontend/app/views/digital_objects/_form_container.html.erb
+++ b/frontend/app/views/digital_objects/_form_container.html.erb
@@ -31,10 +31,11 @@
   <%= render_aspace_partial :partial => "notes/form", :locals => {:form => form, :all_note_types => note_types_for(form['jsonmodel_type'])} %>
 
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents"} %>
-  <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_ids", :hidden => true} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "rights_statements"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "collection_management", :cardinality => :zero_to_one} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "user_defined", :cardinality => :zero_to_one} %>
+
+  <%= render_aspace_partial :partial => "external_ids/edit", :locals => {:form => form, :section_id => "external_ids"} %>
 
   <%= form_plugins_for("digital_object", form) %>
 

--- a/frontend/app/views/digital_objects/_show_inline.html.erb
+++ b/frontend/app/views/digital_objects/_show_inline.html.erb
@@ -92,6 +92,10 @@
           <%= render_aspace_partial :partial => "user_defined/show", :locals => { :user_defined => digital_object.user_defined, :section_id => "digital_object_user_defined_"  } %>
         <% end %>
 
+        <% if digital_object.external_ids.length > 0 && show_external_ids? %>
+          <%= render_aspace_partial :partial => "external_ids/show", :locals => { :external_ids => digital_object.external_ids, :context => readonly, :section_id => "digital_object_external_ids_" } %>
+        <% end %>
+
         <%= show_plugins_for(@digital_object, readonly) %>
       <% end %>
 

--- a/frontend/app/views/digital_objects/_sidebar.html.erb
+++ b/frontend/app/views/digital_objects/_sidebar.html.erb
@@ -19,4 +19,6 @@
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'collection_management', :property => 'collection_management') %>
     <%= sidebar.render_for_view_only(:subrecord_type => 'linked_event', :property => 'linked_events') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'user_defined', :property => 'user_defined') %>
+
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_id', :property => 'external_ids') if show_external_ids? && sidebar.show_external_ids_sidebar_entry? %>
 <% end %>

--- a/frontend/app/views/events/_form.html.erb
+++ b/frontend/app/views/events/_form.html.erb
@@ -85,7 +85,10 @@
   </section>
 <% else %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "linked_records"} %>
-  <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_ids", :hidden => true} %>
 <% end %>
 
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents"} %>
+
+<% if !form.readonly? %>
+  <%= render_aspace_partial :partial => "external_ids/edit", :locals => {:form => form, :section_id => "external_ids"} %>
+<% end %>

--- a/frontend/app/views/events/_sidebar.html.erb
+++ b/frontend/app/views/events/_sidebar.html.erb
@@ -10,4 +10,5 @@
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'linked_agent', :property => 'linked_agents') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'linked_record', :property => 'linked_records') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_document', :property => 'external_documents') %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_id', :property => 'external_ids') if show_external_ids? && sidebar.show_external_ids_sidebar_entry? %>
 <% end %>

--- a/frontend/app/views/events/show.html.erb
+++ b/frontend/app/views/events/show.html.erb
@@ -16,6 +16,10 @@
       <%= readonly_context :event, @event do |readonly| %>
         <%= render_aspace_partial :partial => "events/form", :locals => {:form => readonly} %>
       <% end %>
+
+      <% if @event.external_ids.length > 0 && show_external_ids? %>
+        <%= render_aspace_partial :partial => "external_ids/show", :locals => { :external_ids => @event.external_ids, :section_id => "event_external_ids_" } %>
+      <% end %>
       <%# read_only_view(@event.to_hash) %>
     </div>
   </div>

--- a/frontend/app/views/external_ids/_edit.html.erb
+++ b/frontend/app/views/external_ids/_edit.html.erb
@@ -1,0 +1,16 @@
+<% if ASUtils.wrap(form["external_ids"]).length > 0 %>
+  <div class="subrecord-form-container">
+    <% if show_external_ids? %>
+      <%= render_aspace_partial :partial => "external_ids/show", :locals=>{:section_id => form.id_for("external_ids"), :external_ids => form["external_ids"]} %>
+    <% end %>
+
+    <% define_template "external_id" do |form| %>
+      <%= form.hidden_input("source") %>
+      <%= form.hidden_input("external_id") %>
+    <% end %>
+
+    <%= form.list_for(form["external_ids"], "external_ids[]") do |item| %>
+      <% form.emit_template("external_id", item) %>
+    <% end %>
+  </div>
+<% end %>

--- a/frontend/app/views/external_ids/_show.html.erb
+++ b/frontend/app/views/external_ids/_show.html.erb
@@ -1,0 +1,26 @@
+<%
+   section_id = "visible_external_ids" if section_id.blank?
+%>
+<section id="<%= section_id %>" class="subrecord-form-dummy">
+  <h3><%= I18n.t("external_id._plural")%></h3>
+  <div class="subrecord-form-container">
+    <div class="subrecord-form-fields">
+      <table class="table table-striped table-bordered table-condensed table-hover">
+        <thead>
+        <tr>
+          <td><%= I18n.t("external_id.source") %></td>
+          <td><%= I18n.t("external_id.external_id") %></td>
+        </tr>
+        </thead>
+        <tbody>
+        <% ASUtils.wrap(external_ids).each do |external_id| %>
+          <tr>
+            <td><%= external_id['source'] %></td>
+            <td><%= external_id['external_id'] %></td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>

--- a/frontend/app/views/locations/_form.html.erb
+++ b/frontend/app/views/locations/_form.html.erb
@@ -24,4 +24,4 @@
 
 <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:object => @location, :form => form} %>
 <% form.emit_template("location") %>
-<%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_ids", :hidden => true} %>
+<%= render_aspace_partial :partial => "external_ids/edit", :locals => {:form => form, :section_id => "external_ids"} %>

--- a/frontend/app/views/locations/_sidebar.html.erb
+++ b/frontend/app/views/locations/_sidebar.html.erb
@@ -5,4 +5,5 @@
              :plusone => :submit
            }) do |sidebar| %>
     <%= sidebar.render_for_view_only(:subrecord_type => 'search_embedded', :property => :none, :anchor => 'search_embedded') %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_id', :property => 'external_ids') if show_external_ids? && sidebar.show_external_ids_sidebar_entry? %>
 <% end %>

--- a/frontend/app/views/locations/show.html.erb
+++ b/frontend/app/views/locations/show.html.erb
@@ -14,6 +14,10 @@
       <%= read_only_view(@location.to_hash) %>
 
       <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @location, :filter_term => {"location_uris" => @location.uri}.to_json, :heading_text => I18n.t("location._frontend.section.search_embedded")} %>
+
+      <% if @location.external_ids.length > 0 && show_external_ids? %>
+        <%= render_aspace_partial :partial => "external_ids/show", :locals => { :external_ids => @location.external_ids, :section_id => "location_external_ids_" } %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/frontend/app/views/resources/_form_container.html.erb
+++ b/frontend/app/views/resources/_form_container.html.erb
@@ -73,12 +73,12 @@
 <%# render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "notes", :template => "note_form_selector", :section_id => "notes"} %>
 <%= render_aspace_partial :partial => "notes/form", :locals => {:form => form} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents"} %>
-<%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_ids", :hidden => true} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "rights_statements"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "instances", :custom_action_template => "instances/subrecord_form_action"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "deaccessions"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "collection_management", :cardinality => :zero_to_one} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "classifications"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "user_defined", :cardinality => :zero_to_one} %>
+<%= render_aspace_partial :partial => "external_ids/edit", :locals => {:form => form, :section_id => "external_ids"} %>
 
   <%= form_plugins_for("resource", form) %>

--- a/frontend/app/views/resources/_show_inline.html.erb
+++ b/frontend/app/views/resources/_show_inline.html.erb
@@ -110,6 +110,10 @@
           <%= render_aspace_partial :partial => "user_defined/show", :locals => { :user_defined => @resource.user_defined, :context => readonly, :section_id => "resource_user_defined_" } %>
         <% end %>
 
+        <% if @resource.external_ids.length > 0 && show_external_ids? %>
+          <%= render_aspace_partial :partial => "external_ids/show", :locals => { :external_ids => @resource.external_ids, :section_id => "resource_external_ids_" } %>
+        <% end %>
+
         <%= show_plugins_for(@resource, readonly) %>
 
       <% end %>

--- a/frontend/app/views/resources/_sidebar.html.erb
+++ b/frontend/app/views/resources/_sidebar.html.erb
@@ -18,5 +18,6 @@
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'classification', :property => 'classifications') %>
     <%= sidebar.render_for_view_only(:subrecord_type => 'linked_event', :property => 'linked_events') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'user_defined', :property => 'user_defined') %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_id', :property => 'external_ids') if show_external_ids? && sidebar.show_external_ids_sidebar_entry? %>
 <% end %>
 

--- a/frontend/app/views/subjects/_form.html.erb
+++ b/frontend/app/views/subjects/_form.html.erb
@@ -20,6 +20,7 @@
 
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "terms", :required => true, :heading_text => I18n.t("subject._frontend.section.terms")} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents"} %>
+  <%= render_aspace_partial :partial => "external_ids/edit", :locals => {:form => form, :section_id => "external_ids"} %>
 
   <%= form_plugins_for("subject", form) %>
 

--- a/frontend/app/views/subjects/_sidebar.html.erb
+++ b/frontend/app/views/subjects/_sidebar.html.erb
@@ -7,4 +7,5 @@
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'terms', :property => 'terms') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_document', :property => 'external_documents') %>
     <%= sidebar.render_for_view_only(:subrecord_type => 'search_embedded', :property => :none, :anchor => 'search_embedded') %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_id', :property => 'external_ids') if show_external_ids? && sidebar.show_external_ids_sidebar_entry? %>
 <% end %>

--- a/frontend/app/views/subjects/show.html.erb
+++ b/frontend/app/views/subjects/show.html.erb
@@ -34,6 +34,10 @@
       <%= show_plugins_for(@subject, readonly) %>
 
       <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @subject, :filter_term => {"subjects" => @subject.title}.to_json, :heading_text => I18n.t("subject._frontend.section.search_embedded")} %>
+
+      <% if @subject.external_ids.length > 0 && show_external_ids? %>
+        <%= render_aspace_partial :partial => "external_ids/show", :locals => { :external_ids => @subject.external_ids, :section_id => "subject_external_ids_" } %>
+      <% end %>
     <% end %>
    </div>
   </div>


### PR DESCRIPTION
Hi there,

In developing a plugin for Dartmouth College to expose External IDs for archival records, we found there wasn't really a nice way to do so consistently for all records via the plugin framework.

The changes in this PR are mostly simple template wrangling and the behaviour can be switched on and off via a configuration option `AppConfig[:show_external_ids]` - it is `false` by default.

Would the community be interested in such a feature?  

Thanks,
Payten