### PR TITLE
Return a 200 HTTP response and an indicator of what happened

### DIFF
--- a/backend/app/controllers/users.rb
+++ b/backend/app/controllers/users.rb
@@ -239,6 +239,9 @@ class ArchivesSpaceService < Sinatra::Base
   do
     if session
       Session.expire(session.id)
+      json_response('status' => 'session_logged_out')
+    else
+      json_response('status' => 'no_active_session')
     end
   end
 


### PR DESCRIPTION
Just a small change to ensure we return a sane 200 response when logging out a session.