### PR TITLE
Fix instance container template. No I18n translations yet.

### DIFF
--- a/public/app/views/records/_instances.html.erb
+++ b/public/app/views/records/_instances.html.erb
@@ -13,14 +13,14 @@
                 <%= link_to instance['digital_object']['_resolved']['title'], {:controller => :records, :action => :digital_object, :id => JSONModel(:digital_object).id_for(instance['digital_object']['ref'])} %>
               </dd>
             <% else %>
-              <%= label_and_value I18n.t("container.type_1"), i18n_enum(:container, 'type_1', instance['container']['type_1']) %>
-              <%= label_and_value I18n.t("container.indicator_1"), instance['container']['indicator_1'] %>
-              <%= label_and_value I18n.t("container.barcode_1"), instance['container']['barcode_1'] %>
-              <%= label_and_value I18n.t("container.type_2"), i18n_enum(:container, 'type_2', instance['container']['type_2']) %>
-              <%= label_and_value I18n.t("container.indicator_2"), instance['container']['indicator_2'] %>
-              <%= label_and_value I18n.t("container.type_3"), i18n_enum(:container, 'type_3', instance['container']['type_3']) %>
-              <%= label_and_value I18n.t("container.indicator_3"), instance['container']['indicator_3'] %>
-              <%= label_and_value I18n.t("container.container_extent"), "#{instance['container']['container_extent']} #{i18n_enum(:container, 'container_extent_type', instance['container']['container_extent_type'])}" %>
+              <% top_container = JSONModel::HTTP::get_json(instance['sub_container']['top_container']['ref']) %>
+              <%= label_and_value "top_container_type", i18n_enum(:container, 'type_1', top_container['type']) %>
+              <%= label_and_value "top_container_indicator", top_container['indicator'] %>
+              <%= label_and_value "top_container_barcode", top_container['barcode'] %>
+              <%= label_and_value "container2_type", i18n_enum(:container, 'type_2', instance['sub_container']['type_2']) %>
+              <%= label_and_value "container2_indicator", instance['sub_container']['indicator_2'] %>
+              <%= label_and_value "container3_type", i18n_enum(:container, 'type_3', instance['sub_container']['type_3']) %>
+              <%= label_and_value "container3_indicator", instance['sub_container']['indicator_3'] %>
             <% end %>
           </dl>
         </li>


### PR DESCRIPTION
fix issue #802
Not including I18n translations: locales strings for containers were removed in https://github.com/archivesspace/archivesspace/commit/164c0fbc27720427e06009c3a7a671d7975e327c

but it no longer throws Something Went Wrong errors. 