### PR TITLE
Disable norms for sort_string

### DIFF
--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -306,7 +306,7 @@
       </analyzer>
     </fieldType>
 
-    <fieldType name="sort_string" class="solr.TextField" positionIncrementGap="100">
+    <fieldType name="sort_string" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
       <analyzer>
         <tokenizer class="solr.KeywordTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory" />


### PR DESCRIPTION
Thanks to Mark Triggs:

Newer versions of Solr changed the way norms are implemented, and they
no longer require as much memory in most cases. However, since
ArchivesSpace doesn't really use norms anyway, there's no harm in
disabling them for the "sort_string" field type (used by AR-1027), and
that removes the need to target a specific version of Solr.