### PR TITLE
Rights Management enhancements and redesign

### DIFF
--- a/backend/app/model/agent_corporate_entity.rb
+++ b/backend/app/model/agent_corporate_entity.rb
@@ -10,7 +10,6 @@ class AgentCorporateEntity < Sequel::Model(:agent_corporate_entity)
   include RecordableCataloging
   include Notes
   include Publishable
-  include RightsStatements
 
 
   register_agent_type(:jsonmodel => :agent_corporate_entity,

--- a/backend/app/model/agent_family.rb
+++ b/backend/app/model/agent_family.rb
@@ -10,7 +10,6 @@ class AgentFamily < Sequel::Model(:agent_family)
   include RecordableCataloging
   include Notes
   include Publishable
-  include RightsStatements
 
 
   register_agent_type(:jsonmodel => :agent_family,

--- a/backend/app/model/agent_person.rb
+++ b/backend/app/model/agent_person.rb
@@ -10,7 +10,6 @@ class AgentPerson < Sequel::Model(:agent_person)
   include RecordableCataloging
   include Notes
   include Publishable
-  include RightsStatements
 
 
   register_agent_type(:jsonmodel => :agent_person,

--- a/backend/app/model/agent_software.rb
+++ b/backend/app/model/agent_software.rb
@@ -10,7 +10,6 @@ class AgentSoftware < Sequel::Model(:agent_software)
   include RecordableCataloging
   include Notes
   include Publishable
-  include RightsStatements
 
 
   register_agent_type(:jsonmodel => :agent_software,

--- a/backend/app/model/mixins/rights_statement_external_documents.rb
+++ b/backend/app/model/mixins/rights_statement_external_documents.rb
@@ -1,0 +1,11 @@
+module RightsStatementExternalDocuments
+
+  def self.included(base)
+    base.one_to_many(:external_document, :class => "RightsStatementExternalDocument")
+
+    base.def_nested_record(:the_property => :external_documents,
+                           :contains_records_of_type => :rights_statement_external_document,
+                           :corresponding_to_association  => :external_document)
+  end
+
+end

--- a/backend/app/model/mixins/rights_statements_acts.rb
+++ b/backend/app/model/mixins/rights_statements_acts.rb
@@ -1,0 +1,11 @@
+module RightsStatementActs
+
+  def self.included(base)
+    base.one_to_many :rights_statement_act
+
+    base.def_nested_record(:the_property => :acts,
+                           :contains_records_of_type => :rights_statement_act,
+                           :corresponding_to_association  => :rights_statement_act)
+  end
+
+end

--- a/backend/app/model/rights_statement.rb
+++ b/backend/app/model/rights_statement.rb
@@ -4,15 +4,23 @@ class RightsStatement < Sequel::Model(:rights_statement)
   include ASModel
   corresponds_to JSONModel(:rights_statement)
 
-  include ExternalDocuments
+  include RightsStatementExternalDocuments
+  include Notes
+  include Agents
   include AutoGenerator
+  include RightsStatementActs
 
   set_model_scope :global
+
+  # All records that link to agents need to specify a role/relator enum
+  # but be aware in this context these fields are not exposed to via the staff
+  # interface.
+  agent_role_enum("linked_agent_role")
+  agent_relator_enum("linked_agent_archival_record_relators")
 
   auto_generate :property => :identifier,
                 :generator => proc  { |json|
                   SecureRandom.hex
                 },
                 :only_on_create => true
-
 end

--- a/backend/app/model/rights_statement_act.rb
+++ b/backend/app/model/rights_statement_act.rb
@@ -1,0 +1,8 @@
+class RightsStatementAct < Sequel::Model(:rights_statement_act)
+  include ASModel
+  corresponds_to JSONModel(:rights_statement_act)
+
+  include Notes
+
+  set_model_scope :global
+end

--- a/backend/app/model/rights_statement_external_document.rb
+++ b/backend/app/model/rights_statement_external_document.rb
@@ -1,0 +1,7 @@
+class RightsStatementExternalDocument < ExternalDocument
+  include ASModel
+
+  corresponds_to JSONModel(:rights_statement_external_document)
+
+  set_model_scope :global
+end

--- a/backend/spec/controller_accession_spec.rb
+++ b/backend/spec/controller_accession_spec.rb
@@ -85,14 +85,14 @@ describe 'Accession controller' do
                                           "rights_statements" => [
                                             {
                                               "identifier" => "abc123",
-                                              "rights_type" => "intellectual_property",
-                                              "ip_status" => "copyrighted",
+                                              "rights_type" => "copyright",
+                                              "status" => "copyrighted",
                                               "jurisdiction" => "AU",
+                                              "start_date" => "1999-01-01",
                                             }
                                           ]).save
     JSONModel(:accession).find(acc).rights_statements.length.should eq(1)
     JSONModel(:accession).find(acc).rights_statements[0]["identifier"].should eq("abc123")
-    JSONModel(:accession).find(acc).rights_statements[0]["active"].should eq(true)
   end
 
 

--- a/backend/spec/factories.rb
+++ b/backend/spec/factories.rb
@@ -488,6 +488,16 @@ FactoryGirl.define do
     content { [ generate(:string), generate(:string) ] }
   end
 
+  factory :json_note_rights_statement, class: JSONModel(:note_rights_statement) do
+    type { generate(:rights_statement_note_type)}
+    content { [ generate(:string), generate(:string) ] }
+  end
+
+  factory :json_note_rights_statement_act, class: JSONModel(:note_rights_statement_act) do
+    type { generate(:rights_statement_act_note_type)}
+    content { [ generate(:string), generate(:string) ] }
+  end
+
   factory :json_resource, class: JSONModel(:resource) do
     title { "Resource #{generate(:html_title)}" }
     id_0 { generate(:alphanumstr) }
@@ -525,10 +535,22 @@ FactoryGirl.define do
 
   # may need factories for each rights type
   factory :json_rights_statement, class: JSONModel(:rights_statement) do
-    rights_type 'intellectual_property'
-    ip_status { generate(:ip_status) }
+    rights_type 'copyright'
+    status { generate(:status) }
     jurisdiction { generate(:jurisdiction) }
-    active true
+    start_date { generate(:yyyy_mm_dd) }  
+  end
+
+  factory :json_rights_statement_act, class: JSONModel(:rights_statement_act) do
+    act_type { generate(:act_type) }
+    restriction { generate(:act_restriction) }
+    start_date { generate(:yyyy_mm_dd) }
+  end
+
+  factory :json_rights_statement_external_document, class: JSONModel(:rights_statement_external_document) do
+    title { "External Document #{generate(:generic_title)}" }
+    location { generate(:url) }
+    identifier_type { generate(:external_document_identifier_type) }
   end
 
   factory :json_subject, class: JSONModel(:subject) do

--- a/backend/spec/model_accession_spec.rb
+++ b/backend/spec/model_accession_spec.rb
@@ -162,9 +162,10 @@ describe 'Accession model' do
                                                  :rights_statements => [
                                                     {
                                                       "identifier" => "abc123",
-                                                      "rights_type" => "intellectual_property",
-                                                      "ip_status" => "copyrighted",
+                                                      "rights_type" => "copyright",
+                                                      "status" => "copyrighted",
                                                       "jurisdiction" => "AU",
+                                                      "start_date" => '1999-01-01',
                                                     }
                                                   ]
                                                  ),
@@ -172,6 +173,27 @@ describe 'Accession model' do
 
     Accession[accession[:id]].rights_statement.length.should eq(1)
     Accession[accession[:id]].rights_statement[0].identifier.should eq("abc123")
+  end
+
+  it "allows accessions to be created with a rights statement with an external document and identifier type" do
+    accession = Accession.create_from_json(build(:json_accession,
+                                                 :rights_statements => [
+                                                   {
+                                                     "identifier" => "abc123",
+                                                     "rights_type" => "copyright",
+                                                     "status" => "copyrighted",
+                                                     "jurisdiction" => "AU",
+                                                     "start_date" => '1999-01-01',
+                                                     "external_documents" => [build(:json_rights_statement_external_document,
+                                                                                    :identifier_type => 'trove')]
+                                                   }
+                                                 ]
+                                           ),
+                                           :repo_id => $repo_id)
+
+    Accession.to_jsonmodel(accession[:id]).rights_statements.length.should eq(1)
+    Accession.to_jsonmodel(accession[:id]).rights_statements.first['external_documents'].length.should eq(1)
+    Accession.to_jsonmodel(accession[:id]).rights_statements.first['external_documents'].first['identifier_type'].should eq('trove')
   end
 
 

--- a/backend/spec/model_rights_statement_spec.rb
+++ b/backend/spec/model_rights_statement_spec.rb
@@ -9,23 +9,11 @@ describe 'Rights Statement model' do
 
   it "Supports creating a new rights statement" do
     
-    opts = {:identifier => generate(:alphanumstr), :active => true}
+    opts = {:identifier => generate(:alphanumstr)}
     
     rights_statement = create_rights_statement(opts)
 
     RightsStatement[rights_statement[:id]].identifier.should eq(opts[:identifier])
-    RightsStatement[rights_statement[:id]].active.should eq(1)
-  end
-
-
-  it "creating a new rights statement and with active set to false" do
-    
-    opts = {:identifier => generate(:alphanumstr), :active => false}
-    
-    rights_statement = create_rights_statement(opts)
-
-    RightsStatement[rights_statement[:id]].identifier.should eq(opts[:identifier])
-    RightsStatement[rights_statement[:id]].active.should eq(0)
   end
 
 
@@ -48,19 +36,13 @@ describe 'Rights Statement model' do
   end
 
 
-  it "Enforces validation rules when rights_type is intellectual_property" do
+  it "Enforces validation rules when rights_type is copyright" do
     
-    opts = {:rights_type => 'intellectual_property', :ip_status => nil, :jurisdiction => nil}
+    opts = {:rights_type => 'copyright'}
     
-    expect { create_rights_statement(opts) }.to raise_error(JSONModel::ValidationException)
-
-    opts.delete(:ip_status)
-
-    expect { create_rights_statement(opts) }.to raise_error(JSONModel::ValidationException)
-
-    opts.delete(:jurisdiction)
-
-    # this is ok though
+    expect { create_rights_statement(opts.merge(:status => nil)) }.to raise_error(JSONModel::ValidationException)
+    expect { create_rights_statement(opts.merge(:jurisdiction => nil)) }.to raise_error(JSONModel::ValidationException)
+    expect { create_rights_statement(opts.merge(:start_date => nil)) }.to raise_error(JSONModel::ValidationException)
     expect { create_rights_statement(opts) }.to_not raise_error
   end
 
@@ -68,20 +50,13 @@ describe 'Rights Statement model' do
   it "Enforces validation rules when rights_type is statute" do
     
     opts = {:rights_type => 'statute', 
-            :ip_status => nil, 
-            :jurisdiction => nil,
+            :status => nil,
             :statute_citation => generate(:alphanumstr)
             }
             
-    expect { create_rights_statement(opts) }.to raise_error(JSONModel::ValidationException)
-
-    opts.delete(:statute_citation)
-    opts[:jurisdiction] = generate(:jurisdiction)
-
-    expect { create_rights_statement(opts) }.to raise_error(JSONModel::ValidationException)
-
-    opts[:statute_citation] = generate(:alphanumstr)
-    
+    expect { create_rights_statement(opts.merge(:jurisdiction => nil)) }.to raise_error(JSONModel::ValidationException)
+    expect { create_rights_statement(opts.merge(:statute_citation => nil)) }.to raise_error(JSONModel::ValidationException)
+    expect { create_rights_statement(opts.merge(:start_date => nil)) }.to raise_error(JSONModel::ValidationException)
     expect { create_rights_statement(opts) }.to_not raise_error
   end
 
@@ -89,27 +64,94 @@ describe 'Rights Statement model' do
   it "Enforces validation rules when rights_type is license" do
     
     opts = {:rights_type => 'license', 
-            :ip_status => nil, 
+            :status => nil, 
             :jurisdiction => nil,
+            :license_terms => generate(:alphanumstr)
             }
             
-    expect { create_rights_statement(opts) }.to raise_error(JSONModel::ValidationException)
+    expect { create_rights_statement(opts.merge(:license_terms => nil)) }.to raise_error(JSONModel::ValidationException)
+    expect { create_rights_statement(opts.merge(:start_date => nil)) }.to raise_error(JSONModel::ValidationException)
+    expect { create_rights_statement(opts) }.to_not raise_error
+  end
 
-    opts[:license_identifier_terms] = generate(:alphanumstr)
+  it "Enforces validation rules when rights_type is other" do
 
+    opts = {:rights_type => 'other',
+            :status => nil,
+            :jurisdiction => nil,
+            :other_rights_basis => generate(:other_rights_basis)
+    }
+
+    expect { create_rights_statement(opts.merge(:other_rights_basis => nil)) }.to raise_error(JSONModel::ValidationException)
+    expect { create_rights_statement(opts.merge(:start_date => nil)) }.to raise_error(JSONModel::ValidationException)
     expect { create_rights_statement(opts) }.to_not raise_error
   end
 
   it "Allows a rights statement to be created with an external document" do
-    
-    opts = {:external_documents => [build(:json_external_document)]}
+    opts = {'external_documents' => [build(:json_rights_statement_external_document,
+                                           :identifier_type => 'trove')]}
     
     rights_statement = create_rights_statement(opts)
 
     RightsStatement[rights_statement[:id]].external_document.length.should eq(1)
-    RightsStatement[rights_statement[:id]].external_document[0].title.should eq(opts[:external_documents][0]['title'])
+    RightsStatement[rights_statement[:id]].external_document[0].title.should eq(opts['external_documents'][0]['title'])
+    RightsStatement.to_jsonmodel(rights_statement[:id]).external_documents[0]['identifier_type'] == 'trove'
   end
 
+  it "requires an identifier type for any external document" do
+    opts = {'external_documents' => [build(:json_rights_statement_external_document, {:identifier_type => nil})]}
+
+    expect { create_rights_statement(opts) }.to raise_error(JSONModel::ValidationException)
+  end
+
+  it "Allows a rights statement to be created with a linked agent" do
+
+    agent = create(:json_agent_person)
+    opts = {'linked_agents' => [{'ref' => agent.uri}]}
+
+    rights_statement = create_rights_statement(opts)
+
+    RightsStatement.to_jsonmodel(rights_statement[:id]).linked_agents.length.should eq(1)
+    RightsStatement.to_jsonmodel(rights_statement[:id]).linked_agents[0]['ref'].should eq(agent.uri)
+  end
+
+  it "Allows a rights statement to be created with a note" do
+    opts = {
+      'notes' => [build(:json_note_rights_statement)]
+    }
+
+    rights_statement = create_rights_statement(opts)
+
+    RightsStatement.to_jsonmodel(rights_statement[:id]).notes.length.should eq(1)
+  end
+
+  it "Allows a rights statement to be created with an act" do
+    opts = {
+      :acts => [build(:json_rights_statement_act)]
+    }
+
+    rights_statement = create_rights_statement(opts)
+
+    RightsStatement.to_jsonmodel(rights_statement[:id]).acts.length.should eq(1)
+  end
+
+  it "applies validation rules to act" do
+    expect { create_rights_statement({
+                                       'acts' => [build(:json_rights_statement_act, :act_type => nil)]
+                                     }) }.to raise_error(JSONModel::ValidationException)
+
+    expect { create_rights_statement({
+                                       'acts' => [build(:json_rights_statement_act, :restriction => nil)]
+                                     }) }.to raise_error(JSONModel::ValidationException)
+
+    expect { create_rights_statement({
+                                       'acts' => [build(:json_rights_statement_act, :start_date => nil)]
+                                     }) }.to raise_error(JSONModel::ValidationException)
+
+    expect { create_rights_statement({
+                                       'acts' => [build(:json_rights_statement_act)]
+                                     }) }.to_not raise_error
+  end
 
   it "will generate a ref_id if non is provided" do
     rights_statement = create_rights_statement(:identifier => nil)

--- a/common/db/migrations/088_rights_management.rb
+++ b/common/db/migrations/088_rights_management.rb
@@ -1,0 +1,722 @@
+require 'securerandom'
+require 'json'
+
+
+def backup_rights_statement_table
+  create_table(:rights_statement_pre_088, :as => self[:rights_statement])
+end
+
+
+def create_rights_statement_act
+  create_table(:rights_statement_act) do
+    primary_key :id
+
+    Integer :rights_statement_id, :null => false
+    DynamicEnum :act_type_id, :null => false
+    DynamicEnum :restriction_id, :null => false
+    Date :start_date, :null => false
+    Date :end_date, :null => true
+
+    apply_mtime_columns
+  end
+
+  alter_table(:rights_statement_act) do
+    add_foreign_key([:rights_statement_id], :rights_statement, :key => :id)
+  end
+
+  create_editable_enum("rights_statement_act_type",
+                       ['delete', 'disseminate', 'migrate', 'modify', 'replicate', 'use'])
+
+  create_editable_enum("rights_statement_act_restriction",
+                       ['allow', 'disallow', 'conditional'])
+end
+
+
+def link_acts_to_notes
+  alter_table(:note) do
+    add_column(:rights_statement_act_id, Integer,  :null => true)
+    add_foreign_key([:rights_statement_act_id], :rights_statement_act, :key => :id)
+  end
+
+  create_enum("note_rights_statement_act_type",
+              ['permissions', 'restrictions', 'extension', 'expiration', 'additional_information'])
+
+end
+
+
+def link_rights_statements_to_agents
+  alter_table(:linked_agents_rlshp) do
+    add_column(:rights_statement_id, Integer,  :null => true)
+    add_foreign_key([:rights_statement_id], :rights_statement, :key => :id)
+  end
+end
+
+
+def link_rights_statements_to_notes
+  alter_table(:note) do
+    add_column(:rights_statement_id, Integer,  :null => true)
+    add_foreign_key([:rights_statement_id], :rights_statement, :key => :id)
+  end
+
+  create_enum("note_rights_statement_type",
+              ['materials', 'type_note', 'additional_information'])
+
+end
+
+
+def add_identifier_type_to_external_documents
+  alter_table(:external_document) do
+    add_column(:identifier_type_id, Integer, :null => true)
+    add_foreign_key([:identifier_type_id], :enumeration_value, :key => :id, :name => 'external_document_identifier_type_id_fk')
+  end
+
+  create_editable_enum('rights_statement_external_document_identifier_type',
+                       [ 'agrovoc',
+                                'allmovie',
+                                'allmusic',
+                                'allocine',
+                                'amnbo',
+                                'ansi',
+                                'artsy',
+                                'bdusc',
+                                'bfi',
+                                'bnfcg',
+                                'cantic',
+                                'cgndb',
+                                'danacode',
+                                'datoses',
+                                'discogs',
+                                'dkfilm',
+                                'doi',
+                                'ean',
+                                'eidr',
+                                'fast',
+                                'filmport',
+                                'findagr',
+                                'freebase',
+                                'gec',
+                                'geogndb',
+                                'geonames',
+                                'gettytgn',
+                                'gettyulan',
+                                'gnd',
+                                'gnis',
+                                'gtin-14',
+                                'hdl',
+                                'ibdb',
+                                'idref',
+                                'imdb',
+                                'isan',
+                                'isbn',
+                                'isbn-a',
+                                'isbnre',
+                                'isil',
+                                'ismn',
+                                'isni',
+                                'iso',
+                                'isrc',
+                                'issn',
+                                'issn-l',
+                                'issue-number',
+                                'istc',
+                                'iswc',
+                                'itar',
+                                'kinopo',
+                                'lccn',
+                                'lcmd',
+                                'lcmpt',
+                                'libaus',
+                                'local',
+                                'matrix-number',
+                                'moma',
+                                'munzing',
+                                'music-plate',
+                                'music-publisher',
+                                'musicb',
+                                'natgazfid',
+                                'nga',
+                                'nipo',
+                                'nndb',
+                                'npg',
+                                'odnb',
+                                'opensm',
+                                'orcid',
+                                'oxforddnb',
+                                'porthu',
+                                'rbmsbt',
+                                'rbmsgt',
+                                'rbmspe',
+                                'rbmsppe',
+                                'rbmspt',
+                                'rbmsrd',
+                                'rbmste',
+                                'rid',
+                                'rkda',
+                                'saam',
+                                'scholaru',
+                                'scope',
+                                'scopus',
+                                'sici',
+                                'spotify',
+                                'sprfbsb',
+                                'sprfbsk',
+                                'sprfcbb',
+                                'sprfcfb',
+                                'sprfhoc',
+                                'sprfoly',
+                                'sprfpfb',
+                                'stock-number',
+                                'strn',
+                                'svfilm',
+                                'tatearid',
+                                'theatr',
+                                'trove',
+                                'upc',
+                                'uri',
+                                'urn',
+                                'viaf',
+                                'videorecording-identifier',
+                                'wikidata',
+                                'wndla'])
+
+  # Default identifier type to 'local' for any rights statement
+  # external documents
+  enum_local_id = self[:enumeration_value]
+                     .filter(:enumeration_id => self[:enumeration]
+                                                  .filter(:name => 'rights_statement_external_document_identifier_type')
+                                                  .select(:id))
+                     .filter(:value => 'local')
+                     .select(:id)
+                     .first[:id]
+
+  self[:external_document]
+    .filter(Sequel.~(:rights_statement_id => nil))
+    .update(:identifier_type_id => enum_local_id)
+end
+
+
+def add_new_rights_statement_columns
+  alter_table(:rights_statement) do
+    add_column(:status_id, Integer,  :null => true)
+    add_column(:start_date, Date, :null => true)
+    add_column(:end_date, Date, :null => true)
+    add_column(:determination_date, Date, :null => true)
+    add_column(:license_terms, String, :null => true)
+    add_column(:other_rights_basis_id, Integer, :null => true)
+
+    add_foreign_key([:status_id], :enumeration_value, :key => :id, :name => 'rights_statement_status_id_fk')
+    add_foreign_key([:other_rights_basis_id], :enumeration_value, :key => :id, :name => 'rights_statement_other_rights_basis_id_fk')
+  end
+
+  create_editable_enum('rights_statement_other_rights_basis',
+                       ['donor', 'policy'])
+end
+
+
+# - Populate a meaningful start_date for rights statements
+def migrate_rights_statement_start_date
+  self[:rights_statement]
+    .filter(Sequel.~(:restriction_start_date => nil))
+    .update(:start_date => :restriction_start_date)
+
+  # - Ensure all rights statements have a start_date
+
+  # For accessions use the accession_date
+  self[:accession]
+    .left_outer_join(:rights_statement, :rights_statement__accession_id => :accession__id)
+    .filter(:rights_statement__start_date => nil)
+    .select(Sequel.as(:rights_statement__id, :rights_statement_id),
+            Sequel.as(:accession__accession_date, :accession_date))
+    .order(:rights_statement__id)
+    .each do |row|
+
+    next if row[:rights_statement_id].nil?
+
+    self[:rights_statement]
+      .filter(:id => row[:rights_statement_id])
+      .update(:start_date => row[:accession_date])
+  end
+
+  # For resources or archival objects
+  # take the begin from a 'creation' date and fallback to the 
+  # creation timestamp
+  ['resource', 'archival_object'].each do |record_type|
+    last_rights_statement_id = nil
+    # find a date with a 'begin' date
+    self[:"#{record_type}"]
+      .left_outer_join(:rights_statement, :"rights_statement__#{record_type}_id" => :"#{record_type}__id")
+      .left_outer_join(:date, :"date__#{record_type}_id" => :"#{record_type}__id")
+      .filter(:rights_statement__start_date => nil)
+      .filter(Sequel.~(:date__begin => nil))
+      .filter(:date__label_id => self[:enumeration_value]
+                                   .filter(:value => 'creation')
+                                   .filter(:enumeration_id => self[:enumeration]
+                                                                .filter(:name => 'date_label')
+                                                                .select(:id))
+                                   .select(:id))
+      .select(Sequel.as(:rights_statement__id, :rights_statement_id),
+              Sequel.as(:date__begin, :begin))
+      .order(:rights_statement__id)
+      .each do |row|
+
+      next if last_rights_statement_id == row[:rights_statement_id] || row[:rights_statement_id].nil?
+
+      start_date = coerce_date(row[:begin])
+
+      self[:rights_statement]
+        .filter(:id => row[:rights_statement_id])
+        .update(:start_date => start_date)
+
+      last_rights_statement_id = row[:rights_statement_id]
+    end
+
+    # fallback to the create timestamp
+    self[:"#{record_type}"]
+      .left_outer_join(:rights_statement, :"rights_statement__#{record_type}_id" => :"#{record_type}__id")
+      .filter(:rights_statement__start_date => nil)
+      .select(Sequel.as(:rights_statement__id, :rights_statement_id),
+              Sequel.as(:"#{record_type}__create_time", :create_time))
+      .order(:rights_statement__id)
+      .each do |row|
+
+      next if row[:rights_statement_id].nil?
+
+      start_date = coerce_timestamp(row[:create_time])
+
+      self[:rights_statement]
+        .filter(:id => row[:rights_statement_id])
+        .update(:start_date => start_date)
+    end
+  end
+end
+
+
+# - Rights types coded as "Intellectual Property" should be converted to
+#   "Copyright", and Rights types coded as "Institutional Policy"
+#   should be converted to "Other".
+def migrate_rights_statement_types
+  @rights_type_enum_id = self[:enumeration]
+                           .filter(:name => 'rights_statement_rights_type')
+                           .select(:id)
+
+  self[:enumeration_value]
+    .filter(:enumeration_id => @rights_type_enum_id)
+    .filter(:value => 'intellectual_property')
+    .update(:value => 'copyright')
+
+  self[:enumeration_value]
+    .filter(:enumeration_id => @rights_type_enum_id)
+    .filter(:value => 'institutional_policy')
+    .update(:value => 'other')
+end
+
+# - Order Rights Type enums as follows
+#   'Copyright', 'License', 'Statute', 'Other'
+def reorder_rights_statement_types
+  # pump up order to avoid unique constraints
+  ['copyright', 'license', 'statute', 'other'].each_with_index do |type, i|
+    self[:enumeration_value]
+      .filter(:enumeration_id => @rights_type_enum_id)
+      .filter(:value => type)
+      .update(:position => 10000 + i)
+  end
+
+  # now apply the correct order
+  ['copyright', 'license', 'statute', 'other'].each_with_index do |type, i|
+    self[:enumeration_value]
+      .filter(:enumeration_id => @rights_type_enum_id)
+      .filter(:value => type)
+      .update(:position => i)
+  end
+
+end
+
+
+# Copy ip_status_id into status_id
+def migrate_ip_status
+  self[:rights_statement]
+    .filter(Sequel.~(:ip_status_id => nil))
+    .update(:status_id => :ip_status_id)
+end
+
+
+# - Migrate data currently encoded in "IP Expiration Date" on the
+#   "Intellectual Property" template to "End Date" on the Copyright
+#   template
+def migrate_ip_expiration_date
+  self[:rights_statement]
+    .filter(Sequel.~(:ip_expiration_date => nil))
+    .update(:end_date => :ip_expiration_date)
+end
+
+
+#  - When a rights type is converted from "Institutional Policy" to
+#    "Other", the "Other Rights Basis" value should be "Institutional
+#    Policy"
+def migrate_other_rights_basis
+  other_rights_basis_enum = self[:enumeration]
+                              .filter(:name => 'rights_statement_other_rights_basis')
+                              .select(:id)
+  policy_enum_id = self[:enumeration_value]
+                     .filter(:enumeration_id => other_rights_basis_enum)
+                     .filter(:value => 'policy')
+                     .select(:id)
+  other_type_id = self[:enumeration_value]
+                    .filter(:enumeration_id => @rights_type_enum_id)
+                    .filter(:value => 'other')
+                    .select(:id)
+  self[:rights_statement]
+    .filter(:rights_type_id => other_type_id)
+    .update(:other_rights_basis_id => policy_enum_id)
+end
+
+
+# - All data currently included in the "Materials" element should be
+#   migrated to the note with the label "Materials".
+def migrate_materials_to_note
+  self[:rights_statement]
+    .filter(Sequel.~(:materials => nil))
+    .select(:id, :materials, :last_modified_by, :create_time, :system_mtime, :user_mtime)
+    .each do |row|
+    self[:note].insert(
+      :rights_statement_id => row[:id],
+      :publish => 1,
+      :notes_json_schema_version => 1,
+      :notes => JSON.generate({
+                                  'jsonmodel_type' => 'note_rights_statement',
+                                  'content' => [row[:materials]],
+                                  'type' => 'materials',
+                                  'persistent_id' => SecureRandom.hex
+                                }),
+      :last_modified_by => row[:last_modified_by],
+      :create_time => row[:create_time],
+      :system_mtime => row[:system_mtime],
+      :user_mtime => row[:user_mtime]
+    )
+  end
+end
+
+
+# - Also, all data currently included in the "Type" note should be
+# migrated to the note with the label "Type".
+def migrate_type_to_note
+  self[:rights_statement]
+    .filter(Sequel.~(:type_note => nil))
+    .select(:id, :type_note, :last_modified_by, :create_time, :system_mtime, :user_mtime)
+    .each do |row|
+    self[:note].insert(
+      :rights_statement_id => row[:id],
+      :publish => 1,
+      :notes_json_schema_version => 1,
+      :notes => JSON.generate({
+                                  'jsonmodel_type' => 'note_rights_statement',
+                                  'content' => [row[:type_note]],
+                                  'type' => 'type_note',
+                                  'persistent_id' => SecureRandom.hex
+                                }),
+      :last_modified_by => row[:last_modified_by],
+      :create_time => row[:create_time],
+      :system_mtime => row[:system_mtime],
+      :user_mtime => row[:user_mtime]
+    )
+  end
+end
+
+
+# - Migrate data currently encoded in "Permissions" to a Rights Statement note
+#   with type 'Additional Information' and label 'Permissions'
+def migrate_permissions_to_note
+  self[:rights_statement]
+    .filter(Sequel.~(:permissions => nil))
+    .select(:id, :permissions, :last_modified_by, :create_time, :system_mtime, :user_mtime)
+    .each do |row|
+    self[:note].insert(
+      :rights_statement_id => row[:id],
+      :publish => 1,
+      :notes_json_schema_version => 1,
+      :notes => JSON.generate({
+                                  'jsonmodel_type' => 'note_rights_statement',
+                                  'content' => [row[:permissions]],
+                                  'type' => 'additional_information',
+                                  'label' => 'Permissions',
+                                  'persistent_id' => SecureRandom.hex
+                                }),
+      :last_modified_by => row[:last_modified_by],
+      :create_time => row[:create_time],
+      :system_mtime => row[:system_mtime],
+      :user_mtime => row[:user_mtime]
+    )
+  end
+end
+
+
+# - Migrate data currently encoded in "Restrictions" to a Rights Statement note
+#   with type 'Additional Information' and label 'Restrictions'
+def migrate_restrictions_to_note
+  self[:rights_statement]
+    .filter(Sequel.~(:restrictions => nil))
+    .select(:id, :restrictions, :last_modified_by, :create_time, :system_mtime, :user_mtime)
+    .each do |row|
+    self[:note].insert(
+      :rights_statement_id => row[:id],
+      :publish => 1,
+      :notes_json_schema_version => 1,
+      :notes => JSON.generate({
+                                  'jsonmodel_type' => 'note_rights_statement',
+                                  'content' => [row[:restrictions]],
+                                  'type' => 'additional_information',
+                                  'label' => 'Restrictions',
+                                  'persistent_id' => SecureRandom.hex
+                                }),
+      :last_modified_by => row[:last_modified_by],
+      :create_time => row[:create_time],
+      :system_mtime => row[:system_mtime],
+      :user_mtime => row[:user_mtime]
+    )
+  end
+end
+
+
+# - Migrate data currently encoded in "Granted Note" to a Rights Statement note
+#   with type 'Additional Information' and label 'Granted Note' 
+def migrate_granted_note_to_note
+  self[:rights_statement]
+    .filter(Sequel.~(:granted_note => nil))
+    .select(:id, :granted_note, :last_modified_by, :create_time, :system_mtime, :user_mtime)
+    .each do |row|
+    self[:note].insert(
+      :rights_statement_id => row[:id],
+      :publish => 1,
+      :notes_json_schema_version => 1,
+      :notes => JSON.generate({
+                                  'jsonmodel_type' => 'note_rights_statement',
+                                  'content' => [row[:granted_note]],
+                                  'type' => 'additional_information',
+                                  'label' => 'Granted Note',
+                                  'persistent_id' => SecureRandom.hex
+                                }),
+      :last_modified_by => row[:last_modified_by],
+      :create_time => row[:create_time],
+      :system_mtime => row[:system_mtime],
+      :user_mtime => row[:user_mtime]
+    )
+  end
+end
+
+
+def migrate_license_terms
+  self[:rights_statement]
+    .filter(Sequel.~(:license_identifier_terms => nil))
+    .update(:license_terms => :license_identifier_terms)
+end
+
+
+def migrate_agent_rights_statements
+  # Migrate any agent rights statements to a new note type 'Rights Statement'
+  # known by the schema note_agent_rights_statement
+  #
+  # Required fields:
+  #   Rights Type; Materials; Type Note; Permissions; Restrictions; State Date;
+  #   End Date; Granted Note; IP Status; IP Expiration Date; Jurisdiction;
+  #   License Identifier Terms; Statute Citation
+  #
+  [:agent_person_id,
+   :agent_family_id,
+   :agent_corporate_entity_id,
+   :agent_software_id].each do |agent_fk|
+    self[:rights_statement]
+      .left_outer_join(:enumeration_value,
+                    {
+                      :rights_type_enum__id => :rights_statement__rights_type_id,
+                    },
+                    {
+                      :table_alias => :rights_type_enum
+                    })
+      .left_outer_join(:enumeration_value,
+                       {
+                         :jurisdiction_enum__id => :rights_statement__jurisdiction_id,
+                       },
+                       {
+                         :table_alias => :jurisdiction_enum
+                       })
+      .left_outer_join(:enumeration_value,
+                       {
+                         :ip_status_enum__id => :rights_statement__ip_status_id,
+                       },
+                       {
+                         :table_alias => :ip_status_enum
+                       })
+      .filter(Sequel.~(Sequel.qualify(:rights_statement, agent_fk) => nil))
+      .select(Sequel.as(:rights_type_enum__value, :rights_type),
+              Sequel.as(:rights_statement__materials, :materials),
+              Sequel.as(:rights_statement__type_note, :type_note),
+              Sequel.as(:rights_statement__permissions, :permissions),
+              Sequel.as(:rights_statement__restrictions, :restrictions),
+              Sequel.as(:rights_statement__restriction_start_date, :start_date),
+              Sequel.as(:rights_statement__restriction_end_date, :end_date),
+              Sequel.as(:rights_statement__granted_note, :granted_note),
+              Sequel.as(:ip_status_enum__value, :ip_status),
+              Sequel.as(:rights_statement__ip_expiration_date, :ip_expiration_date),
+              Sequel.as(:jurisdiction_enum__value, :jurisdiction),
+              Sequel.as(:rights_statement__license_identifier_terms, :license_identifier_terms),
+              Sequel.as(:rights_statement__statute_citation, :statute_citation),
+              Sequel.as(Sequel.qualify(:rights_statement, agent_fk), agent_fk),
+              Sequel.as(:rights_statement__last_modified_by, :last_modified_by),
+              Sequel.as(:rights_statement__create_time, :create_time),
+              Sequel.as(:rights_statement__system_mtime, :system_mtime),
+              Sequel.as(:rights_statement__user_mtime, :user_mtime))
+      .each do |row|
+
+      note_content = ""
+      note_content += "Rights Type: #{row[:rights_type]}"
+      note_content += "\nMaterials: #{row[:materials]}" if row[:materials]
+      note_content += "\nType Note: #{row[:type_note]}" if row[:type_note]
+      note_content += "\nPermissions: #{row[:permissions]}" if row[:permissions]
+      note_content += "\nRestrictions: #{row[:restrictions]}" if row[:restrictions]
+      note_content += "\nStart Date: #{row[:start_date]}" if row[:start_date]
+      note_content += "\nEnd Date: #{row[:end_date]}" if row[:end_date]
+      note_content += "\nGranted Note: #{row[:granted_note]}" if row[:granted_note]
+      note_content += "\nIP Status: #{row[:ip_status]}" if row[:ip_status]
+      note_content += "\nIP Expiration Date: #{row[:ip_expiration_date]}" if row[:ip_expiration_date]
+      note_content += "\nJurisdiction: #{row[:jurisdiction]}" if row[:jurisdiction]
+      note_content += "\nLicense Identifier Terms: #{row[:license_identifier_terms]}" if row[:license_identifier_terms]
+      note_content += "\nStatute Citation #{row[:statute_citation]}" if row[:statute_citation]
+
+      self[:note].insert(
+        agent_fk => row[agent_fk],
+        :publish => 0,
+        :notes_json_schema_version => 1,
+        :notes => JSON.generate({
+                                    'jsonmodel_type' => 'note_agent_rights_statement',
+                                    'content' => [note_content],
+                                    'persistent_id' => SecureRandom.hex
+                                  }),
+        :last_modified_by => row[:last_modified_by],
+        :create_time => row[:create_time],
+        :system_mtime => row[:system_mtime],
+        :user_mtime => row[:user_mtime]
+      )
+    end
+
+    # link any agent rights statement external documents to the agent instead
+    self[:external_document]
+      .join(:rights_statement, :rights_statement__id => :external_document__rights_statement_id)
+      .filter(Sequel.~(Sequel.qualify(:rights_statement, agent_fk) => nil))
+      .select(Sequel.as(:external_document__id, :external_document_id),
+              Sequel.as(Sequel.qualify(:rights_statement, agent_fk), agent_fk))
+      .each do |row|
+
+      self[:external_document]
+        .filter(:id => row[:external_document_id])
+        .update(:rights_statement_id => nil,
+                :identifier_type_id => nil,
+                agent_fk => row[agent_fk])
+    end
+  end
+end
+
+
+def drop_old_rights_statement_columns
+  alter_table(:rights_statement) do
+    # drop fks
+    drop_foreign_key [:ip_status_id] #, :name => :rights_statement_ibfk_2
+
+    # drop columns
+    drop_column(:active)
+    drop_column(:ip_status_id)
+    drop_column(:restriction_start_date)
+    drop_column(:restriction_end_date)
+    drop_column(:materials)
+    drop_column(:ip_expiration_date)
+    drop_column(:type_note)
+    drop_column(:permissions)
+    drop_column(:restrictions)
+    drop_column(:granted_note)
+    drop_column(:license_identifier_terms)
+  end
+end
+
+
+def drop_agent_rights_statements
+  self[:rights_statement]
+    .filter(Sequel.|(
+      Sequel.~(:agent_person_id => nil),
+      Sequel.~(:agent_family_id => nil),
+      Sequel.~(:agent_corporate_entity_id => nil),
+      Sequel.~(:agent_software_id => nil)
+    ))
+    .delete
+
+  alter_table(:rights_statement) do
+    drop_foreign_key [:agent_person_id]
+    drop_foreign_key [:agent_family_id]
+    drop_foreign_key [:agent_corporate_entity_id]
+    drop_foreign_key [:agent_software_id]
+
+    drop_column(:agent_person_id)
+    drop_column(:agent_family_id)
+    drop_column(:agent_corporate_entity_id)
+    drop_column(:agent_software_id)
+  end
+end
+
+
+def coerce_date(date)
+  if date =~ /[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/
+    date # Date.strptime(date, '%Y-%m-%d')
+  elsif date =~ /[0-9][0-9][0-9][0-9]-[0-9][0-9]/
+    "#{date}-01" # Date.strptime("#{date}-01", '%Y-%m-%d')
+  elsif date =~ /[0-9][0-9][0-9][0-9]/
+    "#{date}-01-01" # Date.strptime("#{date}-01-01", '%Y-%m-%d')
+  else
+    raise "Not a date: #{date}"
+  end
+end
+
+
+def coerce_timestamp(timestamp)
+  timestamp.strftime('%Y-%m-%d')
+end
+
+Sequel.migration do
+
+  up do
+    # backup! just. in. case.
+    backup_rights_statement_table
+
+    # create new tables/relationships
+    create_rights_statement_act
+    link_acts_to_notes
+    link_rights_statements_to_agents
+    link_rights_statements_to_notes
+    add_identifier_type_to_external_documents
+    add_new_rights_statement_columns
+
+    # drop agent rights statements first...
+    migrate_agent_rights_statements
+    drop_agent_rights_statements
+
+    # migrate all the other rights statements now...
+    migrate_rights_statement_start_date
+    migrate_rights_statement_types
+    reorder_rights_statement_types
+    migrate_ip_status
+    migrate_license_terms
+    migrate_ip_expiration_date
+    migrate_other_rights_basis
+    migrate_materials_to_note
+    migrate_type_to_note
+    migrate_permissions_to_note
+    migrate_restrictions_to_note
+    migrate_granted_note_to_note
+
+    # and drop what we don't need anymore...
+    drop_old_rights_statement_columns
+  end
+
+  down do
+    # To recover pre-088 rights statements, refer to the copy of the
+    # rights_statement table named `rights_statement_pre_088`
+  end
+
+end

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -671,6 +671,9 @@ en:
     note_outline: Outline
     note_text: Text
     note_type: Note Type
+    note_rights_statement: Rights Statement Note
+    note_rights_statement_act: Act Note
+    note_agent_rights_statement: Rights Statement Note (do not use)
     _singular: Note
     _plural: Notes
 
@@ -702,6 +705,15 @@ en:
     sub_notes_singular: Sub Note
 
   note_digital_object:
+    <<: *note_attributes
+
+  note_rights_statement:
+    <<: *note_attributes
+
+  note_rights_statement_act:
+    <<: *note_attributes
+
+  note_agent_rights_statement:
     <<: *note_attributes
 
   note_bibliography:
@@ -904,6 +916,12 @@ en:
     _plural: External Documents
     _singular: External Document
 
+  rights_statement_external_document:
+    <<: *external_document_attributes
+    identifier_type: Identifier Type
+    identifier_type_tooltip: |
+        <p>The identifier type indicates what domain the external document belongs to.</p>
+
   external_id:
     _plural: External IDs
     _singular: External ID
@@ -918,28 +936,18 @@ en:
     identifier_auto_generate_message: "-- auto-generated upon save --"
     rights_type: Rights Type
     rights_type_tooltip: |
-        <p>The basis for the rights statement being made.Four bases are allowed: intellectual property, license, such as donor agreement, legal statutes such as Fair Use or FERPA, and institutional policy.</p>
+        <p>The basis for the rights statement being made.  Four bases are allowed:  Copyright, License, Statute, and Other.  License is for formal and informal licenses, such as donor and purchase agreements.  Statute is for codified laws such as Fair Use or FERPA in the United States.  Other is for institutional policy or other bases other than copyright, license, and statute.  It too may be used for donor and purchase agreements if the repository prefers.</p>
     rights_type_message: Please select a Rights Type
-    active: Active
-    active_tooltip: |
-        <p>Indicates whether a rights record is active or inactive.</p>
-    active_true: Active
-    active_false: Inactive
-    materials: Materials
-    materials_tooltip: |
-        <p>A term or brief phrase describing the materials in the accession, resource or collection to which the rights record applies.</p>
-        <p>Examples:</p>
-        <ul>
-        <li>Diaries by Alex Doe</li>
+    status: Status
+    status_tooltip: |
+        <p>A coded designation for the copyright status of the object at the time the rights statement is recorded.</p>
+        <ul> 
+          <li>Copyrighted = Under copyright.</li>
+          <li>Public domain = In the public domain.</li>
+          <li>Unknown = Copyright status of the resource is unknown</li>
         </ul>
-    ip_status: IP Status
-    ip_status_tooltip: |
-        <p>A term indicating the intellectual property status of the described materials.</p>
-    ip_expiration_date: IP Expiration Date
-    ip_expiration_date_tooltip: |
-        <p>The date the copyright or other intellectual property status is expected to expire.</p>
-    license_identifier_terms: License Identifier Terms
-    license_identifier_terms_tooltip: |
+    license_terms: License Terms
+    license_terms_tooltip: |
         <p>A statement (actual text snippet or summary) of the permissions granted in the license.</p>
     statute_citation: Statute Citation
     statute_citation_tooltip: |
@@ -950,7 +958,9 @@ en:
         </ul>
     jurisdiction: Jurisdiction
     jurisdiction_tooltip: |
-        <p>The political entity authorizing the copyright or statute, e.g. country or region.</p>
+        <p>Copyright: The country whose copyright laws apply.</p>
+        <p>Statute: The country or other political body enacting the statute.</p>
+        <p>Conforms to ISO 3166.</p>
     type_note: Type Note
     type_note_tooltip: |
         <p>Any additional information about the copyright, license, statute, or institutional policy and/or about its application to the materials described.</p>
@@ -958,33 +968,23 @@ en:
         <ul>
         <li>Constraint(s) on Use: This work may be protected by copyright law. Use of this work beyond that allowed by the applicable copyright statute requires the written permission of the copyright holder(s). Responsibility for obtaining permissions for any use and distribution of this work rests exclusively with the user and not the UC San Diego Libraries. Inquiries can be made to the Mandeville Special Collections Library (http://libraries.ucsd.edu/locations/mscl/).</li>
         </ul>
-    permissions: Permissions
-    permissions_tooltip: |
-        <p>A description of what kinds of actions are permissible to the repository and/or the end user.</p>
-    restrictions: Restrictions
-    restrictions_tooltip: |
-        <p>A description of what kinds of actions are not permissible to the repository and/or the end user.</p>
-        <p>Examples:</p>
-        <ul>
-        <li>Photocopying, scanning, or photographing of materials not allowed.</li>
-        </ul>
-    restriction_start_date: Restrictions Start Date
-    restriction_start_date_tooltip: |
-        <p>The date the restriction(s) go into effect.</p>
-    restriction_end_date: Restrictions End Date
-    restriction_end_date_tooltip: |
-        <p>The date the restriction(s) cease to apply.</p>
-    granted_note: Granted Note
-    granted_note_tooltip: |
-        <p>Any qualifying information about the permissions granted or restrictions to be enforced.</p>
-        <p>Examples</p>
-        <ul>
-        <li>Contact donor's family if access is requested before restriction end date arrives.</li>
-        </ul>
+    determination_date: Determination Date
+    determination_date_tooltip: |
+        <p>Copyright: The date the copyright status recorded in copyright status was determined.</p>
+        <p>Statute: The date that the determination was made that the statute authorized the permission(s) noted.</p>
+    start_date: Start Date
+    start_date_tooltip: |
+        <p>The date the rights statement went into effect.</p>
+    end_date: End Date
+    end_date_tooltip: |
+        <p>The date the rights statement ends.</p>
+    other_rights_basis: Other Rights Basis
+    other_rights_basis_tooltip: |
+      <p>Rights Type of other rights statements that are not statutes, licenses, or copyright.</p>
     _plural: Rights Statements
     _singular: Rights Statement
 
-  rights_type_intellectual_property:
+  rights_type_copyright:
     <<: *rights_statement_attributes
 
   rights_type_license:
@@ -993,7 +993,7 @@ en:
   rights_type_statute:
     <<: *rights_statement_attributes
 
-  rights_type_institutional_policy:
+  rights_type_other:
     <<: *rights_statement_attributes
 
   date: &date_attributes
@@ -1972,3 +1972,28 @@ en:
     reparent_error:
       title: Unable to perform move
       message: The move has been disallowed as a parent cannot become its own child.
+
+  rights_statement_act: &rights_statement_act_attributes
+    _singular: Act
+    _plural: Acts
+    act_type: Act Type
+    act_type_tooltip: |
+        <p>The action this rights statement allows.</p>
+    restriction: Restriction
+    restriction_tooltip: |
+        <p>A condition or limitation on the act.</p>
+        <p>Examples:</p>
+        <ul>
+          <li>No more than three</li>
+          <li>Allowed only after one year of archival retention has elapsed</li>
+          <li>Rightsholder must be notified after completion of act</li>
+        </ul>
+    start_date: Start Date
+    start_date_tooltip: |
+        <p>The date the act went into effect.</p>
+    end_date: End Date
+    end_date_tooltip: |
+        <p>The date the act ends.</p>
+
+  act:
+    <<: *rights_statement_act_attributes

--- a/common/locales/enums/en.yml
+++ b/common/locales/enums/en.yml
@@ -1293,15 +1293,29 @@ en:
       YE: Yemen
       ZM: Zambia
       ZW: Zimbabwe
+    rights_statement_act_type:
+      delete: Delete
+      disseminate: Disseminate
+      migrate: Migrate
+      modify: Modify
+      replicate: Replicate
+      use: Use
+    rights_statement_act_restriction:
+      allow: Allow
+      disallow: Disallow
+      conditional: Conditional
     rights_statement_rights_type:
-      intellectual_property: Intellectual Property
+      copyright: Copyright
       license: License
       statute: Statute
-      institutional_policy: Institutional Policy
+      other: Other
     rights_statement_ip_status:
       copyrighted: Copyrighted
       public_domain: Public Domain
       unknown: Unknown
+    rights_statement_other_rights_basis:
+      donor: Donor
+      policy: Policy
     subject_term_type:
       cultural_context: Cultural context
       function: Function
@@ -1349,12 +1363,23 @@ en:
       physloc: Physical Location
       materialspec: Materials Specific Details
       physfacet: Physical Facet
+      rights_statement: Rights
     note_digital_object_type:
       <<: *note_type_definitions
     note_multipart_type:
       <<: *note_type_definitions
     note_singlepart_type:
       <<: *note_type_definitions
+    note_rights_statement_type:
+      materials: Materials
+      type_note: Type Note
+      additional_information: Additional Information
+    note_rights_statement_act_type:
+      expiration: Expiration
+      extension: Extension
+      permissions: Permissions
+      restrictions: Restrictions
+      additional_information: Additional Information
     linked_agent_role:
       creator: Creator
       source: Source
@@ -1414,7 +1439,114 @@ en:
       av_materials: Audiovisual Materials
       arrivals: Arrivals
       shared: Shared
-
+    rights_statement_external_document_identifier_type:
+      agrovoc: "AGROVOC multilingual agricultural thesaurus. (Rome: APIMONDIA)"
+      allmovie: "AllMovie"
+      allmusic: "AllMusic"
+      allocine: "AlloCiné"
+      amnbo: "American National Biography Online"
+      ansi: "American National Standards Institute and National Information Standards Organisation number for an ANSI or ANSI/NISO standard"
+      artsy: "Artsy"
+      bdusc: "Biographical Directory of the United States Congress (United States Congress)"
+      bfi: "BFI - British Film Institute"
+      bnfcg: "BnF catalogue général (Paris: Bibliothèque nationale de France)"
+      cantic: "CANTIC (Catàleg d'autoritats de noms i títols de Catalunya) (Biblioteca de Catalunya)"
+      cgndb: "Canadian Geographical Names Database (Natural Resources Canada)"
+      danacode: "Danacode (Bnei Brak, Israel: D.A.N.A. Systems)"
+      datoses: "datos.bne.es (Biblioteca Nacional de España)"
+      discogs: "Discogs"
+      dkfilm: "Det Danske Filminstitut Filmdatabasen"
+      doi: "Digital Object Identifier"
+      ean: "International Article Number"
+      eidr: "EIDR: Entertainment Identifier Registry"
+      fast: "Faceted Application of Subject Terminology (Dublin, Ohio: OCLC)"
+      filmport: "filmportal.de"
+      findagr: "Find a Grave"
+      freebase: "Freebase"
+      gec: "Gran enciclopèdia catalana"
+      geogndb: "Geographic Names Database"
+      geonames: "GeoNames"
+      gettytgn: "Getty Thesaurus of Geographic Names Online (J. Paul Getty Trust)"
+      gettyulan: "Union List of Artist Names Online (J. Paul Getty Trust)"
+      gnd: "Gemeinsame Normdatei (Leipzig, Frankfurt: Deutsche Nationalbibliothek)"
+      gnis: "Geographic Names Information System (GNIS) (United States Geological Survey, Board on Geographic Names)"
+      gtin-14: "Global Trade Identification Number 14 (EAN/UCC-128 or ITF-14)"
+      hdl: "Handle"
+      ibdb: "IBDB - Internet Broadway Database"
+      idref: "IdRef: le referentiel des autorites Sudoc (L'agence bibliographique de l'enseignement superieur (ABES))"
+      imdb: "IMDb - Internet Movie Database"
+      isan: "International Standard Audiovisual Number"
+      isbn: "International Standard Book Number"
+      isbn-a: "International Standard Book Number (the actionable ISBN) (International DOI Foundation (IDF))"
+      isbnre: "ISBN (International Standard Book Number) registrant element"
+      isil: "ISIL (International Standard Identifier for Libraries and Related Organizations)"
+      ismn: "International Standard Music Number"
+      isni: "International Standard Name Identifier"
+      iso: "International Organization for Standardization number for an ISO standard"
+      isrc: "International Standard Recording Code"
+      issn: "International Standard Serial Number"
+      issn-l: "Linking International Standard Serial Number"
+      issue-number: "Sound recording issue number"
+      istc: "International Standard Text Code"
+      iswc: "International Standard Musical Work Code"
+      itar: "ITAR (Importtjeneste og autoritetsregistre)"
+      kinopo: "КиноПоиск = KinoPoisk"
+      lccn: "Library of Congress Control Number"
+      lcmd: "Library of Congress Manuscript Division (Washington, DC: Library of Congress)"
+      lcmpt: "Library of Congress Medium of Performance Thesaurus for Music (LCMPT) (Washington, DC: Library of Congress)"
+      libaus: "Libraries Australia (National Library of Australia)"
+      local: "Locally defined identifier"
+      matrix-number: "Sound recording matrix number"
+      moma: "Museum of Modern Art (New York: Museum of Modern Art)"
+      munzing: "Munzinger (Munzinger Archiv)"
+      music-plate: "Publisher's music plate number"
+      music-publisher: "Publisher-assigned music number"
+      musicb: "MusicBrainz"
+      natgazfid: "U.S. National Gazetteer Feature Name Identifier"
+      nga: "National Gallery of Art (Washington DC: National Gallery of Art)"
+      nipo: "Número de Identificación de las Publicaciones Oficiales"
+      nndb: "NNDB (Notable Names Database)"
+      npg: "National Portrait Gallery (London: National Portrait Gallery)"
+      odnb: "Oxford Dictionary of National Biography (Oxford University Press)"
+      opensm: "OpenStreetMap"
+      orcid: "Open Researcher and Contributor IDentifier"
+      oxforddnb: "Oxford Biography Index"
+      porthu: "PORT.hu"
+      rbmsbt: "RBMS Controlled Vocabularies: Binding Terms (Rare Books and Manuscripts Section, Association of College & Research Libraries)"
+      rbmsgt: "RBMS Controlled Vocabularies: Genre Terms (Rare Books and Manuscripts Section, Association of College & Research Libraries)"
+      rbmspe: "RBMS Controlled Vocabularies: Provenance Evidence (Rare Books and Manuscripts Section, Association of College & Research Libraries)"
+      rbmsppe: "RBMS Controlled Vocabularies: Printing and Publishing Evidence (Rare Books and Manuscripts Section, Association of College & Research Libraries)"
+      rbmspt: "RBMS Controlled Vocabularies: Paper Terms (Rare Books and Manuscripts Section Association of College & Research Libraries)"
+      rbmsrd: "RBMS Controlled Vocabularies: Relationship Designators (Rare Books and Manuscripts Section, Association of College & Research Libraries)"
+      rbmste: "RBMS Controlled Vocabularies: Type Evidence (Rare Books and Manuscripts Section, Association of College & Research Libraries)"
+      rid: "ResearcherID (Thomson Reuters)"
+      rkda: "RKDartists& (Den Haag: Rijksbureau voor Kunsthistorische Documentatie)"
+      saam: "Smithsonian American Art Museum (Washington DC: Smithsonian Institution)"
+      scholaru: "Scholar Universe"
+      scope: "Scope"
+      scopus: "Scopus Author Identifier"
+      sici: "Serial Item and Contribution Identifier"
+      spotify: "Spotify"
+      sprfbsb: "Sports Reference: Baseball"
+      sprfbsk: "Sports Reference: Basketball"
+      sprfcbb: "Sports Reference: College Basketball"
+      sprfcfb: "Sports Reference: College Football"
+      sprfhoc: "Sports Reference: Hockey"
+      sprfoly: "Sports Reference: Olympic Sports"
+      sprfpfb: "Sports Reference: Pro Football"
+      stock-number: "Publisher, distributor, or vendor stock number"
+      strn: "Standard Technical Report Number"
+      svfilm: "Svensk Filmdatabas"
+      tatearid: "Tate Artist Identifier"
+      theatr: "Theatricalia"
+      trove: "Trove (National Library of Australia)"
+      upc: "Universal Product Code"
+      uri: "Uniform Resource Identifier"
+      urn: "Uniform Resource Name"
+      viaf: "Virtual International Authority File number"
+      videorecording-identifier: "Publisher-assigned videorecording number"
+      wikidata: "Wikidata (Wikimedia Foundation)"
+      wndla: "Web NDL Authorities (Tokyo: National Diet Library (NDL))"
 
   enumeration_names:
     accession_acquisition_type: Accession Acquisition Type
@@ -1467,6 +1599,8 @@ en:
     note_index_type: Note Index Type
     note_multipart_type: Note Multipart Type
     note_orderedlist_enumeration: Note Orderedlist Enumeration
+    note_rights_statement_act_type: Note Rights Statement Act Type
+    note_rights_statement_type: Note Rights Statement Type
     note_singlepart_type: Note Singlepart Type
     telephone_number_type: Telephone Number Type 
     resource_finding_aid_description_rules: Resource Finding Aid Description Rules
@@ -1484,3 +1618,7 @@ en:
     dimension_units: Dimension Units
     restriction_type: Local Access Restriction Type
     location_function_type: Location Function Type
+    rights_statement_external_document_identifier_type: Rights Statement External Document Identifier Type
+    rights_statement_act_restriction: Rights Statement Act Restriction
+    rights_statement_act_type: Rights Statement Act Type
+    rights_statement_other_rights_basis: Rights Statement Other Rights Basis

--- a/common/locales/es.yml
+++ b/common/locales/es.yml
@@ -917,11 +917,6 @@
     rights_type_tooltip: |
         <p>La base para la declaración de los derechos lograda.Se permiten cuatro bases
     rights_type_message: Por favor seleccione un tipo de norma
-    active: Activo
-    active_tooltip: |
-        <p>Indica si un registro de los derechos está activa o inactiva.</p>
-    active_true: Activo
-    active_false: Inactivo
     materials: Materiales
     materials_tooltip: |
         <p>Un término o frase breve que describe los materiales en el acta de ingreso, recurso o colección a la que grabación los derechos se aplica.</p>

--- a/common/locales/fr.yml
+++ b/common/locales/fr.yml
@@ -920,11 +920,6 @@ fr:
     rights_type_tooltip: |
         <p>La base servant à la mention des droits. Quatre bases sont autorisées: propriété intellectuelle, permission telle qu'un accord du donateur, statut légal tel que le Fair Use ou le FERPA, et règles de l'institution.</p>
     rights_type_message: Merci de sélectionner un type de droits
-    active: Valide
-    active_tooltip: |
-        <p>Indique si la mention des droits est ou non valide.</p>
-    active_true: Valide
-    active_false: Invalide
     materials: Documents
     materials_tooltip: |
         <p>Un terme ou une phrase brève décrivant les documents dans l'acquisition, la ressource ou la collection à laquelle s'applique la mention des droits.</p>

--- a/common/schemas/abstract_agent.rb
+++ b/common/schemas/abstract_agent.rb
@@ -31,7 +31,6 @@
       },
 
       "external_documents" => {"type" => "array", "items" => {"type" => "JSONModel(:external_document) object"}},
-      "rights_statements" => {"type" => "array", "items" => {"type" => "JSONModel(:rights_statement) object"}},
 
       "system_generated" => {
         "readonly" => true,
@@ -40,7 +39,8 @@
 
       "notes" => {
         "type" => "array",
-        "items" => {"type" => [{"type" => "JSONModel(:note_bioghist) object"}]},
+        "items" => {"type" => [{"type" => "JSONModel(:note_bioghist) object"},
+                               {"type" => "JSONModel(:note_agent_rights_statement) object"}]},
       },
 
       "used_within_repositories" => {"type" => "array", "items" => {"type" => "JSONModel(:repository) uri"}, "readonly" => true},

--- a/common/schemas/note_agent_rights_statement.rb
+++ b/common/schemas/note_agent_rights_statement.rb
@@ -1,0 +1,17 @@
+{
+  :schema => {
+    "$schema" => "http://www.archivesspace.org/archivesspace.json",
+    "version" => 1,
+    "type" => "object",
+    "parent" => "abstract_note",
+
+    "properties" => {
+      "content" => {
+        "type" => "array",
+        "items" => {"type" => "string", "maxLength" => 65000},
+        "minItems" => 1,
+        "ifmissing" => "error",
+      },
+    },
+  },
+}

--- a/common/schemas/note_rights_statement.rb
+++ b/common/schemas/note_rights_statement.rb
@@ -1,0 +1,23 @@
+{
+  :schema => {
+    "$schema" => "http://www.archivesspace.org/archivesspace.json",
+    "version" => 1,
+    "type" => "object",
+    "parent" => "abstract_note",
+
+    "properties" => {
+      "content" => {
+        "type" => "array",
+        "items" => {"type" => "string", "maxLength" => 65000},
+        "minItems" => 1,
+        "ifmissing" => "error",
+      },
+
+      "type" => {
+        "type" => "string",
+        "ifmissing" => "error",
+        "dynamic_enum" => "note_rights_statement_type"
+      },
+    },
+  },
+}

--- a/common/schemas/note_rights_statement_act.rb
+++ b/common/schemas/note_rights_statement_act.rb
@@ -1,0 +1,23 @@
+{
+  :schema => {
+    "$schema" => "http://www.archivesspace.org/archivesspace.json",
+    "version" => 1,
+    "type" => "object",
+    "parent" => "abstract_note",
+
+    "properties" => {
+      "content" => {
+        "type" => "array",
+        "items" => {"type" => "string", "maxLength" => 65000},
+        "minItems" => 1,
+        "ifmissing" => "error",
+      },
+
+      "type" => {
+        "type" => "string",
+        "ifmissing" => "error",
+        "dynamic_enum" => "note_rights_statement_act_type"
+      },
+    },
+  },
+}

--- a/common/schemas/rights_statement.rb
+++ b/common/schemas/rights_statement.rb
@@ -8,28 +8,42 @@
       "rights_type" => {"type" => "string", "minLength" => 1, "ifmissing" => "error", "dynamic_enum" => "rights_statement_rights_type"},
       "identifier" => {"type" => "string", "maxLength" => 255, "minLength" => 1, "required" => false},
 
-      "active" => {"type" => "boolean", "default" => true},
+      "status" => {"type" => "string", "required" => false, "dynamic_enum" => "rights_statement_ip_status"},
+      "determination_date" => {"type" => "date", "required" => false},
+      "start_date" => {"type" => "date", "required" => false},
+      "end_date" => {"type" => "date", "required" => false},
 
-      "materials" => {"type" => "string", "maxLength" => 255, "required" => false},
-
-      "ip_status" => {"type" => "string", "required" => false, "dynamic_enum" => "rights_statement_ip_status"},
-      "ip_expiration_date" => {"type" => "date", "required" => false},
-
-      "license_identifier_terms" => {"type" => "string", "maxLength" => 255, "required" => false},
+      "license_terms" => {"type" => "string", "maxLength" => 255, "required" => false},
 
       "statute_citation" => {"type" => "string", "maxLength" => 255, "required" => false},
-
       "jurisdiction" => {"type" => "string", "required" => false, "dynamic_enum" => "country_iso_3166"},
-      "type_note" => {"type" => "string", "maxLength" => 255, "required" => false},
 
-      "permissions" => {"type" => "string", "maxLength" => 65000, "required" => false},
-      "restrictions" => {"type" => "string", "maxLength" => 65000, "required" => false},
-      "restriction_start_date" => {"type" => "date", "required" => false},
-      "restriction_end_date" => {"type" => "date", "required" => false},
+      "other_rights_basis" => {"type" => "string", "required" => false, "dynamic_enum" => "rights_statement_other_rights_basis"},
 
-      "granted_note" => {"type" => "string", "maxLength" => 255, "required" => false},
-
-      "external_documents" => {"type" => "array", "items" => {"type" => "JSONModel(:external_document) object"}},
+      "external_documents" => {"type" => "array", "items" => {"type" => "JSONModel(:rights_statement_external_document) object"}},
+      "acts" => {"type" => "array", "items" => {"type" => "JSONModel(:rights_statement_act) object"}},
+      "linked_agents" => {
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "subtype" => "ref",
+          "properties" => {
+            "ref" => {"type" => [{"type" => "JSONModel(:agent_corporate_entity) uri"},
+                                 {"type" => "JSONModel(:agent_family) uri"},
+                                 {"type" => "JSONModel(:agent_person) uri"},
+                                 {"type" => "JSONModel(:agent_software) uri"}],
+                      "ifmissing" => "error"},
+            "_resolved" => {
+              "type" => "object",
+              "readonly" => "true"
+            }
+          }
+        }
+      },
+      "notes" => {
+        "type" => "array",
+        "items" => {"type" => "JSONModel(:note_rights_statement) object"},
+      },
     },
   },
 }

