### PR TITLE
AR-1134 and AR-1270: account for all physdesc subtags in EAD import

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -247,8 +247,12 @@ class EADConverter < Converter
       dimensions_texts = []
       physfacet_texts = []
     
-      # If there is already a portion specified, use it
-      portion = att('altrender') || 'whole'
+      # If there is already a portion of 'part' specified, use it
+      if att('altrender').downcase == 'part'
+        portion = 'part'
+      else
+        portion = 'whole'
+      end
     
       physdesc.children.each do |child|
         # "extent" can have one of two kinds of semantic meanings: either a true extent with number and type,

--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -248,7 +248,7 @@ class EADConverter < Converter
       physfacet_texts = []
     
       # If there is already a portion of 'part' specified, use it
-      if att('altrender').downcase == 'part'
+      if att('altrender') && att('altrender').downcase == 'part'
         portion = 'part'
       else
         portion = 'whole'

--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -204,50 +204,109 @@ class EADConverter < Converter
     end
 
 
+    def make_single_note(note_name, tag, tag_name="")
+      content = tag.inner_text
+      if !tag_name.empty?
+        content = tag_name + ": " + content
+      end
+      make :note_singlepart, {
+        :type => note_name,
+        :persistent_id => att('id'),
+        :content => format_content( content.sub(/<head>.?<\/head>/, '').strip)
+      } do |note|
+        set ancestor(:resource, :archival_object), :notes, note
+      end
+    end
+    
+    def make_nested_note(note_name, tag)
+      content = tag.inner_text
+    
+      make :note_multipart, {
+        :type => note_name,
+        :persistent_id => att('id'),
+        :subnotes => {
+          'jsonmodel_type' => 'note_text',
+          'content' => format_content( content )
+        }
+      } do |note|
+        set ancestor(:resource, :archival_object), :notes, note
+      end
+    end
+    
     with 'physdesc' do
       physdesc = Nokogiri::XML::DocumentFragment.parse(inner_xml)
+    
       extent_number_and_type = nil
+    
+      dimensions = []
+      physfacets = []
+      container_summaries = []
       other_extent_data = []
-      make_note_too = false
+    
+      container_summary_texts = []
+      dimensions_texts = []
+      physfacet_texts = []
+    
+      # If there is already a portion specified, use it
+      portion = att('altrender') || 'whole'
+    
       physdesc.children.each do |child|
-        if child.respond_to?(:name) && child.name == 'extent'
-          child_content = child.content.strip 
+        # "extent" can have one of two kinds of semantic meanings: either a true extent with number and type,
+        # or a container summary. Disambiguation is done through a regex.
+        if child.name == 'extent'
+          child_content = child.content.strip
           if extent_number_and_type.nil? && child_content =~ /^([0-9\.]+)+\s+(.*)$/
             extent_number_and_type = {:number => $1, :extent_type => $2}
           else
-            other_extent_data << child_content
+            container_summaries << child
+            container_summary_texts << child.content.strip
           end
-        else
-          # there's other info here; make a note as well
-          make_note_too = true unless child.text.strip.empty?
+    
+        elsif child.name == 'physfacet'
+          physfacets << child
+          physfacet_texts << child.content.strip
+    
+        elsif child.name == 'dimensions'
+          dimensions << child
+          dimensions_texts << child.content.strip
+    
+        elsif child.name != 'text'
+          other_extent_data << child
         end
       end
-
-      # only make an extent if we got a number and type
+    
+      # only make an extent if we got a number and type, otherwise put all tags in the physdesc in new notes
       if extent_number_and_type
         make :extent, {
           :number => $1,
           :extent_type => $2,
-          :portion => 'whole',
-          :container_summary => other_extent_data.join('; ')
+          :portion => portion,
+          :container_summary => container_summary_texts.join('; '),
+          :physical_details => physfacet_texts.join('; '),
+          :dimensions => dimensions_texts.join('; ')
         } do |extent|
           set ancestor(:resource, :archival_object), :extents, extent
         end
+    
+      # there's no true extent; split up the rest into individual notes
       else
-        make_note_too = true;
-      end
-
-      if make_note_too
-        content =  physdesc.to_xml(:encoding => 'utf-8') 
-        make :note_singlepart, {
-          :type => 'physdesc',
-          :persistent_id => att('id'),
-          :content => format_content( content.sub(/<head>.*?<\/head>/, '').strip )
-        } do |note|
-          set ancestor(:resource, :archival_object), :notes, note
+        container_summaries.each do |summary|
+          make_single_note("physdesc", summary)
+        end
+    
+        physfacets.each do |physfacet|
+          make_single_note("physfacet", physfacet)
+        end
+        
+        dimensions.each do |dimension|
+          make_nested_note("dimensions", dimension)
         end
       end
