### PR TITLE
Issue #284 https://github.com/archivesspace/archivesspace/issues/284 …

### DIFF
--- a/common/aspace_gems.rb
+++ b/common/aspace_gems.rb
@@ -30,7 +30,7 @@ class ASpaceGems
     ASUtils.find_local_directories.each do |plugin|
       gemdir = File.join(plugin, "gems")
 
-      if Dir.exists?(gemdir)
+      if gemdir && Dir.exists?(gemdir)
         gem_paths << gemdir
       end
     end

--- a/common/asutils.rb
+++ b/common/asutils.rb
@@ -82,7 +82,7 @@ module ASUtils
     [java.lang.System.get_property("ASPACE_LAUNCHER_BASE"),
      java.lang.System.get_property("catalina.base"),
      File.join(*[File.dirname(__FILE__), "..", root].compact)].find {|dir|
-      Dir.exists?(dir)
+      dir && Dir.exists?(dir)
     }
   end
 


### PR DESCRIPTION
… Dir.exists? nil breaks on jruby

https://github.com/archivesspace/archivesspace/issues/284


It appears that this change in behavior makes jruby conform closer to ruby-1.9.3, so it needs to be fixed in aspace_gems. 

