### PR TITLE
catch the right exception for optimistic locking

### DIFF
--- a/backend/app/model/db.rb
+++ b/backend/app/model/db.rb
@@ -144,7 +144,7 @@ EOF
         sleep(opts[:db_failed_retry_delay] || 3)
 
 
-      rescue Sequel::DatabaseError => e
+      rescue Sequel::NoExistingObject, Sequel::DatabaseError => e
         if (attempt + 1) < retries && is_retriable_exception(e, opts) && transaction
           Log.info("Retrying transaction after retriable exception (#{e})")
           sleep(opts[:retry_delay] || 1)
@@ -230,7 +230,7 @@ EOF
     (exception.instance_of?(RetryTransaction) ||
      (opts[:retry_on_optimistic_locking_fail] &&
       exception.instance_of?(Sequel::Plugins::OptimisticLocking::Error)) ||
-     (exception.wrapped_exception.cause or exception.wrapped_exception).getSQLState() =~ /^(40|41)/)
+     (exception.wrapped_exception && ( exception.wrapped_exception.cause or exception.wrapped_exception).getSQLState() =~ /^(40|41)/) )
   end
 
 

--- a/backend/spec/model_db_spec.rb
+++ b/backend/spec/model_db_spec.rb
@@ -14,5 +14,33 @@ describe 'DB Model' do
 
     attempt.should eq(5)
   end
+  
+  it "Retries transactions on NoExistingObject/OptimisticLocking exception if told to retry on optimistic locking fail" do
+
+    attempt = 0
+    
+    expect {
+      supports_mvcc = true
+      DB.open( supports_mvcc,  :retry_delay => 0 ) do
+        attempt += 1
+        raise Sequel::Plugins::OptimisticLocking::Error.new("Couldn't create version of blah")
+      end
+    }.to raise_error(Sequel::NoExistingObject)
+
+    # the default it 10
+    attempt.should eq(1)
+    attempt = 0
+
+    expect {
+      supports_mvcc = true
+      DB.open( supports_mvcc, :retry_on_optimistic_locking_fail => true, :retry_delay => 0 ) do
+        attempt += 1
+        raise Sequel::Plugins::OptimisticLocking::Error.new("Couldn't create version of blah")
+      end
+    }.to raise_error(Sequel::NoExistingObject)
+
+    # the default it 10
+    attempt.should eq(10)
+  end
 
 end


### PR DESCRIPTION
in regards to : #517  

We're not catching the right exception on an optimistic locking error. Instead of retrying (when that option is set to retry on optimistic locking errors, like on streaming imports ), app is dropping it quietly, like it does in usual situations. 

This catches the right exception. 

Doesn't fix the underlying problem of EAD importing being super slow...

