### PR TITLE
Compress the 'permissions' cookie value

### DIFF
--- a/frontend/app/models/user.rb
+++ b/frontend/app/models/user.rb
@@ -1,5 +1,6 @@
 require 'net/http'
 require 'json'
+require 'zlib'
 
 class User < JSONModel(:user)
 
@@ -23,7 +24,7 @@ class User < JSONModel(:user)
 
 
   def self.store_permissions(permissions, context)
-    context.send(:cookies).signed[:archivesspace_permissions] = ASUtils.to_json(Permissions.pack(permissions))
+    context.send(:cookies).signed[:archivesspace_permissions] = 'ZLIB:' + Zlib::Deflate.deflate(ASUtils.to_json(Permissions.pack(permissions)))
     context.session[:last_permission_refresh] = Time.now.to_i
   end
 


### PR DESCRIPTION
These can get quite large for users with a lot of repositories, and
compressing cuts the size down by a half or more.