### PR TITLE
Correct implied publication when dealing with unpublished repositories

### DIFF
--- a/backend/app/model/implied_publication_calculator.rb
+++ b/backend/app/model/implied_publication_calculator.rb
@@ -222,7 +222,7 @@ class ImpliedPublicationCalculator
       return result if root_record_id_to_child.empty?
 
       root_model
-        .filter(:id => tree_nodes.map(&:root_record_id).uniq)
+        .filter(:id => root_record_id_to_child.keys)
         .filter(Sequel.|({:publish => 0},
                          {:suppressed => 1}))
         .select(:id)


### PR DESCRIPTION
If a record belonged to an unpublished tree within an unpublished
repository, the tree check would be superseded by the repository check
and throw an error.