### PR TITLE
fix undefined method 'defaults_for' issue #879

### DIFF
--- a/backend/app/controllers/preferences.rb
+++ b/backend/app/controllers/preferences.rb
@@ -20,7 +20,7 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([])
     .returns([200, "(defaults)"]) \
   do
-    json_response(Preference.defaults_for(params[:repo_id], params[:username]))
+    json_response(Preference.parsed_defaults_for( :repo_id => params[:repo_id], :user_id => params[:username] ))
   end
 
 


### PR DESCRIPTION
Issue: https://github.com/archivesspace/archivesspace/issues/879

calls to GET /repositories/:repo_id/preferences/defaults in current master ( v2.1.0-RC ) return "error":"undefined method `defaults_for' for Preference:Class\nDid you mean? defaults"

