### PR TITLE
AR-1299 remove marcxml rules that add all 610 or 611 names into each generated corporate entity

### DIFF
--- a/backend/app/converters/lib/marcxml_base_map.rb
+++ b/backend/app/converters/lib/marcxml_base_map.rb
@@ -92,8 +92,6 @@ module MarcXMLBaseMap
           :defaults => {
             :name_order => 'direct',
             :source => 'ingest'
-          
-          
           }
         }
       }
@@ -236,24 +234,6 @@ module MarcXMLBaseMap
           }
         },
         "//datafield[@tag='411']" => {
-          :obj => :name_corporate_entity,
-          :rel => :names,
-          :map => name_corp_map,
-          :defaults => {
-            :name_order => 'direct',
-            :source => 'ingest'
-          }
-        },
-        "//datafield[@tag='610']" => {
-          :obj => :name_corporate_entity,
-          :rel => :names,
-          :map => name_corp_map,
-          :defaults => {
-            :name_order => 'direct',
-            :source => 'ingest'
-          }
-        },
-        "//datafield[@tag='611']" => {
           :obj => :name_corporate_entity,
           :rel => :names,
           :map => name_corp_map,


### PR DESCRIPTION
Delivers https://archivesspace.atlassian.net/browse/AR-1299

Slight variation on the original #601 PR.  We now simply remove the nested mapping for 610 and 611 fields so they are not duplicated as alternate names for other 610/611 fields in the MarcXML.