### PR TITLE
Ensure the right version of solr is packaged

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -281,7 +281,7 @@
 
   <!-- Solr -->
   <target name="solr:war" depends="set-classpath, bootstrap-downloads" description="Repack the Solr .war file with our configs">
-    <copy file="${solr_file}" tofile="solr.war" />
+    <copy file="${solr_file}" tofile="solr.war" overwrite="true" />
     <war destfile="solr.war" update="true">
       <zipfileset dir="../solr" prefix="WEB-INF/classes"/>
     </war>


### PR DESCRIPTION
If a version of solr.war already exists and the solr version is updated (and bootstrapped), solr.war is not updated to the new version. Force it by overwriting (`war destfile="solr.war" update="true"` is not doing it). Adds a negligible ~2s to the build time.