### PR TITLE
AR-1643 remove the MARC XML importer mapping for an agents authority_id

### DIFF
--- a/backend/app/converters/lib/marcxml_base_map.rb
+++ b/backend/app/converters/lib/marcxml_base_map.rb
@@ -269,7 +269,6 @@ module MarcXMLBaseMap
         },
         "self::datafield" => {
           :map => {
-            "//controlfield[@tag='001']" => :authority_id, 
             "@ind1" => sets_name_order_from_ind1,
             "subfield[@code='v']" => adds_prefixed_qualifier('Form subdivision'),
             "subfield[@code='x']" => adds_prefixed_qualifier('General subdivision'),

--- a/backend/spec/lib_marcxml_converter_spec.rb
+++ b/backend/spec/lib_marcxml_converter_spec.rb
@@ -351,7 +351,6 @@ END
 
       new_record = json.last
 
-      new_record['names'][0]['authority_id'].should eq("n88218900")
       new_record['names'][0]['primary_name'].should eq("Davis")
       new_record['names'][0]['rest_of_name'].should eq("John W.")
       new_record['names'][0]['dates'].should eq("1873-1955")


### PR DESCRIPTION
… from Marc001 as it cannot be used as a unique id when there are multiple agents in the import.

Fixes https://archivesspace.atlassian.net/browse/AR-1643.