### PR TITLE
Handle multiple EAD unitids. First unitid is always primary one.

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -161,7 +161,7 @@ class EADConverter < Converter
         unless obj.class.record_type == "note_multipart"
           title = Nokogiri::XML::DocumentFragment.parse(inner_xml.strip)
           title.xpath(".//unitdate").remove
-          obj.title = format_content( title.to_xml(:encoding => 'utf-8') ) if obj.title.nil? || obj.title.empty?
+          obj.title = format_content( title.to_xml(:encoding => 'utf-8') )
         end
       end
     end

--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -161,7 +161,7 @@ class EADConverter < Converter
         unless obj.class.record_type == "note_multipart"
           title = Nokogiri::XML::DocumentFragment.parse(inner_xml.strip)
           title.xpath(".//unitdate").remove
-          obj.title = format_content( title.to_xml(:encoding => 'utf-8') )
+          obj.title = format_content( title.to_xml(:encoding => 'utf-8') ) if obj.title.nil? || obj.title.empty?
         end
       end
     end

--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -132,9 +132,25 @@ class EADConverter < Converter
           # inner_xml.split(/[\/_\-\.\s]/).each_with_index do |id, i|
           #   set receiver, "id_#{i}".to_sym, id
           # end
-          set obj, :id_0, inner_xml
-        when 'archival_object'
-          set obj, :component_id, inner_xml
+          set obj, :id_0, inner_xml if  obj.id_0.nil? || obj.id_0.empty?
+            if node.attribute( "type")
+              make :external_id, {
+                  :source => node.attribute( "type"),
+                  :external_id => inner_xml
+              } do |ext_id|
+                set ancestor(:resource ), :external_ids, ext_id
+              end
+            end
+          when 'archival_object'
+          set obj, :component_id, inner_xml if obj.component_id.nil? || obj.component_id.empty?
+            if node.attribute( "type" )
+            make :external_id, {
+                :source => node.attribute( "type" ),
+                :external_id => inner_xml
+            } do |ext_id|
+              set ancestor(:resource, :archival_object), :external_ids, ext_id
+              end
+            end
         end
       end
     end

--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -159,6 +159,10 @@ class EADSerializer < ASpaceExport::Serializer
 
             xml.unitid (0..3).map{|i| data.send("id_#{i}")}.compact.join('.')
 
+            data.external_ids.each do |exid|
+              xml.unitid  ({ "type" => exid['source'], "identifier" => exid['external_id']}) { xml.text exid['external_id']}
+            end
+
             serialize_extents(data, xml, @fragments)
 
             serialize_dates(data, xml, @fragments)
@@ -252,8 +256,14 @@ class EADSerializer < ASpaceExport::Serializer
           xml.unittitle {  sanitize_mixed_content( val,xml, fragments) }
         end
 
-        if !data.component_id.nil? && !data.component_id.empty?
+        if !data.component_id.nil? && !data.component_id.empty? &&
+          !(data.external_ids.select {|x| x['external_id'] == data.component_id }).empty?
           xml.unitid data.component_id
+
+        end
+
+        data.external_ids.each do |exid|
+          xml.unitid  ({ "type" => exid['source'], "identifier" => exid['external_id']}) { xml.text exid['external_id']}
         end
 
         serialize_origination(data, xml, fragments)


### PR DESCRIPTION
Additional unitids are made into external_ids if they have a @type (external_id.source = @type)
On export, external_ids are exported as additional unitids with @type=source

https://archivesspace.atlassian.net/browse/AS-99
https://archivesspace.atlassian.net/browse/AR-1542
https://archivesspace.atlassian.net/browse/AR-1268

