### PR TITLE
Handle empty node['containers'] correctly

### DIFF
--- a/public-new/app/controllers/trees_controller.rb
+++ b/public-new/app/controllers/trees_controller.rb
@@ -20,7 +20,7 @@ class TreesController < ApplicationController
       title.strip!
       title.sub!(/<title\s+render=['"]italic['"][^>]*>([^<]+)<\/title>/, '<i>\1</i>')
 
-      if node['containers'].length
+      if !node['containers'].blank?
         node['container_label'] = [node['containers'][0]['type_1'], node['containers'][0]['indicator_1'], node['containers'][0]['type_2'], node['containers'][0]['indicator_2']].compact.join(" ")
       end
 


### PR DESCRIPTION
If the archival object had no containers, the trees_controller would throw a

>   [java] NoMethodError (undefined method `[]' for nil:NilClass):

>    [java]   app/controllers/trees_controller.rb:24:in `fetch'

This is because 
`node['containers'].length `
evaluates to **true** when the length == 0.