### PR TITLE
Enhancements to I18n handling when dealing with enumerations

### DIFF
--- a/backend/app/exporters/lib/exporter.rb
+++ b/backend/app/exporters/lib/exporter.rb
@@ -17,8 +17,6 @@ module ASpaceExport
     Dir.glob(File.dirname(__FILE__) + '/../serializers/*.rb', &method(:require))
     Dir.glob(File.dirname(__FILE__) + '/../models/*.rb', &method(:require))
 
-    I18n.enforce_available_locales = false # do not require locale to be in available_locales for export
-    I18n.load_path += ASUtils.find_locales_directories(File.join("enums", "#{AppConfig[:locale]}.yml"))
     @@initialized = true
   end
 

--- a/backend/app/lib/aspace_i18n.rb
+++ b/backend/app/lib/aspace_i18n.rb
@@ -1,0 +1,19 @@
+require 'i18n'
+require 'aspace_i18n_enumeration_support'
+
+I18n.enforce_available_locales = false # do not require locale to be in available_locales for export
+I18n.load_path += ASUtils.find_locales_directories(File.join("enums", "#{AppConfig[:locale]}.yml"))
+
+# Allow overriding of the i18n locales via the 'local' folder(s)
+ASUtils.wrap(ASUtils.find_local_directories).map{|local_dir| File.join(local_dir, 'frontend', 'locales')}.reject { |dir| !Dir.exists?(dir) }.each do |locales_override_directory|
+  I18n.load_path += Dir[File.join(locales_override_directory, '**' , '*.{rb,yml}')]
+end
+
+
+module I18n
+
+  def self.t(*args)
+    self.t_raw(*args)
+  end
+
+end

--- a/backend/app/lib/bootstrap.rb
+++ b/backend/app/lib/bootstrap.rb
@@ -26,6 +26,7 @@ require_relative 'exceptions'
 require_relative 'logging'
 require 'config/config-distribution'
 require_relative 'username'
+require_relative 'aspace_i18n'
 
 
 class ASpaceEnvironment

--- a/common/aspace_i18n_enumeration_support.rb
+++ b/common/aspace_i18n_enumeration_support.rb
@@ -1,0 +1,38 @@
+# Define a new :t_raw method that knows how to handle ArchivesSpace-specific
+# enumeration translations.
+#
+# Called by both the ArchivesSpace backend and frontend, so avoid any Rails-isms
+# here.
+
+module I18n
+
+  def self.t_raw(*args)
+    key = args[0]
+    default = if args[1].is_a?(String)
+                args[1]
+              else
+                (args[1] || {}).fetch(:default, "")
+              end
+
+    # String
+    if key && key.kind_of?(String) && key.end_with?(".")
+      return default
+    end
+
+    # Hash / Enumeration Value
+    if key && key.kind_of?(Hash) && key.has_key?(:enumeration)
+      backend  = config.backend
+      locale   = config.locale
+      # Null character to cope with enumeration values containing dots.  Eugh.
+      translation = backend.send(:lookup, locale, ['enumerations', key[:enumeration], key[:value]].join("\0"), [], {:separator => "\0"}) || default
+
+      if translation && !translation.empty?
+        return translation
+      end
+    end
+
+
+    self.translate(*args)
+  end
+
+end

--- a/frontend/app/helpers/aspace_form_helper.rb
+++ b/frontend/app/helpers/aspace_form_helper.rb
@@ -771,7 +771,7 @@ module AspaceFormHelper
 
       if schema and schema["properties"].has_key?(property)
         if (schema["properties"][property].has_key?('dynamic_enum'))
-          value = I18n.t("#{prefix}enumerations.#{schema["properties"][property]["dynamic_enum"]}.#{value}", :default => value)
+          value = I18n.t({:enumeration => schema["properties"][property]["dynamic_enum"], :value => value}, :default => value)
         elsif schema["properties"][property].has_key?("enum")
           value = I18n.t("#{prefix}#{jsonmodel_type.to_s}.#{property}_#{value}", :default => value)
         elsif schema["properties"][property]["type"] === "boolean"

--- a/frontend/config/initializers/i18n.rb
+++ b/frontend/config/initializers/i18n.rb
@@ -1,3 +1,5 @@
+require 'aspace_i18n_enumeration_support'
+
 module I18n
 
   # Override the I18n string pattern to take into account
@@ -36,34 +38,6 @@ module I18n
     results.nil? ? "" : results.html_safe
   end
 
-  def self.t_raw(*args)
-    key = args[0]
-    default = if args[1].is_a?(String)
-                args[1]
-              else
-                (args[1] || {}).fetch(:default, "")
-              end
-
-    # String
-    if key && key.kind_of?(String) && key.end_with?(".")
-      return default
-    end
-
-    # Hash / Enumeration Value
-    if key && key.kind_of?(Hash) && key.has_key?(:enumeration)
-      backend  = config.backend
-      locale   = config.locale
-      # Null character to cope with enumeration values containing dots.  Eugh.
-      translation =  backend.send(:lookup, locale, ['enumerations', key[:enumeration], key[:value]].join("\0"), [], {:separator => "\0"}) || default
-      
-      unless translation.blank?
-        return translation
-      end
-    end
-
-
-    self.translate(*args)
-  end
 end
 
 I18n.exception_handler = :try_really_hard_to_find_a_key


### PR DESCRIPTION
Here are some changes to I18n translations for enumerations that have come up while working with @jdshaw at Dartmouth.

A couple of changes around this:

  * Modified the backend to support the same method for looking up
    enumeration values (which might contain dots and other interesting
    characters).  Pulled the code that handles this out from the
    frontend initializer and into a common spot that both backend and
    frontend can use.

  * Have the backend load any plugin-supplied I18n yml files.
    Previously it was only looking at the distribution defaults.

  * Modify aspace_form_helper.rb to use the custom enumeration syntax
    when resolving enumeration values.  Ensures that enumeration values
    containing dots still get translated correctly.
