### PR TITLE
Expand find-by-id endpoints to include looking up Resource and Digital object records

### DIFF
--- a/backend/app/controllers/id_lookup_controller.rb
+++ b/backend/app/controllers/id_lookup_controller.rb
@@ -1,5 +1,26 @@
 class ArchivesSpaceService < Sinatra::Base
 
+  Endpoint.get('/repositories/:repo_id/find_by_id/resources')
+    .description("Find Resources by their identifiers")
+    .params(["repo_id", :repo_id],
+            ["identifier", [String], "A 4-part identifier expressed as JSON array (of up to 4 strings)", :optional => true],
+            ["resolve", :resolve])
+    .permissions([:view_repository])
+    .returns([200, "JSON array of refs"]) \
+  do
+    identifiers = Array(params[:identifier]).map {|identifier|
+      parsed = ASUtils.json_parse(identifier)
+
+      if parsed.is_a?(Array) && parsed.length > 0 && parsed.length <= 4
+        padded = (parsed + ([nil] * 3)).take(4)
+        ASUtils.to_json(padded)
+      end
+    }.compact
+
+    refs = IDLookup.new.find_by_ids(Resource, :identifier => identifiers)
+    json_response(resolve_references({'resources' => refs}, params[:resolve]))
+  end
+
   Endpoint.get('/repositories/:repo_id/find_by_id/archival_objects')
     .description("Find Archival Objects by ref_id or component_id")
     .params(["repo_id", :repo_id],
@@ -24,6 +45,18 @@ class ArchivesSpaceService < Sinatra::Base
   do
     refs = IDLookup.new.find_by_ids(DigitalObjectComponent, :component_id => params[:component_id])
     json_response(resolve_references({'digital_object_components' => refs}, params[:resolve]))
+  end
+
+  Endpoint.get('/repositories/:repo_id/find_by_id/digital_objects')
+    .description("Find Digital Objects by digital_object_id")
+    .params(["repo_id", :repo_id],
+            ["digital_object_id", [String], "A set of digital object IDs", :optional => true],
+            ["resolve", :resolve])
+    .permissions([:view_repository])
+    .returns([200, "JSON array of refs"]) \
+  do
+    refs = IDLookup.new.find_by_ids(DigitalObject, :digital_object_id => params[:digital_object_id])
+    json_response(resolve_references({'digital_objects' => refs}, params[:resolve]))
   end
 
 end


### PR DESCRIPTION
Reported several times on Slack and a bit surprising from an API
standpoint that these weren't there.  Easy to add so here they are.