### PR TITLE
Add support for new "ID Lookup" endpoints.

### DIFF
--- a/backend/app/controllers/id_lookup_controller.rb
+++ b/backend/app/controllers/id_lookup_controller.rb
@@ -1,0 +1,29 @@
+class ArchivesSpaceService < Sinatra::Base
+
+  Endpoint.get('/repositories/:repo_id/find_by_id/archival_objects')
+    .description("Find Archival Objects by ref_id or component_id")
+    .params(["repo_id", :repo_id],
+            ["ref_id", [String], "A set of record Ref IDs", :optional => true],
+            ["component_id", [String], "A set of record component IDs", :optional => true],
+            ["resolve", :resolve])
+    .permissions([:view_repository])
+    .returns([200, "JSON array of refs"]) \
+  do
+    refs = IDLookup.new.find_by_ids(ArchivalObject, :ref_id => params[:ref_id], :component_id => params[:component_id])
+    json_response(resolve_references({'archival_objects' => refs}, params[:resolve]))
+  end
+
+
+  Endpoint.get('/repositories/:repo_id/find_by_id/digital_object_components')
+    .description("Find Digital Object Components by component_id")
+    .params(["repo_id", :repo_id],
+            ["component_id", [String], "A set of record component IDs", :optional => true],
+            ["resolve", :resolve])
+    .permissions([:view_repository])
+    .returns([200, "JSON array of refs"]) \
+  do
+    refs = IDLookup.new.find_by_ids(DigitalObjectComponent, :component_id => params[:component_id])
+    json_response(resolve_references({'digital_object_components' => refs}, params[:resolve]))
+  end
+
+end

--- a/backend/app/model/idlookup.rb
+++ b/backend/app/model/idlookup.rb
@@ -1,0 +1,20 @@
+class IDLookup
+
+  def find_by_ids(model, id_maps)
+    filters = {}
+
+    id_maps.each do |column, ids|
+      if !Array(ids).empty?
+        filters[column] = Array(ids)
+
+      end
+    end
+
+    return [] if filters.empty?
+
+    model.filter(filters).select(:id).map {|record|
+      {'ref' => record.uri}
+    }
+  end
+
+end

--- a/backend/spec/controller_idlookup_spec.rb
+++ b/backend/spec/controller_idlookup_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe 'ID Lookup controller' do
+
+  let (:archival_objects) {(0..5).map {|_| create(:json_archival_object, :component_id => SecureRandom.hex)}}
+  let (:digital_object_components) {(0..5).map {|_| create(:json_digital_object_component, :component_id => SecureRandom.hex)}}
+
+  it "lets you find archival objects by ref_id or component_id" do
+    ['ref_id', 'component_id'].each do |id_field|
+      get "#{$repo}/find_by_id/archival_objects", {"#{id_field}[]" => archival_objects.map {|ao| ao[id_field]}}
+      last_response.should be_ok
+      ao_lookup = ASUtils.json_parse(last_response.body)
+
+      ao_lookup['archival_objects'].length.should eq(archival_objects.length), "Failed lookup by #{id_field}"
+    end
+  end
+
+  it "lets you find digital objects by component_id" do
+    ['component_id'].each do |id_field|
+      get "#{$repo}/find_by_id/digital_object_components", {"#{id_field}[]" => digital_object_components.map {|doc| doc[id_field]}}
+      last_response.should be_ok
+      doc_lookup = ASUtils.json_parse(last_response.body)
+
+      doc_lookup['digital_object_components'].length.should eq(digital_object_components.length), "Failed lookup by #{id_field}"
+    end
+  end
+
+  it "can resolve the response it gets back" do
+    ao = create(:json_archival_object)
+    get "#{$repo}/find_by_id/archival_objects", {
+          "ref_id[]" => ao['ref_id'],
+          "resolve[]" => "archival_objects"
+        }
+
+    last_response.should be_ok
+    ao_lookup = ASUtils.json_parse(last_response.body)
+
+    ao_lookup['archival_objects'][0]['_resolved']['title'].should eq(ao['title'])
+  end
+
+end

--- a/common/asconstants.rb
+++ b/common/asconstants.rb
@@ -42,7 +42,7 @@ module ASConstants
   def self.SCHEMA_INFO
     return @SCHEMA_INFO if @SCHEMA_INFO
     # this gets changed by dist ant task 
-    @SCHEMA_INFO = 59
+    @SCHEMA_INFO = 60
   end
 
 end

--- a/common/db/migrations/060_index_id_lookup_fields.rb
+++ b/common/db/migrations/060_index_id_lookup_fields.rb
@@ -1,0 +1,27 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    alter_table(:archival_object) do
+      add_index(:ref_id)
+      add_index(:component_id)
+    end
+
+    alter_table(:digital_object_component) do
+      add_index(:component_id)
+    end
+  end
+
+  down do
+    alter_table(:archival_object) do
+      drop_index(:ref_id)
+      drop_index(:component_id)
+    end
+
+    alter_table(:digital_object_component) do
+      drop_index(:component_id)
+    end
+  end
+
+end


### PR DESCRIPTION
Hi there,

This is based on some work that Hudmol is doing with Artefactual to help them with their integration between Archivematica and ArchivesSpace.  I've added some new endpoints that will ultimately be used by Rockefeller and Bentley.

I've popped in a few unit tests and have also added some new DB indexes for these columns.  I bumped the migration counter in asconstants.rb too--hopefully that was the right thing to do :)

Thanks,

Mark

-----
This commit adds some new endpoints to be used by the integration
between ArchivesSpace and Archivematica.  They allow you to provide
either a ref_id or a component_id and get back a list of matching
Archival Objects or Digital Object Components.