### PR TITLE
[ead import] - fix primary language of material handling

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -174,8 +174,31 @@ class EADConverter < Converter
     end
 
 
-    with 'language' do |node|
-      set ancestor(:resource, :archival_object), :language, att('langcode')
+    with "langmaterial" do
+      # first, assign the primary language to the ead
+      langmaterial = Nokogiri::XML::DocumentFragment.parse(inner_xml)
+      langmaterial.children.each do |child|
+        if child.name == 'language'
+          set ancestor(:resource, :archival_object), :language, child.attr("langcode")
+          break
+        end
+      end
+
+      # write full tag content to a note, subbing out the language tags
+      content = inner_xml
+      next if content =~ /\A<language langcode=\"[a-z]+\"\/>\Z/
+
+      if content.match(/\A<language langcode=\"[a-z]+\"\s*>([^<]+)<\/language>\Z/)
+        content = $1
+      end
+
+      make :note_singlepart, {
+        :type => "langmaterial",
+        :persistent_id => att('id'),
+        :content => format_content( content.sub(/<head>.*?<\/head>/, '') )
+      } do |note|
+        set ancestor(:resource, :archival_object), :notes, note
+      end
     end
 
 
@@ -318,14 +341,9 @@ class EADConverter < Converter
     end
 
 
-    %w(abstract langmaterial materialspec physfacet physloc).each do |note|
+    %w(abstract materialspec physfacet physloc).each do |note|
       with note do |node|
         content = inner_xml
-        next if content =~ /\A<language langcode=\"[a-z]+\"\/>\Z/
-
-        if content.match(/\A<language langcode=\"[a-z]+\"\s*>([^<]+)<\/language>\Z/)
-          content = $1
-        end
 
         make :note_singlepart, {
           :type => note,


### PR DESCRIPTION
Fix for #326

Since since we're moving ```<langmaterial>``` handling elsewhere, and since ```<langmaterial>``` is the only tag in the (abstract langmaterial materialspec physfacet) list that can legally have a ```<language>``` subtag, we can also clear out the language tag removal code in that block.