### PR TITLE
Security updates

### DIFF
--- a/common/asutils.rb
+++ b/common/asutils.rb
@@ -112,10 +112,7 @@ module ASUtils
  def self.get_diagnostics(exception = nil )
     runtime = java.lang.Runtime.getRuntime
    {
-      :version =>ASConstants.VERSION,  
-      :environment => java.lang.System.getenv.to_hash,
-      :jvm_properties => java.lang.System.getProperties.to_hash,
-      :globals => Hash[global_variables.map {|v| [v, eval(v.to_s)]}],
+      :version =>ASConstants.VERSION,
       :appconfig => defined?(AppConfig) ? AppConfig.dump_sanitized : "not loaded",
       :memory => {
         :free => runtime.freeMemory,

--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -180,6 +180,10 @@ class ApplicationController < ActionController::Base
     }
   end
 
+  def user_is_global_admin?
+    session['user'] and session['user'] == "admin"
+  end
+
 
   def user_must_have(permission)
     unauthorised_access if !session['user'] || !user_can?(permission)
@@ -198,6 +202,9 @@ class ApplicationController < ActionController::Base
     unauthorised_access if session['user'] and not user_can? 'manage_users'
   end
 
+  def user_needs_to_be_global_admin
+    unauthorised_access if not user_is_global_admin?
+  end
 
   helper_method :user_prefs
   def user_prefs

--- a/frontend/app/controllers/system_info_controller.rb
+++ b/frontend/app/controllers/system_info_controller.rb
@@ -1,6 +1,7 @@
 class SystemInfoController < ApplicationController
   
   set_access_control  "administer_system" => [ :show, :stream_log]
+  before_filter :user_needs_to_be_global_admin
 
   def show 
     @app_context = params[:app_context] ? params[:app_context] : "frontend_info"

--- a/frontend/app/controllers/users_controller.rb
+++ b/frontend/app/controllers/users_controller.rb
@@ -48,11 +48,23 @@ class UsersController < ApplicationController
 
   def edit
     @user = JSONModel(:user).find(params[:id])
+
+    if @user.is_system_user and not user_is_global_admin?
+      flash[:error] = I18n.t("user._frontend.messages.access_denied", JSONModelI18nWrapper.new(:user => @user))
+      redirect_to(:controller => :users, :action => :index) and return
+    end
+
     render action: "edit"
   end
 
   def edit_groups
     @user = JSONModel(:user).from_hash(JSONModel::HTTP::get_json("/repositories/#{session[:repo_id]}/users/#{params[:id]}"))
+
+    if @user.is_system_user or @user.is_admin
+      flash[:error] = I18n.t("user._frontend.messages.group_not_required", JSONModelI18nWrapper.new(:user => @user))
+      redirect_to(:controller => :users, :action => :manage_access) and return
+    end
+
     @groups = JSONModel(:group).all
     render action: "edit_groups"
   end

--- a/frontend/app/models/user.rb
+++ b/frontend/app/models/user.rb
@@ -42,6 +42,7 @@ class User < JSONModel(:user)
 
 
   def self.become_user(context, username)
+    return false if username == "admin"
     uri = JSONModel(:user).uri_for("#{username}/become-user")
 
     response = JSONModel::HTTP.post_form(uri)

--- a/frontend/app/views/users/index.html.erb
+++ b/frontend/app/views/users/index.html.erb
@@ -39,8 +39,8 @@
               <td><%= user.username %></td>
               <td>
                  <div class="btn-group" style="float: right">
-                   <% if @manage_access %>
-                    <%= link_to I18n.t("actions.edit_groups"), {:controller => :users, :action => :edit_groups, :id => user.id}, :class => "btn btn-xs btn-default" %>
+                   <% if @manage_access; disabled = user.is_admin ? " disabled" : "" %>
+                      <%= link_to I18n.t("actions.edit_groups"), {:controller => :users, :action => :edit_groups, :id => user.id}, :class => "btn btn-xs btn-default".concat(disabled) %>
                    <% else %>
                     <%= link_to I18n.t("actions.edit"), {:controller => :users, :action => :edit, :id => user.id}, :class => "btn btn-xs btn-primary" %>
                    <% end %>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -831,11 +831,13 @@ en:
   user:
     _frontend:
       messages:
+        access_denied: Access denied. Login as the admin user to perform this action.
         created: User Created
         updated: User Saved
         deleted: User Deleted
         error_update: User not saved
         error_create: User not created
+        group_not_required: User is an administrator or system user, group selection is not required.
       section:
         manage_access: Manage User Access
         account: Account

--- a/selenium/spec/groups_spec.rb
+++ b/selenium/spec/groups_spec.rb
@@ -170,4 +170,27 @@ describe "Groups" do
       @driver.ensure_no_such_element(:link, "Create")
     }
   end
