### PR TITLE
AR-1320 #finish assign ASpace as the agent in a null agent relationship

### DIFF
--- a/common/db/migrations/053_collection_management_redo.rb
+++ b/common/db/migrations/053_collection_management_redo.rb
@@ -1,98 +1,107 @@
 require_relative 'utils'
 
 def create_event_from_collection_management(dataset, event_type)
-      
-      event_type_list_id = self[:enumeration].filter( :name => 'event_event_type' ).get(:id)
-      cataloged = self[:enumeration_value].filter( :enumeration_id => event_type_list_id, :value => event_type ).get(:id)
-      unless cataloged
-        counter = self[:enumeration_value].filter( :enumeration_id => event_type_list_id ).count
-        cataloged = self[:enumeration_value].insert( :enumeration_id => event_type_list_id, :value => event_type, 
-                                                   :readonly => 0, :position => counter + 1  )
-      end
-      
-      linked_agent_event_roles_list_id = self[:enumeration].filter(:name => "linked_agent_event_roles").get(:id)
-      implementer = self[:enumeration_value].filter( :enumeration_id => linked_agent_event_roles_list_id,
-                                                     :value => 'implementer' ).get(:id)
 
-      dataset.each do |row| 
+  event_type_list_id = self[:enumeration].filter( :name => 'event_event_type' ).get(:id)
+  cataloged = self[:enumeration_value].filter( :enumeration_id => event_type_list_id, :value => event_type ).get(:id)
+  unless cataloged
+    counter = self[:enumeration_value].filter( :enumeration_id => event_type_list_id ).count
+    cataloged = self[:enumeration_value].insert( :enumeration_id => event_type_list_id, :value => event_type,
+                                                 :readonly => 0, :position => counter + 1  )
+  end
 
-        repo_id = if row[:accession_id]
-          self[:accession].filter(:id => row[:accession_id]).get(:repo_id)
-        elsif row[:resource_id]
-          self[:resource].filter(:id => row[:resource_id]).get(:repo_id)
-        elsif row[:digital_object]
-          self[:digital_object].filter(:id => row[:digital_object_id]).get(:repo_id)
-        else
-          nil
-        end
+  linked_agent_event_roles_list_id = self[:enumeration].filter(:name => "linked_agent_event_roles").get(:id)
+  implementer = self[:enumeration_value].filter( :enumeration_id => linked_agent_event_roles_list_id,
+                                                 :value => 'implementer' ).get(:id)
 
-        next if repo_id.nil?
+  dataset.each do |row|
 
-        event = self[:event].insert( 
-                              :json_schema_version => row[:json_schema_version], 
-                              :repo_id => repo_id,
-                              :event_type_id => cataloged, 
-                              :outcome_note => row[:cataloged_note],
-                             :create_time => row[:create_time],
-                             :system_mtime => row[:system_mtime],
-                             :user_mtime => row[:user_mtime]
-                           ) 
-        linked_event_archival_record_roles_id = self[:enumeration].filter(:name => 'linked_event_archival_record_roles').get(:id)
-        outcome_id = self[:enumeration_value].filter( :enumeration_id => linked_event_archival_record_roles_id, :value => "outcome" ).get(:id) 
-        
-        self[:event_link_rlshp].insert(
-              :event_id => event, 
-              :role_id => outcome_id, 
-              :accession_id => row[:accession_id],
-              :resource_id => row[:resource_id],
-              :digital_object_id => row[:digital_object_id],
-              :system_mtime => row[:system_mtime],
-              :user_mtime => row[:user_mtime],
-              :aspace_relationship_position => 0 
-        ) 
-      
-        date_type_list = self[:enumeration].filter(:name => "date_type").get(:id)
-        single_date_id = self[:enumeration_value].filter(:enumeration_id => date_type_list, :value => 'single').get(:id)
-        
-        date_label_list = self[:enumeration].filter(:name => "date_label").get(:id)
-        date_label_id = self[:enumeration_value].filter(:enumeration_id => date_label_list, :value => 'agent_relation').get(:id)
-        
-        begin_date = row[:user_mtime].strftime('%Y-%m-%d')
-        self[:date].insert(  
-                            :json_schema_version => row[:json_schema_version], 
-                            :event_id => event,
-                            :date_type_id => single_date_id,
-                            :label_id => date_label_id, 
-                            :begin => begin_date, 
-                            :create_time => row[:create_time],
-                             :system_mtime => row[:system_mtime],
-                             :user_mtime => row[:user_mtime]
-                           )
+    repo_id = if row[:accession_id]
+                self[:accession].filter(:id => row[:accession_id]).get(:repo_id)
+              elsif row[:resource_id]
+                self[:resource].filter(:id => row[:resource_id]).get(:repo_id)
+              elsif row[:digital_object]
+                self[:digital_object].filter(:id => row[:digital_object_id]).get(:repo_id)
+              else
+                nil
+              end
 
