### PR TITLE
AR-1493 change remove templates form to use checkboxes instead of buttons

### DIFF
--- a/frontend/app/assets/javascripts/rde.js
+++ b/frontend/app/assets/javascripts/rde.js
@@ -751,14 +751,9 @@ $(function() {
 
         var $templatesTable = $('table tbody', $manageContainer);
 
-        var templatesToDelete = [];
-
         $containerToggle.off("click").on("click", function(event) {
           event.preventDefault();
           event.stopPropagation();
-
-          templatesToDelete = [];
-
 
           // toggle other panel if it is active
           if (!$(this).hasClass("active")) {
@@ -776,15 +771,18 @@ $(function() {
           e.preventDefault();
           e.stopPropagation();
           $containerToggle.toggleClass("active");
-          $manageContainer.slideToggle(function() {
-            templatesToDelete = [];
-          });
+          $manageContainer.slideToggle();
         });
 
 
         $("button.btn-primary", $manageContainer).off("click").on("click", function(e) {
           e.preventDefault();
           e.stopPropagation();
+
+          var templatesToDelete = [];
+          $manageContainer.find(":checkbox:checked").each(function(){
+            templatesToDelete.push($(this).val());
+          });
 
           $.ajax({
             url: $rde_form.data("list-templates-uri") + "/batch_delete",
@@ -806,23 +804,17 @@ $(function() {
 
 
         var renderTable = function() {
+          if (templateList.length == 0) {
+            $(".no-templates-message", $manageContainer).show();
+            $(".btn-primary", $manageContainer).hide();
+            return;
+          } else {
+            $(".no-templates-message", $manageContainer).hide();
+            $(".btn-primary", $manageContainer).show();
+          }
+
           _.each(templateList, function(item) {
             $templatesTable.append(AS.renderTemplate("rde_template_table_row", {item: item}));
-          });
-
-          $("button", $templatesTable).click(function(e) {
-            e.preventDefault();
-            e.stopPropagation();
-
-            var $id = $(this).closest("tr").data('templateId');
-
-            if (_.indexOf(templatesToDelete, $id) > -1) {
-              _.remove(templatesToDelete, $id)
-              $(this).text("Remove");
-            } else {
-              templatesToDelete.push($id);
-              $(this).text("Keep");
-            }
           });
         };
 

--- a/frontend/app/views/shared/_rde.html.erb
+++ b/frontend/app/views/shared/_rde.html.erb
@@ -138,13 +138,15 @@
 
 
         <div id="manageTemplatesForm" class="rde-inline-form form-horizontal" style="display: none;">
-          <h3>Templates</h3>
+          <h3><%= I18n.t("rde.templates.listing") %></h3>
+          <div class="no-templates-message alert alert-warning" style="display: none">
+            <%= I18n.t("rde.templates.no_templates") %>
+          </div>
           <table class="table">
             <tbody class="table-striped"></tbody>
           </table>
           <button class="btn btn-primary btn-sm"><%= I18n.t("rde.save_template.confirm_removal") %></button>
-          <button class="btn btn-sm btn-cancel"><%= I18n.t("actions.cancel") %></button>
-
+          <button class="btn btn-sm btn-default btn-cancel"><%= I18n.t("actions.cancel") %></button>
         </div>
 
 
@@ -232,5 +234,8 @@
 
 
 <div id="rde_template_table_row"><!--
-<tr data-template-id="${item.id}"><td>${item.name}</td><td><button class="btn btn-default">Remove</button></td></tr>
+<tr>
+  <td style='width: 30px;'><input id='remove_me_please_${item.id}' type='checkbox' name='remove_me_please' value='${item.id}'/></td>
+  <td><label for='remove_me_please_${item.id}'>${item.name}</label></td>
+</tr>
 --></div>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -901,6 +901,9 @@ en:
       save_template: Save Template
       template_name: Template name
       confirm_removal: Confirm Removal
+    templates:
+      listing: Templates
+      no_templates: No templates defined
     default_template: Default Template
     messages:
       error_prefix: Row

--- a/selenium/spec/rde_templates_spec.rb
+++ b/selenium/spec/rde_templates_spec.rb
@@ -84,7 +84,7 @@ describe "RDE Templates" do
 
     @driver.wait_for_ajax
 
-    @driver.find_element(:xpath => "//tr[td/text()='#{template.name}']/td[2]/button").click
+    @driver.find_element(:id => "remove_me_please_#{template.id}").click
 
     @driver.find_element(:css => "#manageTemplatesForm button.btn-primary").click
     @driver.wait_for_ajax


### PR DESCRIPTION
Delivers https://archivesspace.atlassian.net/browse/AR-1493 by changing the remove template form interaction to use checkboxes:
<img width="1195" alt="screen shot 2017-01-24 at 11 40 32 am" src="https://cloud.githubusercontent.com/assets/608337/22229160/05c02570-e22a-11e6-899a-f0d9303cd371.png">

Also added a message if there are no template:
<img width="1198" alt="screen shot 2017-01-24 at 11 40 48 am" src="https://cloud.githubusercontent.com/assets/608337/22229158/0395df7e-e22a-11e6-81ba-ca438edb9252.png">

And added some locales for a few hardcoded strings.