### PR TITLE
Docfix  

### DIFF
--- a/_yard/API.erb
+++ b/_yard/API.erb
@@ -169,7 +169,7 @@ As of <%= @time.inspect %> the following REST endpoints exist in the master bran
 
 <% @endpoints.each do | e | %>
 
-## <%= e[:method].upcase%> <%= e[:uri]%> 
+## <%= e[:method].map &:upcase %> <%= e[:uri]%> 
 
 __Description__
 

--- a/_yard/templates/default/schema/html/schema.erb
+++ b/_yard/templates/default/schema/html/schema.erb
@@ -28,7 +28,7 @@
       </table>
 			<br />
 			<span><a href="<%= @schema[:name].to_s %>.txt">Plain Text Version</a></span>
-			</div>
+
 
 
 


### PR DESCRIPTION
[1]  `./build/run doc:build` fails 
`     [java] NoMethodError: undefined method `upcase' for [:post]:Array `

method is an array, not a string, since:
https://github.com/archivesspace/archivesspace/commit/693c6f76c956b32d20a3798e7daf85ea1687add9

[2] https://github.com/archivesspace/archivesspace/issues/712 
  fix the unmatched ending `</div>` in the template. 

I haven't figured out where in the template to make the 3rd fix to get the index menus correctly generated.  ( This is my 2nd try. First time I edited the *_schema.html files instead of fixing their yarddoc template. ) 