### PR TITLE
Use the hash syntax when translating enumeration values in the listing.

### DIFF
--- a/frontend/app/views/enumerations/_list.html.erb
+++ b/frontend/app/views/enumerations/_list.html.erb
@@ -26,7 +26,7 @@
       <% @enumeration["enumeration_values"].each_with_index do |enum_value, i| %>
         <tr>
           <td><%= enum_value["value"] %></td>
-          <td><%= I18n.t("enumerations.#{@enumeration["name"]}.#{enum_value["value"]}", :default => enum_value['value']) %></td>
+          <td><%= I18n.t({:enumeration => @enumeration['name'], :value => enum_value['value']}, :default => enum_value['value']) %></td>
           <td> 
             <%= enum_value["position"] %> 
             <% unless i == 0 %>   


### PR DESCRIPTION
Avoids problems when the enumeration value contains dots.