### PR TITLE
Remove the need for a hard-coded migration number

### DIFF
--- a/README_RELEASE.md
+++ b/README_RELEASE.md
@@ -110,11 +110,9 @@ a zip file.
 
 ## Commit and Tag the release
 
-The scripts/build_release script updates the [SCHEMA_INFO
-number](https://github.com/archivesspace/archivesspace/blob/master/common/asconstants.rb#L45) that blocks the
-application from starting if the migrations have not completed. So, after
-you've run the build_release.sh script, you'll need to commit the
-asconstants.rb file, then tag the release in git.
+The release process adds the version number to
+`common/asconstants.rb`.  After you've run the `build_release.sh`
+script, you'll need to commit that file then tag the release in git.
 
 ```
 $ git add common/asconstants.rb
@@ -123,7 +121,7 @@ $ git tag vX.X.X
 $ git push --tags
 ```
 
-##Build the release announcement
+## Build the release announcement
 
 The release announcement needs to have all the tickets that make up the
 changelog for the replease. In the past, this list has been written into

--- a/backend/app/main.rb
+++ b/backend/app/main.rb
@@ -99,21 +99,25 @@ class ArchivesSpaceService < Sinatra::Base
 
       # let's check that our migrations have passed and we're on the right
       # schema_info version
-      unless AppConfig[:ignore_schema_info_check] 
+      unless AppConfig[:ignore_schema_info_check]
         schema_info = 0
-        DB.open do |db| schema_info =  db[:schema_info].get(:version) end
-        if schema_info != ASConstants.SCHEMA_INFO
-          Log.error("***** DATABASE MIGRATION ERROR *****\n" +
-                    "\n" +
-                    "ArchivesSpace has encountered a problem with your database schema info version.\n\n" +
-                    "The schema info version should be #{ ASConstants.SCHEMA_INFO} for ArchivesSpace version #{ ASConstants.VERSION}.\n " +
-                    "However, your schema info version is set at #{schema_info}\n" + 
-                    "Please ensure your migrations have been run and completed by using the setup-database script.\n\n ")
-          raise "Schema Info Mismatch. Expected #{ ASConstants.SCHEMA_INFO }, received #{ schema_info } for ASPACE version #{ ASConstants.VERSION }. "
+        DB.open do |db|
+          schema_info =  db[:schema_info].get(:version)
+          required_schema_info = DBMigrator.latest_migration_number(db)
 
+          if schema_info != required_schema_info
+            Log.error("***** DATABASE MIGRATION ERROR *****\n" +
+                      "\n" +
+                      "ArchivesSpace has encountered a problem with your database schema info version.\n\n" +
+                      "The schema info version should be #{required_schema_info} for ArchivesSpace version #{ASConstants.VERSION}.\n " +
+                      "However, your schema info version is set at #{schema_info}\n" +
+                      "Please ensure your migrations have been run and completed by using the setup-database script.\n\n ")
+            raise "Schema Info Mismatch. Expected #{required_schema_info}, received #{schema_info} for ASPACE version #{ASConstants.VERSION}. "
+          end
         end
-      end 
-      
+
+      end
+
       if AppConfig[:enable_jasper] && DB.supports_jasper? 
         require_relative 'model/reports/jasper_report' 
         require_relative 'model/reports/jasper_report_register' 

--- a/build/build.xml
+++ b/build/build.xml
@@ -592,9 +592,6 @@
         <include name="*_*.rb" />
       </fileset>
     </resourcecount>
-    <!-- now add that value to asconstants -->
-    <replaceregexp byline='true' flags='g' file="../common/asconstants.rb" match='@SCHEMA_INFO = (.\d+)' replace="@SCHEMA_INFO = ${schema_info}" />
-
 
     <jar jarfile="target/archivesspace/lib/common.jar">
       <fileset dir="../common" excludes="lib/*" />

--- a/common/asconstants.rb
+++ b/common/asconstants.rb
@@ -6,7 +6,6 @@
 module ASConstants
 
   @VERSION
-  @SCHEMA_INFO
 
   module Repository
 
@@ -33,16 +32,6 @@ module ASConstants
     rescue
       @VERSION = "NO VERSION"
     end
-  end
-
-  # Schema Info is a number set by the migration process. We need to store what
-  # this value is supposed to be and check it against the value that's stored
-  # in the db post-migration. Backend will not start if this value is off. 
-  #
-  def self.SCHEMA_INFO
-    return @SCHEMA_INFO if @SCHEMA_INFO
-    # this gets changed by dist ant task 
-    @SCHEMA_INFO = 74
   end
 
 end

--- a/common/db/db_migrator.rb
+++ b/common/db/db_migrator.rb
@@ -225,4 +225,18 @@ EOF
     return false
   end
 
+  def self.latest_migration_number(db)
+    migration_numbers = Dir.entries(MIGRATIONS_DIR).map {|e|
+      if e =~ Sequel::Migrator::MIGRATION_FILE_PATTERN
+        # $1 is the migration number (e.g. '075')
+        Integer($1, 10)
+      end
+    }.compact
+
+    if migration_numbers.empty?
+      0
+    else
+      migration_numbers.max
+    end
+  end
 end

--- a/docs/user/building-an-archivesspace-release.md
+++ b/docs/user/building-an-archivesspace-release.md
@@ -114,11 +114,9 @@ a zip file.
 
 ## Commit and Tag the release
 
-The scripts/build_release script updates the [SCHEMA_INFO
-number](https://github.com/archivesspace/archivesspace/blob/master/common/asconstants.rb#L45) that blocks the
-application from starting if the migrations have not completed. So, after
-you've run the build_release.sh script, you'll need to commit the
-asconstants.rb file, then tag the release in git.
+The release process adds the version number to
+`common/asconstants.rb`.  After you've run the `build_release.sh`
+script, you'll need to commit that file then tag the release in git.
 
 ```
 $ git add common/asconstants.rb
@@ -127,7 +125,7 @@ $ git tag vX.X.X
 $ git push --tags
 ```
 
-##Build the release announcement
+## Build the release announcement
 
 The release announcement needs to have all the tickets that make up the
 changelog for the replease. In the past, this list has been written into


### PR DESCRIPTION
It's pretty common to see test failures in branches due to the hard-coded migration number in ASConstants.  I think we can avoid needing to hard-code it by checking the migration files themselves.