### PR TITLE
Drops the assertion that java 6 is supported. Solr 4.10 requires java…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ArchivesSpace README
 
 # System requirements
 
-* Java 1.6 or higher; Java 1.7 or 1.8 recommended.
+* Java 1.7 or 1.8.
 * At least 1024 MB RAM allocated to the application
 * A [supported browser](https://archivesspace.atlassian.net/wiki/display/ADC/Supported+Browsers)
 


### PR DESCRIPTION
… >= 7 so

currently the application won't run at all on java 6. Also it was removed from
the travis matrix.

see #616 