### PR TITLE
Don't show an empty classifications box for resources either

### DIFF
--- a/frontend/app/views/resources/_show_inline.html.erb
+++ b/frontend/app/views/resources/_show_inline.html.erb
@@ -100,7 +100,7 @@
           <%= render_aspace_partial :partial => "collection_management/show", :locals => { :collection_management => @resource.collection_management, :context => readonly, :section_id => "resource_collection_management_" } %>
         <% end %>
 
-        <% if @resource.classifications %>
+        <% if @resource.classifications && !@resource.classifications.empty? %>
           <%= render_aspace_partial :partial => "classifications/show", :locals => { :classifications => @resource.classifications, :context => readonly, :section_id => "resource_classifications_" } %>
         <% end %>
 


### PR DESCRIPTION
Oops... I fixed accessions but missed resources.