### PR TITLE
Don't allow a direct upgrade from <= 1.4.2 to >= 2.1

### DIFF
--- a/common/db/migrations/064_container_management_warning.rb
+++ b/common/db/migrations/064_container_management_warning.rb
@@ -12,8 +12,11 @@ Sequel.migration do
       String :message
 
     end
-    
-    warning = <<EOF
+
+    ## This warning is now disabled because ArchivesSpace 2.1 and above assume
+    ## the user has already migrated to the new container model.
+    if false
+      warning = <<EOF
 
 
     #{ "*" * 100 }
@@ -36,8 +39,9 @@ Sequel.migration do
 
 
 EOF
-    
+      
       $stderr.puts(warning)
+    end
   end
 
   down do


### PR DESCRIPTION
Now that the container mapping code is gone, people upgrading from
1.4.2 or prior will need to first upgrade to 1.5.3 to get their
containers migrated.  If we notice someone trying to do this, give
them the lowdown.