### PR TITLE
Don't log in on every request

### DIFF
--- a/public-new/app/controllers/application_controller.rb
+++ b/public-new/app/controllers/application_controller.rb
@@ -19,10 +19,7 @@ class ApplicationController < ActionController::Base
   helper_method :process_json_notes
   helper_method :get_note
 
-
-
   protect_from_forgery with: :exception
-
 
   # Allow overriding of templates via the local folder(s)
   if not ASUtils.find_local_directories.blank?
@@ -31,9 +28,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  ArchivesSpaceClient.init
 
   def archivesspace
-    ArchivesSpaceClient.new
+    ArchivesSpaceClient.instance
   end
 
 end

--- a/public-new/app/models/record.rb
+++ b/public-new/app/models/record.rb
@@ -319,8 +319,7 @@ class Record
   end
   
   def archives_space_client
-    @service ||= ArchivesSpaceClient.new
-    @service
+    ArchivesSpaceClient.instance
   end
 
   def cite_url_and_timestamp


### PR DESCRIPTION
Keep the ArchivesSpace session in memory and share it between all request threads.

If the session expires, get a new one.