### PR TITLE
AR-1853 Reintroduce strip mixed content on facets

### DIFF
--- a/public/app/controllers/concerns/handle_faceting.rb
+++ b/public/app/controllers/concerns/handle_faceting.rb
@@ -31,13 +31,7 @@ module HandleFaceting
   end
    # bury the mess! 
   def get_pretty_facet_value(k, v)
-#    Rails.logger.debug("input v: #{v}")
-
-    # Note: Previously we would strip mixed content here, but the performance
-    # impact of doing this for every facet value was too great.
-    #
-    # pv = strip_mixed_content(v)
-    pv = v
+    pv = strip_mixed_content(v)
     if k == 'primary_type'
       pv = I18n.t("#{v}._singular")
     elsif %w(repository used_within_published_repository).include?(k)


### PR DESCRIPTION
Added this note to the JIRA issue:

> This got changed when trying to address overall search performance, since firing up an XML parser for every facet made things slow.

> I've put the XML parsing back in, and hopefully the other improvements we made to avoid doing a parse unless absolutely necessary will avoid too much of a slowdown. We'll have to keep an eye on it, though.