### PR TITLE
AR-1413 Don't inadvertently hide instances

### DIFF
--- a/frontend/app/assets/javascripts/notes.crud.js
+++ b/frontend/app/assets/javascripts/notes.crud.js
@@ -389,9 +389,14 @@ $(function() {
         });
         initRemoveActions();
       }
-      
+
       $existingNotes = $(".subrecord-form-list:first > .subrecord-form-wrapper", $this);
-      tooManyNotes = AS.initTooManySubRecords($this, $existingNotes.length, initNoteForms );
+      tooManyNotes = AS.initTooManySubRecords($this, $existingNotes.length, (function (callback) {
+          initNoteForms($this);
+          if (callback) {
+              callback();
+          }
+      }));
 
       if (tooManyNotes === false ) {
         $this.addClass("initialised");


### PR DESCRIPTION
When clicking the "Click to load records" button on a resource record
containing many notes and some instances, the instances section would be
collapsed, never to be seen again.

The code used to initialize the notes section wasn't being properly
scoped, so it was applying to the entire form.  Modified this to only
apply to the notes in question.