### PR TITLE
Ar 1326 transfer sequence

### DIFF
--- a/backend/app/model/mixins/tree_nodes.rb
+++ b/backend/app/model/mixins/tree_nodes.rb
@@ -234,7 +234,7 @@ module TreeNodes
         if json.parent
           "#{json.parent['ref']}_children_position"
         else
-          "#{json[root_record_type]['ref']}__children_position"
+          "#{json[root_record_type]['ref']}_children_position"
         end
       end
     end

--- a/backend/app/model/mixins/tree_nodes.rb
+++ b/backend/app/model/mixins/tree_nodes.rb
@@ -130,7 +130,7 @@ module TreeNodes
   def update_position_only(parent_id, position)
     if self[:root_record_id]
       root_uri = self.class.uri_for(self.class.root_record_type.intern, self[:root_record_id])
-      parent_uri = parent_id ? self.class.uri_for(self.class.node_record_type.intern, parent_id) : nil
+      parent_uri = parent_id ? self.class.uri_for(self.class.node_record_type.intern, parent_id) : root_uri
       sequence = "#{parent_uri}_children_position"
 
       parent_name = if parent_id

--- a/backend/app/model/mixins/tree_nodes.rb
+++ b/backend/app/model/mixins/tree_nodes.rb
@@ -131,7 +131,7 @@ module TreeNodes
     if self[:root_record_id]
       root_uri = self.class.uri_for(self.class.root_record_type.intern, self[:root_record_id])
       parent_uri = parent_id ? self.class.uri_for(self.class.node_record_type.intern, parent_id) : nil
-      sequence = "#{root_uri}_#{parent_uri}_children_position"
+      sequence = "#{parent_uri}_children_position"
 
       parent_name = if parent_id
                       "#{parent_id}@#{self.class.node_record_type}"
@@ -232,7 +232,7 @@ module TreeNodes
     def sequence_for(json)
       if json[root_record_type]
         if json.parent
-          "#{json[root_record_type]['ref']}_#{json.parent['ref']}_children_position"
+          "#{json.parent['ref']}_children_position"
         else
           "#{json[root_record_type]['ref']}__children_position"
         end

--- a/backend/spec/component_transfer_spec.rb
+++ b/backend/spec/component_transfer_spec.rb
@@ -2,104 +2,104 @@ require 'spec_helper'
 
 describe "Resource Component Transfer Endpoint" do
 
-  before(:each) do    
+  before(:each) do
     @resource_alpha = create(:json_resource)
     @resource_beta = create(:json_resource)
   end
-  
+
   def transfer(resource, object)
     uri = "/repositories/#{$repo_id}/component_transfers"
-    url = URI("#{JSONModel::HTTP.backend_url}#{uri}")  
-    
+    url = URI("#{JSONModel::HTTP.backend_url}#{uri}")
+
     request = Net::HTTP::Post.new(url.request_uri)
     request.set_form_data({"target_resource" => resource.uri, "component" => object.uri})
-     
-    response = JSONModel::HTTP.do_http_request(url, request)    
-    
+
+    response = JSONModel::HTTP.do_http_request(url, request)
+
     response
   end
-    
-  
+
+
   it "can move an archival object from one resource tree to another" do
-    
+
     object = create(:json_archival_object, :resource => {:ref => @resource_alpha.uri})
-    
+
     object.resource['ref'].should eq(@resource_alpha.uri)
-  
+
     response = transfer(@resource_beta, object)
-    
+
     response.code.should eq('200')
-    
+
     refreshed_object = JSONModel(:archival_object).find(object.id)
-    
+
     refreshed_object.resource['ref'].should eq(@resource_beta.uri)
-    
+
     JSONModel(:resource_tree).find(nil, :resource_id => @resource_beta.id).children.length.should eq(1)
-        
+
   end
-  
-  
+
+
   it "returns a 404 response code when asked to transfer a non-existent object" do
-    
+
     fake_uri = JSONModel(:archival_object).uri_for(99*99)
-    
+
     response = transfer(@resource_alpha, build(:json_archival_object, :uri => fake_uri))
-    
+
     response.code.should eq('404')
     response.body.should match(/That which does not exist cannot be moved/)
   end
-  
-  
+
+
   it "returns a 400 response code when asked to transfer an object to a resource containing a conflicting object" do
