### PR TITLE
booleans need to be booleans, not strings #issue 665

### DIFF
--- a/common/advanced_query_builder.rb
+++ b/common/advanced_query_builder.rb
@@ -10,7 +10,7 @@ class AdvancedQueryBuilder
     if field_or_subquery.is_a?(AdvancedQueryBuilder)
       push_subquery('AND', field_or_subquery)
     else
-      raise "Missing value" unless value
+      raise "Missing value" if value.nil?
       push_term('AND', field_or_subquery, value, type, literal, negated)
     end
 

--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -247,12 +247,12 @@ class TopContainersController < ApplicationController
 
     unless params['exported'].blank?
       builder.and('exported_u_sbool',
-                  (params['exported'] == "yes" ? 'true' : 'false'),
+                  (params['exported'] == "yes" ? true : false),
                   'boolean')
     end
 
     unless params['empty'].blank?
-      builder.and('empty_u_sbool', (params['empty'] == "yes" ? 'true' : 'false'), 'boolean')
+      builder.and('empty_u_sbool', (params['empty'] == "yes" ? true : false), 'boolean')
     end
 
     unless params['barcodes'].blank?


### PR DESCRIPTION
Setting YES or NO to either "Exported to ILS" or "Unassociated containers" in frontend top_container search parameter yields error:
`JSONModel::ValidationException (#<:ValidationException: {:errors=>{"value"=>["Must be a boolean (you provided a String)"]}}>)`

Also note TODO note at top of 
https://github.com/archivesspace/archivesspace/blob/master/public-new/app/lib/advanced_query_builder.rb#L1-L4

However, I see diffs between version in common and version in public-new.
Don't know what's intended here. 