### PR TITLE
AR-1826 clean up public search rows and allow the first row to use the NOT operator

### DIFF
--- a/public/app/assets/javascripts/search.js.erb
+++ b/public/app/assets/javascripts/search.js.erb
@@ -47,7 +47,16 @@ function initialize_search() {
     $template.find(".hidden").each(function() {$(this).removeClass("hidden"); });
     $template.find("#op0").removeProp("disabled"); /* the disabled boolean operator */
     $template.find("#op0").val('AND');
-    $template.find("#op_").remove(); 
+    $template.find("#op0 option").each(function() {
+        if (this.value == "") {
+            $(this).remove();
+        }
+    });
+    $first.find("#op0 option").each(function() {
+        if (this.value == 'OR' || this.value == 'AND') {
+            $(this).hide();
+        }
+    });
     $first.find("#q0").keypress(function (e) {
 	    var key = e.which;
 	    if (key == 13) {

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -455,7 +455,9 @@ h5 {
 .search_row * .form-control {
    margin-right: .3rem;
 }
-
+.search_row .fill-column {
+    width: 100%;
+}
 .searchterm, .keywordscontext li em {
   font-weight:bold;
   padding: 0 0.2em;
@@ -464,7 +466,9 @@ h5 {
 .searchterm {
   background-color: $highlight;
 }
-
+#submit_search {
+  width: 100%;
+}
 .searchstatement {
   background-color: $row-background;
 }

--- a/public/app/controllers/concerns/searchable.rb
+++ b/public/app/controllers/concerns/searchable.rb
@@ -350,7 +350,13 @@ module Searchable
     condition = " "
     @search[:q].each_with_index do |q,i|
       condition += '<li>'
-      condition += I18n.t("search_results.op.#{@search[:op][i]}").downcase unless i == 0
+      if i == 0
+        if !@search[:op][i].blank?
+          condition += I18n.t("search_results.op_first_row.#{@search[:op][i]}", :default => "").downcase
+        end
+      else
+        condition += I18n.t("search_results.op.#{@search[:op][i]}", :default => "").downcase
+      end
       f = @search[:field][i].blank? ? 'keyword' : @search[:field][i]
       condition += ' ' + I18n.t("search_results.#{f}_contain", :kw =>  CGI::escapeHTML((q == '*' ? I18n.t('search_results.anything') : q)) )
       unless @search[:from_year][i].blank? &&  @search[:to_year][i].blank?

--- a/public/app/controllers/search_controller.rb
+++ b/public/app/controllers/search_controller.rb
@@ -22,6 +22,7 @@ class SearchController < ApplicationController
       set_up_advanced_search(DEFAULT_TYPES, DEFAULT_SEARCH_FACET_TYPES, search_opts, params)
 #NOTE the redirect back here on error!
     rescue Exception => error
+      p error
       flash[:error] = I18n.t('search_results.error')
       redirect_back(fallback_location: root_path ) and return
     end

--- a/public/app/views/shared/_search.html.erb
+++ b/public/app/views/shared/_search.html.erb
@@ -10,19 +10,20 @@
   <% (0...[1, @search.q.length].max).each do |i| %>
   <div class="row search_row" id="search_row_<%= i %>">
     <div class="col-sm-1 bool form-group form-inline">
+      <% op_options = Search.get_boolean_opts %>
+      <% op_options = [''] + op_options if i == 0 %>
       <%= label_tag("op#{i}", t('advanced_search.operator_label'), :class => 'sr-only') %>
-      <%= select_tag('op[]', options_for_select(Search.get_boolean_opts), disabled: (i == 0), :id => "op#{i}",:class=> 'form-control' + (i == 0 ? ' hidden' : '')) %>
-      <%= hidden_field_tag('op[]','', :id => 'op_') if i == 0 %>
-      </div>
+      <%= select_tag('op[]', options_for_select(op_options, @search[:op][i]), :id => "op#{i}",:class=> 'form-control fill-column') %>
+    </div>
     <div class="col-sm-3 form-group form-inline">
       <%= label_tag(:"q#{i}", t('navbar.search_placeholder'),:class => 'sr-only repeats') %>
       <%= text_field_tag('q[]', @search[:q][i], :placeholder =>  t('navbar.search_placeholder'), :id => "q#{i}", 
-            :class=> 'form-control repeats') %>
+            :class=> 'form-control repeats fill-column') %>
     </div>
     <div class="col-sm-3 form-group form-inline norepeat">
       <% if i == 0 %>
       <%= label_tag(:limit, t('search-limit'),:class => 'sr-only') %>
-      <%= select_tag(:limit, options_for_select(limit_options, @search[:limit]), :class=> 'form-control') %>
+      <%= select_tag(:limit, options_for_select(limit_options, @search[:limit]), :class=> 'form-control fill-column') %>
       <% end %>
     </div>
     <div class="col-sm-5 form-group form-inline">
@@ -44,7 +45,9 @@
   </div>
   <% end %>
   <div class="row" id="submit_div">
-    <%= submit_tag(t('search-button.label'), :class=>'btn btn-primary', :id => 'submit_search') %>
+    <div class="col-sm-2">
+      <%= submit_tag(t('search-button.label'), :class=>'btn btn-primary', :id => 'submit_search') %>
+    </div>
   </div>
   <% end %>
 </div>

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -146,6 +146,8 @@ en:
       AND: and
       OR:  or
       NOT:  and not
+    op_first_row:
+      NOT: not
     filter:
       head: Filter Results
       add: Additional filters


### PR DESCRIPTION
So we now get something like this:
<img width="916" alt="screen shot 2017-06-21 at 11 54 15 am" src="https://user-images.githubusercontent.com/608337/27363520-6b95725c-5678-11e7-889d-f5c51e14bb5a.png">

And the first row only ever offers 'NOT' as an operator.