### PR TITLE
Show "No Search Results" found message

### DIFF
--- a/public/app/controllers/accessions_controller.rb
+++ b/public/app/controllers/accessions_controller.rb
@@ -29,6 +29,9 @@ class AccessionsController <  ApplicationController
     search_opts = default_search_opts( DEFAULT_AC_SEARCH_OPTS)
     begin
       set_up_and_run_search( DEFAULT_AC_TYPES, DEFAULT_AC_FACET_TYPES,  search_opts, params)
+    rescue NoResultsError
+      flash[:error] = I18n.t('search_results.no_results')
+      redirect_back(fallback_location: '/') and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
       redirect_back(fallback_location: '/') and return
@@ -58,6 +61,9 @@ class AccessionsController <  ApplicationController
     page = Integer(params.fetch(:page, "1"))
     begin
       set_up_and_run_search( DEFAULT_AC_TYPES, DEFAULT_AC_FACET_TYPES,  DEFAULT_AC_SEARCH_OPTS, params)
+    rescue NoResultsError
+      flash[:error] = I18n.t('search_results.no_results')
+      redirect_back(fallback_location: '/') and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
       redirect_back(fallback_location: '/') and return

--- a/public/app/controllers/agents_controller.rb
+++ b/public/app/controllers/agents_controller.rb
@@ -34,6 +34,9 @@ class AgentsController <  ApplicationController
     page = Integer(params.fetch(:page, "1"))
     begin
       set_up_and_run_search( DEFAULT_AG_TYPES, default_facets,  search_opts, params)
+    rescue NoResultsError
+      flash[:error] = I18n.t('search_results.no_results')
+      redirect_back(fallback_location: '/') and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
       redirect_back(fallback_location: '/') and return
@@ -65,6 +68,9 @@ class AgentsController <  ApplicationController
     page = Integer(params.fetch(:page, "1"))
     begin
       set_up_and_run_search( DEFAULT_AG_TYPES, DEFAULT_AG_FACET_TYPES,  DEFAULT_AG_SEARCH_OPTS, params)
+    rescue NoResultsError
+      flash[:error] = I18n.t('search_results.no_results')
+      redirect_back(fallback_location: '/') and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
       redirect_back(fallback_location: '/agents') and return

--- a/public/app/controllers/classifications_controller.rb
+++ b/public/app/controllers/classifications_controller.rb
@@ -36,6 +36,9 @@ class ClassificationsController <  ApplicationController
 
     begin
       set_up_and_run_search( DEFAULT_CL_TYPES, DEFAULT_CL_FACET_TYPES,  search_opts, params)
+    rescue NoResultsError
+      flash[:error] = I18n.t('search_results.no_results')
+      redirect_back(fallback_location: '/') and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
       redirect_back(fallback_location: '/') and return
@@ -72,6 +75,9 @@ class ClassificationsController <  ApplicationController
     page = Integer(params.fetch(:page, "1"))
     begin
       set_up_and_run_search( DEFAULT_CL_TYPES, DEFAULT_CL_FACET_TYPES,  DEFAULT_CL_SEARCH_OPTS, params)
+    rescue NoResultsError
+      flash[:error] = I18n.t('search_results.no_results')
+      redirect_back(fallback_location: '/') and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
       redirect_back(fallback_location: '/') and return

--- a/public/app/controllers/concerns/searchable.rb
+++ b/public/app/controllers/concerns/searchable.rb
@@ -4,6 +4,9 @@ module Searchable
 # TODO: refactor processing
   ABSTRACT = %w(abstract scopecontent)
 
+  class NoResultsError < StandardError; end
+
+
   def set_up_search(default_types = [],default_facets=[],default_search_opts={}, params={}, q='')
     @search = Search.new(params)
     limit = params.fetch(:limit,'')
