### PR TITLE
Export performance

### DIFF
--- a/backend/app/exporters/lib/streaming_xml.rb
+++ b/backend/app/exporters/lib/streaming_xml.rb
@@ -36,7 +36,6 @@ module ASpaceExport
       ":aspace_section_#{id}_"
     end
 
-
     def stream_out(doc, fragments, y, depth=0)
       xml_text = doc.to_xml(:encoding => 'utf-8')
 
@@ -52,7 +51,7 @@ module ASpaceExport
         next_section = queue.shift
         next_id = next_section.slice!(/^_(\w+)_/).gsub(/_/, '')
         next_fragments = RawXMLHandler.new
-        doc_frag = Nokogiri::XML::DocumentFragment.parse ""
+        doc_frag = Nokogiri::XML::DocumentFragment.new(Nokogiri::XML::Document.new)
         Nokogiri::XML::Builder.with(doc_frag) do |xml|
           @sections[next_id].call(xml, next_fragments)
         end

--- a/backend/app/exporters/models/ead.rb
+++ b/backend/app/exporters/models/ead.rb
@@ -79,7 +79,7 @@ class EADModel < ASpaceExport::ExportModel
   end
 
 
-  def initialize(obj, opts)
+  def initialize(obj, tree, opts)
     @json = obj
     opts.each do |k, v|
       self.instance_variable_set("@#{k}", v)
@@ -87,13 +87,13 @@ class EADModel < ASpaceExport::ExportModel
     repo_ref = obj.repository['ref']
     @repo_id = JSONModel::JSONModel(:repository).id_for(repo_ref)
     @repo = Repository.to_jsonmodel(@repo_id)
-    @children = @json.tree['_resolved']['children']
+    @children = tree['children']
     @child_class = self.class.instance_variable_get(:@ao)
   end
 
 
-  def self.from_resource(obj, opts)
-    self.new(obj, opts)
+  def self.from_resource(obj, tree, opts)
+    self.new(obj, tree, opts)
   end
 
 

--- a/backend/app/exporters/models/ead.rb
+++ b/backend/app/exporters/models/ead.rb
@@ -27,14 +27,65 @@ class EADModel < ASpaceExport::ExportModel
   end
 
 
+  # For a given set of ArchivalObject IDs attempt to pull the records from Solr.
+  # If they're in there and are up-to-date, this saves us hitting the database.
+  #
+  # In the future we might want to generalize this to other record types and use
+  # it elsewhere, but for now I'll let it incubate here :)
+  #
+  class IndexedArchivalObjectPrefetcher
+    RecordVersion = Struct.new(:id, :lock_version)
+
+    def fetch(ao_ids, resolve)
+      # For each record of interest, calculate its URI and obtain its latest lock_version.
+      uri_to_version = {}
+
+      ArchivalObject.filter(:id => ao_ids).select(:id, :lock_version).each do |row|
+        uri = ArchivalObject.uri_for(:archival_object, row[:id])
+        uri_to_version[uri] = RecordVersion.new(row[:id], row[:lock_version])
+      end
+
+      # Try the search index
+      results = Search.records_for_uris(uri_to_version.keys)
+      indexed_records = results['results'].map {|result| ASUtils.json_parse(result['json'])}
+
+      # Walk through our results and throw out any that aren't up-to-date
+      good_records = []
+      indexed_records.each do |indexed|
+        desired_version = uri_to_version.fetch(indexed['uri']).lock_version
+        indexed_version = indexed['lock_version']
+
+        if desired_version == indexed_version
+          good_records << indexed
+        end
+      end
+
+      uris_needing_refetch = uri_to_version.keys - (good_records.map {|json| json['uri']})
+
+      unless uris_needing_refetch.empty?
+        # We've got some records that weren't available in the index.  Plan B...
+        ids_needing_refetch = uris_needing_refetch.map {|uri| uri_to_version[uri][:id]}
+
+        objs = ArchivalObject.sequel_to_jsonmodel(ArchivalObject.filter(:id => ids_needing_refetch).all)
+        good_records.concat(URIResolver.resolve_references(objs, resolve))
+      end
+
+      good_records.sort_by {|record| record.fetch('position')}
+    end
+  end
+
   @ao = Class.new do
     include ASpaceExport::ArchivalObjectDescriptionHelpers
     include ASpaceExport::LazyChildEnumerations
 
     def self.prefetch(tree_nodes, repo_id)
+      resolve = ['subjects', 'linked_agents', 'digital_object', 'top_container']
+
       RequestContext.open(:repo_id => repo_id) do
