### PR TITLE
Fix for #328 - Removes gsub from unitid handling

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -136,7 +136,7 @@ class EADConverter < Converter
           # end
           set obj, :id_0, inner_xml
         when 'archival_object'
-          set obj, :component_id, inner_xml.gsub(/[\/_\-.]/, '_')
+          set obj, :component_id, inner_xml
         end
       end
     end

--- a/backend/spec/lib_ead_converter_spec.rb
+++ b/backend/spec/lib_ead_converter_spec.rb
@@ -602,6 +602,47 @@ ANEAD
     end
   end
 
+  describe "Mapping '<unitid>' without altering content" do
+    def test_doc
+      src = <<ANEAD
+<ead>
+  <archdesc level="collection" audience="internal">
+  <did>
+       <descgrp>
+          <processinfo/>
+      </descgrp>
+      <unittitle>unitid test</unittitle>
+      <unitdate normal="1907/1911" era="ce" calendar="gregorian" type="inclusive">1907-1911</unitdate>
+      <unitid>Resource_ID/AT-thing.stuff</unitid>
+      <physdesc>
+       (folders 14–15 of 15 folders)
+        <extent>5.0 Linear feet</extent>
+      </physdesc>
+    </did>
+    <dsc>
+    <c id="1" level="file" audience="internal">
+      <unittitle>oh well</unittitle>
+      <unitdate normal="1907/1911" era="ce" calendar="gregorian" type="inclusive">1907-1911</unitdate>
+    </c>
+    </dsc>
+  </archdesc>
+</ead>
+ANEAD
+
+      get_tempfile_path(src)
+    end
+
+    before do
+      parsed = convert(test_doc)
+      @resource = parsed.find{|r| r['jsonmodel_type'] == 'resource'}
+      @components = parsed.select{|r| r['jsonmodel_type'] == 'archival_object'}
+    end
+
+    it "captures unitid content verbatim" do
+      expect(@resource["id_0"]).to eq("Resource_ID/AT-thing.stuff")
+    end
+  end
+
   describe "Mapping the EAD @audience attribute" do
     def test_doc
       src = <<ANEAD


### PR DESCRIPTION
Refs #328 

unitid content should not be rewritten on import, particularly in ways
that might produce the same value for different unitid values, e.g.
  - "this.id" != "this/id"
  - "not_the_same" != "not-the-same"

Note that the fix and test are pretty naive - if there is other stuff
depending on the textual structure of id_0, this will cause problems.