### PR TITLE
AR-1483 better support mixed content in public-new trees

### DIFF
--- a/backend/app/model/large_tree.rb
+++ b/backend/app/model/large_tree.rb
@@ -1,5 +1,7 @@
 # TODO: Some documentation on what's going on
 
+require 'mixed_content_parser'
+
 class LargeTree
 
   include JSONModel
@@ -155,7 +157,8 @@ class LargeTree
           path << {"node" => JSONModel(@node_type).uri_for(parent_node, :repo_id => repo_id),
                    "root_record_uri" => root_record_uri,
                    "title" => node_to_title_map.fetch(parent_node),
-                   "offset" => node_to_waypoint_map.fetch(current_node)}
+                   "offset" => node_to_waypoint_map.fetch(current_node),
+                   "parsed_title" => MixedContentParser.parse(node_to_title_map.fetch(parent_node), '/')}
 
           current_node = parent_node
         end
@@ -163,7 +166,8 @@ class LargeTree
         path << {"node" => nil,
                  "root_record_uri" => root_record_uri,
                  "offset" => node_to_waypoint_map.fetch(current_node),
-                 "title" => root_record_titles[root_record_id]}
+                 "title" => root_record_titles[root_record_id],
+                 "parsed_title" => MixedContentParser.parse(root_record_titles[root_record_id], '/')}
 
         result[node_id] = path.reverse
       end
