### PR TITLE
tweak digital object converter test to ignore unrelated schema changes

### DIFF
--- a/backend/spec/lib_digital_object_converter_spec.rb
+++ b/backend/spec/lib_digital_object_converter_spec.rb
@@ -28,16 +28,18 @@ describe 'Digital Object converter' do
   end
 
 
-  
-  it "maps digital_object_file version information to the object" do    
-    @digital_objects[0]['file_versions'].length.should eq(1) 
-    @digital_objects[0]["file_versions"].should eq([{"jsonmodel_type"=>"file_version", "uri"=>nil, "file_uri"=>"http://aspace.me", "publish"=>nil, "use_statement"=>"It's all good", "xlink_actuate_attribute"=>"onRequest", "xlink_show_attribute"=>"embed", "file_format_name"=>"jpeg", "file_format_version"=>"1", "file_size_bytes"=>100, "checksum"=>"xxxxxxx", "checksum_method"=>"md5"}])
+
+  it "maps digital_object_file version information to the object" do
+    @digital_objects[0]['file_versions'].length.should eq(1)
+    {"jsonmodel_type"=>"file_version", "uri"=>nil, "file_uri"=>"http://aspace.me", "publish"=>nil, "use_statement"=>"It's all good", "xlink_actuate_attribute"=>"onRequest", "xlink_show_attribute"=>"embed", "file_format_name"=>"jpeg", "file_format_version"=>"1", "file_size_bytes"=>100, "checksum"=>"xxxxxxx", "checksum_method"=>"md5"}.each do |k, v|
+      @digital_objects[0]["file_versions"][0][k].should eq(v)
+    end
   end
 
 
   describe "utf-8 encoding" do
     let(:test_file_bom) {
-      File.expand_path('../app/exporters/examples/digital_object/test_digital_object_utf8_bom.csv', 
+      File.expand_path('../app/exporters/examples/digital_object/test_digital_object_utf8_bom.csv',
                        File.dirname(__FILE__))
     }
 
@@ -52,4 +54,3 @@ describe 'Digital Object converter' do
     end
   end
 end
-


### PR DESCRIPTION
This fixes a test broken by https://github.com/archivesspace/archivesspace/pull/381