### PR TITLE
Try and fix some more of the EAD wack-a-mole problems

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -75,7 +75,7 @@ class EADConverter < Converter
           # what a hack. ripping out the list might leave some dangling <p>s 
           [sn, theleftovers].each do |s|
             next if s["content"].nil?
-            s["content"] = Nokogiri::XML::DocumentFragment.parse(s["content"].strip.gsub(/^<\/p[^>]*>/,'')).to_xml(:encoding => 'utf-8') 
+            s["content"] = Nokogiri::HTML::DocumentFragment.parse(s["content"].strip.gsub(/^<\/p[^>]*>/,''), "uft-8").to_xml(:encoding => 'utf-8') 
           end
         end
         
@@ -147,7 +147,7 @@ class EADConverter < Converter
     with 'unittitle' do |node|
       ancestor(:note_multipart, :resource, :archival_object) do |obj|
         unless obj.class.record_type == "note_multipart"   
-          title = Nokogiri::XML::DocumentFragment.parse(inner_xml.strip)
+          title = Nokogiri::HTML::DocumentFragment.parse(inner_xml.strip, 'utf-8')
           title.xpath(".//unitdate").remove 
           obj.title = format_content( title.to_xml(:encoding => 'utf-8') ) 
         end
@@ -181,7 +181,7 @@ class EADConverter < Converter
 
     with "langmaterial" do
       # first, assign the primary language to the ead
-      langmaterial = Nokogiri::XML::DocumentFragment.parse(inner_xml)
+      langmaterial = Nokogiri::HTML::DocumentFragment.parse(inner_xml, 'uft-8')
       langmaterial.children.each do |child|
         if child.name == 'language'
           set ancestor(:resource, :archival_object), :language, child.attr("langcode")
@@ -240,7 +240,7 @@ class EADConverter < Converter
     end
     
     with 'physdesc' do
-      physdesc = Nokogiri::XML::DocumentFragment.parse(inner_xml)
+      physdesc = Nokogiri::HTML::DocumentFragment.parse(inner_xml, 'utf-8')
 
       extent_number_and_type = nil
     

--- a/backend/app/converters/lib/xml_sax.rb
+++ b/backend/app/converters/lib/xml_sax.rb
@@ -218,7 +218,7 @@ module ASpaceImport
 
 
       def inner_xml
-        @node.inner_xml.gsub("&","&amp;").strip
+        @node.inner_xml.strip
       end
 
       def outer_xml

--- a/backend/app/lib/batch_import_runner.rb
+++ b/backend/app/lib/batch_import_runner.rb
@@ -76,7 +76,7 @@ class BatchImportRunner < JobRunner
                 converter.run
 
                 File.open(converter.get_output_path, "r") do |fh|
-                  batch = StreamingImport.new(fh, ticker, @import_canceled)
+                  batch = StreamingImport.new(fh, ticker, @import_canceled, true)
                   batch.process
 
                   if batch.created_records


### PR DESCRIPTION
This tries to fix some problems with EAD conversion and export that seem to keep popping up. 

For conversion
- use Nokogiri::HTML::DocumentFragment instead of ::XML::DocumentFragment ( more forgiving, doesn't do things like delete &, converts them instead )
- remove the switch from & => `&amp;` in inner_xml method ( not needed if using HTML::DocumentFragment ) 
-  add migration = true to the stream importer so the tree doesnt get resequenced each time a new node gets added ( this was done for AT migration but never applied to EAD importer. should reduce load on DB ) 

For exporters:
- Try and fix some XML markup errors by calling Nokogiri::HTML.fragement ( things like & and unclosed tags ) 
- Try to make p wrapping a bit smarter ( don't wrap if there's a tag that isn't allowed in a `<p>`, don't wrap closing tags