-
+    
+      other_extent_data.each do |unknown_tag|
+        make_single_note("physdesc", unknown_tag, unknown_tag.name)
+      end
+    
     end
 
 
@@ -318,7 +377,7 @@ class EADConverter < Converter
 
     %w(accessrestrict accessrestrict/legalstatus \
        accruals acqinfo altformavail appraisal arrangement \
-       bioghist custodhist dimensions \
+       bioghist custodhist \
        fileplan odd otherfindaid originalsloc phystech \
        prefercite processinfo relatedmaterial scopecontent \
        separatedmaterial userestrict ).each do |note|
@@ -343,7 +402,7 @@ class EADConverter < Converter
     end
 
 
-    %w(abstract materialspec physfacet physloc).each do |note|
+    %w(abstract materialspec physloc).each do |note|
       with note do |node|
         content = inner_xml
 

--- a/backend/app/exporters/examples/ead/at-tracer.xml
+++ b/backend/app/exporters/examples/ead/at-tracer.xml
@@ -67,9 +67,11 @@
             </langmaterial>
             <container id="cid1" type="Box" label="Text">1</container>
             <container parent="cid1" type="Folder">1</container>
-            <physdesc>
+            <physdesc altrender="Part">
                 <extent>5.0 Linear feet</extent>
                 <extent>Resource-ContainerSummary-AT</extent>
+                <physfacet>Resource-PhysicalFacet-AT</physfacet>
+                <dimensions>Resource-Dimensions-AT</dimensions>
             </physdesc>
             <unitdate normal="1960/1970" type="bulk">Bulk, 1960-1970</unitdate>
             <unitdate normal="1960/1970" type="inclusive">Resource-Title-AT</unitdate>

--- a/backend/app/exporters/examples/ead/at-tracer.xml
+++ b/backend/app/exporters/examples/ead/at-tracer.xml
@@ -67,7 +67,7 @@
             </langmaterial>
             <container id="cid1" type="Box" label="Text">1</container>
             <container parent="cid1" type="Folder">1</container>
-            <physdesc altrender="Part">
+            <physdesc altrender="part">
                 <extent>5.0 Linear feet</extent>
                 <extent>Resource-ContainerSummary-AT</extent>
                 <physfacet>Resource-PhysicalFacet-AT</physfacet>

--- a/backend/spec/lib_ead_converter_spec.rb
+++ b/backend/spec/lib_ead_converter_spec.rb
@@ -134,13 +134,22 @@ ANEAD
       # 	ELSE
     end
 
-    it "maps '<extent>' correctly" do
+    it "maps '<physdesc>' correctly" do
+      # <extent> tag mapping
       #  	IF value starts with a number followed by a space and can be parsed
       @resource['extents'][0]['number'].should eq("5.0")
       @resource['extents'][0]['extent_type'].should eq("Linear feet")
-
+ 
       # 	ELSE
       @resource['extents'][0]['container_summary'].should eq("Resource-ContainerSummary-AT")
+
+
+      # further physdesc tags - dimensions and physfacet tags are mapped appropriately
+      @resource['extents'][0]['dimensions'].should eq("Resource-Dimensions-AT")
+      @resource['extents'][0]['physical_details'].should eq("Resource-Physfacet-AT")
+
+      # physdesc altrender mapping
+      @resource['extents'][0]['portion'].should eq("part")
     end
 
 


### PR DESCRIPTION
JIRA references: [AR-1134](https://archivesspace.atlassian.net/browse/AR-1134), [AR-1270](https://archivesspace.atlassian.net/browse/AR-1270)

We (at the Bentley Historical Library) wrote up a local fix for these issues, and thought we'd pass it upstream. Happy to refactor / edit if anything seems off!

Previous behavior: given an EAD containing the physdesc below, the ASpace EAD importer would separate the ```<physfacet>``` and ```<dimensions>``` tags into individual ASpace notes, removing them from their intended context within the described extent. It also does not currently account for pre-designated altrenders on physdescs (corresponding to the "portion" attribute of an ASpace extent), instead assuming that all individual extents should be "whole" when imported.

This PR should account for these issues, while retaining note-making behavior for ```<physfacet>```, ```<dimensions>```, container summaries, and other miscellaneous tags that appear on their own without a valid ```<extent>``` tag (one containing both a number and a type).

---------------

```xml
<physdesc altrender="Part">
    <extent>25 photographs</extent>
    <physfacet>black-and-white</physfacet>
    <dimensions>25" x 27"</dimensions>
<physdesc>
```

[note: this does not account for the issues described in [Mark Custer's comment on AR-1134](https://archivesspace.atlassian.net/browse/AR-1134?focusedCommentId=12902&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-12902).]