### PR TITLE
Add support for extended EAD and MARC exports

### DIFF
--- a/backend/app/exporters/serializers/marc21.rb
+++ b/backend/app/exporters/serializers/marc21.rb
@@ -10,10 +10,23 @@ class MARCSerializer < ASpaceExport::Serializer
     builder
   end
 
+  # Allow plugins to wrap the MARC record with their own behavior.  Gives them
+  # the chance to change the leader, 008, add extra data fields, etc.
+  def self.add_decorator(decorator)
+    @decorators ||= []
+    @decorators << decorator
+  end
+
+  def self.decorate_record(record)
+    Array(@decorators).reduce(record) {|result, decorator|
+      decorator.new(result)
+    }
+  end
+
 
   def serialize(marc, opts = {})
 
-    builder = build(marc, opts)
+    builder = build(MARCSerializer.decorate_record(marc), opts)
 
     builder.to_xml
   end


### PR DESCRIPTION
Howdy,

As a part of some work with Dartmouth, I've extended the EAD and MARC exporters to give a spot for plugins to add extensions (adding new EAD tags and extra MARC control/data fields).  You can see how I'm using them here:

# Adding some user defined fields to EAD exports
https://github.com/hudmol/dartmouth_udf_exports/blob/master/backend/lib/ead_user_defined_field_serialize.rb#L5

# Adding new data fields to MARC exports
https://github.com/hudmol/dartmouth_udf_exports/blob/master/backend/lib/marc_user_defined_field_serialize.rb#L54

Does this seem general purpose enough to merge in?

Thanks!
Mark