### PR TITLE
Add annotations to selected rows

### DIFF
--- a/frontend/app/assets/javascripts/largetree_dragdrop.js.erb
+++ b/frontend/app/assets/javascripts/largetree_dragdrop.js.erb
@@ -67,6 +67,18 @@
 
         /* Highlight selected rows */
         $('.multiselected', self.largetree.elt).closest('tr').addClass('multiselected-row');
+
+        self.refreshAnnotations();
+    };
+
+    LargeTreeDragDrop.prototype.refreshAnnotations = function() {
+        var self = this;
+
+        self.large_tree.elt.find('.drag-annotation').remove();
+        self.rowsToMove.map(function (elt, idx) {
+            var $annotation = $('<div>').addClass('drag-annotation').text(idx + 1);
+            $annotation.appendTo($(elt).find('td:first'));
+        });
     };
 
     LargeTreeDragDrop.prototype.handleMultiSelect = function (selection) {
@@ -180,7 +192,7 @@
                                  .css('left', largetree.elt.offset().left);
 
                 self.dragIndicator.empty().hide();
-                self.dragIndicator.append($('<ul />').append(self.rowsToMove.map(function (elt, idx) {
+                self.dragIndicator.append($('<ol />').append(self.rowsToMove.map(function (elt, idx) {
                     return $('<li />').text($(elt).find('.title').text());
                 })));
 

--- a/frontend/app/assets/stylesheets/archivesspace/largetree.less
+++ b/frontend/app/assets/stylesheets/archivesspace/largetree.less
@@ -65,18 +65,18 @@
             display: table-cell;
         }
         td.no-drag-handle {
-            width: 1em;
+            width: 2em;
         }
         td.drag-handle {
-            width: 1em;
+            width: 2em;
             background-image: asset-url('archivesspace/tree_drag_handle.gif');
             background-repeat: no-repeat;
-            background-position: 50% 50%;
+            background-position: 4px 50%;
             cursor: move;
         }
         td.drag-handle.drag-disabled { visibility: hidden; }
         td.drag-handle.multiselected {
-            width: 1em;
+            width: 2em;
             background-color: #0A6AA1;
         }
     }
@@ -275,6 +275,16 @@
         td {
             background-color: #FFF0F0;
         }
+    }
+    .drag-annotation {
+        float: right;
+        width: 12px;
+        text-align: center;
+        height: 1.5em;
+        line-height: 1.5em;
+        margin-right: 2px;
+        font-size: 0.8em;
+        color: #FFF;
     }
 }
 

--- a/selenium/spec/trees_spec.rb
+++ b/selenium/spec/trees_spec.rb
@@ -120,19 +120,27 @@ describe "Tree UI" do
 
     tree_disable_reorder_mode
 
-    2.times {|i|
-      tree_click(tree_node(@a1))
+    tree_click(tree_node(@a1))
 
-      [@a2, @a3].each do |child_ao|
-        parent = @driver.find_element(:id => tree_node(@a1).tree_id)
-        expect(parent.attribute('class')).to include('indent-level-1')
+    [@a2, @a3].each do |child_ao|
+      parent = @driver.find_element(:id => tree_node(@a1).tree_id)
+      expect(parent.attribute('class')).to include('indent-level-1')
 
-        child = @driver.find_element(:id => tree_node(child_ao).tree_id)
-        expect(child.attribute('class')).to include('indent-level-2')
-      end
+      child = @driver.find_element(:id => tree_node(child_ao).tree_id)
+      expect(child.attribute('class')).to include('indent-level-2')
+    end
 
-      @driver.navigate.refresh if i == 0
-    }
+    # refresh the page and make sure they're still visible
+    @driver.navigate.refresh
+
+    [@a2, @a3].each do |child_ao|
+      parent = @driver.find_element(:id => tree_node(@a1).tree_id)
+      expect(parent.attribute('class')).to include('indent-level-1')
+
+      child = @driver.find_element(:id => tree_node(child_ao).tree_id)
+      expect(child.attribute('class')).to include('indent-level-2')
+    end
+
 
     # now move them back
     tree_enable_reorder_mode


### PR DESCRIPTION
Adds annotations to the selected rows for drag/drop showing the index of the row within the selection:

<img width="491" alt="screen shot 2017-03-22 at 5 02 40 pm" src="https://cloud.githubusercontent.com/assets/608337/24184390/ce92d974-0f21-11e7-851c-284cd30084e0.png">

And update the drag helper to be a ordered list:

<img width="435" alt="screen shot 2017-03-22 at 5 03 45 pm" src="https://cloud.githubusercontent.com/assets/608337/24184408/dd6bbc90-0f21-11e7-99e2-8373a4f524b1.png">
