### PR TITLE
AR-1296 fix RDE sticky styling on required columns

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/rde.less
+++ b/frontend/app/assets/stylesheets/archivesspace/rde.less
@@ -19,17 +19,29 @@
   .sections, .fieldset-labels {
     th {
       &.required {
-        background-image: asset-url('archivesspace/required_loud.png');
-        background-repeat: no-repeat;
-        background-position: 2px center;
-        padding-left: 16px;
+        &:before {
+          // apply required icon to the inner kiketable container
+          display: none;
+        } 
+        .kiketable-th-text {
+          background-image: asset-url('archivesspace/required_loud.png');
+          background-repeat: no-repeat;
+          background-position: 2px center;
+          padding-left: 16px;
+        }
       }
 
       &.conditionally-required {
-        background-image: asset-url('archivesspace/conditionally_required.png');
-        background-repeat: no-repeat;
-        background-position: 2px center;
-        padding-left: 16px;
+        &:before {
+          // apply required icon to the inner kiketable container
+          display: none;
+        }
+        .kiketable-th-text {
+          background-image: asset-url('archivesspace/conditionally_required.png');
+          background-repeat: no-repeat;
+          background-position: 2px center;
+          padding-left: 16px;
+        }
       }
     }
   }

--- a/frontend/app/assets/stylesheets/archivesspace/tables.less
+++ b/frontend/app/assets/stylesheets/archivesspace/tables.less
@@ -10,17 +10,22 @@ table {
       }
 
       &.required {
-        background-image: asset-url('archivesspace/required_loud.png');
-        background-repeat: no-repeat;
-        background-position: 2px center;
-        padding-left: 16px;
+        &:before {
+          content: '';
+          background-image: asset-url('archivesspace/required_loud.png');
+          background-repeat: no-repeat;
+          background-position: 2px center;
+          padding-right: 16px;
+        }
       }
 
       &.conditionally-required {
-        background-image: asset-url('archivesspace/conditionally_required.png');
-        background-repeat: no-repeat;
-        background-position: 2px center;
-        padding-left: 16px;
+        &:before {
+          font-family: 'Glyphicons Halflings';
+          content: '\002a';
+          color: #aaa;
+          font-size: 0.8em;
+        }
       }
     }
     .col {


### PR DESCRIPTION
Fixes https://archivesspace.atlassian.net/browse/AR-1296

Problem was due to conflict of background images on the RDE table cell.  Currently the mandatory star is a background image and so is the blue highlight applied for "sticky" columns.  To avoid the conflict, I've changed the required/conditionally-required CSS to apply the background image on the pseudo `:before` element of the cells.