### PR TITLE
Fix 'Method map is deprecated' warning in frontend

### DIFF
--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -330,7 +330,7 @@ module ApplicationHelper
   # controller, etc.)
   def link_to_merge_params(label, new_params, html_options = {})
     link_to(label,
-            url_for + "?" + URI.encode_www_form(params.except(:controller, :action, :format).merge(new_params)),
+            url_for + "?" + URI.encode_www_form(params.except(:controller, :action, :format).to_h.merge(new_params)),
             html_options)
   end
 


### PR DESCRIPTION
Fixes this message showing up here, there and everywhere:

```
[java] DEPRECATION WARNING: Method map is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.1/classes/ActionController/Parameters.html (called from link_to_merge_params at /Users/payten/Development/archivesspace/pui/archivesspace/frontend/app/helpers/application_helper.rb:332)
```