### PR TITLE
AR-1183 another bug fix for certain conditions on moving things around

### DIFF
--- a/frontend/app/controllers/classifications_controller.rb
+++ b/frontend/app/controllers/classifications_controller.rb
@@ -137,8 +137,12 @@ class ClassificationsController < ApplicationController
     flash.keep
 
     tree = []
+    limit_to = if  params[:node_uri] && !params[:node_uri].include?("/classifications/") 
+                 params[:node_uri]
+               else
+                 "root"
+               end
 
-    limit_to = params[:node_uri] || "root"
 
     if !params[:hash].blank?
       node_id = params[:hash].sub("tree::", "").sub("#", "")

--- a/frontend/app/controllers/digital_objects_controller.rb
+++ b/frontend/app/controllers/digital_objects_controller.rb
@@ -257,7 +257,11 @@ class DigitalObjectsController < ApplicationController
   def fetch_tree
     tree = {}
 
-    limit_to = params[:node_uri] || "root"
+    limit_to = if  params[:node_uri] && !params[:node_uri].include?("/digital_objects/") 
+                 params[:node_uri]
+               else
+                 "root"
+               end
 
     if !params[:hash].blank?
       node_id = params[:hash].sub("tree::", "").sub("#", "")

--- a/frontend/app/controllers/resources_controller.rb
+++ b/frontend/app/controllers/resources_controller.rb
@@ -273,7 +273,11 @@ class ResourcesController < ApplicationController
 
     tree = []
 
-    limit_to = params[:node_uri] || "root"
+    limit_to = if  params[:node_uri] && !params[:node_uri].include?("/resources/") 
+                 params[:node_uri]
+               else
+                 "root"
+               end
 
     if !params[:hash].blank?
       node_id = params[:hash].sub("tree::", "").sub("#", "")

--- a/selenium/common/webdriver.rb
+++ b/selenium/common/webdriver.rb
@@ -21,6 +21,11 @@ module DriverMixin
     end
   end
 
+  def wait_until_gone(*selector)
+      timeout = 5
+      wait = Selenium::WebDriver::Wait.new(timeout: timeout)
+      wait.until { !self.find_element_orig(*selector).displayed? }
+  end
 
   def test_group_prefix
     if ENV['TEST_ENV_NUMBER']

--- a/selenium/spec/trees_spec.rb
+++ b/selenium/spec/trees_spec.rb
@@ -338,6 +338,7 @@ describe "Tree UI" do
       offset = ( ( target.location[:y] - a.location[:y] ) - 7 ) 
       @driver.action.click(a).key_down(:shift).click(b).key_up(:shift).drag_and_drop_by(a, 0, offset).perform
       @driver.wait_for_ajax
+      @driver.wait_until_gone(:css, ".spinner") 
     end
 
     # everything should be normal
@@ -356,6 +357,7 @@ describe "Tree UI" do
       offset = ( ( target.location[:y] - a.location[:y] ) + 7 ) 
       @driver.action.click(a).key_down(:shift).click(b).key_up(:shift).drag_and_drop_by(a, 0, offset).perform
       @driver.wait_for_ajax
+      @driver.wait_until_gone(:css, ".spinner") 
     end
     
     # back to normal 
@@ -374,6 +376,7 @@ describe "Tree UI" do
       offset = ( ( target.location[:y] - a.location[:y] ) + 7 ) 
       @driver.action.click(a).key_down(:shift).click(b).key_up(:shift).drag_and_drop_by(a, 0, offset).perform
       @driver.wait_for_ajax
+      @driver.wait_until_gone(:css, ".spinner") 
     end
     
     # and again back to normal 
@@ -391,6 +394,8 @@ describe "Tree UI" do
 
     offset = ( ( target.location[:y] - a.location[:y] ) - 7 ) 
     @driver.action.click(a).key_down(:shift).click(b).key_up(:shift).drag_and_drop_by(a, 0, offset).perform
+    @driver.wait_for_ajax
+    @driver.wait_until_gone(:css, ".spinner") 
    
     # heres the new order of our AOs. all on one level
     new_order = (0..9).to_a + [ @a1.title, @a2.title, @a3.title ]
@@ -412,6 +417,7 @@ describe "Tree UI" do
       offset = ( ( target.location[:y] - a.location[:y] ) - 7 ) 
       @driver.action.click(a).key_down(:shift).click(b).key_up(:shift).drag_and_drop_by(a, 0, offset).perform
       @driver.wait_for_ajax
+      @driver.wait_until_gone(:css, ".spinner") 
       new_order.each_with_index do |v, i|   
         assert(5) {
           @driver.find_element( :xpath => "//li[a/@title='#{@r.title}']/ul/li[position() = #{i + 1 }]/a/span/span[@class='title-column pull-left']").text.should match(/#{v}/)
@@ -430,6 +436,7 @@ describe "Tree UI" do
       offset = ( ( target.location[:y] - a.location[:y] ) + 7 ) 
       @driver.action.click(a).key_down(:shift).click(b).key_up(:shift).drag_and_drop_by(a, 0, offset).perform
       @driver.wait_for_ajax
+      @driver.wait_until_gone(:css, ".spinner") 
       new_order.each_with_index do |v, i|   
         assert(5) {
           @driver.find_element( :xpath => "//li[a/@title='#{@r.title}']/ul/li[position() = #{i + 1 }]/a/span/span[@class='title-column pull-left']").text.should match(/#{v}/)
@@ -449,6 +456,7 @@ describe "Tree UI" do
       offset = ( ( target.location[:y] - a.location[:y] ) + 7 ) 
       @driver.action.click(a).key_down(:shift).click(b).key_up(:shift).drag_and_drop_by(a, 0, offset).perform
       @driver.wait_for_ajax
+      @driver.wait_until_gone(:css, ".spinner") 
       new_order.each_with_index do |v, i|   
         assert(5) {
           @driver.find_element( :xpath => "//li[a/@title='#{@r.title}']/ul/li[position() = #{i + 1 }]/a/span/span[@class='title-column pull-left']").text.should match(/#{v}/)


### PR DESCRIPTION
there's some odd things that happen sometimes that the JS doesn't like when moving objects around at the top level. Some browsers don't seem to mind...also it seems to matter if the app is packaged or in devserver mode. Uh..this double checks what's being requested to the frontend. 