--- a/common/schemas/rights_statement_act.rb
+++ b/common/schemas/rights_statement_act.rb
@@ -1,0 +1,19 @@
+{
+  :schema => {
+    "$schema" => "http://www.archivesspace.org/archivesspace.json",
+    "version" => 1,
+    "type" => "object",
+
+    "properties" => {
+      "act_type" => {"type" => "string", "minLength" => 1, "ifmissing" => "error", "dynamic_enum" => "rights_statement_act_type"},
+      "restriction" => {"type" => "string", "minLength" => 1, "ifmissing" => "error", "dynamic_enum" => "rights_statement_act_restriction"},
+      "start_date" => {"type" => "date", "minLength" => 1, "ifmissing" => "error"},
+      "end_date" => {"type" => "date", "required" => false},
+
+      "notes" => {
+        "type" => "array",
+        "items" => {"type" => "JSONModel(:note_rights_statement_act) object"},
+      },
+    },
+  },
+}

--- a/common/schemas/rights_statement_external_document.rb
+++ b/common/schemas/rights_statement_external_document.rb
@@ -1,0 +1,11 @@
+{
+  :schema => {
+    "$schema" => "http://www.archivesspace.org/archivesspace.json",
+    "version" => 1,
+    "parent" => "external_document",
+    "type" => "object",
+    "properties" => {
+      "identifier_type" => {"type" => "string", "minLength" => 1, "ifmissing" => "error", "dynamic_enum" => "rights_statement_external_document_identifier_type"},
+    },
+  },
+}

