### PR TITLE
added authfilenumber to EAD export

### DIFF
--- a/backend/app/exporters/lib/export_helpers.rb
+++ b/backend/app/exporters/lib/export_helpers.rb
@@ -50,6 +50,7 @@ module ASpaceExport
           sort_name = agent['display_name']['sort_name']
           rules = agent['display_name']['rules']
           source = agent['display_name']['source']
+          authfilenumber = agent['display_name']['authority_id']
           content = sort_name.dup
 
           if link['terms'].length > 0
@@ -67,6 +68,7 @@ module ASpaceExport
           atts[:role] = role if role
           atts[:source] = source if source
           atts[:rules] = rules if rules
+          atts[:authfilenumber] = authfilenumber if authfilenumber
 
           results << {:node_name => node_name, :atts => atts, :content => content}
         end
@@ -101,6 +103,7 @@ module ASpaceExport
 
           atts = {}
           atts['source'] = subject['source'] if subject['source']
+          atts['authfilenumber'] = subject['authority_id'] if subject['authority_id']
 
           results << {:node_name => node_name, :atts => atts, :content => content}
         end
@@ -123,7 +126,7 @@ module ASpaceExport
             normal_suffix = (date['date_type'] == 'single' || date['end'].nil? || date['end'] == date['begin']) ? date['begin'] : date['end']
             normal += normal_suffix ? normal_suffix : ""
           end
-          type = %w(single inclusive).include?(date['date_type']) ? 'inclusive' : 'bulk' 
+          type = %w(single inclusive).include?(date['date_type']) ? 'inclusive' : 'bulk'
           content = if date['expression']
                     date['expression']
                   elsif date['date_type'] == 'bulk'

--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -287,13 +287,14 @@ class EADSerializer < ASpaceExport::Serializer
         sort_name = agent['display_name']['sort_name']
         rules = agent['display_name']['rules']
         source = agent['display_name']['source']