-        user_agent_id = self[:user].filter( :username => row[:last_modified_by] ).get(:agent_record_id)
-        agent_id = self[:agent_person].filter( :id => user_agent_id ).get(:id) 
-        
-        self[:linked_agents_rlshp].insert( 
-                             :aspace_relationship_position => 0, 
-                             :create_time => row[:create_time],
-                             :system_mtime => row[:system_mtime],
-                             :user_mtime => row[:user_mtime],
-                             :agent_person_id => agent_id, 
-                             :role_id => implementer, 
-                             :event_id => event ) 
-        
+    next if repo_id.nil?
+
+    event = self[:event].insert(
+                                :json_schema_version => row[:json_schema_version],
+                                :repo_id => repo_id,
+                                :event_type_id => cataloged,
+                                :outcome_note => row[:cataloged_note],
+                                :create_time => row[:create_time],
+                                :system_mtime => row[:system_mtime],
+                                :user_mtime => row[:user_mtime]
+                                )
+    linked_event_archival_record_roles_id = self[:enumeration].filter(:name => 'linked_event_archival_record_roles').get(:id)
+    outcome_id = self[:enumeration_value].filter( :enumeration_id => linked_event_archival_record_roles_id, :value => "outcome" ).get(:id)
+
+    self[:event_link_rlshp].insert(
+                                   :event_id => event,
+                                   :role_id => outcome_id,
+                                   :accession_id => row[:accession_id],
+                                   :resource_id => row[:resource_id],
+                                   :digital_object_id => row[:digital_object_id],
+                                   :system_mtime => row[:system_mtime],
+                                   :user_mtime => row[:user_mtime],
+                                   :aspace_relationship_position => 0
+                                   )
+
+    date_type_list = self[:enumeration].filter(:name => "date_type").get(:id)
+    single_date_id = self[:enumeration_value].filter(:enumeration_id => date_type_list, :value => 'single').get(:id)
+
+    date_label_list = self[:enumeration].filter(:name => "date_label").get(:id)
+    date_label_id = self[:enumeration_value].filter(:enumeration_id => date_label_list, :value => 'agent_relation').get(:id)
+
+    begin_date = row[:user_mtime].strftime('%Y-%m-%d')
+    self[:date].insert(
+                       :json_schema_version => row[:json_schema_version],
+                       :event_id => event,
+                       :date_type_id => single_date_id,
+                       :label_id => date_label_id,
+                       :begin => begin_date,
+                       :create_time => row[:create_time],
+                       :system_mtime => row[:system_mtime],
+                       :user_mtime => row[:user_mtime]
+                       )
+
+    linked_agent_row = {
+      :aspace_relationship_position => 0,
+      :create_time => row[:create_time],
+      :system_mtime => row[:system_mtime],
+      :user_mtime => row[:user_mtime],
+      :role_id => implementer,
+      :event_id => event
+    }
+
+    user_agent_id = self[:user].filter( :username => row[:last_modified_by] ).get(:agent_record_id)
+    agent_id = self[:agent_person].filter( :id => user_agent_id ).get(:id)
+
+    if agent_id
+      linked_agent_row.merge!({:agent_person_id => agent_id })
+    else # the user may not longer exist, etc. just assign it to ASpace
+      agent_id = self[:agent_software].filter( :system_role => 'archivesspace_agent' ).get(:id)
+      linked_agent_row.merge!({:agent_software_id => agent_id})
     end
+
+    self[:linked_agents_rlshp].insert(linked_agent_row)
+
+  end
 end
 
 Sequel.migration do
-  
+
   up do
-    # turn cataloged note into an event with type = cataloged 
+    # turn cataloged note into an event with type = cataloged
     create_event_from_collection_management( self[:collection_management].filter( Sequel.~(:cataloged_note => nil) ), "cataloged")
     # processing started date into an event with type = "processing_started"
     create_event_from_collection_management( self[:collection_management].filter( Sequel.~(:processing_started_date => nil) ), "processing_started")
 
-   
+
     # take all values from processing_status and turn them into events with
     # type "processing_#{processing_status enumeration value}"
     cmps = self[:enumeration].filter( :name => 'collection_management_processing_status' ).get(:id)
@@ -105,7 +114,7 @@ Sequel.migration do
     alter_table(:collection_management) do
       drop_column(:cataloged_note)
       drop_column(:processing_started_date)
-      # dropping this is a PIA in mysql, so lets just leave it 
+      # dropping this is a PIA in mysql, so lets just leave it
       # drop_column(:processing_status_id)
     end
 

--- a/common/db/migrations/058_ensure_agent_links_have_agents.rb
+++ b/common/db/migrations/058_ensure_agent_links_have_agents.rb
@@ -1,0 +1,19 @@
+# patch up data left in a state where agent relationships have no agent
+# see https://archivesspace.atlassian.net/browse/AR-1320
+
+Sequel.migration do
+
+  up do
+
+    aspace_agent_id = self[:agent_software].filter( :system_role => 'archivesspace_agent' ).get(:id)
+
+    self[:linked_agents_rlshp].filter(:agent_person_id => nil, :agent_software_id => nil, :agent_family_id => nil, :agent_corporate_entity_id => nil).update(:agent_software_id => aspace_agent_id)
+
+  end
+
+
+  down do
+
+  end
+
+end

--- a/common/locales/enums/en.yml
+++ b/common/locales/enums/en.yml
@@ -368,6 +368,7 @@ en:
       migration: Migration
       normalization: Normalization
       processed: Processed
+      processing_new: Processing New
       publication: Publication
       replication: Replication
       rights_transferred: Rights Transferred


### PR DESCRIPTION
This modifies migration 053 to fall back to using ASpace's agent record when creating Event records from Collection Management records if the last modifying user no longer exists or doesn't have an agent record.

There's still an assumption that the install hasn't had it's ASpace agent record deleted. Perhaps this record should be undeletable?

