### PR TITLE
Updating CSS to work with new tablesorter

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/top_containers_bulk.less
+++ b/frontend/app/assets/stylesheets/archivesspace/top_containers_bulk.less
@@ -1,8 +1,8 @@
-#bulk-operation-results .table-sortable th.header {
+#bulk_operation_results .table-sortable th.tablesorter-header {
     cursor: pointer;
 }
-#bulk-operation-results .table-sortable th.header.headerSortUp,
-#bulk-operation-results .table-sortable th.header.headerSortDown {
+#bulk_operation_results .table-sortable th.tablesorter-header.tablesorter-headerAsc,
+#bulk_operation_results .table-sortable th.tablesorter-header.tablesorter-headerDesc {
     padding-right: 20px;
     position: relative;
     background-color: #e8f5fa;
@@ -12,8 +12,8 @@
     background-image: -o-linear-gradient(top, #f0f7fa, #dcf1fa);
     background-image: linear-gradient(to bottom, #f0f7fa, #dcf1fa);
 }
-#bulk-operation-results .table-sortable th.header.headerSortUp:after,
-#bulk-operation-results .table-sortable th.header.headerSortDown:after {
+#bulk_operation_results .table-sortable th.tablesorter-header.tablesorter-headerAsc:after,
+#bulk_operation_results .table-sortable th.tablesorter-header.tablesorter-headerDesc:after {
     content: "";
     position: absolute;
     right: 5px;
@@ -22,7 +22,7 @@
     border-style: solid;
     border-color: #000 transparent;
 }
-#bulk-operation-results .table-sortable th.header.headerSortUp:after {
+#bulk_operation_results .table-sortable th.tablesorter-header.tablesorter-headerAsc:after {
     border-bottom: none !important;
     border-left: 4px solid transparent !important;
     border-right: 4px solid transparent !important;
@@ -33,12 +33,12 @@
     overflow: auto;
 }
 
-#bulk-operation-results .linked-records-listing,
+#bulk_operation_results .linked-records-listing,
 #bulkActionBarcodeRapidEntryModal .linked-records-listing {
     margin: 0;
     list-style-position: inside;
 }
-#bulk-operation-results .linked-records-listing.count-1,
+#bulk_operation_results .linked-records-listing.count-1,
 #bulkActionBarcodeRapidEntryModal .linked-records-listing.count-1 {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
Changes the tc bulk operations css to work with new version of tablesorter. 