### PR TITLE
AR-1387 fix advanced search rows not providing correct 'op' options

### DIFF
--- a/frontend/app/assets/javascripts/header.js
+++ b/frontend/app/assets/javascripts/header.js
@@ -125,7 +125,7 @@ $(function() {
     event.stopPropagation();
     event.preventDefault();
 
-    var index = $("input[id^='v']", $advancedSearchRowContainer).length;
+    var index = $(":input[id^='v']", $advancedSearchRowContainer).length;
 
     var adding_as_first_row = false;
     if (index == 0) {


### PR DESCRIPTION
The first row in the advanced search should only offer the 'op' NOT option. The patch fixes the JavaScript used to determine if a new row is indeed the first row so now subsequent rows offer all 'op' options.

Delivers https://archivesspace.atlassian.net/browse/AR-1387 