### PR TITLE
Save us from eager disabling of buttons

### DIFF
--- a/frontend/app/assets/javascripts/application.js
+++ b/frontend/app/assets/javascripts/application.js
@@ -25,4 +25,4 @@
 //= require lodash
 //= require bootstrap-select
 //= require bootstrap3-typeahead
-AS.tree_data = {};
+

--- a/frontend/app/assets/javascripts/top_containers.bulk.js
+++ b/frontend/app/assets/javascripts/top_containers.bulk.js
@@ -33,11 +33,13 @@ BulkContainerSearch.prototype.perform_search = function(data) {
     data: data,
     type: "post",
     success: function(html) {
+      $.rails.enableFormElements(self.$search_form);
       self.$results_container.html(html);
       self.setup_table_sorter();
       self.update_button_state();
     },
     error: function(jqXHR, textStatus, errorThrown) {
+      $.rails.enableFormElements(self.$search_form);
       var html = AS.renderTemplate("template_bulk_operation_error_message", {message: jqXHR.responseText})
       self.$results_container.html(html);
       self.update_button_state();


### PR DESCRIPTION
Rails 4 introduced a new version of the "Unobtrusive scripting adapter for jQuery" which now disables form submit elements to help avoid double-click resulting in a double submission of the form. Weeeeee!

So we now have to reenable any ajax form submit buttons proactively (if we're not doing that already!). 