### PR TITLE
AR-1823 introduce SOLR fields published_agents and published_agent_ur…

### DIFF
--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -186,6 +186,16 @@ class CommonIndexer
       doc['agents'] = record['record']['linked_agents'].collect{|link| link['_resolved']['display_name']['sort_name']}
       doc['agent_uris'] = record['record']['linked_agents'].collect{|link| link['ref']}
 
+      # only published agents
+      doc['published_agents'] = []
+      doc['published_agent_uris'] = []
+      record['record']['linked_agents'].each do |link|
+        if link['_resolved']['publish']
+          doc['published_agents'] << link['_resolved']['display_name']['sort_name']
+          doc['published_agent_uris'] << link['ref']
+        end
+      end
+
       # index the creators only
       creators = record['record']['linked_agents'].select{|link| link['role'] === 'creator'}
       doc['creators'] = creators.collect{|link| link['_resolved']['display_name']['sort_name']} if not creators.empty?

--- a/public/app/controllers/agents_controller.rb
+++ b/public/app/controllers/agents_controller.rb
@@ -112,7 +112,7 @@ class AgentsController <  ApplicationController
   private
   def fetch_agent_results(title, uri, params)
     @results = []
-    qry = "agents:\"#{title}\" AND types:pui"
+    qry = "published_agent_uris:\"#{uri}\" AND types:pui"
     @base_search = "#{uri}?"
     set_up_search(DEFAULT_AG_TYPES, DEFAULT_AG_FACET_TYPES, DEFAULT_AG_SEARCH_OPTS, params,qry)
   # we do this to compensate for the way @base_search gets munged in the setup

--- a/public/app/controllers/repositories_controller.rb
+++ b/public/app/controllers/repositories_controller.rb
@@ -3,7 +3,7 @@ class RepositoriesController < ApplicationController
   helper_method :process_repo_info
   skip_before_filter  :verify_authenticity_token  
 
-  DEFAULT_SEARCH_FACET_TYPES = ['primary_type', 'subjects', 'agents']
+  DEFAULT_SEARCH_FACET_TYPES = ['primary_type', 'subjects', 'published_agents']
   DEFAULT_REPO_SEARCH_OPTS = {
      'sort' => 'title_sort asc',
     'resolve[]' => ['repository:id', 'resource:id@compact_resource', 'ancestors:id@compact_resource', 'top_container_uri_u_sstr:id'],

--- a/public/app/controllers/search_controller.rb
+++ b/public/app/controllers/search_controller.rb
@@ -1,6 +1,6 @@
 class SearchController < ApplicationController
 
-  DEFAULT_SEARCH_FACET_TYPES = ['repository','primary_type', 'subjects', 'agents']
+  DEFAULT_SEARCH_FACET_TYPES = ['repository','primary_type', 'subjects', 'published_agents']
   DEFAULT_SEARCH_OPTS = {
 #    'sort' => 'title_sort asc',
     'resolve[]' => ['repository:id', 'resource:id@compact_resource', 'ancestors:id@compact_resource', 'top_container_uri_u_sstr:id'],

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -165,7 +165,7 @@ en:
       scope: Scope
       notes: Notes
       source: Source
-      agents: Names
+      published_agents: Names
       agents_text: Names
       classification_uri: Classification
       linked_agent_roles: Role

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -154,7 +154,7 @@ fr:
       scope: Portée
       notes: Notes
       source: Source
-      agents: Créateurs de contenu
+      published_agents: Créateurs de contenu
       agents_text: Créateurs de contenu
       classification_uri: Classification
       linked_agent_roles: Rôle

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -67,7 +67,9 @@
    <field name="subjects" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="creators" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="agents" type="string" indexed="true" stored="true" multiValued="true"/>
+   <field name="published_agents" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="agent_uris" type="string" indexed="true" stored="true" multiValued="true"/>
+   <field name="published_agent_uris" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="related_agent_uris" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="notes" type="text_general" indexed="true" stored="true" multiValued="false"/>
    <field name="years" type="int" indexed="true" stored="false" multiValued="true"/>


### PR DESCRIPTION
…is to store only linked agent data where the agent is published - using these fields for facets ensures only published agents are included as facet values for 'Names'