-    
+
     conflicting_ref_id = generate(:alphanumstr)
-    
+
     object_alpha = create(:json_archival_object, :resource => {:ref => @resource_alpha.uri}, :ref_id => conflicting_ref_id)
     object_beta = create(:json_archival_object, :resource => {:ref => @resource_beta.uri}, :ref_id => conflicting_ref_id)
-    
+
     response = transfer(@resource_beta, object_alpha)
-    
+
     response.code.should eq('400')
     response.body.should match (/unique to its resource/)
   end
-  
-  
+
+
   it "moves children of the component it's moving" do
-    
+
     parent = create(:json_archival_object, :resource => {:ref => @resource_alpha.uri})
     child = create(:json_archival_object, :parent => {:ref => parent.uri}, :resource => {:ref => @resource_alpha.uri})
-  
+
     transfer(@resource_beta, parent)
-    
+
     JSONModel(:archival_object).find(child.id).resource['ref'].should eq(@resource_beta.uri)
-        
+
   end
-  
-  
+
+
   it "can move objects that aren't at the root of the tree" do
-    
+
     parent = create(:json_archival_object, :resource => {:ref => @resource_alpha.uri})
     child = create(:json_archival_object, :parent => {:ref => parent.uri}, :resource => {:ref => @resource_alpha.uri})
-  
+
     transfer(@resource_beta, child)
-    
+
     JSONModel(:archival_object).find(child.id).resource['ref'].should eq(@resource_beta.uri)
-    
+
     tree = JSONModel(:resource_tree).find(nil, :resource_id => @resource_beta.id)
-    
+
     tree.children.length.should eq(1)
   end
-  
+
   it "can move objects to the next available spot in the tree" do
-    
+
     parent = create(:json_archival_object, :resource => {:ref => @resource_alpha.uri})
     child = create(:json_archival_object, :parent => {:ref => parent.uri}, :resource => {:ref => @resource_alpha.uri})
 
     transfer(@resource_beta, child).code.should eq('200')
     transfer(@resource_beta, parent).code.should eq('200')
-        
+
     tree = JSONModel(:resource_tree).find(nil, :resource_id => @resource_beta.id)
-    
+
     tree.children.length.should eq(2)
   end
 
@@ -118,6 +118,33 @@ describe "Resource Component Transfer Endpoint" do
     event.linked_records.select{|link| link["role"] === "outcome"}.first["ref"].should eq(@resource_beta.uri)
     event.linked_records.select{|link| link["role"] === "transfer"}.first["ref"].should eq(archival_object.uri)
   end
-  
-  
+
+
+  it "doesn't break node sequencing" do
+    parent = create(:json_archival_object, :resource => {:ref => @resource_alpha.uri})
+    children = []
+    10.times {
+      children << create(:json_archival_object, :parent => {:ref => parent.uri}, :resource => {:ref => @resource_alpha.uri})
+    }
+
+    # Now transfer
+    transfer(@resource_beta, parent)
+
+    first_child = JSONModel(:archival_object).find(children.first.id)
+    last_child = JSONModel(:archival_object).find(children.last.id)
+
+    last_child.position.should eq(9)
+
+    first_child.title = "something else"
+
+    expect {
+      ArchivalObject[first_child.id].update_from_json(first_child)
+    }.to_not raise_error
+
+    expect {
+      ArchivalObject[last_child.id].update_from_json(last_child)
+    }.to_not raise_error
+
+    last_child.position.should eq(9)
+  end
 end