-        objs = ArchivalObject.sequel_to_jsonmodel(ArchivalObject.filter(:id => tree_nodes.map {|tree| tree['id']}).order(:position).all)
-        URIResolver.resolve_references(objs, ['subjects', 'linked_agents', 'digital_object', 'top_container'])
+        # NOTE: We assume that the above `resolve` properties have also been
+        # resolved by the indexer.
+        IndexedArchivalObjectPrefetcher.new.fetch(tree_nodes.map {|tree| tree['id']},
+                                                  resolve)
       end
     end
 

--- a/backend/app/exporters/models/labels.rb
+++ b/backend/app/exporters/models/labels.rb
@@ -104,7 +104,7 @@ class LabelModel < ASpaceExport::ExportModel
 
         crow = [] 
         if top['type'] && top['indicator'] 
-          crow << "#{top['type_1']} #{top['indicator_1']}"
+          crow << "#{top['type']} #{top['indicator']}"
         end
         if top['barcode']
           crow << top['barcode']

--- a/backend/app/exporters/models/labels.rb
+++ b/backend/app/exporters/models/labels.rb
@@ -24,9 +24,10 @@ class LabelModel < ASpaceExport::ExportModel
   end
     
 
-  def initialize(obj)
+  def initialize(obj, tree)
     @json = obj
-    
+    @tree = tree
+
     @rows = generate_label_rows(self.children) 
   end
   
@@ -41,15 +42,15 @@ class LabelModel < ASpaceExport::ExportModel
   end
   
 
-  def self.from_aspace_object(obj)
-    labler = self.new(obj)
+  def self.from_aspace_object(obj, tree)
+    labler = self.new(obj, tree)
     
     labler
   end
     
   
-  def self.from_resource(obj)
-    labler = self.from_aspace_object(obj)
+  def self.from_resource(obj, tree)
+    labler = self.from_aspace_object(obj, tree)
     
     labler
   end
@@ -80,13 +81,11 @@ class LabelModel < ASpaceExport::ExportModel
   
   
   def children
-    return nil unless @json.tree.has_key?('_resolved') && @json.tree['_resolved']['children']
-    
+    return nil unless @tree.children
+
     ao_class = self.class.instance_variable_get(:@ao)
-    
-    children = @json.tree['_resolved']['children'].map { |subtree| ao_class.new(subtree) }
-    
-    children
+
+    @tree.children.map { |subtree| ao_class.new(subtree) }
   end
   
   
@@ -110,6 +109,7 @@ class LabelModel < ASpaceExport::ExportModel
         if top['barcode']
           crow << top['barcode']
         end
+
         rows << crow
       end
       rows.push(*generate_label_rows(obj.children))

--- a/backend/app/exporters/models/mets.rb
+++ b/backend/app/exporters/models/mets.rb
@@ -53,7 +53,9 @@ class METSModel < ASpaceExport::ExportModel
     attr_accessor :dmd_id
     
     def initialize(tree)
-      obj = DigitalObjectComponent.to_jsonmodel(tree['id'])
+      resolve = ['linked_agents', 'subjects', 'repository', 'repository::agent_representation']
+      obj = URIResolver.resolve_references(DigitalObjectComponent.to_jsonmodel(tree['id']),
+                                           resolve)
       @json = JSONModel::JSONModel(:digital_object_component).new(obj)
       @tree = tree
       @mods_model = ASpaceExport.model(:mods).from_digital_object_component(obj)
@@ -102,8 +104,9 @@ class METSModel < ASpaceExport::ExportModel
   end
 
 
-  def initialize(obj)
+  def initialize(obj, tree)
     @json = obj
+    @tree = tree
     @wrapped_dmd = []    
     @extents = []
     @notes = []
@@ -118,9 +121,9 @@ class METSModel < ASpaceExport::ExportModel
   end
 
 
-  def self.from_aspace_object(obj)
+  def self.from_aspace_object(obj, tree)
   
-    mets = self.new(obj)
+    mets = self.new(obj, tree)
     
     if obj.respond_to?(:repo_id)
       repo_id = RequestContext.get(:repo_id)
@@ -135,17 +138,17 @@ class METSModel < ASpaceExport::ExportModel
   end
 
 
-  def self.from_archival_object(obj)
+  def self.from_archival_object(obj, tree)
 
-    mets = self.from_aspace_object(obj)
+    mets = self.from_aspace_object(obj, tree)
     mets.apply_map(obj, @archival_object_map)
     mets
   end
 
   
-  def self.from_digital_object(obj)
+  def self.from_digital_object(obj, tree)
 
-    mets = self.from_archival_object(obj)
+    mets = self.from_archival_object(obj, tree)
     mets.type_of_resource = obj.digital_object_type
     mets.apply_map(obj, @digital_object_map)
 
@@ -186,11 +189,11 @@ class METSModel < ASpaceExport::ExportModel
 
   
   def children
-    return nil unless @json.tree['_resolved']['children']
+    return nil unless @tree['children']
     
     ao_class = self.class.instance_variable_get(:@doc)
     
