### PR TITLE
Add ability to make path to config.rb an env var

### DIFF
--- a/common/config/config-distribution.rb
+++ b/common/config/config-distribution.rb
@@ -63,6 +63,9 @@ class AppConfig
     if java.lang.System.getProperty("aspace.config")
       # Explicit Java property
       java.lang.System.getProperty("aspace.config")
+    elsif ENV['ASPACE_CONFIG'] && File.exist?(ENV['ASPACE_CONFIG'])
+      # Setting a system config 
+      ENV['ASPACE_CONFIG']
     elsif ENV['ASPACE_LAUNCHER_BASE'] && File.exist?(File.join(ENV['ASPACE_LAUNCHER_BASE'], "config", "config.rb"))
       File.join(ENV['ASPACE_LAUNCHER_BASE'], "config", "config.rb")
     elsif java.lang.System.getProperty("catalina.base")


### PR DESCRIPTION
We would like to have the ability to be able to set the path to the
config.rb file as an env var. This add the ability to set
ASPACE_CONFIG and have it used as the path to the config.rb
file.