### PR TITLE
Check instance not linked to sub_container

### DIFF
--- a/common/db/migrations/069_remove_childless_instances.rb
+++ b/common/db/migrations/069_remove_childless_instances.rb
@@ -12,7 +12,8 @@ Sequel.migration do
     
     # cant remember how to delete with sequel on a join... 
     instances = self[:instance].left_join(:container, { :instance__id => :container__instance_id })
-                  .where(:container__instance_id => nil )
+                  .left_join(:sub_container, { :instance__id => :sub_container__instance_id })
+                  .where(:container__instance_id => nil, :sub_container__instance_id => nil)
                   .exclude(:instance__instance_type_id => enum_val ).select(:instance__id)
                   .map { |v| v[:id] } 
                   


### PR DESCRIPTION
If the database is already using the new container model (via the RC, or latest / nightly build, or container management plugin) then instances not related to anything in "container" can be related to something in "sub_container" which trips up this migration. Does this look good?

@cfitz @quoideneuf 