### PR TITLE
Changes to avoid potential deadlocks when importing multiple files

### DIFF
--- a/backend/app/lib/find_and_replace_runner.rb
+++ b/backend/app/lib/find_and_replace_runner.rb
@@ -89,9 +89,10 @@ class FindAndReplaceRunner < JobRunner
             @job.write_output("All done, logging modified records.")
           end
 
+          self.success!
+
           # just reuse JobCreated api for now...
           @job.record_created_uris(modified_records.uniq)
-
         rescue Exception => e
           terminal_error = e
           raise Sequel::Rollback

--- a/backend/app/lib/job_runner.rb
+++ b/backend/app/lib/job_runner.rb
@@ -33,6 +33,19 @@ class JobRunner
   end
 
 
+  def add_success_hook(&block)
+    @success_hooks ||= []
+    @success_hooks << block
+  end
+
+
+  def success!
+    Array(@success_hooks).each do |hook|
+      hook.call
+    end
+  end
+
+
   def canceled(canceled)
     @job_canceled = canceled
     self

--- a/backend/app/lib/print_to_pdf_runner.rb
+++ b/backend/app/lib/print_to_pdf_runner.rb
@@ -49,6 +49,7 @@ class PrintToPDFRunner < JobRunner
         pdf.unlink
         @job.record_modified_uris( [@json.job["source"]] ) 
         @job.write_output("All done. Please click refresh to view your download link.")
+        self.success!
         job_file
       end 
     rescue Exception => e

--- a/backend/app/lib/reports_runner.rb
+++ b/backend/app/lib/reports_runner.rb
@@ -48,6 +48,7 @@ class ReportRunner < JobRunner
       @job.write_output("Adding report file.")
       @job.add_file( file )
     
+      self.success!
     rescue Exception => e
       @job.write_output(e.message)
       @job.write_output(e.backtrace)

--- a/backend/app/model/job.rb
+++ b/backend/app/model/job.rb
@@ -153,11 +153,22 @@ class Job < Sequel::Model(:job)
   end
 
 
+  def success?
+    self.reload
+    self.status == 'completed'
+  end
+
+
   def cancel!
     if ["queued", "running"].include? self.status
       self.status = "canceled"
       self.save
     end
+  end
+
+
+  def update_mtime
+    Job.update_mtime_for_ids([self.id])
   end
 
 end


### PR DESCRIPTION
(I got nerd sniped)

@sdm7g did some analysis on some troubles he'd had with EAD imports and found that importing multiple files would cause an InnoDB lock timeout that would cause the import job to be marked as failed when it had actually succeeded.

Lock timeouts aside, this seemed like a bug, because the job status should really be set to 'completed' in the same transaction that commits the imported records.  I changed the job runner interface to allow jobs to call a `success!` method to mark the job as completed within the current transaction.  I've modified the existing job runners to call this method (although it's not strictly required).

In testing that, I hit the same InnoDB timeout issue when using multiple files.  The job watchdog thread (which just updates the timestamp on the job to tell the rest of the world that it's still running) was suddenly finding that the job row was locked, and this would cause the timeout to occur.

In the end, I tracked this down to the code that writes the job's created URIs to the `job_created_record` table.  It turns out that inserting a row into `job_created_record` is enough to take a row-level lock on the corresponding entry in the `job` table--just because there's a foreign key relationship between the two.  So that was surprising!

To work around this, I now store the list of created URIs in memory for the duration of the import job run, then when the import finishes, shut down the watchdog thread, log all created URIs in one hit, and commit the transaction.  This avoids the import thread competing with the watchdog for locks on that table.

If storing URIs in memory ends up being no good, I guess another approach would be to have the watchdog thread write its timestamps to a separate `running_job` table that wouldn't be at risk of being locked.