--- a/common/spec/lib/factory_girl_helpers.rb
+++ b/common/spec/lib/factory_girl_helpers.rb
@@ -60,6 +60,8 @@ FactoryGirl.define do
 
   sequence(:multipart_note_type) { sample(JSONModel(:note_multipart).schema['properties']['type'])}
   sequence(:digital_object_note_type) { sample(JSONModel(:note_digital_object).schema['properties']['type'])}
+  sequence(:rights_statement_note_type) { sample(JSONModel(:note_rights_statement).schema['properties']['type'])}
+  sequence(:rights_statement_act_note_type) { sample(JSONModel(:note_rights_statement_act).schema['properties']['type'])}
   sequence(:singlepart_note_type) { sample(JSONModel(:note_singlepart).schema['properties']['type'])}
   sequence(:note_index_type) { sample(JSONModel(:note_index).schema['properties']['type'])}
   sequence(:note_index_item_type) { sample(JSONModel(:note_index_item).schema['properties']['type'])}
@@ -73,8 +75,12 @@ FactoryGirl.define do
   sequence(:instance_type) { sample(JSONModel(:instance).schema['properties']['instance_type'], ['digital_object']) }
 
   sequence(:rights_type) { sample(JSONModel(:rights_statement).schema['properties']['rights_type']) }
