### PR TITLE
Fix auto-deleting supressed enumerations

### DIFF
--- a/backend/app/model/enumeration.rb
+++ b/backend/app/model/enumeration.rb
@@ -91,7 +91,7 @@ class Enumeration < Sequel::Model(:enumeration)
     removed_values.each do |value|
       DB.attempt {
         EnumerationValue.filter(:enumeration_id => obj.id,
-                                :value => value).delete
+                                :value => value, :suppressed => 0 ).delete
       }.and_if_constraint_fails {
         raise ConflictException.new("Can't delete a value that's in use: #{value}")
       }

--- a/backend/spec/controller_enumeration_spec.rb
+++ b/backend/spec/controller_enumeration_spec.rb
@@ -151,7 +151,40 @@ describe "Enumeration controller" do
     obj.values.should include(val["value"])
     
   end
+
+  it "will be keep suppressed values if other changes are made" do
+    obj = JSONModel(:enumeration).find(@enum_id)
+    
+    val = obj.enumeration_values[0]
+    @model.create(:my_enum_id => val['id'])
+   
+    enum_val = JSONModel(:enumeration_value).find(val['id'])
+    enum_val.set_suppressed(true) 
+    
+    
+    obj = nil
+    obj = JSONModel(:enumeration).find(@enum_id)
+    obj.values.should_not include(val["value"])
+    
+    vals = obj.values
+
+    new_val = "moremoremore" 
+    obj.values += [new_val]
+    obj.save
+    
+    # make sure we refresh 
+    obj = nil 
+    obj = JSONModel(:enumeration).find(@enum_id)
+
+    obj.values.should eq( vals << new_val )
+   
+    obj.enumeration_values.map { |v| v["value"] }.should include(val["value"])
+    
+    
+  end
+
   
+
   it "can change positions of  values" do
     obj = JSONModel(:enumeration).find(@enum_id)
     

--- a/frontend/app/views/enumerations/_list.html.erb
+++ b/frontend/app/views/enumerations/_list.html.erb
@@ -66,7 +66,7 @@
               <% else %>
                 <%= link_to I18n.t("actions.suppress"), {:controller => :enumerations, :action => :update_value, :id => JSONModel(:enumeration).id_for(@enumeration["uri"]), :enumeration_value_id => enum_value["id"], :suppressed => 1 }, :method => :post, :class=> "btn btn-xs btn-info", :disabled => 'disabled'  %>
               <% end%>
-              <% if @enumeration['editable'] && !Array(@enumeration['readonly_values']).include?(enum_value['value']) %>
+              <% if @enumeration['editable'] && !Array(@enumeration['readonly_values']).include?(enum_value['value']) && !enum_value["suppressed"] %>
                 <%= link_to I18n.t("actions.merge"), {:controller => :enumerations, :action => :delete, :id => JSONModel(:enumeration).id_for(@enumeration["uri"]), :merge => true, :value => enum_value["value"]}, "data-toggle" => "modal-ajax", :class=> "btn btn-xs btn-warning" %>
                 <%= link_to I18n.t("actions.delete"), {:controller => :enumerations, :action => :delete, :id => JSONModel(:enumeration).id_for(@enumeration["uri"]), :value => enum_value['value']}, "data-toggle" => "modal-ajax", :class=> "btn btn-xs btn-danger" %>
               <% end %>

--- a/selenium/spec/enumeration_management_spec.rb
+++ b/selenium/spec/enumeration_management_spec.rb
@@ -188,6 +188,11 @@ describe "Enumeration Management" do
     assert(5) {
       @driver.find_element_with_text('//tr', /fooman/).find_element(:link, "Unsuppress").should_not be_nil
     }
+    
+    assert(5) {
+      @driver.find_element_with_text('//tr', /fooman/).find_element(:link, 'Delete').should be_nil
+    }
+
     # now lets make sure it's there
     @driver.find_element(:link, "Create").click
     @driver.find_element(:link, "Accession").click

--- a/selenium/spec/enumeration_management_spec.rb
+++ b/selenium/spec/enumeration_management_spec.rb
@@ -190,7 +190,7 @@ describe "Enumeration Management" do
     }
     
     assert(5) {
-      @driver.find_element_with_text('//tr', /fooman/).find_element(:link, 'Delete').should be_nil
+      @driver.find_element_with_text('//tr', /fooman/).find_element(:link, 'Delete').length.should eq(0)
     }
 
     # now lets make sure it's there


### PR DESCRIPTION

Currently, if a value is suppressed, it will be deleted if a user tries any other management actions on the enumeration list. Enumerations treat their values like sets, and the incoming values are checked against the existing values...however, suppressed values are not included in the existing values ( bc they're suppressed from the value list ). 

This fix removed the ability to delete suppressed values. In the frontend, if a value is suppressed, the delete & merge buttons do not appear. In backend, suppressed values are not deleted in the apply_values method. 

To delete or merge values, users have to unsuppress them, then delete. 

 