### PR TITLE
Double line break fix for Archon

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -42,6 +42,8 @@ class EADSerializer < ASpaceExport::Serializer
 
 
   def handle_linebreaks(content)
+    # 4archon... 
+    content.gsub!("\n\t", "\n\n")  
     # if there's already p tags, just leave as is
     return content if ( content.strip =~ /^<p(\s|\/|>)/ or content.strip.length < 1 )
     original_content = content

--- a/common/mixed_content_parser.rb
+++ b/common/mixed_content_parser.rb
@@ -12,6 +12,9 @@ module MixedContentParser
     # (seems like the API falls down when we do this directly...)
     d = org.jsoup.Jsoup.parse("")
     d.outputSettings.prettyPrint(opts[:pretty_print])
+   
+    # archon does things differently.....
+    content.gsub!("\n\t", "\n\n") 
 
     # transform blocks of text seperated by line breaks into <p> wrapped blocks
     content = content.split("\n\n").inject("") { |c,n| c << "<p>#{n}</p>"  } if opts[:wrap_blocks]


### PR DESCRIPTION

Archon doesn't do the AT feature of p's wrapped in double line breaks. This attempts to fix that.

https://groups.google.com/forum/#!topic/archivesspace/_SeaUbmnVXo