### PR TITLE
Add extra error handling to tree fetching

### DIFF
--- a/frontend/app/assets/javascripts/largetree.js.erb
+++ b/frontend/app/assets/javascripts/largetree.js.erb
@@ -76,11 +76,17 @@
         this.node_selected_callback = node_selected_callback;
         this.populateWaypointHooks = [];
 
+        this.errorHandler = $.noop;
+
         this.initEventHandlers();
         this.renderRoot(function () {
             tree_loaded_callback();
         });
     }
+
+    LargeTree.prototype.setGeneralErrorHandler = function (callback) {
+        this.errorHandler = callback;
+    };
 
     LargeTree.prototype.currentlyLoading = function () {
         this.progressIndicator.css('visibility', 'visible');
@@ -444,13 +450,17 @@
             debugger;
         }
 
-        self.source.fetchNode(row.data('uri')).done(function (node) {
-            self.appendWaypoints(row, row.data('uri'), node.waypoints, node.waypoint_size, row.data('level') + 1);
+        self.source.fetchNode(row.data('uri'))
+            .done(function (node) {
+                self.appendWaypoints(row, row.data('uri'), node.waypoints, node.waypoint_size, row.data('level') + 1);
 
-            if (done_callback) {
-                done_callback();
-            }
-        });
+                if (done_callback) {
+                    done_callback();
+                }
+            })
+            .fail(function () {
+                self.errorHandler.apply(self, ['fetch_node_failed'].concat([].slice.call(arguments)));
+            });
     };
 
     LargeTree.prototype.collapseNode = function (row, done_callback) {
@@ -780,6 +790,7 @@
         return $.ajax(this.urlFor("root"),
                       {
                           method: "GET",
+                          dataType: 'json',
                       })
                 .done(function (rootNode) {
                     self.cachePrecomputedWaypoints(rootNode);
@@ -796,6 +807,7 @@
         return $.ajax(this.urlFor("node"),
                       {
                           method: "GET",
+                          dataType: 'json',
                           data: {
                               /* THINKME: Should rename node to node_uri?  S */
                               node: uri,
@@ -804,7 +816,6 @@
                 .done(function (node) {
                     self.cachePrecomputedWaypoints(node);
                 });
-
     };
 
     TreeDataSource.prototype.fetchPathFromRoot = function (node_id) {
@@ -813,6 +824,7 @@
         return $.ajax(this.urlFor("node_from_root"),
                       {
                           method: "GET",
+                          dataType: 'json',
                           data: {
                               node_ids: [node_id],
                           }
@@ -832,6 +844,7 @@
             return $.ajax(this.urlFor("waypoint"),
                           {
                               method: "GET",
+                              dataType: 'json',
                               data: {
                                   node: uri,
                                   offset: offset,

--- a/frontend/app/assets/javascripts/tree.js.erb
+++ b/frontend/app/assets/javascripts/tree.js.erb
@@ -43,6 +43,13 @@
         if (!read_only) {
             self.dragdrop = self.large_tree.addPlugin(new LargeTreeDragDrop(self.large_tree));
         }
+
+        self.large_tree.setGeneralErrorHandler(function (failure_type) {
+            if (failure_type === 'fetch_node_failed') {
+                /* This can happen when the user was logged out behind the scenes. */
+                $('#tree-unexpected-failure').slideDown();
+            }
+        });
     };
 
 

--- a/frontend/app/views/shared/_largetree.html.erb
+++ b/frontend/app/views/shared/_largetree.html.erb
@@ -4,6 +4,7 @@
 
 <div class="row">
   <div class="col-md-12">
+    <div style="display: none" id="tree-unexpected-failure" class="alert alert-warning"><%= I18n.t('tree.unexpected_failure') %></div>
     <div id="tree-toolbar" class="btn-toolbar"></div>
     <div id="tree-container" class="largetree-container"></div>
   </div>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -383,6 +383,7 @@ en:
       before: Add Items Before
       after: Add Items After
       as_child: Add Items as Children 
+    unexpected_failure: Oops! We're having trouble fetching this tree. Please try refreshing the page.
 
   errors:
     sidebar_label: Errors and Warnings


### PR DESCRIPTION
If the user gets logged out behind the scenes, the next AJAX request
will fail.  Show a helpful message when this happens.