### PR TITLE
AR-1700 Don't try to parse a URL out of the location field when displ…

### DIFF
--- a/frontend/app/views/external_documents/_template.html.erb
+++ b/frontend/app/views/external_documents/_template.html.erb
@@ -2,7 +2,7 @@
   <div class="subrecord-form-fields">
     <%= form.label_and_textarea "title" %>
     <%= form.label_and_textarea "location" %>
-    <% unless form["location"].nil? %>
+    <% if form["location"] && form["location"].match(%r{\A[a-zA-Z]+://}) %>
       <%= form.label_with_field("document_link", link_to(form["location"], form["location"], {:target => "_blank"})) %>
     <% end %>
     <%= form.label_and_boolean "publish", {}, user_prefs["publish"] %>

--- a/frontend/app/views/external_documents/_template.html.erb
+++ b/frontend/app/views/external_documents/_template.html.erb
@@ -2,9 +2,8 @@
   <div class="subrecord-form-fields">
     <%= form.label_and_textarea "title" %>
     <%= form.label_and_textarea "location" %>
-    <% loc_uri = (form["location"] || "").slice(URI.regexp) %>
-    <% unless loc_uri.nil? %>
-      <%= form.label_with_field("document_link", link_to(loc_uri, loc_uri, {:target => "_blank"})) %>
+    <% unless form["location"].nil? %>
+      <%= form.label_with_field("document_link", link_to(form["location"], form["location"], {:target => "_blank"})) %>
     <% end %>
     <%= form.label_and_boolean "publish", {}, user_prefs["publish"] %>
   </div>


### PR DESCRIPTION
…aying the doc link

The parser doesn't like windowsy file links with backslashes.

And there's no need to parse the location anyway - if it's wrong then the link will be broken.

After pushing this it occurred to me that people might be putting non-url stuff around their links so this might not be good after all. Should be a conversation starter anyway!
