### PR TITLE
Prevent periodic indexer from gobbling up records with children

### DIFF
--- a/indexer/app/lib/periodic_indexer.rb
+++ b/indexer/app/lib/periodic_indexer.rb
@@ -187,6 +187,7 @@ class PeriodicIndexer < CommonIndexer
 
       if !deletes['results'].empty?
         did_something = true
+        deletes['results'] = deletes['results'].delete_if { |rec| rec.match(/(#{@@records_with_children.join('|')})/) }
       end
 
       delete_records(deletes['results'])

--- a/selenium/spec/collection_management_spec.rb
+++ b/selenium/spec/collection_management_spec.rb
@@ -34,10 +34,13 @@ describe "Collection Management" do
     @driver.find_element(:css => '#accession_collection_management_ .subrecord-form-heading .btn:not(.show-all)').click
     @driver.find_element(:id => "accession_collection_management__processing_priority_").select_option("high")
 
-    # save changes
-    @driver.click_and_wait_until_gone(:css => "form#accession_form button[type='submit']")
+    # save changes (twice to trigger an update also)
+    2.times {
+      @driver.click_and_wait_until_gone(:css => "form#accession_form button[type='submit']")
+      sleep(1)
+    }
 
-    run_index_round
+    run_all_indexers
     # check the CM page
     @driver.find_element(:link, "Browse").click
     @driver.find_element(:link, "Collection Management").click


### PR DESCRIPTION
Records with children from the indexer point of view (such as collection
management records) get special treatment:

https://github.com/archivesspace/archivesspace/blob/ec5762fc9d4b1835181b79c06f69c23e49721047/indexer/app/lib/indexer_common.rb#L557-L569

The child records (if any) are deleted then recreated during the index
process. However the delete step makes the child records available via
the `delete-feed` endpoint, so they are re-deleted after being recreated
when a record is updated =)

This fix filters out the records with children from the delete feed
results, preventing the periodic indexer from acting on them. Without
this fix the updated collection management test fails.