### PR TITLE
AR-1413 Second half of fix for "too many" notes

### DIFF
--- a/frontend/app/assets/javascripts/subrecord.too_many.js
+++ b/frontend/app/assets/javascripts/subrecord.too_many.js
@@ -1,31 +1,29 @@
 AS.initTooManySubRecords = function($containerForm, numberOfSubRecords, callback ) {
-      
+
   if ( numberOfSubRecords > 4 ) {
-    var $tooManyMsgEl = $(AS.renderTemplate("too_many_subrecords_template"));                                                                                                   
-    $tooManyMsgEl.hide();                                                                                                                                                       
-    $containerForm.append($tooManyMsgEl);                                                                                                                                                
-    $tooManyMsgEl.fadeIn();                                                                                                                                                     
-    $('.subrecord-form-container', $containerForm).hide();                                                                                                                              
-     
-    $containerForm.addClass("too-many");                                                                                                                                               
+    var $tooManyMsgEl = $(AS.renderTemplate("too_many_subrecords_template"));
+    $tooManyMsgEl.hide();
+    $containerForm.append($tooManyMsgEl);
+    $tooManyMsgEl.fadeIn();
+    $('.subrecord-form-container', $containerForm).hide();
+
+    $containerForm.addClass("too-many");
     // let's disable the buttons
     $('.subrecord-form-heading .btn', $containerForm).prop('disabled', true);
 
-    $($containerForm).on("click", function(event) {                                                                                                                                     
-      event.preventDefault();                                                                                                                                                
-      $containerForm.children().andSelf().removeClass("too-many");                                                                                                                                        
-      $tooManyMsgEl.html("<i class='spinner'></i>"); 
+    $($containerForm).on("click", function(event) {
+      event.preventDefault();
+      $containerForm.children().andSelf().removeClass("too-many");
+      $tooManyMsgEl.html("<i class='spinner'></i>");
       $('.subrecord-form-heading .btn', $containerForm).prop('disabled', false);
-     
-      // give it at least a second before trying ( and maybe dying.. ) 
-      setTimeout( function(){  
-        callback(function() {  
-          $tooManyMsgEl.remove(); 
-          $('.subrecord-form-container', $containerForm).fadeIn();                                                                                                                              
-          $(document).trigger("loadedrecordsubforms.aspace", $containerForm);
-        });
-      }, 1000); 
-      
+
+      $tooManyMsgEl.remove();
+      $('.subrecord-form-container', $containerForm).show();
+
+      callback(function() {
+        $(document).trigger("loadedrecordsubforms.aspace", $containerForm);
+      });
+
       $containerForm.unbind( event );
     });
     return true;


### PR DESCRIPTION
The root cause of the problems was a function like this:

     function initNoteForms($container) {
       ...
       $('.find-something', $container);
       ... more stuff
     }

being called like this:

     initNoteForms(function () {
       ... callback stuff...
     })

The intention was for the callback to fire after the note forms were
initialized, but in fact the callback was firing first.

The problem was that $container should have been a JQuery
object (matching some DOM element), but instead it was a callback
function.  That function got passed as the second argument to
JQuery.find, which attempts to wrap it in a JQuery function (in case you
passed a naked DOM element, I guess).  Since this:

  $(function () { whatever })

is a synonym for document.onready, the function was immediately
executed, and returned `undefined`.  And since a second argument of
`undefined` to jQuery.find means "search entire document", it happily
applied the selector overly broadly without complaining.

So we ended up with the selector seeming to work, and the callback
running backwards.  Yay, JavaScript!

The thing was, the code was actually mostly working with the callback
being run at the wrong time--and was actually relying on running first.
So, I pulled the "should run first" code out and ran it explicitly, then
initialised the notes form as required, then finally fired a callback to
emit the right events.