### PR TITLE
Replace daogrp handling with arc-aware version

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -772,9 +772,10 @@ class EADConverter < Converter
     end
     
     with 'daogrp' do
-      title = ''
+      title = att('title')
 
-      unless title = att('title')
+      unless title
+        title = ''
         ancestor(:resource, :archival_object ) { |ao| title << ao.title + ' Digital Object' }
       end
 

--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -782,6 +782,7 @@ class EADConverter < Converter
       make :digital_object, {
         :digital_object_id => SecureRandom.uuid,
         :title => title,
+        :publish => att('audience') != 'internal'
        } do |obj|
          ancestor(:resource, :archival_object) do |ao|
           ao.instances.push({'instance_type' => 'digital_object', 'digital_object' => {'ref' => obj.uri}})
@@ -813,6 +814,7 @@ class EADConverter < Converter
            # attrs on <daoloc>
            fv_attrs[:file_uri] = daoloc['xlink:href'] if daoloc['xlink:href']
            fv_attrs[:use_statement] = daoloc['xlink:role'] if daoloc['xlink:role']
+           fv_attrs[:publish] = daoloc['audience'] != 'internal'
 
            obj.file_versions << fv_attrs
          end

--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -772,31 +772,52 @@ class EADConverter < Converter
     end
     
     with 'daogrp' do
-      title = '' 
-      ancestor(:resource, :archival_object ) { |ao| title << ao.title + ' Digital Object' } 
-      
+      title = ''
+
+      unless title = att('title')
+        ancestor(:resource, :archival_object ) { |ao| title << ao.title + ' Digital Object' }
+      end
+
       make :digital_object, {
         :digital_object_id => SecureRandom.uuid,
         :title => title,
        } do |obj|
          ancestor(:resource, :archival_object) do |ao|
           ao.instances.push({'instance_type' => 'digital_object', 'digital_object' => {'ref' => obj.uri}})
-        end
-      end
+         end
 
+         # Actuate and Show values applicable to <daoloc>s can come from <arc> elements,
+         # so daogrp contents need to be handled together
+         dg_contents = Nokogiri::XML::DocumentFragment.parse(inner_xml)
+
+         # Hashify arc attrs keyed by xlink:to
+         arc_by_to_val = dg_contents.xpath('arc').map {|arc|
+           if arc['xlink:to']
+             [arc['xlink:to'], arc]
+           else
+             nil
+           end
+         }.reject(&:nil?).reduce({}) {|hsh, (k, v)| hsh[k] = v;hsh}
+
+
+         dg_contents.xpath('daoloc').each do |daoloc|
+           arc = arc_by_to_val[daoloc['xlink:label']] || {}
+
+           fv_attrs = {}
+
+           # attrs on <arc>
+           fv_attrs[:xlink_show_attribute] = arc['xlink:show'] if arc['xlink:show']
+           fv_attrs[:xlink_actuate_attribute] = arc['xlink:actuate'] if arc['xlink:actuate']
+
+           # attrs on <daoloc>
+           fv_attrs[:file_uri] = daoloc['xlink:href'] if daoloc['xlink:href']
+           fv_attrs[:use_statement] = daoloc['xlink:role'] if daoloc['xlink:role']
+
+           obj.file_versions << fv_attrs
+         end
+         obj
+      end
     end
-  
-  
-   with 'daoloc' do
-     ancestor(:digital_object) do |dobj|
-      dobj.file_versions << {
-       :file_uri => att('href'),
-       :xlink_show_attribute => att('show'),
-       :file_format_name => att('role')  
-       } 
-     end
-   end
-  
   end
  
   

--- a/backend/app/exporters/examples/ead/ead-dao-test.xml
+++ b/backend/app/exporters/examples/ead/ead-dao-test.xml
@@ -45,9 +45,12 @@
                                <extent>2 folders</extent>
                            </physdesc>
                            <daogrp>
-                               <daodesc><p>first daogrp</p></daodesc>
+                             <daodesc><p>first daogrp</p></daodesc>
+                               <arc xlink:to="label1" xlink:actuate="onLoad" xlink:show="new" />
                                <daoloc xlink:href="http://a" xlink:title="imageone" xlink:role="image/jpeg" xlink:label="label1"/>
+                               <arc xlink:to="label2" xlink:actuate="onRequest" xlink:show="embed" />
                                <daoloc xlink:href="http://b" xlink:title="imagetwo" xlink:role="image/jpeg" xlink:label="label2"/>
+                               <arc xlink:to="label3" xlink:actuate="onLoad" xlink:show="new" />
                                <daoloc xlink:href="http://c" xlink:title="imagetwoverso" xlink:role="image/jpeg" xlink:label="label3"/>
                            </daogrp>
                        </did>

--- a/backend/spec/lib_ead_converter_spec.rb
+++ b/backend/spec/lib_ead_converter_spec.rb
@@ -966,6 +966,10 @@ ANEAD
       @file_versions.length.should == 11
     end
 
+    it "should honor xlink:show and xlink:actuate from arc elements" do
+      @file_versions[0..2].map {|fv| fv['xlink_actuate_attribute']}.should == %w|onLoad onRequest onLoad|
+      @file_versions[0..2].map{|fv| fv['xlink_show_attribute']}.should == %w|new embed new|
+    end
 
     it "should turn all the daodsc into notes" do
       @notes.length.should == 3


### PR DESCRIPTION
Fixes #530

In <daogrp>s, xlink:actuate and xlink:show attributes related to the
<daoloc> can be (must be, according to standard) located on <arc>
elements within the <daogrp>, connected via:

  arc#xlink:to -> daoloc#xlink:label

They're at the same level of nesting and have no ordering guarantees, so
this code stops at the <daogrp>, constructs a fragment from its inner_xml,
and processes the whole <daogrp> at once.

This commit also includes a partial improvement to title handling, in
that it looks for an explicit title on the <daogrp>
