### PR TITLE
ANW-114 fix insert blob error in rights migration on a derby database

### DIFF
--- a/common/db/migrations/088_rights_management.rb
+++ b/common/db/migrations/088_rights_management.rb
@@ -382,12 +382,12 @@ def migrate_materials_to_note
       :rights_statement_id => row[:id],
       :publish => 1,
       :notes_json_schema_version => 1,
-      :notes => JSON.generate({
+      :notes => blobify(self, JSON.generate({
                                   'jsonmodel_type' => 'note_rights_statement',
                                   'content' => [row[:materials]],
                                   'type' => 'materials',
                                   'persistent_id' => SecureRandom.hex
-                                }),
+                                })),
       :last_modified_by => row[:last_modified_by],
       :create_time => row[:create_time],
       :system_mtime => row[:system_mtime],
@@ -408,12 +408,12 @@ def migrate_type_to_note
       :rights_statement_id => row[:id],
       :publish => 1,
       :notes_json_schema_version => 1,
-      :notes => JSON.generate({
+      :notes => blobify(self, JSON.generate({
                                   'jsonmodel_type' => 'note_rights_statement',
                                   'content' => [row[:type_note]],
                                   'type' => 'type_note',
                                   'persistent_id' => SecureRandom.hex
-                                }),
+                                })),
       :last_modified_by => row[:last_modified_by],
       :create_time => row[:create_time],
       :system_mtime => row[:system_mtime],
@@ -434,13 +434,13 @@ def migrate_permissions_to_note
       :rights_statement_id => row[:id],
       :publish => 1,
       :notes_json_schema_version => 1,
-      :notes => JSON.generate({
+      :notes => blobify(self, JSON.generate({
                                   'jsonmodel_type' => 'note_rights_statement',
                                   'content' => [row[:permissions]],
                                   'type' => 'additional_information',
                                   'label' => 'Permissions',
                                   'persistent_id' => SecureRandom.hex
-                                }),
+                                })),
       :last_modified_by => row[:last_modified_by],
       :create_time => row[:create_time],
       :system_mtime => row[:system_mtime],
@@ -461,13 +461,13 @@ def migrate_restrictions_to_note
       :rights_statement_id => row[:id],
       :publish => 1,
       :notes_json_schema_version => 1,
-      :notes => JSON.generate({
+      :notes => blobify(self, JSON.generate({
                                   'jsonmodel_type' => 'note_rights_statement',
                                   'content' => [row[:restrictions]],
                                   'type' => 'additional_information',
                                   'label' => 'Restrictions',
                                   'persistent_id' => SecureRandom.hex
-                                }),
+                                })),
       :last_modified_by => row[:last_modified_by],
       :create_time => row[:create_time],
       :system_mtime => row[:system_mtime],
@@ -488,13 +488,13 @@ def migrate_granted_note_to_note
       :rights_statement_id => row[:id],
       :publish => 1,
       :notes_json_schema_version => 1,
-      :notes => JSON.generate({
+      :notes => blobify(self, JSON.generate({
                                   'jsonmodel_type' => 'note_rights_statement',
                                   'content' => [row[:granted_note]],
                                   'type' => 'additional_information',
                                   'label' => 'Granted Note',
                                   'persistent_id' => SecureRandom.hex
-                                }),
+                                })),
       :last_modified_by => row[:last_modified_by],
       :create_time => row[:create_time],
       :system_mtime => row[:system_mtime],
@@ -586,11 +586,11 @@ def migrate_agent_rights_statements
         agent_fk => row[agent_fk],
         :publish => 0,
         :notes_json_schema_version => 1,
-        :notes => JSON.generate({
+        :notes => blobify(self, JSON.generate({
                                     'jsonmodel_type' => 'note_agent_rights_statement',
                                     'content' => [note_content],
                                     'persistent_id' => SecureRandom.hex
-                                  }),
+                                  })),
         :last_modified_by => row[:last_modified_by],
         :create_time => row[:create_time],
         :system_mtime => row[:system_mtime],


### PR DESCRIPTION
Fixes this error `Java::JavaSql::SQLSyntaxErrorException: Columns of type 'BLOB' cannot hold values of type 'CHAR'` caused when creating notes in the rights migration.  This bug only affected derby databases.