### PR TITLE
Limit table of contents entries by depth and series

### DIFF
--- a/backend/app/model/archival_object.rb
+++ b/backend/app/model/archival_object.rb
@@ -76,4 +76,24 @@ class ArchivalObject < Sequel::Model(:archival_object)
     super
   end
 
+  # For archival objects, we want the level returned in our ordered_record
+  # response
+  def self.ordered_record_properties(record_ids)
+    result = super.clone
+
+    self.filter(:id => record_ids).select(:id, :level_id, :other_level).each do |row|
+      id = row[:id]
+      level = if row[:other_level]
+                row[:other_level]
+              else
+                BackendEnumSource.value_for_id('archival_record_level', row[:level_id])
+              end
+
+      result[id] ||= {}
+      result[id][:level] = level
+    end
+
+    result
+  end
+
 end

--- a/backend/app/model/mixins/tree_nodes.rb
+++ b/backend/app/model/mixins/tree_nodes.rb
@@ -451,6 +451,11 @@ module TreeNodes
       # trigger the deletes... 
       super
     end
+
+    # Default: to be overriden by implementing models
+    def ordered_record_properties(record_ids)
+      {}
+    end
   end
 
 end

--- a/backend/app/model/mixins/trees.rb
+++ b/backend/app/model/mixins/trees.rb
@@ -209,14 +209,17 @@ module Trees
       end
     end
 
+    extra_root_properties = self.class.ordered_record_properties([self.id])
+    extra_node_properties = self.class.node_model.ordered_record_properties(result)
+
     [{'ref' => self.uri,
       'display_string' => self.title,
-      'depth' => 0}] +
+      'depth' => 0}.merge(extra_root_properties.fetch(self.id, {}))] +
       result.map {|id| {
                     'ref' => self.class.node_model.uri_for(self.class.node_type, id),
                     'display_string' => id_display_strings.fetch(id),
                     'depth' => id_depths.fetch(id),
-                  }}
+                  }.merge(extra_node_properties.fetch(id, {}))}
   end
 
   def transfer_to_repository(repository, transfer_group = [])
@@ -314,6 +317,11 @@ module Trees
       end
 
       super
+    end
+
+    # Default: to be overriden by implementing models
+    def ordered_record_properties(record_ids)
+      {}
     end
   end
 

--- a/backend/app/model/resource.rb
+++ b/backend/app/model/resource.rb
@@ -54,4 +54,23 @@ class Resource < Sequel::Model(:resource)
     [res[:id_0], res[:id_1], res[:id_2], res[:id_3]].compact.join(".")
   end
 
+  # For resources, we want the level returned in our ordered_record response
+  def self.ordered_record_properties(record_ids)
+    result = super.clone
+
+    self.filter(:id => record_ids).select(:id, :level_id, :other_level).each do |row|
+      id = row[:id]
+      level = if row[:other_level]
+                row[:other_level]
+              else
+                BackendEnumSource.value_for_id('archival_record_level', row[:level_id])
+              end
+
+      result[id] ||= {}
+      result[id][:level] = level
+    end
+
+    result
+  end
+
 end

--- a/common/schemas/resource_ordered_records.rb
+++ b/common/schemas/resource_ordered_records.rb
@@ -18,6 +18,7 @@
             },
             "display_string" => {"type" => "string", "readonly" => true},
             "depth" => {"type" => "integer", "readonly" => true},
+            "level" => {"type" => "string", "readonly" => true},
             "_resolved" => {
               "type" => "object",
               "readonly" => "true"

--- a/public-new/app/models/resource_ordered_records.rb
+++ b/public-new/app/models/resource_ordered_records.rb
@@ -2,13 +2,14 @@ class ResourceOrderedRecords < Record
 
   attr_reader :entries
 
-  Entry = Struct.new(:uri, :display_string, :depth)
+  Entry = Struct.new(:uri, :display_string, :depth, :level)
 
   def initialize(*args)
     super
 
     @entries = Array(json['uris']).map {|entry| Entry.new(entry.fetch('ref'),
                                                           entry.fetch('display_string'),
-                                                          entry.fetch('depth'))}
+                                                          entry.fetch('depth'),
+                                                          entry.fetch('level'))}
   end
 end


### PR DESCRIPTION
Only items up to 2 levels deep will be shown, and then only items with
an appropriate level of description.