### PR TITLE
AR-1724 staff link and a throw RecordNotFound if tree records are yet to be indexed

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -388,6 +388,7 @@ AppConfig[:record_inheritance] = {
 AppConfig[:pui_search_results_page_size] = 25
 AppConfig[:pui_branding_img] = '/img/Aspace-logo.png'
 AppConfig[:pui_block_referrer] = true # patron privacy; blocks full 'referer' when going outside the domain
+AppConfig[:pui_enable_staff_link] = true # attempt to add a link back to the staff interface
 
 # The number of PDFs we'll generate (in the background) at the same time.
 #

--- a/public-new/app/assets/javascripts/smart_staff_links.js
+++ b/public-new/app/assets/javascripts/smart_staff_links.js
@@ -1,0 +1,31 @@
+$(function() {
+
+  if (typeof RECORD_URI === "undefined" || typeof FRONTEND_URL === 'undefined') {
+    return;
+  }
+
+  if ($('#staff-link').length == 0) {
+    return;
+  }
+
+  $.ajax(FRONTEND_URL + "/check_session", {
+    data: {
+      uri: RECORD_URI
+    },
+    type: "GET",
+    dataType: "json",
+    xhrFields: {
+      withCredentials: true
+    }
+  }).done(function( data ) {
+    if (data === true) {
+      var staff = $('#staff-link');
+      link = FRONTEND_URL + "/resolve/edit?uri=" + RECORD_URI + "&autoselect_repo=true";
+      staff.attr("href", link);
+      staff.removeClass("hide");
+    }
+  }).fail(function() {
+    // do nothing
+  });
+
+});

--- a/public-new/app/models/concerns/tree_nodes.rb
+++ b/public-new/app/models/concerns/tree_nodes.rb
@@ -50,6 +50,11 @@ module TreeNodes
   end
 
   def path_to_root
-    archives_space_client.get_raw_record("#{root_node_uri}/tree/node_from_root_#{id}").fetch(id)
+    begin
+      archives_space_client.get_raw_record("#{root_node_uri}/tree/node_from_root_#{id}").fetch(id)
+    rescue RecordNotFound => e
+      $stderr.puts "RecordNotFound: #{"#{root_node_uri}/tree/node_from_root_#{id}"}"
+      []
+    end
   end
 end

--- a/public-new/app/services/archives_space_client.rb
+++ b/public-new/app/services/archives_space_client.rb
@@ -83,6 +83,8 @@ class ArchivesSpaceClient
     url = build_url('/search/records', search_opts.merge("uri[]" => ASUtils.wrap(uri)))
     results = do_search(url)
 
+    raise RecordNotFound.new if results.fetch('results', []).empty?
+
     ASUtils.json_parse(results.fetch('results').fetch(0).fetch('json'))
   end
 

--- a/public-new/app/views/layouts/application.html.erb
+++ b/public-new/app/views/layouts/application.html.erb
@@ -39,5 +39,15 @@
 	</script>
 
 	<%= render partial: 'shared/footer' %>
+
+	<% if AppConfig[:pui_enable_staff_link] %>
+		<% if AppConfig.has_key?(:frontend_proxy_url) && defined?(@result) && @result.respond_to?(:uri) %>
+			<script>
+				FRONTEND_URL = "<%= j(AppConfig[:frontend_proxy_url]) %>";
+				RECORD_URI = "<%= j(@result.uri) %>";
+			</script>
+		<% end %>
+	<% end %>
+
 </body>
 </html>

--- a/public-new/app/views/shared/_staff_link_action.html.erb
+++ b/public-new/app/views/shared/_staff_link_action.html.erb
@@ -1,0 +1,7 @@
+<% if AppConfig[:pui_enable_staff_link] %>
+    <a id="staff-link" href="#" class="btn btn-default hide">
+        <i class="fa fa-pencil fa-3x"></i>
+        <br/>
+        <%= t('actions.staff_link') %>
+    </a>
+<% end %>

--- a/public-new/config/initializers/assets.rb
+++ b/public-new/config/initializers/assets.rb
@@ -9,4 +9,4 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
-Rails.application.config.assets.precompile += %w( infinite_scroll.js largetree.js treesync.js tree_renderer.js )
+Rails.application.config.assets.precompile += %w( infinite_scroll.js largetree.js treesync.js tree_renderer.js smart_staff_links.js )

--- a/public-new/config/initializers/public_new_defaults.rb
+++ b/public-new/config/initializers/public_new_defaults.rb
@@ -137,6 +137,12 @@ module PublicNewDefaults
                               'shared/print_page_action')
   end
 
+  # Link to the Staff Interface 
+  if AppConfig[:pui_enable_staff_link]
+    add_record_page_action_erb(['resource', 'archival_object', 'digital_object', 'digital_object_component', 'accession'],
+                               'shared/staff_link_action')
+  end
+
   # Load any custom actions defined in AppConfig:
   ASUtils.wrap(AppConfig[:pui_page_custom_actions]).each do |action|
     ASUtils.wrap(action.fetch('record_type')).each do |record_type|

--- a/public-new/config/locales/en.yml
+++ b/public-new/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
     clipboard: Copy to clipboard
     search_add_row: Add a search row
     search_remove_row: Remove the row below
+    staff_link: Staff Only
 
   page_actions: Page Actions    
 


### PR DESCRIPTION
First commit fixes an "out of index" error when hitting the Collections tab and the trees are yet to be indexed.

Second commit is a go at porting the smart_staff_link behaviour across to public-new.  I'm guessing some institutions won't want it, given it makes their staff interface public (via the network console and javascript) -- for others they may just not like the 404/500 console errors that show up for their users when the staff interface is behind a firewall.  I'm not really talking it up...  it's great, promise.

... perhaps we should disable it by default? 