### PR TITLE
AR-1842 Fix issue where EAD export (and OAI) would bomb on top containers with profiles

### DIFF
--- a/backend/app/exporters/models/ead.rb
+++ b/backend/app/exporters/models/ead.rb
@@ -4,6 +4,8 @@ class EADModel < ASpaceExport::ExportModel
   include ASpaceExport::ArchivalObjectDescriptionHelpers
   include ASpaceExport::LazyChildEnumerations
 
+  RESOLVE = ['subjects', 'linked_agents', 'digital_object', 'top_container', 'top_container::container_profile']
+
   @data_src = Class.new do
     def initialize(json)
       @json = json
@@ -77,8 +79,6 @@ class EADModel < ASpaceExport::ExportModel
   @ao = Class.new do
     include ASpaceExport::ArchivalObjectDescriptionHelpers
     include ASpaceExport::LazyChildEnumerations
-
-    RESOLVE = ['subjects', 'linked_agents', 'digital_object', 'top_container', 'top_container::container_profile']
 
     def self.prefetch(tree_nodes, repo_id)
       RequestContext.open(:repo_id => repo_id) do

--- a/backend/app/exporters/models/ead.rb
+++ b/backend/app/exporters/models/ead.rb
@@ -78,14 +78,14 @@ class EADModel < ASpaceExport::ExportModel
     include ASpaceExport::ArchivalObjectDescriptionHelpers
     include ASpaceExport::LazyChildEnumerations
 
-    def self.prefetch(tree_nodes, repo_id)
-      resolve = ['subjects', 'linked_agents', 'digital_object', 'top_container']
+    RESOLVE = ['subjects', 'linked_agents', 'digital_object', 'top_container', 'top_container::container_profile']
 
+    def self.prefetch(tree_nodes, repo_id)
       RequestContext.open(:repo_id => repo_id) do
         # NOTE: We assume that the above `resolve` properties have also been
         # resolved by the indexer.
         IndexedArchivalObjectPrefetcher.new.fetch(tree_nodes.map {|tree| tree['id']},
-                                                  resolve)
+                                                  RESOLVE)
       end
     end
 
@@ -100,7 +100,7 @@ class EADModel < ASpaceExport::ExportModel
       @child_class = self.class
       @json = nil
       RequestContext.open(:repo_id => repo_id) do
-        rec = prefetched_rec || URIResolver.resolve_references(ArchivalObject.to_jsonmodel(tree['id']), ['subjects', 'linked_agents', 'digital_object', 'top_container'])
+        rec = prefetched_rec || URIResolver.resolve_references(ArchivalObject.to_jsonmodel(tree['id']), RESOLVE)
         @json = JSONModel::JSONModel(:archival_object).new(rec)
       end
     end

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -3,6 +3,9 @@ require 'nokogiri'
 require 'spec_helper'
 require_relative 'export_spec_helper'
 
+# Used to check that the fields EAD needs resolved are being resolved by the indexer.
+require_relative '../../indexer/app/lib/indexer_common_config'
+
 describe "EAD export mappings" do
 
   #######################################################################
@@ -225,6 +228,14 @@ describe "EAD export mappings" do
 
   let(:repo) { JSONModel(:repository).find($repo_id) }
 
+
+  describe "indexing prerequisites" do
+    it "resolves all required fields for the EAD model" do
+      missing_fields = (EADModel::RESOLVE - CommonIndexerConfig.resolved_attributes)
+
+      missing_fields.should eq([])
+    end
+  end
 
   # Examples used by resource and archival_objects
   shared_examples "archival object desc mappings" do

--- a/common/db/migrations/092_reindex_anything_with_instances.rb
+++ b/common/db/migrations/092_reindex_anything_with_instances.rb
@@ -1,0 +1,17 @@
+require_relative 'utils'
+
+Sequel.migration do
+
+  up do
+    now = Time.now
+    [:accession, :archival_object, :resource].each do |table|
+      self[table].update(:system_mtime => now)
+    end
+  end
+
+
+  down do
+  end
+
+end
+

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -12,60 +12,21 @@ require 'config/config-distribution'
 require 'record_inheritance'
 
 require_relative 'index_batch'
+require_relative 'indexer_common_config'
 
 
 class CommonIndexer
 
   include JSONModel
 