+
+  it "cannot modify the user groups via Manage Access if the user is an admin" do
+    @driver.logout.login_to_repo($admin, @repo_to_manage)
+
+    # change @can_manage_repo to a view only
+    @driver.find_element(:css, '.repo-container .btn.dropdown-toggle').click
+    @driver.find_element(:link, "Manage User Access").click
+
+    while true
+      # Wait for the table to load
+      @driver.find_element(:link, "Edit Groups")
+
+      # assume (for now at least) admin is always on the first page
+      admin_row = @driver.find_element_with_text('//tr', /admin/, true, true)
+      if admin_row
+        expect {
+          admin_row.find_element(:css, 'a.disabled')
+        }.to_not raise_error
+        break
+      end
+    end
+  end
+
 end

--- a/selenium/spec/user_management_spec.rb
+++ b/selenium/spec/user_management_spec.rb
@@ -47,6 +47,8 @@ describe "User management" do
     @driver.clear_and_send_keys([:id, "user_password_"], @test_user.password)
     @driver.clear_and_send_keys([:id, "user_confirm_password_"], @test_user.password)
 
+    @driver.find_element(:id, "user_is_admin_").click
+
     @driver.find_element(:id, 'create_account').click
     @driver.find_element_with_text('//div[contains(@class, "alert-success")]', /User Created: /)
   end
@@ -67,8 +69,17 @@ describe "User management" do
     @user_props.each do |k,val|
       assert(5) { @driver.find_element(:css=> "#user_#{k.to_s}_").attribute('value').should match(val) }
     end
+
+    @driver.find_element(:id, "user_is_admin_" ).attribute("checked").should be_truthy
   end
 
+  it "doesn't allow another user to edit the global admin or a system account" do
+    @driver.login(@test_user)
+    ['1', '2'].each do |user_id|
+      @driver.navigate.to("#{$frontend}/users/#{user_id}/edit")
+      @driver.find_element_with_text('//div[contains(@class, "alert-danger")]', /Access denied/)
+    end
+  end
 
   it "doesn't allow you to edit the user short names" do
     @driver.login($admin)

--- a/selenium/spec/users_and_auth_spec.rb
+++ b/selenium/spec/users_and_auth_spec.rb
@@ -54,6 +54,20 @@ describe "Users and authentication" do
     @driver.clear_and_send_keys([:id, "select-user"], @user.username)
     @driver.find_element(:css, "#new_become_user .btn-primary").click
     @driver.find_element_with_text('//div[contains(@class, "alert-success")]', /Successfully switched users/)
+
+    @driver.logout
+  end
+
+  it "prevents any user from becoming the global admin" do
+    @driver.login($admin)
+
+    @driver.find_element(:css, '.user-container a.btn').click
+    @driver.find_element(:link, "Become User").click
+    @driver.clear_and_send_keys([:id, "select-user"], "admin")
+    @driver.find_element(:css, "#new_become_user .btn-primary").click
+    @driver.find_element_with_text('//div[contains(@class, "alert-danger")]', /Failed to switch/)
+
+    @driver.logout
   end
 
 end


### PR DESCRIPTION
Summary:

Reduces the amount of system information available via the UI. Believe
this was added to help support remote installations, but it's including
too much (and I can't see that it's adding much value). As it's not
uncommon to have api keys and such in the environment it's possible to
inadvertently leak sensitive information.

Restricts access to system information so that only the global admin
account has access to it.

Makes it so only the global admin can edit the global admin and other
system accounts (otherwise any 'admin' user can do this by popping in
the path i.e. /users/2/edit).

Prevents any user from becoming the global admin. That account must be
logged into directly, making it the most privileged account in the
system (as it should be).

Prevents group assignment for 'admin' users. They already have all the
privileges so groups are unnecessary, but this prevents a side effect
where an 'admin' user (including the global admin) can lose admin group
permissions if they are assigned to a group by another admin level user.

These changes are for the frontend only, no backend enforcements added.