### PR TITLE
AR-1501 Allow FireFox users to open accordions

### DIFF
--- a/public-new/app/assets/javascripts/accordion-table.js
+++ b/public-new/app/assets/javascripts/accordion-table.js
@@ -101,7 +101,7 @@
         $elem.off('click.zf.accordionTable keydown.zf.accordionTable')
           .on('click.zf.accordionTable', function(e){
             // ignore hyperlinks in nav rows
-            if(event.target.tagName.toLowerCase() === 'a')
+            if(e.target.tagName.toLowerCase() === 'a')
               return;
         // $(this).children('a').on('click.zf.accordion', function(e) {
             e.preventDefault();


### PR DESCRIPTION
This is a one file, one line fix to handle the "click" event on an accordion widget correctly.  Fixes AR-1501