### PR TITLE
Change inheritance defaults based upon request from Mark Custer and Christine di Bella

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -275,12 +275,12 @@ AppConfig[:max_location_range] = 1000
 # ASpace backend will not start if the db's schema_info version is not set
 # correctly for this version of ASPACE. This is to ensure that all the
 # migrations have run and completed before starting the app. You can override
-# this check here. Do so at your own peril. 
+# this check here. Do so at your own peril.
 AppConfig[:ignore_schema_info_check] = false
 
 # This is a URL that points to some demo data that can be used for testing,
 # teaching, etc. To use this, set an OS environment variable of ASPACE_DEMO = true
-AppConfig[:demo_data_url] = "https://s3-us-west-2.amazonaws.com/archivesspacedemo/latest-demo-data.zip" 
+AppConfig[:demo_data_url] = "https://s3-us-west-2.amazonaws.com/archivesspacedemo/latest-demo-data.zip"
 
 # Expose external ids in the frontend
 AppConfig[:show_external_ids] = false
@@ -289,9 +289,9 @@ AppConfig[:show_external_ids] = false
 # This sets the allowed size of the request/response header that Jetty will accept (
 # anything bigger gets a 403 error ). Note if you want to jack this size up,
 # you will also have to configure your Nginx/Apache  as well if
-# you're using that 
-AppConfig[:jetty_response_buffer_size_bytes] = 64 * 1024 
-AppConfig[:jetty_request_buffer_size_bytes] = 64 * 1024 
+# you're using that
+AppConfig[:jetty_response_buffer_size_bytes] = 64 * 1024
+AppConfig[:jetty_request_buffer_size_bytes] = 64 * 1024
 
 # Define the fields for a record type that are inherited from ancestors
 # if they don't have a value in the record itself.
@@ -320,7 +320,7 @@ AppConfig[:record_inheritance] = {
                           },
                           {
                             :property => 'extents',
-                            :inherit_directly => true
+                            :inherit_directly => false
                           },
                           {
                             :property => 'linked_agents',
@@ -335,6 +335,11 @@ AppConfig[:record_inheritance] = {
                           {
                             :property => 'notes',
                             :inherit_if => proc {|json| json.select {|j| j['type'] == 'scopecontent'} },
+                            :inherit_directly => false
+                          },
+                          {
+                            :property => 'notes',
+                            :inherit_if => proc {|json| json.select {|j| j['type'] == 'langmaterial'} },
                             :inherit_directly => false
                           },
                          ]
@@ -457,7 +462,7 @@ AppConfig[:pui_page_actions_print] = true
 # Add page actions via the configuration
 AppConfig[:pui_page_custom_actions] = []
 # Examples:
-# Javascript action example: 
+# Javascript action example:
 # AppConfig[:pui_page_custom_actions] << {
 #   'record_type' => ['resource', 'archival_object'], # the jsonmodel type to show for
 #   'label' => 'actions.do_something', # the I18n path for the action button
@@ -501,7 +506,7 @@ AppConfig[:pui_email_enabled] = false
 # 'pui_request_email_fallback_from_address' the 'from' email address for repositories that don't define their own email
 #AppConfig[:pui_request_email_fallback_from_address] = 'testing@example.com'
 
-# Example sendmail configuration: 
+# Example sendmail configuration:
 # AppConfig[:pui_email_delivery_method] = :sendmail
 # AppConfig[:pui_email_sendmail_settings] = {
 #   location: '/usr/sbin/sendmail',


### PR DESCRIPTION
1. Extent should be inherited indirectly, not directly
2. “Language of Materials” section is populated from the “langmaterial” note which doesn’t have any inheritance config by default so it needs one.