### PR TITLE
Ensure RDE template JavaScript targets the RDE table

### DIFF
--- a/frontend/app/assets/javascripts/rde.js
+++ b/frontend/app/assets/javascripts/rde.js
@@ -698,7 +698,7 @@ $(function() {
             defaults: {},
           }
 
-          var $firstRow = $("table tbody tr:first")
+          var $firstRow = $("table tbody tr:first", $rde_form);
 
          $("table .fieldset-labels th", $rde_form).each(function() {
             var colId = $(this).attr("id");
@@ -845,7 +845,7 @@ $(function() {
 
         applyColumnOrder();
 
-        var $firstRow = $("tbody tr:first");
+        var $firstRow = $("tbody tr:first", $rde_form);
 
         _.each($("td", $firstRow), function(td) {
           var $td = $( td );


### PR DESCRIPTION
In developing the "visible external IDs" feature, which displays a &lt;table&gt; of the record's external IDs on both the readonly and edit screens of the record, we hit a JavaScript error when trying save and apply RDE templates.  This patch is a simple fix to ensure the RDE JavaScript targets the RDE table, instead of the first table in the DOM, which could sometimes be the External IDs table.