### PR TITLE
Skip adding p tags when result is invalid markup

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -33,12 +33,16 @@ class EADSerializer < ASpaceExport::Serializer
   def handle_linebreaks(content)
     # if there's already p tags, just leave as is
     return content if ( content.strip =~ /^<p(\s|\/|>)/ or content.strip.length < 1 )
+    original_content = content
     blocks = content.split("\n\n").select { |b| !b.strip.empty? }
     if blocks.length > 1
       content = blocks.inject("") { |c,n| c << "<p>#{n.chomp}</p>"  }
     else
       content = "<p>#{content.strip}</p>"
     end
+    # in some cases adding p tags can create invalid markup with mixed content
+    # the "wrap" is just to ensure that there is a psuedo root element to eliminate a "false" error
+    content = original_content if Nokogiri::XML("<wrap>#{content}</wrap>").errors.any?
     content
   end
 

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1006,4 +1006,34 @@ describe "EAD export mappings" do
       end
     end
   end
+
+  describe "Testing EAD Serializer mixed content behavior" do
+
+    let(:note_with_p) { "<p>A NOTE!</p>" }
+    let(:note_with_linebreaks) { "Something, something,\n\nsomething." }
+    let(:note_with_linebreaks_and_good_mixed_content) { "Something, something,\n\n<bioghist>something.</bioghist>\n\n" }
+    let(:note_with_linebreaks_and_evil_mixed_content) { "Something, something,\n\n<bioghist>something.\n\n</bioghist>\n\n" }
+    let(:serializer) { EADSerializer.new }
+
+    it "can strip <p> tags from content when disallowed" do
+      serializer.strip_p(note_with_p).should eq("A NOTE!")
+    end
+
+    it "can leave <p> tags in content" do
+      serializer.handle_linebreaks(note_with_p).should eq(note_with_p)
+    end
+
+    it "will add <p> tags to content with linebreaks" do
+      serializer.handle_linebreaks(note_with_linebreaks).should eq("<p>Something, something,</p><p>something.</p>")
+    end
+
+    it "will add <p> tags to content with linebreaks and mixed content" do
+      serializer.handle_linebreaks(note_with_linebreaks_and_good_mixed_content).should eq("<p>Something, something,</p><p><bioghist>something.</bioghist></p>")
+    end
+
+    it "will return original content when linebreaks and mixed content produce invalid markup" do
+      serializer.handle_linebreaks(note_with_linebreaks_and_evil_mixed_content).should eq(note_with_linebreaks_and_evil_mixed_content)
+    end
+
+  end
 end


### PR DESCRIPTION
Not sure this is the ideal solution, although I think it's probably a niche issue, but the problem being addressed is that handling linebreaks (via handle_linebreaks) with mixed content (that contains linebreaks) can in some cases produce invalid EAD / XML and therefore broken PDF generation.

It might be preferable to pluck out the linebreaks embedded in the mixed content (with a ugly regex?), but then again, it might not depending on local preferences (and there are so many variations on how data is entered and imported), so this approach just leaves the content alone if the generated markup is invalid.