+        authfilenumber = agent['display_name']['authority_id']
         node_name = case agent['agent_type']
                     when 'agent_person'; 'persname'
                     when 'agent_family'; 'famname'
                     when 'agent_corporate_entity'; 'corpname'
                     end
         xml.origination(:label => role) {
-         atts = {:role => relator, :source => source, :rules => rules}
+         atts = {:role => relator, :source => source, :rules => rules, :authfilenumber => authfilenumber}
          atts.reject! {|k, v| v.nil?}
 
           xml.send(node_name, atts) {

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -494,7 +494,7 @@ describe "EAD export mappings" do
       end
 
       it "maps {archival_object}.instances[].container.barcode_1 to {desc_path}/did/container@label" do
-        
+
       end
     end
 
@@ -666,6 +666,7 @@ describe "EAD export mappings" do
           sort_name = agent.names[0]['sort_name']
           rules = agent.names[0]['rules']
           source = agent.names[0]['source']
+          authfilenumber = agent.names[0]['authority_id']
           content = "#{sort_name}"
 
           terms = link[:terms] || link['terms']
@@ -686,6 +687,7 @@ describe "EAD export mappings" do
           mt(rules, path, 'rules')
           mt(source, path, 'source')
           mt(role, path, 'label')
+          mt(authfilenumber, path, 'authfilenumber')
           mt(content.strip, path)
         end
       end
@@ -703,6 +705,7 @@ describe "EAD export mappings" do
 
           mt(term_string, path)
           mt(subject.source, path, 'source')
+          mt(subject.authority_id, path, 'authfilenumber')
         end
       end
     end

--- a/backend/spec/factories.rb
+++ b/backend/spec/factories.rb
@@ -293,7 +293,7 @@ FactoryGirl.define do
     container_extent { generate (:number) }
     container_extent_type { sample(JSONModel(:container).schema['properties']['container_extent_type']) }
   end
-  
+
   factory :json_top_container, class: JSONModel(:top_container) do
     indicator { generate(:alphanumstr) }
     type { generate(:container_type) }
@@ -414,6 +414,8 @@ FactoryGirl.define do
     sort_name_auto_generate true
     dates { generate(:alphanumstr) }
     qualifier { generate(:alphanumstr) }
+    authority_id { generate(:url) }
+    source { generate(:name_source) }
   end
 
   factory :json_name_family, class: JSONModel(:name_family) do
@@ -424,6 +426,8 @@ FactoryGirl.define do
     dates { generate(:alphanumstr) }
     qualifier { generate(:alphanumstr) }
     prefix { generate(:alphanumstr) }
+    authority_id { generate(:url) }
+    source { generate(:name_source) }
   end
 
   factory :json_name_person, class: JSONModel(:name_person) do
@@ -441,6 +445,7 @@ FactoryGirl.define do
     title { [nil, generate(:alphanumstr)].sample }
     suffix { [nil, generate(:alphanumstr)].sample }
     rest_of_name { [nil, generate(:alphanumstr)].sample }
+    authority_id { generate(:url) }
   end
 
   factory :json_name_software, class: JSONModel(:name_software) do

--- a/backend/spec/model_agent_person_spec.rb
+++ b/backend/spec/model_agent_person_spec.rb
@@ -49,7 +49,7 @@ describe 'Agent model' do
 
 
   it "for unauthorized names, no requirement for source or rules" do
-    expect { n1 = build(:json_name_person, :rules => nil, :source => nil, :authorized => false).to_hash }.to_not raise_error
+    expect { n1 = build(:json_name_person, :rules => nil, :source => nil, :authorized => false, :authority_id => nil).to_hash }.to_not raise_error
   end
 
 
@@ -91,9 +91,9 @@ describe 'Agent model' do
   it "truncates an auto-generated sort name of more than 255 chars" do
     name = build(:json_name_person,
                  :primary_name => (0..200).map{ rand(3)==1?rand(10):(65 + rand(25)).chr }.join,
-                 :rest_of_name => (0..200).map{ rand(3)==1?rand(10):(65 + rand(25)).chr }.join 
+                 :rest_of_name => (0..200).map{ rand(3)==1?rand(10):(65 + rand(25)).chr }.join
                  )
-    
+
     agent = AgentPerson.create_from_json(build(:json_agent_person, :names => [name]))
     JSONModel(:agent_person).find(agent[:id]).names[0]['sort_name'].length.should eq(255)
   end
@@ -249,11 +249,11 @@ describe 'Agent model' do
                      :names => [build(:json_name_person,
                      'authority_id' => 'thesame'
                      )])
-   
+
     a1 =    AgentPerson.create_from_json(json)
     a2 =    AgentPerson.ensure_exists(json2, nil)
-    
-    a1.should eq(a2) # the names should still be the same as the first authority_id names 
+
+    a1.should eq(a2) # the names should still be the same as the first authority_id names
   end
 
 
@@ -266,7 +266,7 @@ describe 'Agent model' do
                                                           build(:json_name_person,
                                                                 'authorized' => true,
                                                                 'is_display_name' => false)]))
-    
+
     AgentPerson.to_jsonmodel(agent.id).display_name['primary_name'].should eq(display_name['primary_name'])
   end
 
@@ -332,15 +332,15 @@ describe 'Agent model' do
 
     let(:agent) {
       build(:json_agent_person,
-            :names => [build(:json_name_person), 
-                       build(:json_name_person)],
+            :names => [build(:json_name_person, :authority_id => nil),
+                       build(:json_name_person, :authority_id => nil)],
             :agent_contacts => [build(:json_agent_contact)],
             :external_documents => [build(:json_external_document)],
             :notes => [build(:json_note_bioghist)]
             )
     }
 
-    before(:each) do 
+    before(:each) do
       @agent_obj = AgentPerson.create_from_json(agent)
     end
 


### PR DESCRIPTION
ASpace currently does not export access term URIs in EAD (using the `<persname@authfilenumber>` attribute).  For repositories using EAD for data interchange, this is problematic - URIs live in ASpace, but are lost upon export to other systems.

This PR implements the `authfilenumber` attribute in EAD export when `authority_id` is present.  Notably, it uses the full URI instead of truncating the stem, to be more in line with EAD3's `identifier` attribute.