### PR TITLE
Add a consistency check when saving tree nodes

### DIFF
--- a/backend/app/model/mixins/tree_nodes.rb
+++ b/backend/app/model/mixins/tree_nodes.rb
@@ -176,6 +176,8 @@ module TreeNodes
       set_position_in_list(json.position)
     end
 
+    self.class.ensure_consistent_tree(obj)
+
     trigger_index_of_child_nodes
 
     obj
@@ -301,6 +303,17 @@ module TreeNodes
       Kernel.const_get(node_record_type.camelize)
     end
 
+    def ensure_consistent_tree(obj)
+      if obj.parent_id
+        parent_root_record_id = node_model.filter(:id => obj.parent_id).get(:root_record_id)
+        unless obj.root_record_id == parent_root_record_id
+          raise "Consistency check failed: " \
+                "#{node_model} #{obj.id} is in #{root_model} #{obj.root_record_id}," \
+                " but its parent is in #{root_model} #{parent_root_record_id}."
+        end
+      end
+    end
+
     def create_from_json(json, extra_values = {})
       obj = nil
 
@@ -320,6 +333,8 @@ module TreeNodes
       if json.position && !migration
         obj.set_position_in_list(json.position)
       end
+
+      ensure_consistent_tree(obj)
 
       obj
     end

--- a/backend/spec/model_archival_object_spec.rb
+++ b/backend/spec/model_archival_object_spec.rb
@@ -301,4 +301,18 @@ describe 'ArchivalObject model' do
     }.to_not raise_error
   
   end
+
+  it "won't let you set your parent to a resource that you're not in" do
+    resource_a = create(:json_resource)
+    resource_b = create(:json_resource)
+    parent_in_resource_a = create(:json_archival_object, :resource => {:ref => resource_a.uri})
+
+    expect {
+    create(:json_archival_object,
+           :parent => {:ref => parent_in_resource_a.uri},
+           # absurd!
+           :resource => {:ref => resource_b.uri})
+    }.to raise_error(RuntimeError, /Consistency check failed/)
+  end
+
 end


### PR DESCRIPTION
@lmcglohon I think we can wait until post 2.0 for this, but just adding it in.
-------

If you're saving an archival object within Resource A, you shouldn't
be allowed to make it a child of a record in Resource B.  That's
silly.

Fixes #264 (at last!)