### PR TITLE
AR-1424 fix RDE column widths in all browsers

### DIFF
--- a/frontend/app/assets/javascripts/rde.js
+++ b/frontend/app/assets/javascripts/rde.js
@@ -1044,10 +1044,13 @@ $(function() {
       var persistColumnWidths = function() {
         var widths = {};
         $("table colgroup col", $rde_form).each(function(i, col) {
-          if ($(col).width() === 0) {
-            $(col).width($(col).data("default-width"));
+          if ($(col).prop("width") === null || $(col).prop("width") === "") {
+            $(col).prop("width", $(col).data("default-width"));
+          } else if ($(col).css("width")) {
+            var newWidth = parseInt($(col).css("width"));
+            $(col).prop("width", newWidth);
           }
-          widths[$(col).data("id")] = $(col).width();
+          widths[$(col).data("id")] = parseInt($(col).prop("width"));
         });
 
         COLUMN_WIDTHS = widths;
@@ -1078,13 +1081,20 @@ $(function() {
       var applyPersistentColumnWidths = function() {
         var total_width = 0;
 
-        $("table colgroup col", $rde_form).each(function(i, el) {
+        // force table layout to auto
+        $table.css("tableLayout", "auto");
+
+        $("colgroup col", $table).each(function(i, el) {
           var colW = getColumnWidth($(el).data("id"));
-          $(el).width(colW);
+          $(el).prop("width", colW);
           total_width += colW;
         });
 
         $table.width(total_width);
+
+        // and then change table layout to fixed to force a redraw to
+        // ensure all colgroup widths are obeyed
+        $table.css("tableLayout", "fixed");
       };
 
       var applyPersistentStickyColumns = function() {

--- a/frontend/app/views/archival_objects/_rde_templates.html.erb
+++ b/frontend/app/views/archival_objects/_rde_templates.html.erb
@@ -48,8 +48,8 @@
 
 <% define_template "rde_archival_object_cols" do |form| %>
   <col class="fieldset-col" data-default-width='150' />
-  <col class="fieldset-col" data-default-width='70' />
   <col class="fieldset-col" data-default-width='150' />
+  <col class="fieldset-col" data-default-width='70' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />


### PR DESCRIPTION
Safari and Firefox where not obeying the CSS width on `<col>` elements so I've changed to it all to use the more widely supported `width` property.

There was also a glitch in Safari whereby the table widths were not be reloaded from the cookie.  To fix I've flip the table's CSS property `table-layout` to `auto` and then back to `fixed` after applying all the widths.  This ensures the table is redrawn by the browser and all the new <col> widths are honoured. 

Delivers https://archivesspace.atlassian.net/browse/AR-1424