-  @@record_types = [:resource,
-                    :digital_object,
-                    :accession,
-                    :agent_person,
-                    :agent_software,
-                    :agent_family,
-                    :agent_corporate_entity,
-                    :subject,
-                    :location,
-                    :event,
-                    :top_container,
-                    :classification,
-                    :container_profile,
-                    :location_profile,
-                    :archival_object,
-                    :digital_object_component,
-                    :classification_term]
+  @@record_types = CommonIndexerConfig.record_types
 
-  @@global_types = [:agent_person, :agent_software, :agent_family, :agent_corporate_entity,
-                    :location, :subject]
+  @@global_types = CommonIndexerConfig.global_types
 
   @@records_with_children = []
   @@init_hooks = []
 
-  @@resolved_attributes = [
-    'location_profile',
-    'container_profile',
-    'container_locations',
-    'subjects',
-
-    # EAD export depends on this
-    'linked_agents',
-    'linked_records',
-    'classifications',
-
-    # EAD export depends on this
-    'digital_object',
-    'agent_representation',
-    'repository',
-    'repository::agent_representation',
-    'related_agents',
-
-    # EAD export depends on this
-    'top_container',
-
-    # EAD export depends on this
-    'top_container::container_profile'
-  ]
+  @@resolved_attributes = CommonIndexerConfig.resolved_attributes
 
   @@paused_until = Time.now
 

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -42,13 +42,30 @@ class CommonIndexer
   @@records_with_children = []
   @@init_hooks = []
 
-  @@resolved_attributes = ['location_profile', 'container_profile',
-                           'container_locations', 'subjects',
-                           'linked_agents', 'linked_records',
-                           'classifications', 'digital_object',
-                           'agent_representation', 'repository',
-                           'repository::agent_representation',
-                           'top_container', 'related_agents']
+  @@resolved_attributes = [
+    'location_profile',
+    'container_profile',
+    'container_locations',
+    'subjects',
+
+    # EAD export depends on this
+    'linked_agents',
+    'linked_records',
+    'classifications',
+
+    # EAD export depends on this
+    'digital_object',
+    'agent_representation',
+    'repository',
+    'repository::agent_representation',
+    'related_agents',
+
+    # EAD export depends on this
+    'top_container',
+
+    # EAD export depends on this
+    'top_container::container_profile'
+  ]
 
   @@paused_until = Time.now
 

--- a/indexer/app/lib/indexer_common_config.rb
+++ b/indexer/app/lib/indexer_common_config.rb
@@ -1,0 +1,63 @@
+class CommonIndexerConfig
+
+  def self.record_types
+    [
+      :resource,
+      :digital_object,
+      :accession,
+      :agent_person,
+      :agent_software,
+      :agent_family,
+      :agent_corporate_entity,
+      :subject,
+      :location,
+      :event,
+      :top_container,
+      :classification,
+      :container_profile,
+      :location_profile,
+      :archival_object,
+      :digital_object_component,
+      :classification_term
+    ]
+  end
+
+  def self.global_types
+    [
+      :agent_person,
+      :agent_software,
+      :agent_family,
+      :agent_corporate_entity,
+      :location,
+      :subject
+    ]
+  end
+
+  def self.resolved_attributes
+    [
+      'location_profile',
+      'container_profile',
+      'container_locations',
+      'subjects',
+
+      # EAD export depends on this
+      'linked_agents',
+      'linked_records',
+      'classifications',
+
+      # EAD export depends on this
+      'digital_object',
+      'agent_representation',
+      'repository',
+      'repository::agent_representation',
+      'related_agents',
+
+      # EAD export depends on this
+      'top_container',
+
+      # EAD export depends on this
+      'top_container::container_profile'
+    ]
+  end
+
+end


### PR DESCRIPTION
Hi @lmcglohon,

The fix here was pretty small: just needed to resolve container profiles in the indexer, so that the prefetched version (used by the EAD export) had the data it needed.

But I thought I'd address the more general problem of the EAD export implicitly depending on the indexer having resolved certain fields.  In that spirit, I've:

  * Pulled the list of EAD resolve fields into a constant

  * Pulled the indexer's list of resolved fields (and a few other lists) into a dedicated configuration class

  * Written a new unit test to check that all of the resolves required by EAD are satisfied by the indexer's configuration

Hopefully that will avoid bugs like this one in the future.

Cheers,
Mark