### PR TITLE
Rework file embed helper

### DIFF
--- a/frontend/app/helpers/file_embed_helper.rb
+++ b/frontend/app/helpers/file_embed_helper.rb
@@ -1,13 +1,25 @@
 module FileEmbedHelper
 
+  SUPPORTED_URL_SCHEMES = ['http', 'https']
+
+  def self.supported_scheme?(scheme)
+    SUPPORTED_URL_SCHEMES.include?(scheme)
+  end
+
   def uri_or_string(link)
+    # If `link` can be sensibly rendered as a URL, return a URL object.
     begin
-      link.gsub!(/\\/, '/') # for windows uris
-      link = "file://#{link}" unless link.match(/^(http|file)/)
-      URI(link) 
-    rescue URI::InvalidURIError => e
-      link
+      parsed = URI.parse(link)
+
+      if FileEmbedHelper.supported_scheme?(parsed.scheme)
+        # Great.  We'll take it.
+        return parsed
+      end
+    rescue URI::InvalidURIError
     end
+
+    # Otherwise, return the verbatim string
+    link
   end
 
   def can_embed?(file_version)

--- a/frontend/app/views/file_versions/_file_uri.html.erb
+++ b/frontend/app/views/file_versions/_file_uri.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <div class="control-label col-sm-2"><%= I18n.t("file_version.file_uri") %></div>
   <div class="controls label-only col-sm-8">
-    <% if file_uri.respond_to?(:scheme) && file_uri.scheme.match(/^http/) %>
+    <% if file_uri.respond_to?(:scheme) && FileEmbedHelper.supported_scheme?(file_uri.scheme) %>
   	<%= link_to file_uri.to_s, file_uri.to_s %>
     <% else %>
   	<%= file_uri.to_s %>


### PR DESCRIPTION
The new behavior is:

  * If we're looking at a HTTP/HTTPS url, return a URI object from the
    helper and render a hyperlink in the UI.

  * Otherwise, leave it alone

Previously there was some code in here to handle Windows
paths (turning them info file URIs), but it's not clear that this
still needed: the resulting file links don't get rendered in any
special way in the UI anyway, and if we wanted to fully support these,
we would need to handle spaces in filenames and other Windows
favorites.

More discussion in #702 