### PR TITLE
Indexer timeouts

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -268,7 +268,7 @@
         <java
           classpath="${winstone_file}:../solr:../common/lib/*"
               classname="winstone.Launcher" fork="true">
-          <jvmarg line="${solr.properties} -Djava.io.tmpdir=${java.io.tmpdir}/winstone.${user.name}" />
+          <jvmarg line="${default_java_options} ${solr.properties} -Djava.io.tmpdir=${java.io.tmpdir}/winstone.${user.name}" />
           <arg line="--warfile=${solr_file} --httpPort=${aspace.solr.port} --ajp13Port=-1" />
         </java>
       </daemons>

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -681,8 +681,11 @@ class CommonIndexer
   def do_http_request(url, req)
     req['X-ArchivesSpace-Session'] = @current_session
 
-    ASHTTP.start_uri(url) do |http|
-      http.read_timeout = AppConfig[:indexer_solr_timeout_seconds].to_i
+    opts = {
+      :read_timeout => AppConfig[:indexer_solr_timeout_seconds].to_i
+    }
+
+    ASHTTP.start_uri(url, opts) do |http|
       http.request(req)
     end
   end


### PR DESCRIPTION
In investigating indexer timeouts, we came across a few bugs:

- the timeout for indexer HTTP requests to SOLR was 60 seconds instead of the number set via the configuration option `AppConfig[:indexer_solr_timeout_seconds]`

- (development only) The Winstone servlet container, for SOLR, was not being passed the default set of JAVA_OPTS when run as a devserver.   This left Winstone with a minimal memory allocation.