@@ -204,6 +208,7 @@ class LargeTree
         child_count = child_counts.fetch(id, 0)
 
         waypoint_response(child_count).merge("title" => row[:title],
+                                             "parsed_title" => MixedContentParser.parse(row[:title], '/'),
                                              "uri" => JSONModel(@node_type).uri_for(row[:id], :repo_id => row[:repo_id]),
                                              "position" => (offset * WAYPOINT_SIZE) + idx,
                                              "parent_id" => parent_id,

--- a/backend/app/model/large_tree_digital_object.rb
+++ b/backend/app/model/large_tree_digital_object.rb
@@ -1,9 +1,5 @@
 class LargeTreeDigitalObject
 
-  # FIXME: add: digital object type, file version summary
-  #
-  # summary - go through all file versions, get the file_uri and comma delimit them
-
   def root(response, root_record)
     response['digital_object_type'] = root_record.digital_object_type
     response['file_uri_summary'] = root_record.file_version.map {|file_version|
@@ -19,6 +15,45 @@ class LargeTreeDigitalObject
 
   def waypoint(response, record_ids)
     file_uri_by_digital_object_component = {}
+
+    DigitalObjectComponent
+      .filter(:digital_object_component__id => record_ids)
+      .where(Sequel.~(:digital_object_component__label => nil))
+      .select(Sequel.as(:digital_object_component__id, :id),
+              Sequel.as(:digital_object_component__label, :label))
+      .each do |row|
+      id = row[:id]
+      result_for_record = response.fetch(record_ids.index(id))
+
+      result_for_record['label'] = row[:label]
+    end
+
+    ASDate
+      .left_join(Sequel.as(:enumeration_value, :date_type), :id => :date__date_type_id)
+      .left_join(Sequel.as(:enumeration_value, :date_label), :id => :date__label_id)
+      .filter(:digital_object_component_id => record_ids)
+      .select(:digital_object_component_id,
+              Sequel.as(:date_type__value, :type),
+              Sequel.as(:date_label__value, :label),
+              :expression,
+              :begin,
+              :end)
+      .each do |row|
+
+      id = row[:digital_object_component_id]
+
+      result_for_record = response.fetch(record_ids.index(id))
+      result_for_record['dates'] ||= []
+
+      date_data = {}
+      date_data['type'] = row[:type] if row[:type]
+      date_data['label'] = row[:label] if row[:label]
+      date_data['expression'] = row[:expression] if row[:expression]
+      date_data['begin'] = row[:begin] if row[:begin]
+      date_data['end'] = row[:end] if row[:end]
+
+      result_for_record['dates'] << date_data
+    end
 
     FileVersion.filter(:digital_object_component_id => record_ids)
       .select(:digital_object_component_id,

--- a/backend/spec/common_mixed_content_parser_spec.rb
+++ b/backend/spec/common_mixed_content_parser_spec.rb
@@ -24,4 +24,21 @@ describe 'MixedContentParser' do
     converted.should eq("What the &amp; 'heck' <span class=\"emph render-none\">ok</span>?");
   end
 
+  it "converts emph element correctly", :skip_db_open do
+    text = "<emph render='italic'>emph text</emph>"
+
+    converted = MixedContentParser.parse(text, "http://example.com", {:wrap_blocks => false})
+
+    converted.should eq("<span class=\"emph render-italic\">emph text</span>");
+  end
+
+
+  it "converts title element correctly", :skip_db_open do
+    text = "<title render='italic' xlink:type='simple'>title text</title>"
+
+    converted = MixedContentParser.parse(text, "http://example.com", {:wrap_blocks => false})
+
+    converted.should eq("<span class=\"emph render-italic\">title text</span>");
+  end
+
 end

--- a/common/mixed_content_parser.rb
+++ b/common/mixed_content_parser.rb
@@ -19,7 +19,13 @@ module MixedContentParser
     # transform blocks of text seperated by line breaks into <p> wrapped blocks
     content = content.split("\n\n").inject("") { |c,n| c << "<p>#{n}</p>"  } if opts[:wrap_blocks]
 
-    cleaned_content = org.jsoup.Jsoup.clean(content, base_uri, org.jsoup.safety.Whitelist.relaxed.addTags("emph", "lb").addAttributes("emph", "render"), d.outputSettings())
+    whitelist = org.jsoup.safety.Whitelist.relaxed
+                                          .addTags("emph", "lb", "title", "unitdate")
+                                          .addAttributes("emph", "render")
+                                          .addAttributes("title", "render")
+                                          .addAttributes("unitdate", "render")
+
+    cleaned_content = org.jsoup.Jsoup.clean(content, base_uri, whitelist, d.outputSettings())
 
     document = org.jsoup.Jsoup.parse(cleaned_content, base_uri, org.jsoup.parser.Parser.xmlParser())
     document.outputSettings.escapeMode(Java::OrgJsoupNodes::Entities::EscapeMode.xhtml)

--- a/common/mixed_content_parser.rb
+++ b/common/mixed_content_parser.rb
@@ -5,8 +5,12 @@ module MixedContentParser
   def self.parse(content, base_uri, opts = {} )
     opts[:pretty_print] ||= false
 
+    return if content.nil?
+
     content.strip!
     content.chomp!
+
+    return '' if content.empty?
 
     # create an empty document just to get an outputSettings object
     # (seems like the API falls down when we do this directly...)

--- a/frontend/app/assets/javascripts/tree_renderers.js.erb
+++ b/frontend/app/assets/javascripts/tree_renderers.js.erb
@@ -194,7 +194,35 @@ DigitalObjectRenderer.prototype.add_root_columns = function (row, rootNode) {
 }
 
 DigitalObjectRenderer.prototype.add_node_columns = function (row, node) {
+    var title = this.build_node_title(node);
+
+    row.find('.title .record-title').text(title).attr('title', title);
     row.find('.file-uri-summary').text(node.file_uri_summary).attr('title', node.file_uri_summary);
+};
+
+DigitalObjectRenderer.prototype.build_node_title = function(node) {
+    var title_bits = [];
+
+    if (node.title) {
+        title_bits.push(node.title);
+    }
+
+    if (node.label) {
+        title_bits.push(node.label);
+    }
+
+    if (node.dates && node.dates.length > 0) {
+        var first_date = node.dates[0];
+        if (first_date.expression) {
+            title_bits.push(first_date.expression);
+        } else if (first_date.begin && first_date.end) {
+            title_bits.push(first_date.begin + '-' + first_date.end);
+        } else if (first_date.begin) {
+            title_bits.push(first_date.begin);
+        }
+    }
+
+    return title_bits.join(', ');
 };
 
 function ClassificationRenderer() {

--- a/public-new/app/assets/javascripts/tree_renderer.js
+++ b/public-new/app/assets/javascripts/tree_renderer.js
@@ -1,0 +1,84 @@
+(function(exports) {
+
+    function SimpleRenderer(should_link_to_record) {
+        this.endpointMarkerTemplate = $('<tr class="end-marker" />');
+
+        this.should_link_to_record = should_link_to_record || false;
+
+        this.rootTemplate = $('<tr> ' +
+            '  <td class="no-drag-handle"></td>' +
+            '  <td class="title"></td>' +
+            '</tr>');
+
+
+        this.nodeTemplate = $('<tr> ' +
+            '  <td class="drag-handle"></td>' +
+            '  <td class="title"><span class="indentor"><button class="expandme"><i class="expandme-icon glyphicon glyphicon-chevron-right" /></button></span> </td>' +
+            '</tr>');
+    }
+
+
+    SimpleRenderer.prototype.endpoint_marker = function () {
+        return this.endpointMarkerTemplate.clone(true);
+    }
+
+
+    SimpleRenderer.prototype.get_root_template = function () {
+        return this.rootTemplate.clone(false);
+    }
+
+
+    SimpleRenderer.prototype.get_node_template = function () {
+        return this.nodeTemplate.clone(false);
+    };
+
+
+    SimpleRenderer.prototype.add_root_columns = function (row, rootNode) {
+        var $link = row.find('a.record-title');
+
+        if (this.should_link_to_record) {
+            $link.attr('href', rootNode.uri);
+        }
+
+        $link.html(rootNode.parsed_title);
+    }
+
+
+    SimpleRenderer.prototype.add_node_columns = function (row, node) {
+        var $link = row.find('a.record-title');
+        var title = this.build_node_title(node);
+
+        if (this.should_link_to_record) {
+            $link.attr('href', node.uri);
+        }
+
+        $link.html(title);
+    };
+
+
+    SimpleRenderer.prototype.build_node_title = function (node) {
+        var title_bits = [];
+        if (node.parsed_title) {
+            title_bits.push(node.parsed_title);
+        }
+
+        if (node.label) {
+            title_bits.push(node.label);
+        }
+
+        if (node.dates && node.dates.length > 0) {
+            var first_date = node.dates[0];
+            if (first_date.expression) {
+                title_bits.push(first_date.expression);
+            } else if (first_date.begin && first_date.end) {
+                title_bits.push(first_date.begin + '-' + first_date.end);
+            } else if (first_date.begin) {
+                title_bits.push(first_date.begin);
+            }
+        }
+
+        return title_bits.join(', ');
+    }
+
+    exports.SimpleRenderer = SimpleRenderer;
+})(window);

--- a/public-new/app/assets/stylesheets/application.scss
+++ b/public-new/app/assets/stylesheets/application.scss
@@ -31,3 +31,4 @@
 
 @import "archivesspace/infinite-scroll";
 @import "archivesspace/largetree";
+@import "archivesspace/mixed-content";

--- a/public-new/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public-new/app/assets/stylesheets/archivesspace/aspace.scss
@@ -44,9 +44,6 @@ a {
   float: none !important;
   }
 
-.emph { 
-      font-weight: bold;
-}
 .italic {
 	font-style: italic;
 }

--- a/public-new/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public-new/app/assets/stylesheets/archivesspace/aspace.scss
@@ -691,6 +691,7 @@ span.head {
 
 .breadcrumb>li+li:before {color: $darkest; content: "\007C\00a0";}
 .breadcrumb * a {color: $breadcrumb-link;}
+.breadcrumb li br {display: none;}
 
 .acc_holder {
 	    margin-top: rem-calc(20);

--- a/public-new/app/assets/stylesheets/archivesspace/mixed-content.scss
+++ b/public-new/app/assets/stylesheets/archivesspace/mixed-content.scss
@@ -1,0 +1,14 @@
+.emph {
+    &.render-none {font-style: italic;}
+    &.render-bold, &.render-bolddoublequote, &.render-bolditalic, &.render-boldsinglequote, &.render-boldsmcaps, &.render-boldunderline {font-weight: bold}
+    &.render-italic, &.render-bolditalic {font-style: italic;}
+    &.render-smcaps, &.render-boldsmcaps, {font-variant: small-caps;}
+    &.render-sub {vertical-align: sub; font-size: 80%;}
+    &.render-super {vertical-align: super; font-size: 80%;}
+    &.render-underline {text-decoration: underline;}
+    &.render-nonproport {color: #666;}
+    &.render-doublequote:before, &.render-bolddoublequote:before {content: '"'}
+    &.render-doublequote:after, &.render-bolddoublequote:after {content: '"'}
+    &.render-singlequote:before, &.render-boldsinglequote:before {content: "'"}
+    &.render-singlequote:after, &.render-boldsinglequote:after {content: "'"}
+}

--- a/public-new/app/views/resources/infinite.html.erb
+++ b/public-new/app/views/resources/infinite.html.erb
@@ -26,6 +26,7 @@
 <%= javascript_include_tag 'treesync' %>
 <%= javascript_include_tag 'infinite_scroll' %>
 <%= javascript_include_tag 'largetree' %>
+<%= javascript_include_tag 'tree_renderer' %>
 
 <div class="row" id="tabs">
   <div class="infinite-record-wrapper col-xs-9">
@@ -42,72 +43,6 @@
   <div class="infinite-tree-view largetree-container col-xs-3" id='tree-container'>
   </div>
 </div>
-
-<script>
-
- function BaseRenderer() {
-     this.endpointMarkerTemplate = $('<tr class="end-marker" />');
-
-     this.rootTemplate = $('<tr> ' +
-                           '  <td class="no-drag-handle"></td>' +
-                           '  <td class="title"></td>' +
-                           '</tr>');
-
-
-     this.nodeTemplate = $('<tr> ' +
-                           '  <td class="drag-handle"></td>' +
-                           '  <td class="title"><span class="indentor"><button class="expandme"><i class="expandme-icon glyphicon glyphicon-chevron-right" /></button></span> </td>' +
-                           '</tr>');
- }
-
- BaseRenderer.prototype.endpoint_marker = function () {
-     return this.endpointMarkerTemplate.clone(true);
- }
-
- BaseRenderer.prototype.get_root_template = function () {
-     return this.rootTemplate.clone(false);
- }
-
-
- BaseRenderer.prototype.get_node_template = function () {
-     return this.nodeTemplate.clone(false);
- };
-
- function ResourceRenderer() {
-     BaseRenderer.call(this);
-     this.rootTemplate = $('<tr> ' +
-                           '  <td class="no-drag-handle"></td>' +
-                           '  <td class="title"></td>' +
-                           '  <td class="resource-level"></td>' +
-                           '  <td class="resource-type"></td>' +
-                           '  <td class="resource-container"></td>' +
-                           '</tr>');
-
-     this.nodeTemplate = $('<tr> ' +
-                           '  <td class="drag-handle"></td>' +
-                           '  <td class="title"><span class="indentor"><button class="expandme"><i class="expandme-icon glyphicon glyphicon-chevron-right" /></button></span> </td>' +
-                           '  <td class="resource-level"></td>' +
-                           '  <td class="resource-type"></td>' +
-                           '  <td class="resource-container"></td>' +
-                           '</tr>');
- }
-
- ResourceRenderer.prototype = Object.create(BaseRenderer.prototype);
-
- ResourceRenderer.prototype.add_root_columns = function (row, rootNode) {
-     row.find('.resource-level').text(rootNode.level).attr('title', rootNode.level);
-     row.find('.resource-type').text(rootNode.type).attr('title', rootNode.type);
-     row.find('.resource-container').text(rootNode.container).attr('title', rootNode.container);
- }
-
-
- ResourceRenderer.prototype.add_node_columns = function (row, node) {
-     row.find('.resource-level').text(node.level).attr('title', node.level);
-     row.find('.resource-type').text(node.type).attr('title', node.type);
-     row.find('.resource-container').text(node.container).attr('title', node.container);
- };
-
-</script>
 
 <script>
 // $('.infinite-record-wrapper').css('position', 'relative').css('left', '-200px');
@@ -133,7 +68,7 @@
                           $('.infinite-tree-view'),
                           '<%= @root_uri %>',
                           true,
-                          new ResourceRenderer(),
+                          new SimpleRenderer(),
                           function() {
                               syncer.treeIsReady(tree);
                           },

--- a/public-new/app/views/shared/_children_tree.html.erb
+++ b/public-new/app/views/shared/_children_tree.html.erb
@@ -34,10 +34,14 @@
     };
 
     SimpleRenderer.prototype.add_root_columns = function (row, rootNode) {
-        row.find('a.record-title').attr('href', rootNode.uri);
+        row.find('a.record-title')
+            .attr('href', rootNode.uri)
+            .html(rootNode.parsed_title);
     }
     SimpleRenderer.prototype.add_node_columns = function (row, node) {
-        row.find('a.record-title').attr('href', node.uri);
+        row.find('a.record-title')
+            .attr('href', node.uri)
+            .html(node.parsed_title);
     };
 
     var root_uri = '<%= root_node_uri %>';

--- a/public-new/app/views/shared/_children_tree.html.erb
+++ b/public-new/app/views/shared/_children_tree.html.erb
@@ -39,9 +39,27 @@
             .html(rootNode.parsed_title);
     }
     SimpleRenderer.prototype.add_node_columns = function (row, node) {
+        var title_bits = [];
+        if (node.parsed_title) {
+            title_bits.push(node.parsed_title);
+        }
+
+        if (node.dates && node.dates.length > 0) {
+            var first_date = node.dates[0];
+            if (first_date.expression) {
+                title_bits.push(first_date.expression);
+            } else if (first_date.begin && first_date.end) {
+                title_bits.push(first_date.begin + '-' + first_date.end);
+            } else if (first_date.begin) {
+                title_bits.push(first_date.begin);
+            }
+        }
+
+        var title =  title_bits.join(', ');
+
         row.find('a.record-title')
             .attr('href', node.uri)
-            .html(node.parsed_title);
+            .html(title);
     };
 
     var root_uri = '<%= root_node_uri %>';

--- a/public-new/app/views/shared/_children_tree.html.erb
+++ b/public-new/app/views/shared/_children_tree.html.erb
@@ -1,81 +1,19 @@
 <%= javascript_include_tag 'largetree' %>
+<%= javascript_include_tag 'tree_renderer' %>
 
 <h4><%= heading_text %></h4>
 <div class="infinite-tree-view largetree-container" id='tree-container'></div>
 
 <script>
 
-    function SimpleRenderer() {
-        this.endpointMarkerTemplate = $('<tr class="end-marker" />');
-
-        this.rootTemplate = $('<tr> ' +
-            '  <td class="no-drag-handle"></td>' +
-            '  <td class="title"></td>' +
-            '</tr>');
-
-
-        this.nodeTemplate = $('<tr> ' +
-            '  <td class="drag-handle"></td>' +
-            '  <td class="title"><span class="indentor"><button class="expandme"><i class="expandme-icon glyphicon glyphicon-chevron-right" /></button></span> </td>' +
-            '</tr>');
-    }
-
-    SimpleRenderer.prototype.endpoint_marker = function () {
-        return this.endpointMarkerTemplate.clone(true);
-    }
-
-    SimpleRenderer.prototype.get_root_template = function () {
-        return this.rootTemplate.clone(false);
-    }
-
-
-    SimpleRenderer.prototype.get_node_template = function () {
-        return this.nodeTemplate.clone(false);
-    };
-
-    SimpleRenderer.prototype.add_root_columns = function (row, rootNode) {
-        row.find('a.record-title')
-            .attr('href', rootNode.uri)
-            .html(rootNode.parsed_title);
-    }
-    SimpleRenderer.prototype.add_node_columns = function (row, node) {
-        var title = this.build_node_title(node);
-
-        row.find('a.record-title')
-            .attr('href', node.uri)
-            .html(title);
-    };
-
-    SimpleRenderer.prototype.build_node_title = function(node) {
-        var title_bits = [];
-        if (node.parsed_title) {
-            title_bits.push(node.parsed_title);
-        }
-
-        if (node.label) {
-            title_bits.push(node.label);
-        }
-
-        if (node.dates && node.dates.length > 0) {
-            var first_date = node.dates[0];
-            if (first_date.expression) {
-                title_bits.push(first_date.expression);
-            } else if (first_date.begin && first_date.end) {
-                title_bits.push(first_date.begin + '-' + first_date.end);
-            } else if (first_date.begin) {
-                title_bits.push(first_date.begin);
-            }
-        }
-
-        return title_bits.join(', ');
-    }
-
     var root_uri = '<%= root_node_uri %>';
+    var should_link_to_record = true;
+
     var tree = new LargeTree(new TreeDataSource(root_uri + '/tree'),
         $('#tree-container'),
         root_uri,
         true,
-        new SimpleRenderer(),
+        new SimpleRenderer(should_link_to_record),
         function() {
             var tree_id = TreeIds.uri_to_tree_id('<%= current_node_uri %>');
             tree.setCurrentNode(tree_id, function() {

--- a/public-new/app/views/shared/_children_tree.html.erb
+++ b/public-new/app/views/shared/_children_tree.html.erb
@@ -39,9 +39,21 @@
             .html(rootNode.parsed_title);
     }
     SimpleRenderer.prototype.add_node_columns = function (row, node) {
+        var title = this.build_node_title(node);
+
+        row.find('a.record-title')
+            .attr('href', node.uri)
+            .html(title);
+    };
+
+    SimpleRenderer.prototype.build_node_title = function(node) {
         var title_bits = [];
         if (node.parsed_title) {
             title_bits.push(node.parsed_title);
+        }
+
+        if (node.label) {
+            title_bits.push(node.label);
         }
 
         if (node.dates && node.dates.length > 0) {
@@ -55,12 +67,8 @@
             }
         }
 
-        var title =  title_bits.join(', ');
-
-        row.find('a.record-title')
-            .attr('href', node.uri)
-            .html(title);
-    };
+        return title_bits.join(', ');
+    }
 
     var root_uri = '<%= root_node_uri %>';
     var tree = new LargeTree(new TreeDataSource(root_uri + '/tree'),

--- a/public-new/config/initializers/assets.rb
+++ b/public-new/config/initializers/assets.rb
@@ -9,4 +9,4 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
-Rails.application.config.assets.precompile += %w( infinite_scroll.js largetree.js treesync.js )
+Rails.application.config.assets.precompile += %w( infinite_scroll.js largetree.js treesync.js tree_renderer.js )


### PR DESCRIPTION
Also fixes:
- the `MixedContentParser` was not whitelisting the elements we wished to convert (unit tests added)
- 'null' string in digital object component tree nodes when record didn't have a title (could have a label or date instead).  This was an issue in both the staff and public-new trees.
- 'null' string in archival object tree nodes when record didn't have a title. Due to missing date handling in the public-new tree renderer.
- br element causing newlines in the breadcrumb