### PR TITLE
AR-1344 update tooltip for non-deprecated Dates field

### DIFF
--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -468,7 +468,7 @@ en:
         </ul>
     dates: Dates
     dates_tooltip: |
-        <p>DEPRECIATED. PLEASE USE DATES OF EXISTENCE SECTION</p>
+        <p>Use this field for alignment with MARC authority records. These dates, rather than Dates of Existence, are added to the name entry in the display.</p>
         <p>Dates of existence for the named entity.</p>
         <p>Examples:<p>
         <ul>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1015,13 +1015,19 @@ en:
         add: Add Container Instance
 
   top_container:
+    container_profile: Container Profile
+    container_profile_tooltip: |
+        <p>A description of various characteristics of a particular kind of container, including dimensions.</p>
     indicator: Indicator
     indicator_tooltip: |
         <p>REQUIRED FIELD. An alphanumeric expression for indicating the place of the highest level container, which may also be the position of the container in a sequence of containers.</p>
     barcode: Barcode
     barcode_tooltip: |
         <p>Used to record the barcode that uniquely identifies the highest level container.</p>
-    type: Container Type 
+    type: Container Type
+    type_tooltip: |
+        <p>The type of the highest level container.	
+        <p>Values in this Controlled Value List may be modified.</p>
     ils_holding_id: ILS Holding ID
     ils_holding_id_tooltip: |
         <p>Identifier of associated holding record in the library ILS</p>


### PR DESCRIPTION
As the Dates field is no longer deprecated, revises the tooltip to make this clear. Also addresses the immediate issue described in AR-1322, though the longer term implications and need to perhaps address this through the Agents module redo still apply.