@@ -65,7 +68,7 @@ module Searchable
     page = Integer(params.fetch(:page, "1"))
     @results =  archivesspace.advanced_search('/search', page, @criteria)
     if @results['total_hits'].blank? ||  @results['total_hits'] == 0
-      raise  I18n.t('search_results.no_results')
+      raise NoResultsError.new
     else
       process_search_results(@base_search)
     end

--- a/public/app/controllers/objects_controller.rb
+++ b/public/app/controllers/objects_controller.rb
@@ -30,6 +30,9 @@ class ObjectsController <  ApplicationController
 
     begin
       set_up_and_run_search( params[:limit].split(","), DEFAULT_OBJ_FACET_TYPES, search_opts,params)
+    rescue NoResultsError
+      flash[:error] = I18n.t('search_results.no_results')
+      redirect_back(fallback_location: '/') and return
     rescue Exception => error
      flash[:error] = I18n.t('errors.unexpected_error')
      redirect_back(fallback_location: '/') and return
@@ -57,6 +60,9 @@ class ObjectsController <  ApplicationController
     page = Integer(params.fetch(:page, "1"))
     begin
       set_up_and_run_search(%w(digital_object archival_object),DEFAULT_OBJ_FACET_TYPES,DEFAULT_OBJ_SEARCH_OPTS, params)
+    rescue NoResultsError
+      flash[:error] = I18n.t('search_results.no_results')
+      redirect_back(fallback_location: '/') and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
       redirect_back(fallback_location: '/objects' ) and return

--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -50,6 +50,9 @@ class ResourcesController <  ApplicationController
     facet_types.unshift('repository') if !@repo_id
     begin
       set_up_and_run_search(['resource'], facet_types,search_opts, params)
+    rescue NoResultsError
+      flash[:error] = I18n.t('search_results.no_results')
+      redirect_back(fallback_location: '/') and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
       redirect_back(fallback_location: '/' ) and return

--- a/public/app/controllers/subjects_controller.rb
+++ b/public/app/controllers/subjects_controller.rb
@@ -30,6 +30,9 @@ class SubjectsController <  ApplicationController
     page = Integer(params.fetch(:page, "1"))
     begin
       set_up_and_run_search(['subject'],default_facets,search_opts, params)
+    rescue NoResultsError
+      flash[:error] = I18n.t('search_results.no_results')
+      redirect_back(fallback_location: '/') and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
       redirect_back(fallback_location: '/' ) and return
@@ -62,6 +65,9 @@ Rails.logger.debug("we hit search!")
     page = Integer(params.fetch(:page, "1"))
     begin
       set_up_and_run_search(['subject'],DEFAULT_SUBJ_FACET_TYPES,DEFAULT_SUBJ_SEARCH_OPTS, params)
+    rescue NoResultsError
+      flash[:error] = I18n.t('search_results.no_results')
+      redirect_back(fallback_location: '/') and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
       redirect_back(fallback_location: '/subjects' ) and return

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -59,9 +59,6 @@ en:
 
   page_actions: Page Actions    
 
-  errors:
-    unexpected_error: Your request could not be completed due to an unexpected error
-
   request:
     required: required
     user_name: Your name
@@ -228,6 +225,7 @@ en:
     error_404_message: "The %{type} record you've tried to access does not exist or may have been removed."
     backend_down: Unable to Connect to Database
     backend_down_message: ArchivesSpace is currently experiencing technical difficulties. We apologise for the inconvenience. Please try again later.
+    unexpected_error: Your request could not be completed due to an unexpected error
 
   boolean:
     "true": "Yes"


### PR DESCRIPTION
My last minute change to avoid putting raw exceptions into flash messages (and overloading the Rails session cookie) messed up the "No Search Results" message.  That message was relying on the exception being displayed to the user, but that no longer happens.

So, I've added a new exception type to allow us to distinguish between the "no results found" case and real search errors.  Now I catch those in the right places and display the message to the user.

I also needed to fix up my "unexpected error" I18N because another 'error' key in that file was taking precedence.