### PR TITLE
fix annoying missing i18n message

### DIFF
--- a/frontend/app/controllers/jobs_controller.rb
+++ b/frontend/app/controllers/jobs_controller.rb
@@ -131,7 +131,7 @@ class JobsController < ApplicationController
   end
 
   def import_types
-    Job.available_import_types.map {|e| [I18n.t("import_job.import_type_#{e['name']}"), e['name']]}
+    Job.available_import_types.map {|e| [I18n.t("import_job.import_type_#{e['name']}", default: e['name'] ), e['name']]}
   end
 
 

--- a/frontend/app/views/external_ids/_template.html.erb
+++ b/frontend/app/views/external_ids/_template.html.erb
@@ -1,6 +1,6 @@
 <% define_template "external_id" do |form| %>
   <div class="subrecord-form-fields">
-	  <%= form.hidden_input("source") %>
-    <%= form.hidden_input("external_id") %>
+	  <%= form.label_and_textarea("source") %>
+    <%= form.label_and_textarea("external_id") %>
   </div>
 <% end %>


### PR DESCRIPTION
All this does in give a default for annoying missing I18n translations for import plugins, so adding an locales/en.yml in plugins for this one item is not required.  ( I seem to have to do this a lot. Probably not so annoying for anyone else. ) 
