### PR TITLE
Undo Suppress useless already set config messages because is causes

### DIFF
--- a/common/config/config-distribution.rb
+++ b/common/config/config-distribution.rb
@@ -96,7 +96,7 @@ class AppConfig
       # Explicit Java property
       java.lang.System.getProperty("aspace.config")
     elsif ENV['ASPACE_CONFIG'] && File.exist?(ENV['ASPACE_CONFIG'])
-      # Setting a system config 
+      # Setting a system config
       ENV['ASPACE_CONFIG']
     elsif ENV['ASPACE_LAUNCHER_BASE'] && File.exist?(File.join(ENV['ASPACE_LAUNCHER_BASE'], "config", "config.rb"))
       File.join(ENV['ASPACE_LAUNCHER_BASE'], "config", "config.rb")
@@ -135,23 +135,12 @@ class AppConfig
   def self.load_user_config
     config = find_user_config
 
-    if config && user_config_changed?(config)
+    if config
       puts "Loading ArchivesSpace configuration file from path: #{config}"
       load config
-
-      @user_config_mtime = File.mtime(config)
     end
 
     self.load_overrides_from_properties
-  end
-
-
-  def self.user_config_changed?(file)
-    if @user_config_mtime && File.mtime(file) == @user_config_mtime
-      return false
-    else
-      return true
-    end
   end
 
   def self.demo_db_url
@@ -171,7 +160,6 @@ class AppConfig
 
   def self.reload
     @@parameters = {}
-    @@changed_from_default = {}
 
     require_relative 'config-aliases'
 


### PR DESCRIPTION
the local configuration file to be ignored