-    children = @json.tree['_resolved']['children'].map { |subtree| ao_class.new(subtree) }
+    children = @tree['children'].map { |subtree| ao_class.new(subtree) }
     
     children
   end
@@ -201,7 +204,7 @@ class METSModel < ASpaceExport::ExportModel
     file_versions.each do |fv|
       fv['digital_object_id'] = @json.id
     end
-    file_versions += extract_file_versions(@json.tree['_resolved']['children'])
+    file_versions += extract_file_versions(@tree['children'])
     file_versions.compact!
 
     while file_versions.length > 0
@@ -258,7 +261,7 @@ class METSModel < ASpaceExport::ExportModel
     @@logical_div.new(@json.title,
                       @json.id, 
                       @json.file_versions,
-                      @json.tree['_resolved']['children'])
+                      @tree['children'])
 
   end
 
@@ -268,7 +271,7 @@ class METSModel < ASpaceExport::ExportModel
     @@logical_div.new(@json.title,
                       @json.id, 
                       @json.file_versions,
-                      @json.tree['_resolved']['children'])
+                      @tree['children'])
 
   end  
 

--- a/backend/app/exporters/models/mods.rb
+++ b/backend/app/exporters/models/mods.rb
@@ -23,7 +23,6 @@ class MODSModel < ASpaceExport::ExportModel
   }
   
   @digital_object_map = {
-    :tree => :handle_tree
   }
   
   
@@ -56,7 +55,6 @@ class MODSModel < ASpaceExport::ExportModel
   def self.from_archival_object(obj)
     
     mods = self.new
-    
     mods.apply_map(obj, @archival_object_map)
 
     mods
@@ -64,7 +62,6 @@ class MODSModel < ASpaceExport::ExportModel
     
   
   def self.from_digital_object(obj, opts = {})
-    
     mods = self.from_archival_object(obj)
     
     if obj.respond_to? :digital_object_type
@@ -219,11 +216,6 @@ class MODSModel < ASpaceExport::ExportModel
       parts << part unless part.empty?
     end
     parts    
-  end
-
-
-  def handle_tree(tree)
-    @children = tree['_resolved']['children']
   end
 
 

--- a/backend/app/model/mixins/trees.rb
+++ b/backend/app/model/mixins/trees.rb
@@ -95,7 +95,7 @@ module Trees
   end
 
 
-  def tree(ids_of_interest = :all)
+  def tree(ids_of_interest = :all, display_mode = :full)
     links = {}
     properties = {}
 
@@ -142,7 +142,9 @@ module Trees
           properties[node.id]['has_children'] = !!has_children[node.id]
         end
 
-        load_node_properties(node, properties, ids_of_interest)
+        unless display_mode == :sparse
+          load_node_properties(node, properties, ids_of_interest)
+        end
       end
 
       if nodes.empty?
@@ -162,12 +164,14 @@ module Trees
       :children => top_nodes.sort_by(&:first).map {|position, node| self.class.assemble_tree(node, links, properties)},
       :record_uri => self.class.uri_for(root_type, self.id)
     }
-    
-    if  self.respond_to?(:finding_aid_filing_title) && !self.finding_aid_filing_title.nil? && self.finding_aid_filing_title.length > 0
-      result[:finding_aid_filing_title] = self.finding_aid_filing_title
-    end
 
-    load_root_properties(result, ids_of_interest)
+    unless display_mode == :sparse
+      if self.respond_to?(:finding_aid_filing_title) && !self.finding_aid_filing_title.nil? && self.finding_aid_filing_title.length > 0
+        result[:finding_aid_filing_title] = self.finding_aid_filing_title
+      end
+
+      load_root_properties(result, ids_of_interest)
+    end
 
     JSONModel("#{self.class.root_type}_tree".intern).from_hash(result, true, true)
   end

--- a/common/db/migrations/087_reindex_anything_with_instances.rb
+++ b/common/db/migrations/087_reindex_anything_with_instances.rb
@@ -1,0 +1,17 @@
+require_relative 'utils'
+
+Sequel.migration do
+
+  up do
+    now = Time.now
+    [:accession, :archival_object, :resource].each do |table|
+      self[table].update(:system_mtime => now)
+    end
+  end
+
+
+  down do
+  end
+
+end
+

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -46,7 +46,8 @@ class CommonIndexer
                            'container_locations', 'subjects',
                            'linked_agents', 'linked_records',
                            'classifications', 'digital_object',
-                           'agent_representation', 'repository']
+                           'agent_representation', 'repository',
+                           'top_container']
 
   @@paused_until = Time.now
 


### PR DESCRIPTION
Be faster!  :racing_car:

On my dev machine, EAD export of Copland drops from 3 minutes to 40 seconds (assuming it's fully indexed).  Also remove the dependency on resource tree URIs from the various exporters.