### PR TITLE
Hide db username and password in logs

### DIFF
--- a/backend/app/main.rb
+++ b/backend/app/main.rb
@@ -85,7 +85,7 @@ class ArchivesSpaceService < Sinatra::Base
       if !DB.connected?
         Log.error("***** DATABASE CONNECTION FAILED *****\n" +
                   "\n" +
-                  "ArchivesSpace could not connect to your specified database URL (#{AppConfig[:db_url]}).\n\n" +
+                  "ArchivesSpace could not connect to your specified database URL (#{AppConfig[:db_url_redacted]}).\n\n" +
                   "Please check your configuration and try again.")
         raise "Database connection failed"
       end

--- a/backend/app/model/db.rb
+++ b/backend/app/model/db.rb
@@ -25,7 +25,7 @@ class DB
       end
 
       begin
-        Log.info("Connecting to database: #{AppConfig[:db_url]}")
+        Log.info("Connecting to database: #{AppConfig[:db_url_redacted]}")
         pool = Sequel.connect(AppConfig[:db_url],
                               :max_connections => AppConfig[:db_max_connections],
                               :test => true,

--- a/build/scripts/migrate_db.rb
+++ b/build/scripts/migrate_db.rb
@@ -39,7 +39,7 @@ begin
 
     end
 
-    puts "Running migrations against #{AppConfig[:db_url]}"
+    puts "Running migrations against #{AppConfig[:db_url_redacted]}"
     DBMigrator.setup_database(db)
     puts "All done."
   end

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -29,6 +29,7 @@ AppConfig[:indexer_thread_count] = 4
 AppConfig[:allow_other_unmapped] = false
 
 AppConfig[:db_url] = proc { AppConfig.demo_db_url }
+AppConfig[:db_url_redacted] = proc { AppConfig[:db_url].gsub(/(user|password)=(.*?)&/, '\1=[REDACTED]&') }
 AppConfig[:db_max_connections] = 10
 # Set to true if you have enabled MySQL binary logging
 AppConfig[:mysql_binlog] = false


### PR DESCRIPTION
Logs tend to get shipped around, emailed etc. so it's not secure
having the db username and user password stored in the log.