### PR TITLE
Add a new "checkindex" script for invoking Lucene's CheckIndex tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,20 @@ For example:
            /path/to/archivesspace/data/
 
 
+### Checking your search indexes
+
+ArchivesSpace ships with a script that can run Lucene's CheckIndex
+tool for you, verifying that a given Solr index is free from
+corruption.  To test an index, run the following command from your
+`archivesspace` directory:
+
+     # Or scripts/checkindex.bat for Windows
+     scripts/checkindex.sh data/solr_index/index
+
+You can use the same script to check that your Solr backups are valid:
+
+     scripts/checkindex.sh /unpacked/zip/solr.backup-26475-1373323208/snapshot.20130709084008464
+
 
 # Re-creating indexes
 

--- a/build/build.xml
+++ b/build/build.xml
@@ -599,6 +599,7 @@
     <copy file="../indexer/indexer.war" todir="target/archivesspace/wars" />
 
     <copy file="scripts/migrate_db.rb" todir="target/archivesspace/scripts/rb" />
+    <copy file="scripts/checkindex.rb" todir="target/archivesspace/scripts/rb" />
 
     <copy todir="target/archivesspace/gems">
       <fileset dir="gems" excludes="cache/*,doc/*,gems/jruby-jars-1.7.11/lib/*.dev.jar,gems/saxon-xslt-0.5.1-java/spec/" />
@@ -660,6 +661,8 @@
       <zipfileset dir="../launcher/scripts" includes="find-base.sh" prefix="archivesspace/scripts" filemode="755" />
       <zipfileset dir="../launcher/scripts" includes="setup-database.sh" prefix="archivesspace/scripts" filemode="755" />
       <zipfileset dir="../launcher/scripts" includes="setup-database.bat" prefix="archivesspace/scripts" filemode="755" />
+      <zipfileset dir="../launcher/scripts" includes="checkindex.sh" prefix="archivesspace/scripts" filemode="755" />
+      <zipfileset dir="../launcher/scripts" includes="checkindex.bat" prefix="archivesspace/scripts" filemode="755" />
       <zipfileset dir="../launcher/tomcat" includes="configure-tomcat.sh" prefix="archivesspace/scripts" filemode="755" />
       <zipfileset dir="../launcher/tomcat" includes="configure-tomcat.bat" prefix="archivesspace/scripts" filemode="644" />
       <zipfileset dir="../launcher/plugin_gems" includes="initialize-plugin.sh" prefix="archivesspace/scripts" filemode="755" />

--- a/build/scripts/checkindex.rb
+++ b/build/scripts/checkindex.rb
@@ -1,0 +1,87 @@
+require 'java'
+require 'tempfile'
+
+class CheckIndex
+
+  LUCENE_JAR_PATTERN = /lucene-core-[0-9].*\.jar$/
+
+  # Extract Lucene from the Solr war file and run CheckIndex.
+  def check(args)
+    lucene_jar = extract_zip_entry_to_tempfile(find_solr_war) {|entry| entry.get_name =~ LUCENE_JAR_PATTERN}
+
+    begin
+      launch_check_index(lucene_jar, args)
+    ensure
+      lucene_jar.delete
+    end
+  end
+
+
+  private
+
+  def find_solr_war
+    [File.dirname(__FILE__) + "/../solr-*.war",
+     File.dirname(__FILE__) + "/../../wars/solr.war"].each do |glob|
+      match = Dir.glob(glob).first
+      return match if match
+    end
+
+    raise "Solr war file not found"
+  end
+
+  def extract_zip_entry_to_tempfile(zipfile, &entry_matcher)
+    zip = java.util.zip.ZipFile.new(zipfile)
+    tempfile = java.io.File.createTempFile("tempfile", "")
+    entries = zip.entries
+
+    found = true
+    while entries.has_more_elements
+      entry = entries.next_element
+
+      if entry_matcher.call(entry)
+        jar_stream = zip.get_input_stream(entry)
+        out = java.io.FileOutputStream.new(tempfile)
+
+        copy_stream(jar_stream, out)
+        found = true
+        break
+      end
+    end
+
+    if found
+      tempfile
+    else
+      raise "Matching entry not found in zip file"
+    end
+  end
+
+  def copy_stream(from, to)
+    begin
+      buf = Java::byte[4096].new
+
+      while (len = from.read(buf)) >= 0
+        to.write(buf, 0, len)
+      end
+    ensure
+      to.close
+      from.close
+    end
+  end
+
+  def launch_check_index(lucene_file, args)
+    classloader = java.net.URLClassLoader.new([lucene_file.to_url].to_java(java.net.URL))
+    classloader.set_default_assertion_status(true)
+
+    java.lang.Thread.current_thread.set_context_class_loader(classloader)
+
+    checkindex = classloader.load_class("org.apache.lucene.index.CheckIndex")
+    method = checkindex.get_method("main", [].to_java(java.lang.String).class)
+
+    method.invoke(checkindex, [args.to_java(java.lang.String)].to_java(java.lang.Object))
+  end
+
+end
+
+
+CheckIndex.new.check(ARGV)
+

