### PR TITLE
try to switch out & into &amp; in EAD export

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -31,8 +31,12 @@ class EADSerializer < ASpaceExport::Serializer
   end
 
   def xml_errors(content)
+    # there are message we want to ignore. annoying that java xml lib doesn't
+    # use codes like libxml does...
+    ignore = [ /Namespace prefix .* is not defined/, /The prefix .* is not bound/  ] 
+    ignore = Regexp.union(ignore) 
     # the "wrap" is just to ensure that there is a psuedo root element to eliminate a "false" error
-    Nokogiri::XML("<wrap>#{content}</wrap>").errors
+    Nokogiri::XML("<wrap>#{content}</wrap>").errors.reject { |e| e.message =~ ignore  }
   end 
 
 

--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -30,6 +30,12 @@ class EADSerializer < ASpaceExport::Serializer
     end
   end
 
+  def xml_errors(content)
+    # the "wrap" is just to ensure that there is a psuedo root element to eliminate a "false" error
+    Nokogiri::XML("<wrap>#{content}</wrap>").errors
+  end 
+
+
   def handle_linebreaks(content)
     # if there's already p tags, just leave as is
     return content if ( content.strip =~ /^<p(\s|\/|>)/ or content.strip.length < 1 )
@@ -40,10 +46,17 @@ class EADSerializer < ASpaceExport::Serializer
     else
       content = "<p>#{content.strip}</p>"
     end
+   
+    # first lets see if there are any &
+    # note if there's a &somewordwithnospace , the error is EntityRef and wont
+    # be fixed here...
+    if xml_errors(content).any? { |e| e.message.include?("The entity name must immediately follow the '&' in the entity reference.") }
+      content.gsub!("& ", "&amp; ")
+    end
+
     # in some cases adding p tags can create invalid markup with mixed content
-    # the "wrap" is just to ensure that there is a psuedo root element to eliminate a "false" error
-    content = original_content if Nokogiri::XML("<wrap>#{content}</wrap>").errors.any?
-    content
+    # just return the original content if there's still problems 
+    xml_errors(content).any? ? original_content : content 
   end
 
   def strip_p(content)

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1022,6 +1022,7 @@ describe "EAD export mappings" do
     let(:note_with_linebreaks_and_good_mixed_content) { "Something, something,\n\n<bioghist>something.</bioghist>\n\n" }
     let(:note_with_linebreaks_and_evil_mixed_content) { "Something, something,\n\n<bioghist>something.\n\n</bioghist>\n\n" }
     let(:note_with_linebreaks_but_something_xml_nazis_hate) { "Something, something,\n\n<prefercite>XML & How to Live it!</prefercite>\n\n" }
+    let(:note_with_linebreaks_and_xml_namespaces) { "Something, something,\n\n<prefercite xlink:foo='one' ns2:bar='two' >XML, you so crazy!</prefercite>\n\n" }
     let(:serializer) { EADSerializer.new }
 
     it "can strip <p> tags from content when disallowed" do
@@ -1046,6 +1047,10 @@ describe "EAD export mappings" do
     
     it "will add <p> tags to content with linebreaks and mixed content even if those evil &'s are present in the text" do
       serializer.handle_linebreaks(note_with_linebreaks_but_something_xml_nazis_hate).should eq("<p>Something, something,</p><p><prefercite>XML &amp; How to Live it!</prefercite></p>")
+    end
+    
+    it "will add <p> tags to content with linebreaks and mixed content even there are weird namespace prefixes" do
+      serializer.handle_linebreaks(note_with_linebreaks_and_xml_namespaces).should eq("<p>Something, something,</p><p><prefercite xlink:foo='one' ns2:bar='two' >XML, you so crazy!</prefercite></p>")
     end
 
   end

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1021,6 +1021,7 @@ describe "EAD export mappings" do
     let(:note_with_linebreaks) { "Something, something,\n\nsomething." }
     let(:note_with_linebreaks_and_good_mixed_content) { "Something, something,\n\n<bioghist>something.</bioghist>\n\n" }
     let(:note_with_linebreaks_and_evil_mixed_content) { "Something, something,\n\n<bioghist>something.\n\n</bioghist>\n\n" }
+    let(:note_with_linebreaks_but_something_xml_nazis_hate) { "Something, something,\n\n<prefercite>XML & How to Live it!</prefercite>\n\n" }
     let(:serializer) { EADSerializer.new }
 
     it "can strip <p> tags from content when disallowed" do
@@ -1041,6 +1042,10 @@ describe "EAD export mappings" do
 
     it "will return original content when linebreaks and mixed content produce invalid markup" do
       serializer.handle_linebreaks(note_with_linebreaks_and_evil_mixed_content).should eq(note_with_linebreaks_and_evil_mixed_content)
+    end
+    
+    it "will add <p> tags to content with linebreaks and mixed content even if those evil &'s are present in the text" do
+      serializer.handle_linebreaks(note_with_linebreaks_but_something_xml_nazis_hate).should eq("<p>Something, something,</p><p><prefercite>XML &amp; How to Live it!</prefercite></p>")
     end
 
   end


### PR DESCRIPTION
http://lyralists.lyrasis.org/pipermail/archivesspace_users_group/2016-July/003814.html

Could also try and do something to 1) fix markup problems with Nokogiri doing a to_xml and 2) stick the error messages in an XML comment so people know what to fix in their note content. 

