### PR TITLE
Ignore mysql connector [ci skip]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ locales.diff
 */bower_components
 Gemfile.local
 supervisord.*
+mysql-connector*.jar


### PR DESCRIPTION
Super trivial :smile: 

I use it locally pretty often. It would be a good idea to ignore it as we don't want to bundle it:

https://github.com/archivesspace/archivesspace/#download-mysql-connector