--- a/launcher/scripts/checkindex.bat
+++ b/launcher/scripts/checkindex.bat
@@ -1,0 +1,14 @@
+@echo off
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+cd /d %~dp0%
+
+set GEM_HOME=%~dp0%\..\gems
+set GEM_PATH=
+
+set JRUBY=
+FOR /D %%c IN (..\gems\gems\jruby-*) DO (
+  set JRUBY=!JRUBY!;%%c\lib\*
+)
+
+java %JAVA_OPTS% -cp "..\lib\*!JRUBY!" org.jruby.Main --1.9 ..\scripts\rb\checkindex.rb %*

--- a/launcher/scripts/checkindex.sh
+++ b/launcher/scripts/checkindex.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+export ORIG_PWD="$PWD"
+export ASPACE_LAUNCHER_BASE="$("`dirname $0`"/find-base.sh)"
+
+cd "$ASPACE_LAUNCHER_BASE/scripts"
+
+export GEM_HOME="$PWD/../gems"
+export GEM_PATH=
+
+export JRUBY=
+for dir in ../gems/gems/jruby-*; do
+    JRUBY="$JRUBY:$dir/lib/*"
+done
+
+
+java $JAVA_OPTS -cp "../lib/*$JRUBY" org.jruby.Main --1.9 ../scripts/rb/checkindex.rb ${1+"$@"}


### PR DESCRIPTION
Potentially useful for verifying backups and checking that an index is OK post-rebuild.  I've tested this under Linux & Windows 8:

     $ scripts/checkindex.sh $as/build/solr_index/index/

     Opening index @ /home/mst/projects/archivesspace/build/solr_index/index/

     Segments file=segments_b numSegments=2 version=4.0.0.2 format= userData={commitTimeMSec=1443996386948}
       1 of 2: name=_0 docCount=1
         codec=Lucene40
         compound=false
         numFiles=10
         size (MB)=0.004
         diagnostics = {os=Linux, java.vendor=Oracle Corporation, java.version=1.8.0_31, lucene.version=4.0.0 1394950 - rmuir - 2012-10-06 03:00:40, os.arch=amd64, source=flush, os.version=3.16.0-4-amd64}
         no deletions
         test: open reader.........OK
         test: fields..............OK [16 fields]
         test: field norms.........OK [6 fields]
         test: terms, freq, prox...OK [41 terms; 41 terms/docs pairs; 40 tokens]
         test: stored fields.......OK [14 total field count; avg 14 fields per doc]
         test: term vectors........OK [0 total vector count; avg 0 term/freq vector fields per doc]
         test: DocValues........OK [0 total doc Count; Num DocValues Fields 0

       2 of 2: name=_1 docCount=3
         codec=Lucene40
         compound=false
         numFiles=10
         size (MB)=0.009
         diagnostics = {os=Linux, java.vendor=Oracle Corporation, java.version=1.8.0_31, lucene.version=4.0.0 1394950 - rmuir - 2012-10-06 03:00:40, os.arch=amd64, source=flush, os.version=3.16.0-4-amd64}
         no deletions
         test: open reader.........OK
         test: fields..............OK [22 fields]
         test: field norms.........OK [7 fields]
         test: terms, freq, prox...OK [96 terms; 184 terms/docs pairs; 379 tokens]
         test: stored fields.......OK [52 total field count; avg 17.333 fields per doc]
         test: term vectors........OK [0 total vector count; avg 0 term/freq vector fields per doc]
         test: DocValues........OK [0 total doc Count; Num DocValues Fields 0

     No problems were detected with this index.