### PR TITLE
Set required and missing ENV variable ASPACE_LAUNCHER_BASE to the

### DIFF
--- a/launcher/scripts/setup-database.bat
+++ b/launcher/scripts/setup-database.bat
@@ -3,6 +3,8 @@ SETLOCAL ENABLEDELAYEDEXPANSION
 
 cd /d %~dp0%
 
+set ASPACE_LAUNCHER_BASE=%~dp0%\..
+
 set GEM_HOME=%~dp0%\..\gems
 set GEM_PATH=
 


### PR DESCRIPTION
archivesspace base directory based upon the dp0 variable (which is the scripts directory) and going up one directory

@jambun Bug in setup-database.bat file