### PR TITLE
API: document query string format

### DIFF
--- a/backend/app/controllers/search.rb
+++ b/backend/app/controllers/search.rb
@@ -1,7 +1,7 @@
 class ArchivesSpaceService < Sinatra::Base
 
   BASE_SEARCH_PARAMS =
-    [["q", String, "A search query string",
+    [["q", String, "A search query string.  Uses Lucene 4.0 syntax: http://lucene.apache.org/core/4_0_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html  Search index structure can be found in solr/schema.xml",
       :optional => true],
      ["aq", JSONModel(:advanced_query), "A json string containing the advanced query",
       :optional => true],

--- a/backend/app/lib/base_search_params.rb
+++ b/backend/app/lib/base_search_params.rb
@@ -1,5 +1,5 @@
   BASE_SEARCH_PARAMS =
-      [["q", String, "A search query string",
+      [["q", String, "A search query string.  Uses Lucene 4.0 syntax: http://lucene.apache.org/core/4_0_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html  Search index structure can be found in solr/schema.xml",
         :optional => true],
        ["aq", JSONModel(:advanced_query), "A json string containing the advanced query",
         :optional => true],


### PR DESCRIPTION
I'd also love to see the `aq` parameter documented in depth; I gleaned a bit from reading the source, but it would be very helpful to have it in the API docs.