-  sequence(:ip_status) { sample(JSONModel(:rights_statement).schema['properties']['ip_status']) }
+  sequence(:status) { sample(JSONModel(:rights_statement).schema['properties']['status']) }
   sequence(:jurisdiction) { sample(JSONModel(:rights_statement).schema['properties']['jurisdiction']) }
+  sequence(:other_rights_basis) { sample(JSONModel(:rights_statement).schema['properties']['other_rights_basis']) }
+  sequence(:act_type) { sample(JSONModel(:rights_statement_act).schema['properties']['act_type']) }
+  sequence(:act_restriction) { sample(JSONModel(:rights_statement_act).schema['properties']['restriction']) }
+  sequence(:external_document_identifier_type) { sample(JSONModel(:rights_statement_external_document).schema['properties']['identifier_type']) }
 
   sequence(:container_location_status) { sample(JSONModel(:container_location).schema['properties']['status']) }
   sequence(:temporary_location_type) { sample(JSONModel(:location).schema['properties']['temporary']) }

--- a/common/validations.rb
+++ b/common/validations.rb
@@ -154,14 +154,23 @@ module JSONModel::Validations
   def self.check_rights_statement(hash)
     errors = []
 
-    if hash["rights_type"] == "intellectual_property"
-      errors << ["ip_status", "missing required property"] if hash["ip_status"].nil?
+    if hash["rights_type"] == "copyright"
+      errors << ["status", "missing required property"] if hash["status"].nil?
       errors << ["jurisdiction", "missing required property"] if hash["jurisdiction"].nil?
