### PR TITLE
Don't blow up if we hit orphaned digital object instances

### DIFF
--- a/backend/app/model/mixins/map_to_aspace_container.rb
+++ b/backend/app/model/mixins/map_to_aspace_container.rb
@@ -45,12 +45,12 @@ module MapToAspaceContainer
 
     def sequel_to_jsonmodel(objs, opts = {})
       jsons = super
-      
 
       jsons.zip(objs).each do |record_json, record_obj|
-        Array(record_json['instances']).zip(record_obj.instance).each do |instance_json, instance_obj|
-          next unless instance_json['sub_container']
+        non_do_json_instances = Array(record_json['instances']).select {|instance| instance['instance_type'] != 'digital_object'}
+        non_do_obj_instances = record_obj.instance.select {|instance| instance.instance_type != 'digital_object'}
 
+        non_do_json_instances.zip(non_do_obj_instances).each do |instance_json, instance_obj|
           instance_json['container'] = map_managed_container_to_aspace_json(instance_json, instance_obj)
         end
       end

--- a/backend/spec/controller_digital_object_spec.rb
+++ b/backend/spec/controller_digital_object_spec.rb
@@ -86,7 +86,8 @@ describe 'Digital Objects controller' do
 
     resource = create(:json_resource,
                       :instances => [build(:json_instance,
-                                           :digital_object => {'ref' => digobj.uri})])
+                                           :digital_object => {'ref' => digobj.uri},
+                                           :instance_type => 'digital_object')])
 
     digobj = JSONModel(:digital_object).find(digobj.id)
     digobj.title = "updated"

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -29,7 +29,9 @@ describe "EAD export mappings" do
 
     instances = []
     @digital_objects.keys.each do |ref|
-      instances << build(:json_instance, :digital_object => {:ref => ref})
+      instances << build(:json_instance,
+                         :instance_type => 'digital_object',
+                         :digital_object => {:ref => ref})
     end
 
     #throw in a couple non-digital instances

--- a/backend/spec/model_compatibility_spec.rb
+++ b/backend/spec/model_compatibility_spec.rb
@@ -442,4 +442,29 @@ describe 'Managed Container compatibility' do
     }.to_not raise_error
   end
 
+
+  it "does not blow up if a digital object instance is missing its ref" do
+    digital_object = create(:json_digital_object)
+
+    resource = create(:json_resource,
+           :instances => [
+             build(:json_instance_digital, :digital_object => {:ref => digital_object.uri}),
+             build(:json_instance),
+           ])
+
+    # Currently this leaves the instance but removes its digital object linkage.
+    # In reality we should probably be wiping out the invalidated instance too,
+    # but one bug at a time...
+    DigitalObject[digital_object.id].delete
+
+    # Putting this here to cause this test to fix when the above bug is
+    # addressed.  Feel free to delete this test when that happens!
+    Resource[resource.id].instance.length.should eq(2)
+
+    expect {
+      Resource.to_jsonmodel(resource.id)
+    }.to_not raise_error
+  end
+
+
 end

--- a/backend/spec/model_instance_spec.rb
+++ b/backend/spec/model_instance_spec.rb
@@ -101,4 +101,14 @@ describe 'Instance model' do
     expect { obj.update_from_json(archival_object) }.to_not raise_error
   end
 
+
+  it "throws an error if you supply a digital object URI for a non-digital object type" do
+    expect {
+    JSONModel(:instance)
+      .from_hash(:digital_object => {:ref => '/repositories/#{$repo_id}/digital_objects/123'},
+                 :instance_type => 'text')
+      .validate
+    }.to raise_error(JSONModel::ValidationException)
+  end
+
 end

--- a/common/validations.rb
+++ b/common/validations.rb
@@ -262,6 +262,9 @@ module JSONModel::Validations
     if hash["instance_type"] == "digital_object"
       errors << ["digital_object", "Can't be empty"] if hash["digital_object"].nil?
 
+    elsif hash["digital_object"] && hash["instance_type"] != "digital_object"
+      errors << ["instance_type", "An instance with a digital object reference must be of type 'digital_object'"]
+
     elsif hash["instance_type"]
       errors << ["container", "Can't be empty"] if hash["container"].nil?
     end


### PR DESCRIPTION
Currently if a digital object is deleted, it leaves behind an orphaned
digital object instance with no DO link (this should be fixed too).

Digital object instances with no digital object get filtered by
Instance.sequel_to_jsonmodel, causing a weird situation where the
database knowns about N instances but the JSON only contains N - 1.

This mismatch upset the container mapping code, which is silly because
it doesn't care about digital object instances anyway.  So, modify that
code to ignore them.

(includes a small fix for the EAD tests which were using digital object
 instances without the digital object instance type)