### PR TITLE
AR-1299 remove marcxml rules that add all corporate entity names with…

### DIFF
--- a/backend/app/converters/lib/marcxml_base_map.rb
+++ b/backend/app/converters/lib/marcxml_base_map.rb
@@ -92,8 +92,6 @@ module MarcXMLBaseMap
           :defaults => {
             :name_order => 'direct',
             :source => 'ingest'
-          
-          
           }
         }
       }
@@ -225,42 +223,6 @@ module MarcXMLBaseMap
           :obj => :name_corporate_entity,
           :rel => :names,
           :map => name_corp_map,
-        },
-        "//datafield[@tag='410']" => {
-          :obj => :name_corporate_entity,
-          :rel => :names,
-          :map => name_corp_map,
-          :defaults => {
-            :name_order => 'direct',
-            :source => 'ingest'
-          }
-        },
-        "//datafield[@tag='411']" => {
-          :obj => :name_corporate_entity,
-          :rel => :names,
-          :map => name_corp_map,
-          :defaults => {
-            :name_order => 'direct',
-            :source => 'ingest'
-          }
-        },
-        "//datafield[@tag='610']" => {
-          :obj => :name_corporate_entity,
-          :rel => :names,
-          :map => name_corp_map,
-          :defaults => {
-            :name_order => 'direct',
-            :source => 'ingest'
-          }
-        },
-        "//datafield[@tag='611']" => {
-          :obj => :name_corporate_entity,
-          :rel => :names,
-          :map => name_corp_map,
-          :defaults => {
-            :name_order => 'direct',
-            :source => 'ingest'
-          }
         }
       }
     })


### PR DESCRIPTION
…in the XML into each corporate entity that is created

https://archivesspace.atlassian.net/browse/AR-1299

I'm a little unsure about this one, as the rules were quite clearly adding all matching names for each corporate entity (see field number 610 and the mappings preceding with `//`).

This also happens for both people and family agents if the marc field 400 is present - perhaps a bug too?