### PR TITLE
Don't pass 'reports' to find_base_directory when adding report locale…

### DIFF
--- a/common/aspace_i18n.rb
+++ b/common/aspace_i18n.rb
@@ -13,7 +13,7 @@ ASUtils.wrap(ASUtils.find_local_directories).map{|local_dir| File.join(local_dir
 end
 
 # Add report i18n locales
-I18n.load_path += Dir[File.join(ASUtils.find_base_directory("reports"), '**', '*.yml')]
+I18n.load_path += Dir[File.join(ASUtils.find_base_directory, 'reports', '**', '*.yml')]
 
 
 module I18n


### PR DESCRIPTION
…s files

When running in a dist the arg is ignored and we end up picking up
all sorts of ymls under the root directory, which breaks things.

Instead, just get the base directory and join 'reports' ourselves