### PR TITLE
security fix for aspace-public-formats plugin

### DIFF
--- a/plugins/aspace-public-formats/backend/controllers/public_formats.rb
+++ b/plugins/aspace-public-formats/backend/controllers/public_formats.rb
@@ -6,7 +6,7 @@ class ArchivesSpaceService < Sinatra::Base
             ["type", String, "The type of object, resource or digital_object"],
             ["format", String, "The format to return the object as"],
             ["id", :id])
-    .permissions([])
+    .permissions([:view_repository])
     .returns([200, "Archival Object"]) \
   do
     handle params[:format], params[:id]
@@ -18,7 +18,7 @@ class ArchivesSpaceService < Sinatra::Base
             ["type", String, "The type of object, resource or digital_object"],
             ["format", String, "The format to return the object as"],
             ["id", :id])
-    .permissions([])
+    .permissions([:view_repository])
     .returns([200, "Archival Object"]) \
   do
     handle "#{params[:format]}_pdf", params[:id]

--- a/plugins/aspace-public-formats/public/controllers/public_formats_controller.rb
+++ b/plugins/aspace-public-formats/public/controllers/public_formats_controller.rb
@@ -8,6 +8,17 @@ class PublicFormatsController < ApplicationController
   private
 
   def handle(repo_id, type, format, id)
+    
+    record = case type
+             when "resources"
+                JSONModel(:resource).find(params[:id], :repo_id => params[:repo_id])   
+             when "digital_objects"
+                JSONModel(:digital_object).find(params[:id], :repo_id => params[:repo_id]) 
+             else
+                nil 
+             end
+    raise RecordNotFound.new unless ( record && record.publish ) 
+
     uri      = URI.parse AppConfig[:backend_url]
     http     = Net::HTTP.new uri.host, uri.port
     

--- a/plugins/aspace-public-formats/public/controllers/public_formats_controller.rb
+++ b/plugins/aspace-public-formats/public/controllers/public_formats_controller.rb
@@ -18,15 +18,13 @@ class PublicFormatsController < ApplicationController
                 nil 
              end
     raise RecordNotFound.new unless ( record && record.publish ) 
-
-    uri      = URI.parse AppConfig[:backend_url]
-    http     = Net::HTTP.new uri.host, uri.port
     
     format, mime = format.split("_") 
     mime ||= "xml" 
 
-    request  = Net::HTTP::Get.new "/plugins/public_formats/repository/#{repo_id}/#{type}/#{format}/#{id}.#{mime}"
-    response = http.request request 
+    uri = URI("#{JSONModel::HTTP.backend_url}/plugins/public_formats/repository/#{repo_id}/#{type}/#{format}/#{id}.#{mime}")
+    response  = JSONModel::HTTP.get_response uri
+
     if response.code == "200"
       content_type = format == "html" ? format : mime 
       content = response.body


### PR DESCRIPTION
Currently the aspace-public-formats plugin passes requests directly to the backend without checking if the record is published or not. It's possible to download all the resource/DO records if this is enabled. 
If a record is published, crawlers ( like Google )  can index the link and it will persist despite the record being unpublished. 