### PR TITLE
more fixes to EAD export/import: map file_versions.captions <-> (dao|daoloc)/@xlink:title  (issue #879)

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -866,7 +866,8 @@ class EADConverter < Converter
           :file_uri => att('href'),
           :xlink_actuate_attribute => att('actuate'),
           :xlink_show_attribute => att('show'),
-          :publish => att('audience') != 'internal'
+          :publish => att('audience') != 'internal',
+          :caption => att( 'title' )
         }
         set ancestor(:instance), :digital_object, obj
       end
@@ -932,6 +933,7 @@ class EADConverter < Converter
            fv_attrs[:file_uri] = daoloc['xlink:href'] if daoloc['xlink:href']
            fv_attrs[:use_statement] = daoloc['xlink:role'] if daoloc['xlink:role']
            fv_attrs[:publish] = daoloc['audience'] != 'internal'
+           fv_attrs[:caption] = daoloc['xlink:title'] if daoloc['xlink:title']
 
            obj.file_versions << fv_attrs
          end

--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -892,7 +892,7 @@ class EADConverter < Converter
         title = ''
         ancestor(:resource, :archival_object ) { |ao|
           display_string = ArchivalObject.produce_display_string(ao)
-
+          display_string = Nokogiri::XML::DocumentFragment.parse(display_string).inner_text
           title << display_string + ' Digital Object'
         }
       end

--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -503,6 +503,7 @@ class EADSerializer < ASpaceExport::Serializer
           atts['xlink:type'] = 'locator'
           atts['xlink:href'] = file_version['file_uri'] || digital_object['digital_object_id']
           atts['xlink:role'] = file_version['use_statement'] if file_version['use_statement']
+          atts['xlink:title'] = file_version['caption'] if file_version['caption']
           xml.daoloc(atts)
         end
       }


### PR DESCRIPTION
Issue https://github.com/archivesspace/archivesspace/issues/897

Titles were getting lost on roundtripping EAD import/export. 
Added mapping of  file_versions.captions  <-to/from-> (dao|daoloc)/@xlink:title. 

Also another minor change: when digital object titles are inherited from archival object display_strings, strip out the markup. Before this we were getting lots of letters titled  <persname ... /> to <persname ... /> 