### PR TITLE
AR-1287 fixes login form for mobile/responsive

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/header.less
+++ b/frontend/app/assets/stylesheets/archivesspace/header.less
@@ -79,6 +79,22 @@
   display: none;
 }
 
+// Fix for login on mobile
+.collapsing, .collapse.in {
+  display: block;
+  width:100%;
+  .navbar-login { 
+    width: 100%; 
+    margin: auto; 
+    padding-top: 10px;
+    .login-dropdown .dropdown-menu {
+      width:100%;
+      position: inherit;
+      float: none; 
+    }
+  }  
+}
+
 .inline-login-modal {
   width: 300px;
   margin-left: -150px;

--- a/frontend/app/views/shared/_header_global.html.erb
+++ b/frontend/app/views/shared/_header_global.html.erb
@@ -16,7 +16,7 @@
         </button>
       <% end %>
       <div class="navbar-collapse nav-global-collapse collapse navbar-right navbar-default">
-        <ul class="nav pull-right navbar-nav">
+        <ul class="nav pull-right navbar-nav navbar-login">
           <%= render "shared/header_user" %>
           <% if ArchivesSpaceHelp.enabled? %>
             <li><%= link_to_help :link_opts => {"data-placement" => (session[:user] ? "left" : "bottom")} %></li>


### PR DESCRIPTION
This fixes the login for mobile. However, it looks like there's still a lot of other small errors with the responsive template in the ArchivesSpace theme ( like once logged in, the User narbar is not present ) 

But at least now people can login and see something when they get a link....
