### PR TITLE
set migrate_to_container_management param to true(?)

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -212,4 +212,4 @@ AppConfig[:show_external_ids] = false
 # When updating from < v1.4.2, you will need to migrate your data to the new
 # container management model. This only needs to be done once during an
 # upgrade.
-AppConfig[:migrate_to_container_management]
+AppConfig[:migrate_to_container_management] = true


### PR DESCRIPTION
As the config-defaults is now, it will raise a "No value for config parameter" error. I set it to true, not sure if that's right. Is there actually any way to opt out of the new container management data model anyway? 