--- a/common/db/migrations/058_rename_sequences.rb
+++ b/common/db/migrations/058_rename_sequences.rb
@@ -1,0 +1,50 @@
+require_relative 'utils'
+
+Sequel.migration do
+
+  # dedupe and rename existing sequences see:
+  # https://archivesspace.atlassian.net/browse/AR-1326
+
+  up do
+    puts "Renaming all sequences, this may take a while..."
+
+    self[:sequence].each do |row|
+      name = row[:sequence_name]
+
+      # Fix sequence names for children of the root record
+      if name.match(/__/)
+        self[:sequence].filter(:sequence_name => name).update(:sequence_name => name.sub(/__/, '_'))
+      end
+
+
+      next unless name.match(/\/repositories\/(\d)+\/(resource|digital_object|classification)s\/(\d+)_\/repositories\/\d+\/(archival_object|digital_object_component|classification_term)s\/(\d+)_children_position/)
+
+      repo_id, root_id, record_type, tree_node_id = $1, $3, $4, $5
+
+      all_sequences = self[:sequence].where(Sequel.like(:sequence_name, "%_repositories/#{repo_id}/#{record_type}s/#{tree_node_id}_children_position")).order(:value)
+
+      next unless all_sequences.select(:sequence_name).first[:sequence_name] == name
+
+      sequence_val = if all_sequences.count > 1
+                       # reset the sequence value if there are multiple versions
+                       self[record_type.intern].filter(:parent_id => tree_node_id).order(:position).select(:position).last[:position]
+                     else
+                       row[:value]
+                     end
+
+      # delete old sequences
+      all_sequences.delete
+
+      # update the name and value
+      new_name = "/repositories/#{repo_id}/#{record_type}s/#{tree_node_id}_children_position"
+      self[:sequence].insert(:sequence_name => new_name, :value => sequence_val)
+    end
+  end
+
+  down do
+
+  end
+end
+
+
+

--- a/common/db/migrations/059_rename_sequences.rb
+++ b/common/db/migrations/059_rename_sequences.rb
@@ -8,7 +8,18 @@ Sequel.migration do
   up do
     puts "Renaming all sequences, this may take a while..."
 
+    start_time = Time.now
+
+    count = self[:sequence].count
+    i = 0;
+
     self[:sequence].each do |row|
+      i += 1
+
+      if i % 1000 == 0
+        puts "#{i} rows / #{((i.to_f/count) * 100).round(2)}% complete"
+      end
+
       name = row[:sequence_name]
 
       # Fix sequence names for children of the root record
@@ -16,18 +27,23 @@ Sequel.migration do
         self[:sequence].filter(:sequence_name => name).update(:sequence_name => name.sub(/__/, '_'))
       end
 
-
       next unless name.match(/\/repositories\/(\d)+\/(resource|digital_object|classification)s\/(\d+)_\/repositories\/\d+\/(archival_object|digital_object_component|classification_term)s\/(\d+)_children_position/)
 
-      repo_id, root_id, record_type, tree_node_id = $1, $3, $4, $5
+      repo_id, root_record_type, root_id, record_type, tree_node_id = $1, $2, $3, $4, $5
 
-      all_sequences = self[:sequence].where(Sequel.like(:sequence_name, "%_repositories/#{repo_id}/#{record_type}s/#{tree_node_id}_children_position")).order(:value)
+      all_sequences = self[:sequence].where(Sequel.like(:sequence_name, "%\_/repositories/#{repo_id}/#{record_type}s/#{tree_node_id}\_children\_position")).order(:value)
 
       next unless all_sequences.select(:sequence_name).first[:sequence_name] == name
 
       sequence_val = if all_sequences.count > 1
+                       puts "Merging duplicates for sequence: #{name}"
                        # reset the sequence value if there are multiple versions
-                       self[record_type.intern].filter(:parent_id => tree_node_id).order(:position).select(:position).last[:position]
+                       children = self[record_type.intern].filter(:parent_id => tree_node_id)
+                       if children.count == 0
+                         0
+                       else
+                         self[record_type.intern].filter(:parent_id => tree_node_id).order(:position).select(:position).last[:position]
+                       end
                      else
                        row[:value]
                      end
@@ -37,14 +53,16 @@ Sequel.migration do
 
       # update the name and value
       new_name = "/repositories/#{repo_id}/#{record_type}s/#{tree_node_id}_children_position"
+
       self[:sequence].insert(:sequence_name => new_name, :value => sequence_val)
     end
+
+    end_time = Time.now
+
+    puts "Total time to rename sequences: #{end_time - start_time}"
   end
 
   down do
 
   end
 end
-
-
-


### PR DESCRIPTION
This is a pretty radical change to address the problem of transferred nodes having corrupt sequence values and duplicate sequences.

Instead of naming sequences using the root record's uri and the node's uri, just use the node's uri. Is there a reason not to do this? I can't think of / recall one. Are two uri's ever better than one?

Unfortunately, this create a very long migration for large repositories. 

@cfitz - what do you think? I want to pass this on to Duke to test, but will hold off if you have any concerns.