+      errors << ["start_date", "missing required property"] if hash["start_date"].nil?
+
     elsif hash["rights_type"] == "license"
-      errors << ["license_identifier_terms", "missing required property"] if hash["license_identifier_terms"].nil?
+      errors << ["license_terms", "missing required property"] if hash["license_terms"].nil?
+      errors << ["start_date", "missing required property"] if hash["start_date"].nil?
+
     elsif hash["rights_type"] == "statute"
       errors << ["statute_citation", "missing required property"] if hash["statute_citation"].nil?
       errors << ["jurisdiction", "missing required property"] if hash["jurisdiction"].nil?
+      errors << ["start_date", "missing required property"] if hash["start_date"].nil?
+
+    elsif hash["rights_type"] == "other"
+      errors << ["other_rights_basis", "missing required property"] if hash["other_rights_basis"].nil?
+      errors << ["start_date", "missing required property"] if hash["start_date"].nil?
     end
 
     errors
@@ -514,4 +523,17 @@ module JSONModel::Validations
     end
   end
 
+  def self.check_rights_statement_external_document(hash)
+    errors = []
+
+    errors << ['identifier_type', 'missing required property'] if hash['identifier_type'].nil?
+
+    errors
+  end
+
+  if JSONModel(:rights_statement_external_document)
+    JSONModel(:rights_statement_external_document).add_validation("check_rights_statement_external_document") do |hash|
+      check_rights_statement_external_document(hash)
+    end
+  end
 end

