### PR TITLE
fix docs schema search and nav menu

### DIFF
--- a/_yard/templates/default/fulldoc/html/full_list_schema.erb
+++ b/_yard/templates/default/fulldoc/html/full_list_schema.erb
@@ -1,5 +1,5 @@
-<% n = 1 %>
+<% n = "odd" %>
 <% @items.each do |item| %>
-  <li class="r<%= n %>"><%= link_schema item %></li>
-  <% n = n == 2 ? 1 : 2 %>
+  <li class="<%= n %>"><div class="item"><%= link_schema item %></div></li>
+  <% n = n == "odd" ? "even" : "odd" %>
 <% end %>

--- a/_yard/templates/default/fulldoc/html/setup.rb
+++ b/_yard/templates/default/fulldoc/html/setup.rb
@@ -27,7 +27,7 @@ def generate_schema_list
 
    # optional: the specified stylesheet class
    # when not specified it will default to the value of @list_type
-   @list_class = "class"
+   @list_class = "schema"
 
    # Generate the full list html file with named feature_list.html
    # @note this file must be match the name of the type
@@ -36,7 +36,7 @@ end
 
 
 def link_schema(item)
-  "<span class='object_link'><a href='#{item}.html'>#{item.to_s.sub(/_schema/,'')}</a></span>"
+  "<div class='item'><span class='object_link'><a href='#{item}.html' title='#{item}' >#{item.to_s.sub(/_schema/,'')}</a></span></div>"
  # linkify(item)
 end
   

--- a/_yard/templates/default/layout/html/setup.rb
+++ b/_yard/templates/default/layout/html/setup.rb
@@ -1,3 +1,25 @@
 def menu_lists
   super + [ { :type => 'schema', :title => 'Schema List', :search_title => 'Schema List' } ]
 end
+
+def layout
+  if object.is_a? YARD::CodeObjects::SchemaObject
+      @nav_url = 'schema_list.html'
+  else
+      @nav_url = url_for_list(!(defined?(@file) && @file) || options.index ? 'class' : 'file')
+  end
+
+  @path =
+    if !object || object.is_a?(String)
+      nil
+    elsif defined?(@file) && @file
+      @file.path
+    elsif !object.is_a?(YARD::CodeObjects::NamespaceObject)
+      object.parent.path
+    else
+      object.path
+    end
+
+  erb(:layout)
+
+end


### PR DESCRIPTION
yard doc template fixes:
fixes search for schema list, and keeps it from reverting back to class_list after clicking item. 

Maybe there's a better way to do it, but I couldn't figure it out. 
( I did not push rebuilt docs with this patch. That's seems to be something that's usually done right before release. ) 