### PR TITLE
When resolving an array of records, make sure all of them are converted to hashes up front

### DIFF
--- a/backend/app/lib/uri_resolver.rb
+++ b/backend/app/lib/uri_resolver.rb
@@ -95,11 +95,6 @@ module URIResolver
     def resolve_references(value)
       return value if @properties_to_resolve.empty?
 
-      # If we're handed a JSONModel, convert to a vanilla hash.
-      if value.is_a?(JSONModelType)
-        value = value.to_hash(:trusted)
-      end
-
       # Make sure we have an array, even if there's just one record to resolve
       was_wrapped = false
       if value.is_a?(Array)
@@ -108,6 +103,15 @@ module URIResolver
         records = ASUtils.wrap(value)
         was_wrapped = true
       end
+
+      # Any JSONModels can become vanilla hashes
+      records = records.map {|value|
+        if value.is_a?(JSONModelType)
+          value.to_hash(:trusted)
+        else
+          value
+        end
+      }
 
       # We'll work through our records breadth-first, first resolving non-nested
       # properties, then those that are nested two-levels deep, then

--- a/backend/spec/lib_uri_resolver_spec.rb
+++ b/backend/spec/lib_uri_resolver_spec.rb
@@ -124,6 +124,14 @@ describe 'URIResolver' do
     resolved.should eq(resource.to_hash(:trusted))
   end
 
+  it "converts an array of JSONModel records to regular hashes if provided" do
+    resource1 = build(:json_resource)
+    resource2 = build(:json_resource)
+
+    resolved = resolve([resource1, resource2], ["invalid_property"])
+
+    resolved.should eq([resource1.to_hash(:trusted), resource2.to_hash(:trusted)])
+  end
 
   class MockResolver < URIResolver::ResolverType
     def initialize(*records)


### PR DESCRIPTION
Hi there,

This is a pretty minor bug fix: I noticed when I passed an array of JSONModels to the URI resolver, it didn't properly resolve them.  There was some code in there to handle the case of resolving a single JSONModel, but not an array.

Since this was intended to work, I added a test and fixed the code.  It's only a minor issue since nothing currently depends on this functionality, but for consistency's sake I think it should be supported.
