### PR TITLE
AR-1675 EAD escaping in breadcrumbs / tree

### DIFF
--- a/backend/app/model/large_tree.rb
+++ b/backend/app/model/large_tree.rb
@@ -90,7 +90,8 @@ class LargeTree
 
       response = waypoint_response(child_count).merge("title" => @root_record.title,
                                                       "uri" => @root_record.uri,
-                                                      "jsonmodel_type" => @root_table.to_s)
+                                                      "jsonmodel_type" => @root_table.to_s,
+                                                      "parsed_title" => MixedContentParser.parse(@root_record.title, '/'))
       @decorators.each do |decorator|
         response = decorator.root(response, @root_record)
       end

--- a/public-new/app/views/shared/_result.html.erb
+++ b/public-new/app/views/shared/_result.html.erb
@@ -43,7 +43,7 @@
           <% result.ancestors.each do |ancestor| %>
             /
             <span class="ancestor">
-            <%= link_to ancestor.fetch('title'), ancestor.fetch('uri') %> 
+            <%= link_to process_mixed_content(ancestor.fetch('title')).html_safe, ancestor.fetch('uri') %>
             </span>
           <% end %>
         <% else %>


### PR DESCRIPTION
Fix root title not parsed.
Fix results item breadcrumb ancestor not parsed.