### PR TITLE
Ar 1614 : fix handling of unitdate attributes on EAD & PDF export. 

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -165,7 +165,7 @@ class EADConverter < Converter
       norm_dates.map! {|d| d =~ /^([0-9]{4}(\-(1[0-2]|0[1-9])(\-(0[1-9]|[12][0-9]|3[01]))?)?)$/ ? d : nil}
 
       make :date, {
-        :date_type => att('type') || 'inclusive',
+        :date_type => att('type') || ( norm_dates[1] ? 'inclusive' : 'single' ),
         :expression => inner_xml,
         :label => 'creation',
         :begin => norm_dates[0],

--- a/backend/app/exporters/lib/export_helpers.rb
+++ b/backend/app/exporters/lib/export_helpers.rb
@@ -126,7 +126,8 @@ module ASpaceExport
             normal_suffix = (date['date_type'] == 'single' || date['end'].nil? || date['end'] == date['begin']) ? date['begin'] : date['end']
             normal += normal_suffix ? normal_suffix : ""
           end
-          type = %w(single inclusive).include?(date['date_type']) ? 'inclusive' : 'bulk'
+          # type = %w(single inclusive).include?(date['date_type']) ? 'inclusive' : 'bulk'
+          type = ( date['date_type'] == 'inclusive' ) ? 'inclusive' :  ( ( date['date_type'] == 'single') ? nil : 'bulk')
           content = if date['expression']
                     date['expression']
                   elsif date['date_type'] == 'bulk'
@@ -137,7 +138,9 @@ module ASpaceExport
                     "#{date['begin']}-#{date['end']}"
                   end
 
-          atts = {:type => type}
+          atts = {}
+          atts[:type] = type if type
+          atts[:certainty] = date['certainty'] if date['certainty']
           atts[:normal] = normal unless normal.empty?
 
           results << {:content => content, :atts => atts}

--- a/backend/app/exporters/lib/export_helpers.rb
+++ b/backend/app/exporters/lib/export_helpers.rb
@@ -126,7 +126,6 @@ module ASpaceExport
             normal_suffix = (date['date_type'] == 'single' || date['end'].nil? || date['end'] == date['begin']) ? date['begin'] : date['end']
             normal += normal_suffix ? normal_suffix : ""
           end
-          # type = %w(single inclusive).include?(date['date_type']) ? 'inclusive' : 'bulk'
           type = ( date['date_type'] == 'inclusive' ) ? 'inclusive' :  ( ( date['date_type'] == 'single') ? nil : 'bulk')
           content = if date['expression']
                     date['expression']

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -528,7 +528,8 @@ describe "EAD export mappings" do
         path = "#{desc_path}/did/unitdate[#{count}]"
         normal = "#{date['begin']}/"
         normal += (date['date_type'] == 'single' || date['end'].nil? || date['end'] == date['begin']) ? date['begin'] : date['end']
-        type = %w(single inclusive).include?(date['date_type']) ? 'inclusive' : 'bulk'
+        type = ( date['date_type'] == 'inclusive' ) ? 'inclusive' :  ( ( date['date_type'] == 'single') ? nil : 'bulk')
+        # type = %w(single inclusive).include?(date['date_type']) ? 'inclusive' : 'bulk'
         value = if date['expression']
                   date['expression']
                 elsif date['date_type'] == 'bulk'

--- a/stylesheets/as-ead-pdf.xsl
+++ b/stylesheets/as-ead-pdf.xsl
@@ -1574,6 +1574,8 @@
                     <xsl:if test="@type"> [<xsl:value-of select="@type"/>]</xsl:if>
                 </xsl:otherwise>
             </xsl:choose></fo:inline>: <xsl:apply-templates/>
+            <!-- Test for certainty attribute used by unitdate -->
+            <xsl:if test="@certainty" > <fo:inline font-style="italic"> (<xsl:value-of select="@certainty"/>)</fo:inline></xsl:if>
         </fo:block>
         </xsl:if>
     </xsl:template>


### PR DESCRIPTION
https://archivesspace.atlassian.net/browse/AR-1614

If date type is 'single', don't attach a unitdate/@type attribute. ( it's neither 'bulk' nor 'inclusive' )
Also export date.certainty as unitdate/@certainty, and pass that thru the to pdf. 

On import: if no @type attribute and only a single value, make model type = 'single' , else 'inclusive' 
( unitdate/@certainty appears to map properly on import. )
