### PR TITLE
Fix NameError (undefined local variable or method uri) when SOLR record is missing

### DIFF
--- a/public-new/app/controllers/resources_controller.rb
+++ b/public-new/app/controllers/resources_controller.rb
@@ -164,7 +164,7 @@ class ResourcesController <  ApplicationController
     rescue RecordNotFound
       @type = I18n.t('resource._singular')
       @page_title = I18n.t('errors.error_404', :type => @type)
-      @uri = uri
+      @uri = @root_uri
       @back_url = request.referer || ''
       render  'shared/not_found'
     end


### PR DESCRIPTION
Fixes exception:

```
INFO: F, [2017-03-22T10:02:53.029966 #16957] FATAL -- : [d71e9a06-5977-45a2-a49c-6c1c30e0e083] NameError (undefined local variable or method `uri' for #<ResourcesController:0x135fe9d>
```