--- a/frontend/app/assets/javascripts/notes.crud.js
+++ b/frontend/app/assets/javascripts/notes.crud.js
@@ -325,17 +325,19 @@ $(function() {
 
         var $target_subrecord_list = $(".subrecord-form-list:first", $this);
 
+        var selector_template = "template_note_type_selector";
         var is_inline = $this.hasClass('note-inline');
         // if it's inline, we need to bring a special template, since the
         // template has already been defined for the parent record....
         if ( is_inline == true ) {
-          var form_note_type =  $this.get(0).id;
-          var inline_template = "template_" + form_note_type + "_note_type_selector_inline";
-          var $subform = $(AS.renderTemplate(inline_template));
+          var form_note_type = $this.get(0).id;
+          selector_template = "template_" + form_note_type + "_note_type_selector_inline";
 
-        } else {
-          var $subform = $(AS.renderTemplate("template_note_type_selector"));
+        } else if ($target_subrecord_list.closest("section").data("template")) {
+          selector_template = $target_subrecord_list.closest("section").data("template");
         }
+
+        var $subform = $(AS.renderTemplate(selector_template));
 
         $subform = $("<li>").data("type", $subform.data("type")).append($subform);
         $subform.attr("data-index", index);
@@ -409,6 +411,10 @@ $(function() {
   $(document).ready(function() {
     $(document).bind("loadedrecordform.aspace", function(event, $container) {
       $("section.notes-form.subrecord-form:not(.initialised)", $container).init_notes_form();
+    });
+
+    $(document).bind("subrecordcreated.aspace", function(event, type, $subform) {
+      $("section.notes-form.subrecord-form:not(.initialised)", $subform).init_notes_form();
     });
 
    // $("section.notes-form.subrecord-form:not(.initialised)").init_notes_form();

--- a/frontend/app/assets/javascripts/subrecord.crud.js
+++ b/frontend/app/assets/javascripts/subrecord.crud.js
@@ -84,7 +84,8 @@ $(function() {
 
           $.proxy(init_subform, formEl)();
 
-          //init any sub sub record forms
+          //init any sub sub record forms (treat note sub forms special, because they are)
+          $(".subrecord-form.notes-form:not(.initialised)", formEl).init_notes_form();
           $(".subrecord-form:not(.initialised)", formEl).init_subrecord_form();
 
           $(":input:first", formEl).focus();

--- a/frontend/app/helpers/notes_helper.rb
+++ b/frontend/app/helpers/notes_helper.rb
@@ -3,6 +3,7 @@ require 'mixed_content_parser'
 module NotesHelper
 
   def note_types_for(jsonmodel_type)
+
     note_types = {
       "bibliography" => {
         :target => :note_bibliography,
@@ -25,12 +26,44 @@ module NotesHelper
 
     elsif jsonmodel_type =~ /agent/
 
-      note_types = {"bioghist" => {
+      note_types = {
+        "bioghist" => {
           :target => :note_bioghist,
           :value => "bioghist",
           :i18n => I18n.t("enumerations._note_types.bioghist", :default => "bioghist")
+        },
+        "agent_rights_statement" => {
+          :target => :note_agent_rights_statement,
+          :value => "agent_rights_statement",
+          :i18n => I18n.t("note.note_agent_rights_statement")
         }
       }
+
+    elsif jsonmodel_type == 'rights_statement'
+
+      note_types = {}
+
+      JSONModel.enum_values(JSONModel(:note_rights_statement).schema['properties']['type']['dynamic_enum']).each do |type|
+        note_types[type] = {
+          :target => :note_rights_statement,
+          :enum => JSONModel(:note_rights_statement).schema['properties']['type']['dynamic_enum'],
+          :value => type,
+          :i18n => I18n.t("enumerations.#{JSONModel(:note_rights_statement).schema['properties']['type']['dynamic_enum']}.#{type}", :default => type)
+        }
+      end
+
+    elsif jsonmodel_type == 'rights_statement_act'
+
+      note_types = {}
+
+      JSONModel.enum_values(JSONModel(:note_rights_statement_act).schema['properties']['type']['dynamic_enum']).each do |type|
+        note_types[type] = {
+          :target => :note_rights_statement_act,
+          :enum => JSONModel(:note_rights_statement_act).schema['properties']['type']['dynamic_enum'],
+          :value => type,
+          :i18n => I18n.t("enumerations.#{JSONModel(:note_rights_statement_act).schema['properties']['type']['dynamic_enum']}.#{type}", :default => type)
+        }
+      end
 
     else
 

--- a/frontend/app/views/agents/_form.html.erb
+++ b/frontend/app/views/agents/_form.html.erb
@@ -24,7 +24,6 @@
   <%= render_aspace_partial :partial => "notes/form", :locals => {:form => form, :all_note_types => note_types_for(form['jsonmodel_type']), :section_id => "#{@agent.agent_type}_notes"} %>
   <%= render_aspace_partial :partial => "related_agents/form", :locals => {:form => form} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents", :section_id => "#{@agent.agent_type}_external_documents", :help_topic => "#{@agent.agent_type}_external_documents"} %>
-  <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "rights_statements", :section_id => "#{@agent.agent_type}_rights_statements"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_ids", :hidden => true} %>
 
 <%= form_plugins_for("agent", form) %>

--- a/frontend/app/views/agents/_sidebar.html.erb
+++ b/frontend/app/views/agents/_sidebar.html.erb
@@ -13,7 +13,6 @@
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'note', :property => 'notes', :anchor => "#{@agent.agent_type}_notes") %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'related_agent', :property => 'related_agents', :anchor => "#{@agent.agent_type}_related_agents") %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_document', :property => "external_documents", :anchor => "#{@agent.agent_type}_external_documents") %>
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'rights_statement', :property => 'rights_statements', :anchor => "#{@agent.agent_type}_rights_statements") %>
 
     <%= sidebar.render_for_view_only(:subrecord_type => 'search_embedded', :property => :none, :anchor => 'search_embedded') %>
 <% end %>

--- a/frontend/app/views/agents/show.html.erb
+++ b/frontend/app/views/agents/show.html.erb
@@ -102,14 +102,12 @@
           <%= render_aspace_partial :partial => "external_documents/show", :locals => { :external_documents => @agent.external_documents, :section_id => "#{@agent.agent_type}_external_documents" } %>
         <% end %>
         
-        <% if @agent.rights_statements.length > 0 %>
-          <%= render_aspace_partial :partial => "rights_statements/show", :locals => { :rights_statements => @agent.rights_statements, :section_id => "#{@agent.agent_type}_statements_"  } %>
-        <% end %>
-
         <%= show_plugins_for(@agent, readonly) %>
         
 
         <%= render_aspace_partial :partial => "search/embedded", :locals => {:filter_term => {"agents" => @agent.title}.to_json, :heading_text => I18n.t("agent._frontend.section.search_embedded")} %>
+
+        <%= render_aspace_partial :partial => "search/embedded", :locals => {:filter_term => {"rights_statement_agent_uris" => @agent.uri}.to_json, :heading_text => I18n.t("agent._frontend.section.linked_via_rights_statement")} %>
         
         <%= render_aspace_partial :partial => "search/embedded", :locals => { :extra_columns => [ "event_type"], :record => @agent, :filter_term => {"linked_record_uris" => @agent.uri}.to_json, :heading_text => I18n.t("event._plural")} %>
       

--- a/frontend/app/views/external_documents/_show.html.erb
+++ b/frontend/app/views/external_documents/_show.html.erb
@@ -1,5 +1,6 @@
 <%
    section_id = "external_documents" if section_id.blank?
+   jsonmodel = :external_document if jsonmodel.blank?
 %>
 <section id="<%= section_id %>" class="subrecord-form-dummy">
 
@@ -7,9 +8,10 @@
 
   <div class="subrecord-form-container">
     <% external_documents.each_with_index do | document, index | %>
-      <%= readonly_context :external_document, document do |readonly| %>
+      <%= readonly_context jsonmodel, document do |readonly| %>
       <div class="subrecord-form-fields external-document">
         <%= readonly.label_and_textfield "title" %>
+        <%= readonly.label_and_select "identifier_type", readonly.possible_options_for('identifier_type', true) %>
 
         <% loc_uri = (document["location"] || "").slice(URI.regexp) %>
         <% if loc_uri.nil? %>

--- a/frontend/app/views/external_documents/_template.html.erb
+++ b/frontend/app/views/external_documents/_template.html.erb
@@ -8,3 +8,15 @@
     <%= form.label_and_boolean "publish", {}, user_prefs["publish"] %>
   </div>
 <% end %>
+
+<% define_template "rights_statement_external_document", jsonmodel_definition(:rights_statement_external_document) do |form| %>
+  <div class="subrecord-form-fields">
+    <%= form.label_and_textarea "title" %>
+    <%= form.label_and_select("identifier_type", form.possible_options_for("identifier_type", true), {:required => true}) %>
+    <%= form.label_and_textarea "location" %>
+    <% if form["location"] && form["location"].match(%r{\A[a-zA-Z]+://}) %>
+      <%= form.label_with_field("document_link", link_to(form["location"], form["location"], {:target => "_blank"})) %>
+    <% end %>
+    <%= form.label_and_boolean "publish", {}, user_prefs["publish"] %>
+  </div>
+<% end %>

--- a/frontend/app/views/linked_agents/_show.html.erb
+++ b/frontend/app/views/linked_agents/_show.html.erb
@@ -35,10 +35,10 @@
               </td>
               <td>
                 <dl>
-                  <% if !link['terms'].empty? %>
+                  <% if !ASUtils.wrap(link['terms']).empty? %>
                     <dt><%= I18n.t("linked_agent.terms") %></dt>
 
-                    <% link['terms'].each do |term| %>
+                    <% ASUtils.wrap(link['terms']).each do |term| %>
                       <dd class="label label-info" title="<%= I18n.t("enumerations.subject_term_type.#{term["term_type"]}") %>">
                         <%= term['term'] %>
                       </dd>

--- a/frontend/app/views/linked_agents/_template.html.erb
+++ b/frontend/app/views/linked_agents/_template.html.erb
@@ -1,15 +1,19 @@
 <%= render_aspace_partial :partial => "terms/template", :locals => {:form => form, :show_preview => false} %>
 
-<% [{:type => :accession, :relator => true},
-    {:type => :resource, :relator => true},
-    {:type => :archival_object, :relator => true},
-    {:type => :event, :relator => false},
-    {:type => :digital_object, :relator => true},
-    {:type => :digital_object_component, :relator => true}].each do |defn| %>
+<% [{:type => :accession, :relator => true, :role => true},
+    {:type => :resource, :relator => true, :role => true},
+    {:type => :archival_object, :relator => true, :role => true},
+    {:type => :event, :relator => false, :role => true},
+    {:type => :digital_object, :relator => true, :role => true},
+    {:type => :digital_object_component, :relator => true, :role => true},
+    {:type => :rights_statement, :relator => false, :role => false},
+   ].each do |defn| %>
 
   <% define_template "#{defn[:type]}_linked_agent", jsonmodel_definition(defn[:type], "linked_agents") do |form| %>
     <div class="subrecord-form-fields agent_links">
-      <%= form.label_and_select("role", form.possible_options_for("role", true), :field_opts => {:class => "linked_agent_role"}) %>
+      <% if defn[:role] %>
+        <%= form.label_and_select("role", form.possible_options_for("role", true), :field_opts => {:class => "linked_agent_role"}) %>
+      <% end %>
         
       <div class="agent-creator-title" style="display: none">
         <%= form.label_and_textfield "title" %>

--- a/frontend/app/views/notes/_form.html.erb
+++ b/frontend/app/views/notes/_form.html.erb
@@ -1,18 +1,29 @@
-<% 
-  section_id = "notes" if section_id.blank?
-  all_note_types ||= nil 
-%>
-<%= render_aspace_partial :partial => "notes/template", :locals =>  { :all_note_types => all_note_types, :form_note_type => section_id  }  %>
+<%
+  # define these when nesting notes within a subrecord
+  nested_note_jsonmodel ||= nil
+  nested_in_jsonmodel ||=nil
+  show_apply_note_order_action = true if show_apply_note_order_action.nil?
 
-<section id="<%= section_id %>" class="subrecord-form notes-form  <%= "note-inline" if inline? %>">
-  <h3 class="subrecord-form-heading">
+  section_id = nested_note_jsonmodel unless nested_note_jsonmodel.nil?
+  section_id = "notes" if section_id.blank?
+  header_size = "h3" if header_size.blank?
+  all_note_types ||= nil
+%>
+<%= render_aspace_partial :partial => "notes/template", :locals =>  { :all_note_types => all_note_types, :form_note_type => section_id, :nested_in_jsonmodel => nested_in_jsonmodel } %>
+
+<section id="<%= section_id %>"
+         class="subrecord-form notes-form  <%= "note-inline" if inline? %>"
+         <%= "data-template=template_#{nested_note_jsonmodel}_note_type_selector_inline" if nested_note_jsonmodel %>>
+  <<%= header_size%> class="subrecord-form-heading">
     <%= wrap_with_tooltip(I18n.t("note._plural"), "#{form.i18n_for('notes')}_tooltip", "subrecord-form-heading-label") %>
     <%= link_to_help :topic => "#{form['jsonmodel_type']}_notes" %>
 
+    <% if show_apply_note_order_action %>
       <button class="btn btn-sm btn-default pull-right apply-note-order" disabled="disabled"><%= I18n.t("note._frontend.action.apply_note_order") %></button>
-      <button class="btn btn-sm btn-default pull-right add-note"><%= I18n.t("note._frontend.action.add") %></button>
+    <% end %>
+    <button class="btn btn-sm btn-default pull-right add-note"><%= I18n.t("note._frontend.action.add") %></button>
 
-  </h3>
+  </<%= header_size%>>
   <div class="subrecord-form-container mixed-content-anchor">
     <%= form.list_for(form["notes"], "notes[]") do |note| %>
       <% form.emit_template(note["jsonmodel_type"]) %>

--- a/frontend/app/views/notes/_show.html.erb
+++ b/frontend/app/views/notes/_show.html.erb
@@ -13,6 +13,14 @@
      all_note_types[type] = :note_digital_object
    end
 
+   JSONModel.enum_values(JSONModel(:note_rights_statement).schema['properties']['type']['dynamic_enum']).each do |type|
+     all_note_types[type] = :note_rights_statement
+   end
+
+   JSONModel.enum_values(JSONModel(:note_rights_statement_act).schema['properties']['type']['dynamic_enum']).each do |type|
+     all_note_types[type] = :note_rights_statement_act
+   end
+
    all_note_types["Index"] = :note_index
    all_note_types["Bibliography"] = :note_bibliography
 

--- a/frontend/app/views/notes/_template.html.erb
+++ b/frontend/app/views/notes/_template.html.erb
@@ -6,6 +6,7 @@
   end
 %>
 
+
 <% define_template "rights_restriction", jsonmodel_definition(:rights_restriction) do |form| %>
   <%= form.label_and_date("begin") %>
   <%= form.label_and_date("end") %>
@@ -36,31 +37,12 @@
   </div>
 <% end %>
 
-
-
-<div id="template_note_summary"><!--
-  <div class="subrecord-summary-title">
-    {if type != ""}
-      ${type}
-    {/if}
-    {if label != "" && label != type}
-      {if type != ""} - {/if}
-      ${label}
-    {/if}
-    {if label == "" && type == ""}
-      ${jsonmodel_type}
-    {/if}
-  </div>
-  {if summary.length > 0}
-    <div class="subrecord-summary-content">
-      ${summary}
-    </div>
-  {/if}
---></div>
-
-<% form_note_type ||= nil %>
+<%
+  form_note_type ||= nil
+  nested_in_jsonmodel ||= nil
+%>
   
-<% if ( inline? && form_note_type )  %>
+<% if (inline? && form_note_type) || defined?(nested_in_jsonmodel) %>
   <% define_template "#{form_note_type}_note_type_selector_inline" do |form, item| %>
     <% if item %>
       <% form.emit_template(item["jsonmodel_type"]) %>
@@ -71,7 +53,7 @@
           <div class="col-sm-4">
             <select class="form-control top-level-note-type">
               <option></option>
-              <% model_note_types = all_note_types ? all_note_types : note_types_for(form['jsonmodel_type']) %> 
+              <% model_note_types = all_note_types ? all_note_types : note_types_for(nested_in_jsonmodel || form['jsonmodel_type']) %> 
               <% model_note_types.sort_by {|value, hash| hash[:i18n]}.each do |value, hash| %>
                 <option value="<%= hash[:target] %>"><%= hash[:i18n] %></option>
               <% end %>
@@ -79,10 +61,10 @@
           </div>
         </div>
         <div class="selected-container">
-        <% form.emit_template("note_type_nil") %>
+          <% form.emit_template("note_type_nil") %>
+        </div>
       </div>
-    </div>
-  <% end %>
+    <% end %>
   <% end %>
 <% end %>
 
@@ -652,6 +634,72 @@
 
         <%= form.label_and_boolean("publish", {}, user_prefs["publish"]) %>
       <% end %>
+    </div>
+  </div>
+<% end %>
+
+<%
+  rights_statement_note_types = note_types_for('rights_statement')
+  rights_statement_act_note_types = note_types_for('rights_statement_act')
+%>
+
+<% define_template "note_rights_statement", jsonmodel_definition(:note_rights_statement) do |form| %>
+  <div class="subrecord-form-fields" data-type="note_rights_statement">
+    <h4 class="subrecord-form-heading">
+      <% if form.readonly? %>
+        <%= I18n.t("enumerations.note_rights_statement_type.#{form.obj["type"]}", :default => form.obj["type"]) %>
+      <% else %>
+        <%= I18n.t("note.note_rights_statement") %>
+      <% end %>
+    </h4>
+    <div class="subrecord-form-container">
+      <%= form.hidden_input(:jsonmodel_type, "note_rights_statement") %>
+      <%= form.hidden_input("ingest_problem") %>
+      <%= form.label_and_textfield("persistent_id") %>
+      <%= form.label_and_textfield("label") %>
+      <%= form.label_and_select("type", rights_statement_note_types.map {|value, hash| [hash[:i18n], value]}, :field_opts => {:class => "note-type"}) %>
+      <%= form.label_and_boolean("publish", {}, user_prefs["publish"]) %>
+
+      <% form.emit_template("content_items", :required => form.required?('content')) %>
+    </div>
+  </div>
+<% end %>
+
+<% define_template "note_rights_statement_act", jsonmodel_definition(:note_rights_statement_act) do |form| %>
+  <div class="subrecord-form-fields" data-type="note_rights_statement_act">
+    <h4 class="subrecord-form-heading">
+      <% if form.readonly? %>
+        <%= I18n.t("enumerations.note_rights_statement_act_type.#{form.obj["type"]}", :default => form.obj["type"]) %>
+      <% else %>
+        <%= I18n.t("note.note_rights_statement_act") %>
+      <% end %>
+    </h4>
+    <div class="subrecord-form-container">
+      <%= form.hidden_input(:jsonmodel_type, "note_rights_statement_act") %>
+      <%= form.hidden_input("ingest_problem") %>
+      <%= form.label_and_textfield("persistent_id") %>
+      <%= form.label_and_textfield("label") %>
+      <%= form.label_and_select("type", rights_statement_act_note_types.map {|value, hash| [hash[:i18n], value]}, :field_opts => {:class => "note-type"}) %>
+      <%= form.label_and_boolean("publish", {}, user_prefs["publish"]) %>
+
+      <% form.emit_template("content_items", :required => form.required?('content')) %>
+    </div>
+  </div>
+<% end %>
+
+<% define_template "note_agent_rights_statement", jsonmodel_definition(:note_agent_rights_statement) do |form| %>
+  <div class="subrecord-form-fields" data-type="note_agent_rights_statement">
+    <h4 class="subrecord-form-heading">
+      <%= I18n.t("note.note_agent_rights_statement") %>
+    </h4>
+    <div class="subrecord-form-container">
+      <%= form.hidden_input(:jsonmodel_type, "note_agent_rights_statement") %>
+      <%= form.hidden_input("ingest_problem") %>
+      <%= form.label_and_textfield("persistent_id") %>
+      <%= form.label_and_textfield("label") %>
+      <%= form.label_and_boolean("publish", {}, user_prefs["publish"]) %>
+
+      <% form.emit_template("content_items", :required => form.required?('content')) %>
     </div>
   </div>
 <% end %>

--- a/frontend/app/views/rights_statement_acts/_show.html.erb
+++ b/frontend/app/views/rights_statement_acts/_show.html.erb
@@ -1,0 +1,21 @@
+<%
+  section_id = "rights_statement_acts" if section_id.blank?
+%>
+<section id="<%= section_id %>" class="subrecord-form-dummy">
+
+  <h3><%= I18n.t("rights_statement_act._plural") %></h3>
+
+  <div class="subrecord-form-container">
+    <% acts.each_with_index do | act, index | %>
+      <div class="subrecord-form-fields rights-statement-act">
+        <%= read_only_view(act) %>
+        <% if act['notes'].length > 0 %>
+          <%= readonly_context :rights_statement_act, act do |readonly| %>
+            <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => act['notes'], :context => readonly, :section_id => "rights_statement_act_#{index}_notes" } %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
+</section>

--- a/frontend/app/views/rights_statement_acts/_template.html.erb
+++ b/frontend/app/views/rights_statement_acts/_template.html.erb
@@ -1,0 +1,11 @@
+<% define_template "rights_statement_act", jsonmodel_definition(:rights_statement_act) do |form| %>
+  <div class="subrecord-form-fields">
+    <%= form.label_and_select("act_type", form.possible_options_for("act_type", true)) %>
+    <%= form.label_and_select("restriction", form.possible_options_for("restriction", true)) %>
+    <%= form.label_and_date("start_date") %>
+    <%= form.label_and_date("end_date") %>
+    <div class="subrecord-form-container">
+      <%= render_aspace_partial :partial => "notes/form", :locals => {:header_size => "h4", :form => form, :nested_in_jsonmodel => 'rights_statement_act', :nested_note_jsonmodel => 'rights_statement_act_notes', :show_apply_note_order_action => false} %>
+    </div>
+  </div>
+<% end %>

--- a/frontend/app/views/rights_statements/_show.html.erb
+++ b/frontend/app/views/rights_statements/_show.html.erb
@@ -12,23 +12,37 @@
             <div class="col-md-1">
               <span class="glyphicon"></span>
             </div>
-            <div class="col-md-3">
+            <div class="col-md-2">
               <%= I18n.t("enumerations.rights_statement_rights_type.#{rights_statement['rights_type']}", :default => rights_statement['rights_type']) %>
             </div>
             <div class="col-md-4">
-              <% if rights_statement['ip_status'] %>
-                <%= I18n.t("enumerations.rights_statement_ip_status.#{rights_statement['ip_status']}", :default => rights_statement['ip_status']) %>
+              <% if rights_statement['status'] %>
+                <%= I18n.t("enumerations.rights_statement_ip_status.#{rights_statement['status']}", :default => rights_statement['ip_status']) %>
               <% end %>
             </div>
-            <div class="col-md-1">
-              <%= I18n.t("rights_statement.active_#{rights_statement['active'].to_s}") %>
+            <div class="col-md-4">
+              <%= rights_statement['start_date'] %>
+              <% if rights_statement['end_date'] %>
+                - <%= rights_statement['end_date'] %>
+              <% end %>
             </div>
           </div>
         </div>
         <div id="rights_statement_<%= index %>" class="accordion-body collapse">
           <%= read_only_view(rights_statement) %>
+          <% if rights_statement['notes'].length > 0 %>
+            <%= readonly_context :rights_statement, rights_statement do |readonly| %>
+              <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => rights_statement['notes'], :context => readonly, :section_id => "rights_statement_#{index}_notes" } %>
+            <% end %>
+          <% end %>
+          <% if rights_statement['acts'].length > 0 %>
+            <%= render_aspace_partial :partial => "rights_statement_acts/show", :locals => { :acts => rights_statement['acts'], :section_id => "rights_statement_#{index}_acts" } %>
+          <% end %>
           <% if rights_statement["external_documents"].length > 0 %>
-            <%= render_aspace_partial :partial => "external_documents/show", :locals => { :external_documents => rights_statement["external_documents"], :id => "rights_statement_#{index}_external_documents" } %>
+            <%= render_aspace_partial :partial => "external_documents/show", :locals => { :external_documents => rights_statement["external_documents"], :section_id => "rights_statement_#{index}_external_documents", :jsonmodel => :rights_statement_external_document } %>
+          <% end %>
+          <% if rights_statement['linked_agents'].length > 0 %>
+            <%= render_aspace_partial :partial => "linked_agents/show", :locals => { :linked_agents => rights_statement['linked_agents'], :section_id => "rights_statement_#{index}_linked_agents" } %>
           <% end %>
         </div>
       </div>

--- a/frontend/app/views/rights_statements/_template.html.erb
+++ b/frontend/app/views/rights_statements/_template.html.erb
@@ -1,54 +1,36 @@
-<% define_template "rights_type_intellectual_property", jsonmodel_definition(:rights_statement) do |form| %>
-  <div class="inline-subform rights-type-subform" data-rights-type="intellectual_property">
-    <%= form.label_and_textarea "materials" %>
-    <%= form.label_and_select "ip_status", form.possible_options_for("ip_status") %>
-    <%= form.label_and_date "ip_expiration_date" %>
+<% define_template "rights_type_copyright", jsonmodel_definition(:rights_statement) do |form| %>
+  <div class="inline-subform rights-type-subform" data-rights-type="copyright">
+    <%= form.label_and_select "status", form.possible_options_for("status"), {"required" => true} %>
     <%= form.label_and_select "jurisdiction",  form.possible_options_for("jurisdiction", true, :i18n_prefix => "enumerations.country_iso_3166."), {"required" => true} %>
-    <%= form.label_and_textarea "type_note" %>
-    <%= form.label_and_textarea "permissions" %>
-    <%= form.label_and_textarea "restrictions" %>
-    <%= form.label_and_date "restriction_start_date" %>
-    <%= form.label_and_date "restriction_end_date" %>
-    <%= form.label_and_textarea "granted_note" %>
+    <%= form.label_and_date "determination_date" %>
+    <%= form.label_and_date "start_date", {"required" => true} %>
+    <%= form.label_and_date "end_date" %>
   </div>
 <% end %>
 
 <% define_template "rights_type_license", jsonmodel_definition(:rights_statement) do |form| %>
   <div class="inline-subform rights-type-subform" data-rights-type="license">
-    <%= form.label_and_textarea "materials" %>
-    <%= form.label_and_textarea "license_identifier_terms", {"required" => true} %>
-    <%= form.label_and_textarea "type_note" %>
-    <%= form.label_and_textarea "permissions" %>
-    <%= form.label_and_textarea "restrictions" %>
-    <%= form.label_and_date "restriction_start_date" %>
-    <%= form.label_and_date "restriction_end_date" %>
-    <%= form.label_and_textarea "granted_note" %>
+    <%= form.label_and_textarea "license_terms", {"required" => true} %>
+    <%= form.label_and_date "start_date", {"required" => true} %>
+    <%= form.label_and_date "end_date" %>
   </div>
 <% end %>
 
 <% define_template "rights_type_statute", jsonmodel_definition(:rights_statement) do |form| %>
   <div class="inline-subform rights-type-subform" data-rights-type="statute">
-    <%= form.label_and_textarea "materials" %>
     <%= form.label_and_textarea "statute_citation", {"required" => true} %>
     <%= form.label_and_select "jurisdiction",  form.possible_options_for("jurisdiction", true, :i18n_prefix => "enumerations.country_iso_3166."), {"required" => true} %>
-    <%= form.label_and_textarea "type_note" %>
-    <%= form.label_and_textarea "permissions" %>
-    <%= form.label_and_textarea "restrictions" %>
-    <%= form.label_and_date "restriction_start_date" %>
-    <%= form.label_and_date "restriction_end_date" %>
-    <%= form.label_and_textarea "granted_note" %>
+    <%= form.label_and_date "determination_date" %>
+    <%= form.label_and_date "start_date", {"required" => true} %>
+    <%= form.label_and_date "end_date" %>
   </div>
 <% end %>
 
-<% define_template "rights_type_institutional_policy", jsonmodel_definition(:rights_statement) do |form| %>
-  <div class="inline-subform rights-type-subform" data-rights-type="institutional_policy">
-    <%= form.label_and_textarea "materials" %>
-    <%= form.label_and_textarea "type_note" %>
-    <%= form.label_and_textarea "permissions" %>
-    <%= form.label_and_textarea "restrictions" %>
-    <%= form.label_and_date "restriction_start_date" %>
-    <%= form.label_and_date "restriction_end_date" %>
-    <%= form.label_and_textarea "granted_note" %>
+<% define_template "rights_type_other", jsonmodel_definition(:rights_statement) do |form| %>
+  <div class="inline-subform rights-type-subform" data-rights-type="other">
+    <%= form.label_and_select "other_rights_basis", form.possible_options_for("other_rights_basis"), {"required" => true} %>
+    <%= form.label_and_date "start_date", {"required" => true} %>
+    <%= form.label_and_date "end_date" %>
   </div>
 <% end %>
 
@@ -69,8 +51,6 @@
       <%= form.label_with_field "identifier", form.hidden_input("identifier") + "<span class='identifier-display'><span class='identifier-display-part'>#{form.obj["identifier"]}</span></span>".html_safe %>
     <% end %>
 
-    <%= form.label_and_boolean "active", {}, form.default_for("active") %>
-
     <%= form.label_and_select "rights_type", form.possible_options_for("rights_type", true) %>
 
     <% if !form.obj["rights_type"].blank? %>
@@ -83,7 +63,10 @@
 
 
     <div class="subrecord-form-container">
-      <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents", :heading_size => "h4", :help_topic => "rights_statement_external_documents"} %>
+      <%= render_aspace_partial :partial => "notes/form", :locals => {:header_size => "h4", :form => form, :nested_in_jsonmodel => 'rights_statement', :nested_note_jsonmodel => 'rights_statement_notes', :show_apply_note_order_action => false} %>
+      <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "acts", :template => "rights_statement_act", :template_erb => "rights_statement_acts/template", :heading_size => "h4", :help_topic => "rights_statement_acts"} %>
+      <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents", :template => "rights_statement_external_document", :heading_size => "h4", :help_topic => "rights_statement_external_documents"} %>
+      <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "linked_agents", :heading_size => "h4", :template => 'rights_statement_linked_agent', :help_topic => "rights_statement_linked_agents"} %>
     </div>
   </div>
 

--- a/frontend/app/views/shared/_templates.html.erb
+++ b/frontend/app/views/shared/_templates.html.erb
@@ -236,3 +236,23 @@
     </div>
   </div>
 --></div>
+
+<div id="template_note_summary"><!--
+  <div class="subrecord-summary-title">
+    {if type != ""}
+    ${type}
+    {/if}
+    {if label != "" && label != type}
+    {if type != ""} - {/if}
+    ${label}
+    {/if}
+    {if label == "" && type == ""}
+    ${jsonmodel_type}
+    {/if}
+  </div>
+  {if summary.length > 0}
+  <div class="subrecord-summary-content">
+    ${summary}
+  </div>
+  {/if}
+--></div>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -178,6 +178,7 @@ en:
       location_profile_height_u_sstr: Height
       location_profile_depth_u_sstr: Depth
       location_profile_dimension_units_u_sstr: Dimension Units
+      rights_statement_agent_uris: Rights Statement Agent
     help:
       row_selection: Click a row to select it for bulk operations. Hold alt while clicking a checkbox to select, or unselect, multple previous rows.
 
@@ -427,6 +428,7 @@ en:
         name: Name Forms
         contacts: Contact Details
         search_embedded: Linked Records
+        linked_via_rights_statement: Linked Records via Rights Statement
       action:
         create: Create Agent
 
@@ -1293,3 +1295,8 @@ en:
     create_success: Date Created Successfully.  Refreshing page...
     no_dates: No suitable dates found
     no_dates_for_label: No suitable %{label} dates found
+
+  act:
+    _frontend:
+      action:
+        add: Add Act

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -606,6 +606,15 @@ class CommonIndexer
       }
     }
 
+    add_document_prepare_hook {|doc, record|
+      ASUtils.wrap(record['record']['rights_statements']).each do |rights_statement|
+        ASUtils.wrap(rights_statement['linked_agents']).each do |agent_link|
+          doc['rights_statement_agent_uris'] ||= []
+          doc['rights_statement_agent_uris'] << agent_link['ref']
+        end
+      end
+    }
+
     record_has_children('collection_management')
     add_extra_documents_hook {|record|
       docs = []

--- a/selenium/spec/accessions_spec.rb
+++ b/selenium/spec/accessions_spec.rb
@@ -53,21 +53,24 @@ describe "Accessions" do
 
     # add a rights subrecord
     @driver.find_element(:css => '#accession_rights_statements_ .subrecord-form-heading .btn:not(.show-all)').click
-    @driver.find_element(:id => "accession_rights_statements__0__rights_type_").select_option("intellectual_property")
-    @driver.find_element(:id => "accession_rights_statements__0__ip_status_").select_option("copyrighted")
+    @driver.find_element(:id => "accession_rights_statements__0__rights_type_").select_option("copyright")
+    @driver.find_element(:id => "accession_rights_statements__0__status_").select_option("copyrighted")
+    @driver.clear_and_send_keys([:id, "accession_rights_statements__0__start_date_"], "2012-01-01")
     combo = @driver.find_element(:xpath => '//div[@class="combobox-container"][following-sibling::select/@id="accession_rights_statements__0__jurisdiction_"]//input[@type="text"]');
     combo.clear
     combo.click
     combo.send_keys("AU")
     combo.send_keys(:tab)
 
-    # @driver.clear_and_send_keys([:id => "accession_rights_statements__0__jurisdiction__combobox"], ["AU", :return])
-    @driver.find_element(:id, "accession_rights_statements__0__active_").click
-
     # add an external document
     @driver.find_element(:css => "#accession_rights_statements__0__external_documents_ .subrecord-form-heading .btn:not(.show-all)").click
     @driver.clear_and_send_keys([:id, "accession_rights_statements__0__external_documents__0__title_"], "Agreement")
     @driver.clear_and_send_keys([:id, "accession_rights_statements__0__external_documents__0__location_"], "http://locationof.agreement.com")
+    combo = @driver.find_element(:xpath => '//div[@class="combobox-container"][following-sibling::select/@id="accession_rights_statements__0__external_documents__0__identifier_type_"]//input[@type="text"]');
+    combo.clear
+    combo.click
+    combo.send_keys("Trove")
+    combo.send_keys(:tab)
 
     # save
     @driver.find_element(:css => "form#accession_form button[type='submit']").click
@@ -400,19 +403,25 @@ describe "Accessions" do
     # add a rights sub record
     @driver.find_element(:css => '#accession_rights_statements_ .subrecord-form-heading .btn:not(.show-all)').click
 
-    @driver.find_element(:id => "accession_rights_statements__0__rights_type_").select_option("intellectual_property")
-    @driver.find_element(:id => "accession_rights_statements__0__ip_status_").select_option("copyrighted")
+    @driver.find_element(:id => "accession_rights_statements__0__rights_type_").select_option("copyright")
+    @driver.find_element(:id => "accession_rights_statements__0__status_").select_option("copyrighted")
+    @driver.clear_and_send_keys([:id, "accession_rights_statements__0__start_date_"], "2012-01-01")
     combo = @driver.find_element(:xpath => '//div[@class="combobox-container"][following-sibling::select/@id="accession_rights_statements__0__jurisdiction_"]//input[@type="text"]');
     combo.clear
     combo.click
     combo.send_keys("AU")
     combo.send_keys(:tab)
-    @driver.find_element(:id, "accession_rights_statements__0__active_").click
 
     # add an external document
     @driver.find_element(:css => "#accession_rights_statements__0__external_documents_ .subrecord-form-heading .btn:not(.show-all)").click
     @driver.clear_and_send_keys([:id, "accession_rights_statements__0__external_documents__0__title_"], "Agreement")
     @driver.clear_and_send_keys([:id, "accession_rights_statements__0__external_documents__0__location_"], "http://locationof.agreement.com")
+    combo = @driver.find_element(:xpath => '//div[@class="combobox-container"][following-sibling::select/@id="accession_rights_statements__0__external_documents__0__identifier_type_"]//input[@type="text"]');
+    combo.clear
+    combo.click
+    combo.send_keys("Trove")
+    combo.send_keys(:tab)
+
 
     # save changes
     @driver.click_and_wait_until_gone(:css => "form#accession_form button[type='submit']")

--- a/selenium/spec/notes_spec.rb
+++ b/selenium/spec/notes_spec.rb
@@ -187,6 +187,80 @@ describe "Notes" do
   end
 
 
+  it "types for rights statements are correct" do
+    @driver.get_edit_page(@resource)
+
+    # add rights statement
+    @driver.find_element(:css => '#resource_rights_statements_ .subrecord-form-heading button').click
+
+    # add rights statement note
+    @driver.find_element(:css => '#rights_statement_notes .subrecord-form-heading .add-note').click
+
+    # note types should be rights note type only
+    @driver.find_elements(:css => '#rights_statement_notes .top-level-note-type option').each_with_index do |option_element, i|
+      if i == 0
+        option_element.attribute('value').should eq("")
+      else
+        option_element.attribute('value').should eq("note_rights_statement")
+      end
+    end
+
+    @driver.find_element(:css, "#rights_statement_notes .top-level-note-type").select_option_with_text("Additional Information")
+    @driver.find_element(:id, "resource_rights_statements__0__notes__0__type_").get_select_value.should eq("additional_information")
+
+    # add rights statement act
+    @driver.find_element(:css => '#resource_rights_statements__0__acts_ .subrecord-form-heading button').click
+
+    # add rights statement act note
+    @driver.find_element(:css => '#resource_rights_statements__0__acts_ .subrecord-form-heading .add-note').click
+
+    # note types should be act note type only
+    @driver.find_elements(:css => '#resource_rights_statements__0__acts_ .top-level-note-type option').each_with_index do |option_element, i|
+      if i == 0
+        option_element.attribute('value').should eq("")
+      else
+        option_element.attribute('value').should eq("note_rights_statement_act")
+      end
+    end
+
+    @driver.find_element(:css, "#resource_rights_statements__0__acts_ .top-level-note-type").select_option_with_text("Additional Information")
+    @driver.find_element(:id, "resource_rights_statements__0__acts__0__notes__0__type_").get_select_value.should eq("additional_information")
+
+    # Force a save
+    @driver.find_element(:css => "form#resource_form button[type='submit']").click
+
+    # And check things again
+    @driver.find_element(:id, "resource_rights_statements__0__notes__0__type_").get_select_value.should eq("additional_information")
+    @driver.find_element(:id, "resource_rights_statements__0__acts__0__notes__0__type_").get_select_value.should eq("additional_information")
+
+    # Add a second note, are they cool?
+    @driver.find_element(:css => '#rights_statement_notes .subrecord-form-heading .add-note').click
+    @driver.find_elements(:css => '#rights_statement_notes .top-level-note-type option').each_with_index do |option_element, i|
+      if i == 0
+        option_element.attribute('value').should eq("")
+      else
+        option_element.attribute('value').should eq("note_rights_statement")
+      end
+    end
+    @driver.find_element(:css, "#rights_statement_notes .top-level-note-type").select_option_with_text("Additional Information")
+    @driver.find_element(:id, "resource_rights_statements__0__notes__2__type_").get_select_value.should eq("additional_information")
+
+    @driver.find_element(:css => '#rights_statement_act_notes.initialised .add-note').click
+    @driver.find_elements(:css => '#resource_rights_statements__0__acts_ .top-level-note-type option').each_with_index do |option_element, i|
+      if i == 0
+        option_element.attribute('value').should eq("")
+      else
+        option_element.attribute('value').should eq("note_rights_statement_act")
+      end
+    end
+    @driver.find_element(:css, "#resource_rights_statements__0__acts_ .top-level-note-type").select_option_with_text("Additional Information")
+    @driver.find_element(:id, "resource_rights_statements__0__acts__0__notes__2__type_").get_select_value.should eq("additional_information")
+
+
+    @driver.click_and_wait_until_gone(:css => '.btn.btn-cancel.btn-default')
+  end
+
+
   it "can attach notes to archival objects" do
     @driver.navigate.to("#{$frontend}")
     # Create a resource

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -161,6 +161,7 @@
    <field name="linked_instance_uris" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="related_accession_uris" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="related_resource_uris" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="rights_statement_agent_uris" type="string" indexed="true" stored="true" multiValued="true" />
 
    <!-- Event properties required for facets -->
    <field name="event_type" type="string" indexed="true" stored="true" multiValued="false" />


### PR DESCRIPTION
Namely add new rights_statement fields and relationships, rights_statement_act, rights_statement_external_document, migration, backend tests, and locales, including JIRAs:

ANW-105 Revise the overall rights statement template
ANW-106 Replace rights type Intellectual Property with rights type Copyright and revise the associated template
ANW-107 Replace rights type Institutional Policy with rights type Other and revise the associated template
ANW-108 Revise the template for rights type License
ANW-110 Create a new Notes sub-record that is repeatable and can be linked to Rights Statement sub-records
ANW-111 Create a new Acts sub-record that is repeatable and can be linked to Rights Statement sub-records
ANW-112 Enable Agents Links sub-records to be linked from Rights Statement sub-records
ANW-113 Revise the External Documents sub-record for Rights
ANW-114 Database migration for new rights schemas
ANW-115 Rights statement schema updates
ANW-118 New tooltips
ANW-120 Rights statement schema updates
ANW-124 Revise the template for rights type Statute
ANW-139 Remove the unintended functionality allowing users to create a rights statement subrecord for an agent
ANW-140 Migrate existing rights statements attached to agents to a note with type Rights Statement
AR-1676 Rights type note field should accept more than 255 characters