### PR TITLE
Fixed incorrect APP_URL in public interface template

### DIFF
--- a/public/app/views/layouts/application.html.erb
+++ b/public/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
   <script>
     FRONTEND_URL = "<%= j(AppConfig[:frontend_proxy_url]) %>";
     PUBLIC_URL = "<%= j(AppConfig[:public_proxy_url]) %>";
-    APP_PATH = "<%= j(AppConfig[:frontend_proxy_prefix]) %>";
+    APP_PATH = "<%= j(AppConfig[:public_proxy_prefix]) %>";
     FACET_SHOW_FEWER = "<%= I18n.t("search_results.filter.show_fewer") %>";
     FACET_SHOW_MORE = "<%= I18n.t("search_results.filter.show_more") %>";
   </script>


### PR DESCRIPTION
See comments on commit for details. The template that outputs the APP_URL javascript variable in the public-facing interface appears to be using a wrong proxy prefix.
