### PR TITLE
Update the luceneMatchVersion to match with version of Solr

### DIFF
--- a/solr/solrconfig.xml
+++ b/solr/solrconfig.xml
@@ -8,7 +8,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>LUCENE_40</luceneMatchVersion>
+  <luceneMatchVersion>4.10.4</luceneMatchVersion>
 
   
   <!-- Data Directory


### PR DESCRIPTION
Solr was updated to 4.10.4 awhile but the solrconfig kept the luceneVersion to the
4.0. This is very suboptimal both in terms of perfomrance and amount of
disk space used.

During upgrade, it is important that the old index is deleted and
rebuilt from scratch.