### PR TITLE
fix duplicate URI and text misalignment AR-1192 

### DIFF
--- a/frontend/app/views/file_versions/_image.html.erb
+++ b/frontend/app/views/file_versions/_image.html.erb
@@ -1,5 +1,5 @@
 <div class="form-group">
-  <div class="control-label"><%= I18n.t("file_version.file") %></div>
+  <div class="control-label col-sm-2"><%= I18n.t("file_version.file") %></div>
   <div class="controls label-only">
     <div class="image-container">
       <img class="image-responsive" src="<%= file['file_uri'] %>" />

--- a/frontend/app/views/file_versions/_show.html.erb
+++ b/frontend/app/views/file_versions/_show.html.erb
@@ -21,7 +21,6 @@
           <div class="form-horizontal">
             <% if can_embed?(file_version) %>
               <%= render_aspace_partial :partial => "file_versions/image", :locals => {:file => file_version} %>
-              <%= render_aspace_partial :partial => "file_versions/file_uri", :locals => {:file_uri => URI(file_version['file_uri'])} %>
             <% end %>
             <%= render_aspace_partial :partial => "file_versions/file_uri", :locals => {:file_uri => uri_or_string( file_version['file_uri'] ) } %>
           </div>


### PR DESCRIPTION
I'm not sure if these are the original issues reported in [AR-1192](https://archivesspace.atlassian.net/browse/AR-1192) but they are seen in the last screenshot on that JIRA issue. ( Maybe original issue was something else. ) 

[1] label "File" is pushed against the right margin. 
[2] "File URI" is listed twice if file version is embeddable. 