### PR TITLE
adding some translations to event_event_type

### DIFF
--- a/common/locales/enums/en.yml
+++ b/common/locales/enums/en.yml
@@ -346,6 +346,7 @@ en:
       accumulation: Accumulation
       acknowledgement: Acknowledgement
       acknowledgement_sent: Acknowledgement Sent
+      acknowledgement_received: Acknowledgement Received
       agreement_received: Agreement Received
       agreement_sent: Agreement Sent
       agreement_signed: Agreement Signed
@@ -371,6 +372,9 @@ en:
       normalization: Normalization
       processed: Processed
       processing_new: Processing New
+      processing_started: Processing Started
+      processing_in_progress: Processing in Progress
+      processing_completed: Processing Completed
       publication: Publication
       replication: Replication
       rights_transferred: Rights Transferred


### PR DESCRIPTION
While I was testing AR-825 I noticed a couple of other translation missing errors. This fixes those minor issues, but I also know this is an area of ongoing discussion. I'm not taking sides on the whole processing status as collection management vs. events discussion... 

Also, "Processed" is already on the list, so I don't really even know if we need "Processing Completed."