### PR TITLE
hopefully, more specific to windows pathnames  #AR-1561

### DIFF
--- a/frontend/app/helpers/file_embed_helper.rb
+++ b/frontend/app/helpers/file_embed_helper.rb
@@ -3,7 +3,7 @@ module FileEmbedHelper
   def uri_or_string(link)
     begin
       link.gsub!(/\\/, '/') # for windows uris
-      link = "file://#{link}" unless link.match(/^(http|file)/)
+      link = "file://#{link}" if link.match(/^[a-zA-Z]:/)
       URI(link) 
     rescue URI::InvalidURIError => e
       link


### PR DESCRIPTION
Is this sufficient to keep the fix for windows while not mangling other URIs ? 

https://archivesspace.atlassian.net/browse/AR-1561


My preference would be to remove this line completely. 
As discussed in another thread, I don't think the display should be making the assumption that my URLs are incorrect. If the system is going to enforce some rules, they should be applied to the model during data entry, not change valid data on display.  