### PR TITLE
Use html_safe for message

### DIFF
--- a/public-new/app/helpers/application_helper.rb
+++ b/public-new/app/helpers/application_helper.rb
@@ -11,7 +11,7 @@ module ApplicationHelper
           concat content_tag(:span, '&times;'.html_safe, 'aria-hidden' => true)
           concat content_tag(:span, 'Close', class: 'sr-only')
         end)
-        concat (message.kind_of?(Array) ?  message.join('<br/>').html_safe : message)
+        concat (message.kind_of?(Array) ?  message.join('<br/>').html_safe : message.html_safe)
       end)
     end
     nil


### PR DESCRIPTION
Just a very small thing I came across while working on a new pui plugin. Can override, but seems better contributed ...