### PR TITLE
AR-1472 only published resources can be printed to PDF 

### DIFF
--- a/backend/app/lib/print_to_pdf_runner.rb
+++ b/backend/app/lib/print_to_pdf_runner.rb
@@ -37,7 +37,12 @@ class PrintToPDFRunner < JobRunner
           :include_daos => true,
           :use_numbered_c_tags => false 
         }
-        
+
+        if !obj['publish']
+          @job.write_output("Error: This resource is not published and cannot be exported to PDF")
+          return
+        end
+
         record = JSONModel(:resource).new(obj) 
         ead = ASpaceExport.model(:ead).from_resource( record, opts)
         xml = "" 

--- a/backend/spec/model_print_to_pdf_job_spec.rb
+++ b/backend/spec/model_print_to_pdf_job_spec.rb
@@ -28,8 +28,8 @@ describe "Print to PDF job model" do
     job.owner.username.should eq('nobody')
   end
 
-  it "can create a pdf from a resource" do
-    opts = {:title => generate(:generic_title)}
+  it "can create a pdf from a published resource" do
+    opts = {:title => generate(:generic_title), :publish => true}
     resource = create_resource(opts)
     
     json = print_to_pdf_job(resource.uri)
@@ -39,6 +39,23 @@ describe "Print to PDF job model" do
     jr = JobRunner.for(job) 
     jr.run
 
+    job.refresh
+    job.job_files.length.should eq(1)
+  end
+
+  it "will not create a pdf from an unpublished resource" do
+    opts = {:title => generate(:generic_title), :publish => false}
+    resource = create_resource(opts)
+
+    json = print_to_pdf_job(resource.uri)
+    job = Job.create_from_json( json,
+                                :repo_id => $repo_id,
+                                :user => user )
+    jr = JobRunner.for(job)
+    jr.run
+
+    job.refresh
+    job.job_files.should be_empty
   end
 
 end


### PR DESCRIPTION
The AR-1472 describes only allowing published content to be printed to PDF.   This change adds handling to the PDF job to show a message when a user attempts to print an unpublished resource.  This mimics the same behaviour when exporting EAD XML from an unpublished resource (it returns an empty XML file).  Tests have been updated accordingly. 