### PR TITLE
Ar 994 mixed content rendered correctly

### DIFF
--- a/public-new/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public-new/app/assets/stylesheets/archivesspace/aspace.scss
@@ -438,3 +438,20 @@ i.giant {
   font-weight: bold;
   font-family: $serif-font;
 }
+
+/* the following are needed to support the @render attribute */
+
+/* smart double quotes, with nested smart single quotes
+q { quotes: '\201c' '\201d' '\2018' '\2019'; }
+q:before { content: open-quote; }
+q:after  { content: close-quote; }
+
+/* smart singles, with nested doubles */
+q.single { quotes: '\2018' '\2019'  '\201c' '\201d';}
+
+/* this one's up for grabs, using angle quotation marks at the moment */
+q.altrender {quotes: '\00ab' '\00bb' '\2039' '\203a' ;}
+
+.bold { font-weight: bold;}
+.italic {font-style: italic}
+.smcaps {font-variant: small-caps;}

--- a/public-new/app/controllers/concerns/manipulate_node.rb
+++ b/public-new/app/controllers/concerns/manipulate_node.rb
@@ -1,0 +1,98 @@
+module ManipulateNode
+  extend ActiveSupport::Concern
+  require 'nokogiri'
+
+  # the beginning of processing mixed content  nodes for titles, notes, etc.
+  def process_content(txt)
+    txt.strip!
+    frag = Nokogiri::XML.fragment(txt);
+    frag.traverse { |el| 
+      # we don't do anything at the top level of the fragment or if it's text
+      node_check(el) if el.parent && !el.text?
+    }
+    frag.to_xml
+  end
+
+  private 
+
+  def node_check(el)
+    newnode = el.clone
+    if newnode.key? "render"
+      newnode = process_render(newnode)
+    elsif newnode.name.match(/ptr$/)
+      newnode = process_pointer(newnode)
+    elsif newnode.name == 'lb'
+      newnode.name = 'br'
+    else
+      if newnode.name != 'p'
+        clss = newnode['class'] || ''
+        newnode['class']  = "#{newnode.name} #{clss}".strip 
+        newnode.name = 'span'
+      end
+    end
+    newnode = process_anchor(newnode) if newnode.name != 'a'
+    el.replace(newnode)
+  end
+
+  def process_anchor(node)
+    href = node['href']
+    href.strip? if href
+    target = node['target']
+    target.strip? if target
+    return node if !href && target.blank? 
+    ttl = node['title']
+    anchornode = node.document.create_element('a')
+    anchornode['href'] = href || "\##{target}"
+    anchornode['title'] = ttl.strip if ttl
+    if !node.name.match(/ptr$/)
+      node.remove_attribute('href')
+      node.remove_attribute('title')
+      anchornode.add_child(node.to_xml)
+    else
+      ttl = ttl | 'link'
+      anchornode.add_child(ttl)
+    end
+    anchornode
+  end
+
+  # right now, assumes that show == embed is an embedde object; otherwise an anchor
+  def process_pointer(node)
+    if node['show'] == "embed"
+      newnode = node.document.create_element('embed')
+      newnode['src'] = node['href']
+      newnode['class'] = node.name
+      newnode['id'] = node['id'] if node['id']
+      return newnode
+    else
+      return process_anchor(node)
+    end
+  end
+
+  def process_render(node)
+    name = node.name
+    node.name = case node['render']
+             when /quote/
+              'q'
+             when /alt/
+              'q'
+             when /super/ 
+              'sup'
+              when /sub/
+              'sub'
+              when /underline/
+              'u'
+            else
+              'span'
+            end
+    clss = node['class'] || ""
+    clss = "#{name} #{clss}"
+    %w{altrender bold single italic smcaps nonproport}.each do |w|
+      if node['render'].include?(w)
+        clss = "#{w} #{clss}"
+      end
+    end
+    node['class'] = clss.strip if !clss.blank?
+    node.remove_attribute('render')
+    return node
+   end
+end

--- a/public-new/app/controllers/concerns/manipulate_node.rb
+++ b/public-new/app/controllers/concerns/manipulate_node.rb
@@ -4,6 +4,7 @@ module ManipulateNode
 
   # the beginning of processing mixed content  nodes for titles, notes, etc.
   def process_content(txt)
+    return if !txt
     txt.strip!
     frag = Nokogiri::XML.fragment(txt);
     frag.traverse { |el| 

--- a/public-new/app/controllers/records_controller.rb
+++ b/public-new/app/controllers/records_controller.rb
@@ -1,5 +1,6 @@
 class RecordsController < ApplicationController
   include TreeApis
+  include ManipulateNode
 
   before_filter :get_repository
 
@@ -24,8 +25,8 @@ class RecordsController < ApplicationController
     raise RecordNotFound.new if (!archival_object || archival_object.has_unpublished_ancestor || !archival_object.publish)
     hash = archival_object.to_hash()
     hash['path'] =  get_path(hash['uri'])
-    json =  ASUtils.to_json(hash, {:max_nesting => false})
-    render :json => json
+     hash['title'] = process_content(hash['title'])
+     render :json => ASUtils.to_json(hash)
   end
 
 

--- a/public-new/app/controllers/records_controller.rb
+++ b/public-new/app/controllers/records_controller.rb
@@ -25,8 +25,8 @@ class RecordsController < ApplicationController
     raise RecordNotFound.new if (!archival_object || archival_object.has_unpublished_ancestor || !archival_object.publish)
     hash = archival_object.to_hash()
     hash['path'] =  get_path(hash['uri'])
-     hash['title'] = process_content(hash['title'])
-     render :json => ASUtils.to_json(hash)
+    hash['title'] = process_content(hash['title'])
+    render :json => ASUtils.to_json(hash)
   end
 
 


### PR DESCRIPTION
I created a new module **/public-new/app/controllers/concerns/manipulate_node.rb** that contains a method to process ead nodes embedded in text fragments (such as title).  Currently, it is only the title of the archival object that gets this treatment (mostly because I'm still lacking in understanding where other text fragments (such as those that compose the Abstract or Note) are found.  Once all the places where the text should be processed  are identified, the method can be invoked there, as well.

In order to support the rendering, I added more styles to the .scss