### PR TITLE
Endpoint[:method] is now an array,  not a string

### DIFF
--- a/_yard/API.erb
+++ b/_yard/API.erb
@@ -169,7 +169,7 @@ As of <%= @time.inspect %> the following REST endpoints exist in the master bran
 
 <% @endpoints.each do | e | %>
 
-## <%= e[:method].upcase%> <%= e[:uri]%> 
+## <%= e[:method].map &:upcase %> <%= e[:uri]%> 
 
 __Description__
 

--- a/docs/doc/abstract_agent_relationship_schema.html
+++ b/docs/doc/abstract_agent_relationship_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -120,9 +120,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/abstract_agent_schema.html
+++ b/docs/doc/abstract_agent_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -220,9 +220,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/abstract_archival_object_schema.html
+++ b/docs/doc/abstract_archival_object_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -310,9 +310,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/abstract_classification_schema.html
+++ b/docs/doc/abstract_classification_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -236,9 +236,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/abstract_name_schema.html
+++ b/docs/doc/abstract_name_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -154,9 +154,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/abstract_note_schema.html
+++ b/docs/doc/abstract_note_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -126,9 +126,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/accession_parts_relationship_schema.html
+++ b/docs/doc/accession_parts_relationship_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -162,9 +162,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/accession_schema.html
+++ b/docs/doc/accession_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -522,9 +522,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/accession_sibling_relationship_schema.html
+++ b/docs/doc/accession_sibling_relationship_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -162,9 +162,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/active_edits_schema.html
+++ b/docs/doc/active_edits_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -142,9 +142,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/advanced_query_schema.html
+++ b/docs/doc/advanced_query_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -118,9 +118,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/agent_contact_schema.html
+++ b/docs/doc/agent_contact_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -174,9 +174,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/agent_corporate_entity_schema.html
+++ b/docs/doc/agent_corporate_entity_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -162,9 +162,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/agent_family_schema.html
+++ b/docs/doc/agent_family_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -156,9 +156,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/agent_person_schema.html
+++ b/docs/doc/agent_person_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -160,9 +160,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/agent_relationship_associative_schema.html
+++ b/docs/doc/agent_relationship_associative_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -154,9 +154,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/agent_relationship_earlierlater_schema.html
+++ b/docs/doc/agent_relationship_earlierlater_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -154,9 +154,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/agent_relationship_parentchild_schema.html
+++ b/docs/doc/agent_relationship_parentchild_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -150,9 +150,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/agent_relationship_subordinatesuperior_schema.html
+++ b/docs/doc/agent_relationship_subordinatesuperior_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -150,9 +150,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/agent_software_schema.html
+++ b/docs/doc/agent_software_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -140,9 +140,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/archival_object_schema.html
+++ b/docs/doc/archival_object_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -280,9 +280,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/archival_record_children_schema.html
+++ b/docs/doc/archival_record_children_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -124,9 +124,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/boolean_field_query_schema.html
+++ b/docs/doc/boolean_field_query_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -126,9 +126,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/boolean_query_schema.html
+++ b/docs/doc/boolean_query_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -122,9 +122,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/classification_schema.html
+++ b/docs/doc/classification_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -112,9 +112,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/classification_term_schema.html
+++ b/docs/doc/classification_term_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -174,9 +174,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/classification_tree_schema.html
+++ b/docs/doc/classification_tree_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -130,9 +130,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/collection_management_schema.html
+++ b/docs/doc/collection_management_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -164,9 +164,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/container_conversion_job_schema.html
+++ b/docs/doc/container_conversion_job_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -128,9 +128,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/container_location_schema.html
+++ b/docs/doc/container_location_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -142,9 +142,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/container_profile_schema.html
+++ b/docs/doc/container_profile_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -162,9 +162,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/container_schema.html
+++ b/docs/doc/container_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -176,9 +176,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/date_field_query_schema.html
+++ b/docs/doc/date_field_query_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -130,9 +130,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/date_schema.html
+++ b/docs/doc/date_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -146,9 +146,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/deaccession_schema.html
+++ b/docs/doc/deaccession_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -146,9 +146,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/default_values_schema.html
+++ b/docs/doc/default_values_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -124,9 +124,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/defaults_schema.html
+++ b/docs/doc/defaults_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -334,9 +334,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/digital_object_component_schema.html
+++ b/docs/doc/digital_object_component_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -218,9 +218,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/digital_object_schema.html
+++ b/docs/doc/digital_object_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -240,9 +240,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/digital_object_tree_schema.html
+++ b/docs/doc/digital_object_tree_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -138,9 +138,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/digital_record_children_schema.html
+++ b/docs/doc/digital_record_children_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -124,9 +124,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/enumeration_migration_schema.html
+++ b/docs/doc/enumeration_migration_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -128,9 +128,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/enumeration_schema.html
+++ b/docs/doc/enumeration_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -180,9 +180,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/enumeration_value_schema.html
+++ b/docs/doc/enumeration_value_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -130,9 +130,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/event_schema.html
+++ b/docs/doc/event_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -292,9 +292,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/extent_schema.html
+++ b/docs/doc/extent_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -138,9 +138,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/external_document_schema.html
+++ b/docs/doc/external_document_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -122,9 +122,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/external_id_schema.html
+++ b/docs/doc/external_id_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -118,9 +118,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/field_query_schema.html
+++ b/docs/doc/field_query_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -130,9 +130,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/file_version_schema.html
+++ b/docs/doc/file_version_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -172,9 +172,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/find_and_replace_job_schema.html
+++ b/docs/doc/find_and_replace_job_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -174,9 +174,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/group_schema.html
+++ b/docs/doc/group_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -136,9 +136,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/import_job_schema.html
+++ b/docs/doc/import_job_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -146,9 +146,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/instance_schema.html
+++ b/docs/doc/instance_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -162,9 +162,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/job_schema.html
+++ b/docs/doc/job_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -230,9 +230,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/location_batch_schema.html
+++ b/docs/doc/location_batch_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -204,9 +204,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/location_batch_update_schema.html
+++ b/docs/doc/location_batch_update_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -132,9 +132,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/location_function_schema.html
+++ b/docs/doc/location_function_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -114,9 +114,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/location_profile_schema.html
+++ b/docs/doc/location_profile_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -148,9 +148,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/location_schema.html
+++ b/docs/doc/location_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -254,9 +254,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/merge_request_schema.html
+++ b/docs/doc/merge_request_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -174,9 +174,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/name_corporate_entity_schema.html
+++ b/docs/doc/name_corporate_entity_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -130,9 +130,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/name_family_schema.html
+++ b/docs/doc/name_family_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -122,9 +122,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/name_form_schema.html
+++ b/docs/doc/name_form_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -128,9 +128,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/name_person_schema.html
+++ b/docs/doc/name_person_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -146,9 +146,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/name_software_schema.html
+++ b/docs/doc/name_software_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -126,9 +126,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_abstract_schema.html
+++ b/docs/doc/note_abstract_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -128,9 +128,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_bibliography_schema.html
+++ b/docs/doc/note_bibliography_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -156,9 +156,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_bioghist_schema.html
+++ b/docs/doc/note_bioghist_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -138,9 +138,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_chronology_schema.html
+++ b/docs/doc/note_chronology_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -154,9 +154,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_citation_schema.html
+++ b/docs/doc/note_citation_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -160,9 +160,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_definedlist_schema.html
+++ b/docs/doc/note_definedlist_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -148,9 +148,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_digital_object_schema.html
+++ b/docs/doc/note_digital_object_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -142,9 +142,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_index_item_schema.html
+++ b/docs/doc/note_index_item_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -152,9 +152,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_index_schema.html
+++ b/docs/doc/note_index_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -156,9 +156,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_multipart_schema.html
+++ b/docs/doc/note_multipart_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -156,9 +156,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_orderedlist_schema.html
+++ b/docs/doc/note_orderedlist_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -154,9 +154,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_outline_level_schema.html
+++ b/docs/doc/note_outline_level_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -136,9 +136,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_outline_schema.html
+++ b/docs/doc/note_outline_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -136,9 +136,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_singlepart_schema.html
+++ b/docs/doc/note_singlepart_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -144,9 +144,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/note_text_schema.html
+++ b/docs/doc/note_text_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -130,9 +130,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/permission_schema.html
+++ b/docs/doc/permission_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -130,9 +130,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/preference_schema.html
+++ b/docs/doc/preference_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -130,9 +130,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/print_to_pdf_job_schema.html
+++ b/docs/doc/print_to_pdf_job_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -132,9 +132,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/rde_template_schema.html
+++ b/docs/doc/rde_template_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -136,9 +136,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/record_tree_schema.html
+++ b/docs/doc/record_tree_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -142,9 +142,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/report_job_schema.html
+++ b/docs/doc/report_job_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -140,9 +140,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/repository_schema.html
+++ b/docs/doc/repository_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -182,9 +182,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/repository_with_agent_schema.html
+++ b/docs/doc/repository_with_agent_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -126,9 +126,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:33 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/resource_schema.html
+++ b/docs/doc/resource_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -404,9 +404,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/resource_tree_schema.html
+++ b/docs/doc/resource_tree_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -146,9 +146,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/revision_statement_schema.html
+++ b/docs/doc/revision_statement_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -124,9 +124,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/rights_restriction_schema.html
+++ b/docs/doc/rights_restriction_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -184,9 +184,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/rights_statement_schema.html
+++ b/docs/doc/rights_statement_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -194,9 +194,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/sub_container_schema.html
+++ b/docs/doc/sub_container_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -168,9 +168,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/subject_schema.html
+++ b/docs/doc/subject_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -174,9 +174,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/telephone_schema.html
+++ b/docs/doc/telephone_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -128,9 +128,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/term_schema.html
+++ b/docs/doc/term_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -132,9 +132,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/top_container_schema.html
+++ b/docs/doc/top_container_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -322,9 +322,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/user_defined_schema.html
+++ b/docs/doc/user_defined_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -226,9 +226,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/user_schema.html
+++ b/docs/doc/user_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -234,9 +234,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).

--- a/docs/doc/vocabulary_schema.html
+++ b/docs/doc/vocabulary_schema.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="class_list.html"></iframe>
+      <iframe id="nav" src="schema_list.html"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -59,7 +59,7 @@
         <div class="clear"></div>
       </div>
 
-      <iframe id="search_frame" src="class_list.html"></iframe>
+      <iframe id="search_frame" src="schema_list.html"></iframe>
 
       <div id="content">
 
@@ -130,9 +130,7 @@
 
 
 
-</div>
-
-      <div id="footer">
+<div id="footer">
   ArchivesSpace Version v1.5.3.a Documentation Generated on Thu Mar 16 15:24:32 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.0 (ruby-1.9.3).


### PR DESCRIPTION
`./build/run doc:build` fails 
`     [java] NoMethodError: undefined method `upcase' for [:post]:Array `

method is an array, not a string, since:
https://github.com/archivesspace/archivesspace/commit/693c6f76c956b32d20a3798e7daf85ea1687add9
