### PR TITLE
Set Enumeration default value to null when value deleted

### DIFF
--- a/common/db/migrations/091_enum_default_value_fk.rb
+++ b/common/db/migrations/091_enum_default_value_fk.rb
@@ -1,0 +1,15 @@
+require_relative 'utils'
+
+Sequel.migration do
+
+  up do
+    alter_table(:enumeration) do
+      add_foreign_key([:default_value], :enumeration_value, :key => :id, :on_delete => :set_null)
+    end
+  end
+
+  down do
+    # nothing!
+  end
+
+end


### PR DESCRIPTION
It is possible to delete / merge a controlled value that was set
as a default (particularly where the value is used by multiple
enumerations) and this crashes things hard.

So, leverage the database to ensure default value is set to null
if the value is deleted (which is a good thing regardless).