### PR TITLE
Refactor toolbars for accession/resource/archival object to show a "More" menu

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/toolbar.less
+++ b/frontend/app/assets/stylesheets/archivesspace/toolbar.less
@@ -44,3 +44,8 @@
 .dropdown-menu > li {
   text-align: left;
 }
+
+.toolbar-spacer {
+    width: 1em;
+    height: 1em;
+}

--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -22,7 +22,6 @@
         <% end %>
         <div class="btn-toolbar pull-right">
           <div class="btn-group">
-            <%= render_aspace_partial :partial => "extent_calculator/toolbar_button", :locals => {:record => @accession} %>
             <% if @accession.publish %>
               <div class="btn btn-inline-form">
                 <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], @accession.uri).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
@@ -57,6 +56,22 @@
                                                                 :target => @accession.title)}
               %>
             <% end %>
+
+            <div class="btn-group dropdown" id="other-dropdown">
+              <a class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <%= I18n.t('actions.more') %>
+                <span class="caret"></span>
+              </a>
+
+              <ul class="dropdown-menu">
+                <li><%= render_aspace_partial :partial => "extent_calculator/toolbar_button", :locals => {:record => @accession} %></li>
+              </ul>
+            </div>
+
+            <% if user_can?('suppress_archival_record') || user_can?('delete_archival_record') %>
+              <div class="btn-group"><div class="toolbar-spacer"></div></div>
+            <% end %>
+
 
             <% if user_can?('suppress_archival_record') || user_can?('delete_archival_record') %>
               <% if user_can?('suppress_archival_record') %>

--- a/frontend/app/views/extent_calculator/_toolbar_button.html.erb
+++ b/frontend/app/views/extent_calculator/_toolbar_button.html.erb
@@ -1,5 +1,3 @@
 <%= render_aspace_partial :partial => "extent_calculator/show_calculation_template", :locals => {:record => record} %>
-<div class="btn-group">
-  <a href="javascript:void(0);" class="btn btn-sm btn-default extent-calculator-btn"><%= I18n.t("extent_calculator.calculate_extent") %></a>
-</div>
+<a href="javascript:void(0);" class="extent-calculator-btn"><%= I18n.t("extent_calculator.calculate_extent") %></a>
 

--- a/frontend/app/views/shared/_component_toolbar.html.erb
+++ b/frontend/app/views/shared/_component_toolbar.html.erb
@@ -26,11 +26,30 @@
       <% end %>
       <div class="btn-toolbar pull-right">
         <div class="btn-group">
-          <% if ['resource', 'archival_object'].include?(record.jsonmodel_type) %>
-            <%= render_aspace_partial :partial => "extent_calculator/toolbar_button", :locals => {:record => record} %>
-          <% end %>
           <% if user_can?('update_event_record') && supports_events && ((suppressible && !record.suppressed) || !suppressible ) %>
             <%= render_aspace_partial :partial => "shared/event_dropdown", :locals => {:record => record} %>
+          <% end %>
+
+          <div class="btn-group dropdown" id="other-dropdown" style="display: none">
+            <a class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+              <%= I18n.t('actions.more') %>
+              <span class="caret"></span>
+            </a>
+
+            <% other_shown = false %>
+            <ul class="dropdown-menu">
+              <% if ['archival_object'].include?(record.jsonmodel_type) %>
+                <% other_shown = true %>
+                <li><%= render_aspace_partial :partial => "extent_calculator/toolbar_button", :locals => {:record => record} %></li>
+              <% end %>
+
+            <% if other_shown %><script>$('#other-dropdown').show();</script><% end %>
+          </div>
+
+          <% if user_can?('suppress_archival_record') || user_can?('delete_archival_record') %>
+            <div class="btn-group">
+              <div class="toolbar-spacer" />
+            </div>
           <% end %>
 
           <% if suppressible && user_can?('suppress_archival_record') %>

--- a/frontend/app/views/shared/_resource_toolbar.html.erb
+++ b/frontend/app/views/shared/_resource_toolbar.html.erb
@@ -19,9 +19,6 @@
       <% end %>
       <div class="btn-toolbar pull-right">
         <div class="btn-group">
-          <% if ['resource', 'archival_object'].include?(record_type) %>
-            <%= render_aspace_partial :partial => "extent_calculator/toolbar_button", :locals => {:record => record} %>
-          <% end %>
           <% if user_can?('update_event_record') && !record.suppressed %>
             <%= render_aspace_partial :partial => "shared/event_dropdown", :locals => {:record => record} %>
           <% end %>
@@ -71,6 +68,30 @@
                                                               :target => record.title)}
             %>
           <% end %>
+          <div class="btn-group dropdown" id="other-dropdown" style="display: none">
+            <a class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+              <%= I18n.t('actions.more') %>
+              <span class="caret"></span>
+            </a>
+
+            <% other_shown = false %>
+            <ul class="dropdown-menu">
+              <% if ['resource', 'archival_object'].include?(record_type) %>
+                <% other_shown = true %>
+                <li><%= render_aspace_partial :partial => "extent_calculator/toolbar_button", :locals => {:record => record} %></li>
+              <% end %>
+            </ul>
+
+            <% if other_shown %><script>$('#other-dropdown').show();</script><% end %>
+          </div>
+
+          <% if user_can?('suppress_archival_record') || user_can?('delete_archival_record') %>
+            <div class="btn-group">
+              <div class="toolbar-spacer" />
+            </div>
+
+          <% end %>
+
           <% if user_can?('suppress_archival_record') %>
 
             <% if record.suppressed %>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
     spawn: Spawn
     show_all: Show All
     transfer_record: Transfer
+    more: More
     link_to: Link To
     add_prefix: Add
     merge_confirm_title: Merge into this record?

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -23,6 +23,7 @@
     view: Ver
     spawn: Heredar
     show_all: Mostrar todo
+    more: Más
     transfer_record: Transferir
     link_to: Enlazar a
     add_prefix: Añadir

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -24,6 +24,7 @@ fr:
     spawn: Hériter
     show_all: Montrer tout
     transfer_record: Transférer
+    more: Plus
     link_to: Lier à
     add_prefix: Ajouter
     merge_confirm_title: Fusionner avec cette notice?

--- a/selenium/spec/instances_and_containers_spec.rb
+++ b/selenium/spec/instances_and_containers_spec.rb
@@ -254,6 +254,7 @@ describe "Resource instances and containers" do
   it "can calculate extents" do
 
     @driver.navigate.to("#{$frontend}#{@resource.uri.sub(/\/repositories\/\d+/, '')}/edit")
+    @driver.find_element(:link, 'More').click
     @driver.find_element(:link, 'Calculate Extent').click
     
     modal = @driver.find_element(:id => "extentCalculationModal")
@@ -277,6 +278,7 @@ describe "Resource instances and containers" do
   it "& fer accessions too!" do
 
     @driver.navigate.to("#{$frontend}#{@accession.uri.sub(/\/repositories\/\d+/, '')}/edit")
+    @driver.find_element(:link, 'More').click
     @driver.find_element(:link, 'Calculate Extent').click
     
     modal = @driver.find_element(:id => "extentCalculationModal")


### PR DESCRIPTION
We're running out of space for more buttons!  Especially when plugins want to add their own.  I've added a "More" menu to give some of the less frequently used actions a place to live:

accessions: http://tsp.nz/s/a02cad2ded5ac5337252a2e4f4c289a9317aa302.jpg

resources: http://tsp.nz/s/b7842ea640b45849caa59f48b731e7f15eb3a353.jpg

archival objects: http://tsp.nz/s/87901ada3e0004cc9380b94b4f45e69e1f667c40.jpg