### PR TITLE
https://archivesspace.atlassian.net/browse/AR-1421

### DIFF
--- a/backend/app/converters/lib/xml_sax.rb
+++ b/backend/app/converters/lib/xml_sax.rb
@@ -226,7 +226,7 @@ module ASpaceImport
       end
 
       def pprint_current_node
-        Nokogiri::XML::Builder.new {|b|
+        Nokogiri::XML::Builder.new( :encoding => 'UTF-8' ) {|b|
           b.send(@node.name.intern, @node.attributes).cdata(" ... ")
         }.doc.root.to_s
       end


### PR DESCRIPTION
[AR-1421](https://archivesspace.atlassian.net/browse/AR-1421) fix. 

    Encoding::InvalidByteSequenceError: ""\xE2"" on US-ASCII