### PR TITLE
AR-1443 remove duplicate Finding Aid Author

### DIFF
--- a/public-new/app/views/site/index.html.erb
+++ b/public-new/app/views/site/index.html.erb
@@ -592,8 +592,7 @@
         <div></div>
         <div>
           <ul>
-            <% %w(finding_aid_author
-                  finding_aid_title
+            <% %w(finding_aid_title
                   finding_aid_subtitle
                   finding_aid_filing_title
                   finding_aid_date


### PR DESCRIPTION
Removed a duplication of the finding_aid_author token.  Fixes AR-1443