### PR TITLE
Ead importer updates

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -101,11 +101,16 @@ class EADConverter < Converter
 
     ignore "titlepage"
 
+    # addresses https://archivesspace.atlassian.net/browse/AR-1282
+    with 'eadheader' do
+      set :finding_aid_status, att('findaidstatus')
+    end
 
     with 'archdesc' do
       set :level, att('level') || 'otherlevel'
       set :other_level, att('otherlevel')
       set :publish, att('audience') != 'internal'
+      # set :publish, att('audience') == 'external'
     end
 
 
@@ -153,9 +158,10 @@ class EADConverter < Converter
     with 'unitdate' do |node|
 
       norm_dates = (att('normal') || "").sub(/^\s/, '').sub(/\s$/, '').split('/')
-      if norm_dates.length == 1
-        norm_dates[1] = norm_dates[0]
-      end
+      # why were the next 3 lines added?  removed for now, since single dates can stand on their own.
+      #if norm_dates.length == 1
+      #  norm_dates[1] = norm_dates[0]
+      #end
       norm_dates.map! {|d| d =~ /^([0-9]{4}(\-(1[0-2]|0[1-9])(\-(0[1-9]|[12][0-9]|3[01]))?)?)$/ ? d : nil}
       
       make :date, {
@@ -194,6 +200,7 @@ class EADConverter < Converter
       make :note_singlepart, {
         :type => "langmaterial",
         :persistent_id => att('id'),
+        :publish => att('audience') != 'internal',
         :content => format_content( content.sub(/<head>.*?<\/head>/, '') )
       } do |note|
         set ancestor(:resource, :archival_object), :notes, note
@@ -209,6 +216,7 @@ class EADConverter < Converter
       make :note_singlepart, {
         :type => note_name,
         :persistent_id => att('id'),
+		    :publish => att('audience') != 'internal',
         :content => format_content( content.sub(/<head>.?<\/head>/, '').strip)
       } do |note|
         set ancestor(:resource, :archival_object), :notes, note
@@ -221,6 +229,7 @@ class EADConverter < Converter
       make :note_multipart, {
         :type => note_name,
         :persistent_id => att('id'),
+		    :publish => att('audience') != 'internal',
         :subnotes => {
           'jsonmodel_type' => 'note_text',
           'content' => format_content( content )
@@ -392,7 +401,9 @@ class EADConverter < Converter
         make :note_multipart, {
           :type => node.name,
           :persistent_id => att('id'),
+          :publish => att('audience') != 'internal',
           :subnotes => {
+            :publish => att('audience') != 'internal',
             'jsonmodel_type' => 'note_text',
             'content' => format_content( content )
           }
@@ -410,6 +421,7 @@ class EADConverter < Converter
         make :note_singlepart, {
           :type => note,
           :persistent_id => att('id'),
+          :publish => att('audience') != 'internal',
           :content => format_content( content.sub(/<head>.*?<\/head>/, '') )
         } do |note|
           set ancestor(:resource, :archival_object), :notes, note
@@ -431,6 +443,7 @@ class EADConverter < Converter
         make :note_multipart, {
           :type => node.name,
           :persistent_id => att('id'),
+          :publish => att('audience') != 'internal'
         } do |note|
           set ancestor(:resource, :archival_object), :notes, note
         end
@@ -469,6 +482,7 @@ class EADConverter < Converter
         make :note_multipart, {
           :type => 'odd',
           :persistent_id => att('id'),
+          :publish => att('audience') != 'internal'
         } do |note|
           set ancestor(:resource, :archival_object), :notes, note
         end
@@ -840,3 +854,4 @@ class EADConverter < Converter
     end
   end
 end
+


### PR DESCRIPTION
I just made the following minor updates to the EAD importer:

- notes can be published upon import, unless they're set to internal only in the EAD
- single dates don't need to have their values repeated in the begin and end fields
- finding aid status is imported

I was also going to add an update that forced users to include the audience='external' attribute at the archdesc level in order to publish newly ingested finding aids immediately (line 113), but I commented that out and added the regular behavior back for now.

I'll hopefully dig into a few of the other updates requested here, https://docs.google.com/document/d/1wMGPDSdhfh3FsFZmJ3tngMWtmFNkRUHqwfFcxZp5Txk/edit, next week.
