### PR TITLE
Fix doc:build target (fixes #384)

### DIFF
--- a/_yard/rakefile.rb
+++ b/_yard/rakefile.rb
@@ -37,7 +37,7 @@ namespace :doc do
 
     require_relative '../backend/app/lib/export'
 
-    Dir.glob(File.dirname(__FILE__) + '/../backend/app/controllers/*.rb') {|file| require file unless file =~ /system/}
+    Dir.glob(File.dirname(__FILE__) + '/../backend/app/controllers/*.rb').sort.each {|file| require file unless file =~ /system/}
 
     @endpoints = ArchivesSpaceService::Endpoint.all.sort{|a,b| a[:uri] <=> b[:uri]}
     @examples = JSON.parse( IO.read File.dirname(__FILE__) + "/../endpoint_examples.json" )

--- a/backend/app/controllers/container.rb
+++ b/backend/app/controllers/container.rb
@@ -1,4 +1,4 @@
-require_relative './search'
+require_relative 'search'
 
 class ArchivesSpaceService < Sinatra::Base
 

--- a/backend/app/controllers/location_profile.rb
+++ b/backend/app/controllers/location_profile.rb
@@ -1,3 +1,5 @@
+require_relative 'search'
+
 class ArchivesSpaceService < Sinatra::Base
 
   Endpoint.post('/location_profiles/:id')

--- a/backend/app/controllers/oai.rb
+++ b/backend/app/controllers/oai.rb
@@ -7,7 +7,7 @@ class ArchivesSpaceService < Sinatra::Base
     .params(["verb", String, "The OAI verb (Identify, ListRecords, GetRecord, etc.)"],
             ["metadataPrefix",
              String,
-             "One of: " + ArchivesSpaceOAIRepository::AVAILABLE_RECORD_TYPES.keys.join(", "),
+             "One of the supported metadata types.  See verb=ListMetadataFormats for a list.",
              :optional => true],
             ["from", String, "Start date (yyyy-mm-dd, yyyy-mm-ddThh:mm:ssZ)", :optional => true],
             ["until", String, "End date (yyyy-mm-dd, yyyy-mm-ddThh:mm:ssZ)", :optional => true],


### PR DESCRIPTION
Two issues here:

  * The new OAI controller was assuming that models would be loaded
    before it was.  Normally this is true, but YARD turns out to load
    controllers without also loading models.  Reworked the controller to
    remove the load-time dependency on the models.

  * The YARD code was loading controllers in arbitrary order, so I got a
    different error to the one Laney saw.  Sort the list of files and
    always load them in the same order to avoid these sorts of
    surprises.