### PR TITLE
AR-1134 When a physdesc element just has a text child node, use it as a note

### DIFF
--- a/backend/spec/fixtures/ead_with_extents.xml
+++ b/backend/spec/fixtures/ead_with_extents.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/css" href="EAD_edits/ead_for_Oxygen_2013_11_07.css"?>
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd">
+    <eadheader countryencoding="iso3166-1" dateencoding="iso8601" langencoding="iso639-2b"
+        repositoryencoding="iso15511" scriptencoding="iso15924">
+        <eadid countrycode="US" mainagencycode="MAMr-A">testPhysfacetDimensions_2016_07_08</eadid>
+        <filedesc>
+            <titlestmt>
+                <titleproper>TEST dimensions physfacet_2016_06_27</titleproper>
+            </titlestmt>
+        </filedesc>
+        <profiledesc>
+            <langusage><language langcode="eng">English</language></langusage>
+        </profiledesc>
+    </eadheader>
+    <archdesc level="collection"><did>
+        <unitid>testPhysfacetDimensions_2016_07_08</unitid><unittitle>TEST dimensions physfacet_2016_06_27</unittitle>
+            <unitdate>1880-1970</unitdate>
+            <physdesc><extent>20 cubic feet</extent><extent>60 boxes</extent></physdesc>
+            <physdesc><extent>10000 photographs</extent><physfacet>gelatin
+                    silver</physfacet><dimensions>8 x 10 or larger</dimensions></physdesc>
+            <langmaterial><language langcode="eng">English</language></langmaterial></did>
+        <dsc>
+            <c level="item">
+                <did>
+                    <unittitle>No extent, single dimensions, single physfacet</unittitle>
+                    <physdesc>1 photograph <physfacet>gelatin silver
+                    </physfacet><dimensions>8 x 10 inches</dimensions></physdesc>
+                </did>
+            </c>
+            <c level="item">
+                <did>
+                    <unittitle>Test single extent and single dimensions</unittitle>
+                    <physdesc><extent>1 photograph</extent><dimensions>8 x 10
+                        inches</dimensions></physdesc>
+                </did>
+            </c>
+            <c level="item">
+                <did>
+                    <unittitle>Test single extent and single physfacet</unittitle>
+                    <physdesc><extent>1 photograph</extent><physfacet>gelatin silver
+                        </physfacet></physdesc>
+                </did>
+            </c>
+            <c level="item">
+                <did>
+                    <unittitle>Test single extent, single dimensions, single physfacet</unittitle>
+                    <physdesc><extent>1 photograph</extent><physfacet>gelatin silver
+                            </physfacet><dimensions>8 x 10 inches</dimensions></physdesc>
+                </did>
+            </c>
+            <c level="item">
+                <did>
+                    <unittitle>Test single extent and two physfacet</unittitle>
+                    <physdesc><extent>1 photograph</extent><physfacet>black and
+                            white</physfacet><physfacet>gelatin silver</physfacet></physdesc>
+                </did>
+            </c>
+            <c level="item">
+                <did>
+                    <unittitle>Test single extent and two dimensions</unittitle>
+                    <physdesc><extent>1 photograph</extent><dimensions>8 x 10 inches (photograph)
+                            </dimensions><dimensions>11 x 14 inches (support)
+                        </dimensions></physdesc>
+                </did>
+            </c>
+            <c level="item">
+                <did>
+                    <unittitle>Physdesc only</unittitle>
+                    <physdesc>1  photograph: 8 x 10 inches (photograph) 11 x 14 inches (support) </physdesc>
+                </did>
+            </c>
+        </dsc>
+    </archdesc>
+</ead>

--- a/backend/spec/lib_ead_converter_spec.rb
+++ b/backend/spec/lib_ead_converter_spec.rb
@@ -1049,5 +1049,76 @@ ANEAD
       @record['extents'][0]['physical_details'].should eq('gelatin silver')
     end
 
+    let (:records_with_extents) {
+      records = convert(File.join(File.dirname(__FILE__), 'fixtures', 'ead_with_extents.xml'))
+      Hash[records.map {|rec| [rec['title'], rec]}]
+    }
+
+    it "maps no extent, single dimensions, single physfacet to notes" do
+      rec = records_with_extents.fetch('No extent, single dimensions, single physfacet')
+
+      rec['extents'].should be_empty
+      rec['notes'][0]['content'].should eq(['gelatin silver'])
+      rec['notes'][1]['subnotes'][0]['content'].should eq('8 x 10 inches')
+    end
+
+    it "maps single extent and single dimensions to extent record" do
+      rec = records_with_extents.fetch('Test single extent and single dimensions')
+
+      rec['extents'].length.should eq(1)
+      rec['extents'][0]['extent_type'].should eq('photograph')
+      rec['extents'][0]['dimensions'].should eq('8 x 10 inches')
+    end
+
+    it "maps single extent and single physfacet to extent record" do
+      rec = records_with_extents.fetch('Test single extent and single physfacet')
+
+      rec['extents'].length.should eq(1)
+      rec['extents'][0]['extent_type'].should eq('photograph')
+      rec['extents'][0]['number'].should eq('1')
+      rec['extents'][0]['portion'].should eq('whole')
+      rec['extents'][0]['physical_details'].should eq('gelatin silver')
+    end
+
+    it "maps single extent, single dimensions, single physfacet to extent record" do
+      rec = records_with_extents.fetch('Test single extent, single dimensions, single physfacet')
+
+      rec['extents'].length.should eq(1)
+      rec['extents'][0]['extent_type'].should eq('photograph')
+      rec['extents'][0]['number'].should eq('1')
+      rec['extents'][0]['portion'].should eq('whole')
+      rec['extents'][0]['physical_details'].should eq('gelatin silver')
+      rec['extents'][0]['dimensions'].should eq('8 x 10 inches')
+    end
+
+    it "maps single extent and two physfacet to extent record" do
+      rec = records_with_extents.fetch('Test single extent and two physfacet')
+
+      rec['extents'].length.should eq(1)
+      rec['extents'][0]['extent_type'].should eq('photograph')
+      rec['extents'][0]['number'].should eq('1')
+      rec['extents'][0]['portion'].should eq('whole')
+      rec['extents'][0]['physical_details'].should eq('black and white; gelatin silver')
+    end
+
+    it "maps single extent and two dimensions to extent record" do
+      rec = records_with_extents.fetch('Test single extent and two dimensions')
+
+      rec['extents'].length.should eq(1)
+      rec['extents'][0]['extent_type'].should eq('photograph')
+      rec['extents'][0]['number'].should eq('1')
+      rec['extents'][0]['portion'].should eq('whole')
+      rec['extents'][0]['dimensions'].should eq('8 x 10 inches (photograph); 11 x 14 inches (support)')
+    end
+
+    it "maps text physdesc element to note" do
+      rec = records_with_extents.fetch('Physdesc only')
+
+      rec['extents'].should be_empty
+      rec['notes'].should_not be_empty
+      rec['notes'][0]['content'].should eq(["1 photograph: 8 x 10 inches (photograph) 11 x 14 inches (support)"])
+    end
+
   end
+
 end


### PR DESCRIPTION
Also extends the EAD import unit tests for extents based on provided
test data.