### PR TITLE
AR-1424 fix add/remove row actions not visible on AO RDE

### DIFF
--- a/frontend/app/views/archival_objects/_rde_templates.html.erb
+++ b/frontend/app/views/archival_objects/_rde_templates.html.erb
@@ -80,6 +80,7 @@
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
+  <col class="fieldset-col" data-default-width='150' />
 <% end %>
 
 <% define_template "rde_archival_object_row", jsonmodel_definition(:archival_object) do |form, archival_object| %>


### PR DESCRIPTION
Patch adds missing <col> so RDE javascript can calculate the correct table width for archival object rows.  This ensure the actions 'add row' and 'remove row' are visible.

Delivers https://archivesspace.atlassian.net/browse/AR-1424