### PR TITLE
Add ability to set plugins directory outside aspace base

### DIFF
--- a/common/asutils.rb
+++ b/common/asutils.rb
@@ -101,8 +101,14 @@ module ASUtils
 
   def self.find_local_directories(base = nil, *plugins)
     plugins = AppConfig[:plugins] if plugins.empty?
-    base_directory = self.find_base_directory
-    Array(plugins).map { |plugin| File.join(*[base_directory, "plugins", plugin, base].compact) }
+    # if a specific plugins directory is set in config.rb,
+    # we use that. Otherwise, find the 'plugins' dir in the 
+    # aspace base.
+    base_directory =
+      AppConfig.changed?(:plugins_directory) ?
+        AppConfig[:plugins_directory] :
+        File.join( *[ self.find_base_directory, 'plugins'])
+    Array(plugins).map { |plugin| File.join(*[base_directory, plugin, base].compact) }
   end
 
 

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -146,6 +146,10 @@ AppConfig[:report_pdf_font_family] = "\"DejaVu Sans\", sans-serif"
 AppConfig[:plugins] = ['local',  'lcnaf']
 # The aspace-public-formats plugin is not supported in the new public application
 AppConfig[:plugins] << 'aspace-public-formats' unless ENV['ASPACE_PUBLIC_NEW'] == 'true'
+# By default, the plugins directory will be in your ASpace Home.
+# If you want to override that, update this with an absolute
+# path
+AppConfig[:plugins_directory] = "plugins"
 
 # URL to direct the feedback link
 # You can remove this from the footer by making the value blank.


### PR DESCRIPTION
This allows for the plugins directory to be specificed in the
config.rb. If nothing is set, Aspace should use the 'plugins'
directory in the Aspace base.