### PR TITLE
AR-1494 add breadcrumbs to CONTEXT for objects

### DIFF
--- a/public-new/app/assets/javascripts/records.js
+++ b/public-new/app/assets/javascripts/records.js
@@ -155,6 +155,7 @@ var app = app || {};
     this.finding_aid_series_statement = _.get(model.attributes, 'finding_aid_series_statement');
     this.finding_aid_status = _.get(model.attributes, 'finding_aid_status');
     this.finding_aid_note = _.get(model.attributes, 'finding_aid_note');
+    this.path = _.get(model.attributes, 'path');
   }
 
   RecordPresenter.prototype = Object.create(app.AbstractRecordPresenter.prototype);

--- a/public-new/app/controllers/concerns/tree_apis.rb
+++ b/public-new/app/controllers/concerns/tree_apis.rb
@@ -1,0 +1,13 @@
+module TreeApis
+  extend ActiveSupport::Concern
+  # fetch the tree to be manipulated by other methods in this controller
+  # TODO: try/catch for non 200 responses
+  def fetch_tree(node_uri)
+    response = JSONModel::HTTP::get_json("/search/published_tree", :node_uri => node_uri)
+
+    Rails.logger.debug(response.inspect)
+    return nil unless response and response.has_key?('tree_json')
+    tree = ASUtils.json_parse(response['tree_json'])
+  end
+
+end

--- a/public-new/app/views/site/index.html.erb
+++ b/public-new/app/views/site/index.html.erb
@@ -254,7 +254,13 @@
       { if(hasFullWidthContext) {}
       <div class="row collapse context-row">
         <div class="columns small-12">
-          CONTEXT: | <a href="${repositoryPublicUrl}">${repositoryName}</a> | ${title}
+          CONTEXT: | <a href="${repositoryPublicUrl}">${repositoryName}</a> 
+             { if ( present('path')) {}
+	       {_.forEach(path, function(obj) {}
+	         | <a href="${obj.uri}">${obj.crumb}</a>
+               {}); }
+             {}}
+	  | ${title}
         </div>
       </div>
       {}}


### PR DESCRIPTION
The breadcrumbs are being created from information that's available through the indexer; I haven't been able to find any objects with [grand]parents that don't have titles, so I'm not sure what to do about the following comment in the story:

> Testing group should comment on how breadcrumb links appear for components that only have a date, no title, in their display string, especially once the inheritance story is delivered.