### PR TITLE
Fix auto-deleting supressed enumerations

### DIFF
--- a/backend/app/model/enumeration.rb
+++ b/backend/app/model/enumeration.rb
@@ -91,7 +91,7 @@ class Enumeration < Sequel::Model(:enumeration)
     removed_values.each do |value|
       DB.attempt {
         EnumerationValue.filter(:enumeration_id => obj.id,
-                                :value => value).delete
+                                :value => value, :suppressed => 0 ).delete
       }.and_if_constraint_fails {
         raise ConflictException.new("Can't delete a value that's in use: #{value}")
       }

--- a/backend/spec/controller_enumeration_spec.rb
+++ b/backend/spec/controller_enumeration_spec.rb
@@ -151,7 +151,40 @@ describe "Enumeration controller" do
     obj.values.should include(val["value"])
     
   end
+
+  it "will be keep suppressed values if other changes are made" do
+    obj = JSONModel(:enumeration).find(@enum_id)
+    
+    val = obj.enumeration_values[0]
+    @model.create(:my_enum_id => val['id'])
+   
+    enum_val = JSONModel(:enumeration_value).find(val['id'])
+    enum_val.set_suppressed(true) 
+    
+    
+    obj = nil
+    obj = JSONModel(:enumeration).find(@enum_id)
+    obj.values.should_not include(val["value"])
+    
+    vals = obj.values
+
+    new_val = "moremoremore" 
+    obj.values += [new_val]
+    obj.save
+    
+    # make sure we refresh 
+    obj = nil 
+    obj = JSONModel(:enumeration).find(@enum_id)
+
+    obj.values.should eq( vals << new_val )
+   
+    obj.enumeration_values.map { |v| v["value"] }.should include(val["value"])
+    
+    
+  end
+
   
+
   it "can change positions of  values" do
     obj = JSONModel(:enumeration).find(@enum_id)
     

--- a/frontend/app/views/enumerations/_list.html.erb
+++ b/frontend/app/views/enumerations/_list.html.erb
@@ -66,7 +66,7 @@
               <% else %>
                 <%= link_to I18n.t("actions.suppress"), {:controller => :enumerations, :action => :update_value, :id => JSONModel(:enumeration).id_for(@enumeration["uri"]), :enumeration_value_id => enum_value["id"], :suppressed => 1 }, :method => :post, :class=> "btn btn-xs btn-info", :disabled => 'disabled'  %>
               <% end%>
-              <% if @enumeration['editable'] && !Array(@enumeration['readonly_values']).include?(enum_value['value']) %>
+              <% if @enumeration['editable'] && !Array(@enumeration['readonly_values']).include?(enum_value['value']) && !enum_value["suppressed"] %>
                 <%= link_to I18n.t("actions.merge"), {:controller => :enumerations, :action => :delete, :id => JSONModel(:enumeration).id_for(@enumeration["uri"]), :merge => true, :value => enum_value["value"]}, "data-toggle" => "modal-ajax", :class=> "btn btn-xs btn-warning" %>
                 <%= link_to I18n.t("actions.delete"), {:controller => :enumerations, :action => :delete, :id => JSONModel(:enumeration).id_for(@enumeration["uri"]), :value => enum_value['value']}, "data-toggle" => "modal-ajax", :class=> "btn btn-xs btn-danger" %>
               <% end %>

--- a/selenium/spec/enumeration_management_spec.rb
+++ b/selenium/spec/enumeration_management_spec.rb
@@ -188,6 +188,11 @@ describe "Enumeration Management" do
     assert(5) {
       @driver.find_element_with_text('//tr', /fooman/).find_element(:link, "Unsuppress").should_not be_nil
     }
+    
+    assert(5) {
+      @driver.find_element_with_text('//tr', /fooman/).find_elements(:link, 'Delete').length.should eq(0)
+    }
+
     # now lets make sure it's there
     @driver.find_element(:link, "Create").click
     @driver.find_element(:link, "Accession").click


### PR DESCRIPTION
Currently if a enumeration_value is suppressed, it will be deleted if the enumaration is
edited. They will disapear without the user knowing or throw an error if the suppressed
value is in use.
This removed the ability to delete suppressed values, ensuring they will be kept.
