### PR TITLE
Transfer error

### DIFF
--- a/backend/spec/lib_container_management_conversion_spec.rb
+++ b/backend/spec/lib_container_management_conversion_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe "Container Management Conversion" do
+
+  it "can run" do
+     ContainerManagementConversion.new.run
+  end
+
+  it "will delete instances that have no containers or DOs" do
+    digital_object =  create(:json_digital_object)
+    archival_object = create(:json_archival_object,
+                             :instances => [{"instance_type" => "digital_object",
+                                              "digital_object" => {"ref" => digital_object.uri},
+                                              "container" => nil
+                                            },
+                                            { "instance_type" => "mixed_materials",
+                                               "container" => build(:json_container, {:container_extent => "1.0",
+                                                  :container_extent_type => "cassettes"
+                                                 })
+                                             }
+                                            ]) 
+    
+    json = ArchivalObject.to_jsonmodel(archival_object.id)
+    json["instances"].length.should eq(2)
+    
+    json["instances"].last["container"] = nil # we fudge this a bit 
+    json["instances"].last["sub_container"] = nil # we fudge this a bit 
+    
+    ContainerManagementConversion::MigrationMapper.new(json, false, {}).call
+    ArchivalObject.to_jsonmodel(archival_object.id)["instances"].length.should eq(1)
+
+  end
+
+
+end

--- a/common/db/migrations/069_remove_childless_instances.rb
+++ b/common/db/migrations/069_remove_childless_instances.rb
@@ -1,0 +1,22 @@
+require_relative 'utils'
+
+Sequel.migration do
+
+  # sometimes is snows in April. Sometimes instances lose their containers.
+  # This is rare but we should remove them here, since this might cause prob
+  # with TC conversion..
+	up do
+    # we exclude DO instances
+		enum = self[:enumeration].filter(:name => "instance_instance_type").get(:id)
+    enum_val = self[:enumeration_value].filter( :enumeration_id => enum, :value => "digital_object").get(:id)
+    
+    # cant remember how to delete with sequel on a join... 
+    instances = self[:instance].left_join(:container, { :instance__id => :container__instance_id })
+                  .where(:container__instance_id => nil )
+                  .exclude(:instance__instance_type_id => enum_val ).select(:instance__id)
+                  .map { |v| v[:id] } 
+                  
+    self[:instance].where(:id => instances).delete 
+  end
+
+end


### PR DESCRIPTION
This is a spec to show the repo transfer issue. 
Accessions with TCs break when transferred, since the TC link is removed ( it's repo scoped ). 

This should be the same for Accession, Resource, AOs. 