### PR TITLE
Add launcher_rc.rb to the zip file if it exists when a build is created

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -754,6 +754,7 @@
       <zipfileset dir=".." includes="README.md" prefix="archivesspace" filemode="644" />
       <zipfileset dir=".." includes="UPGRADING.md" prefix="archivesspace" filemode="644" />
       <zipfileset dir=".." includes="COPYING" prefix="archivesspace" filemode="644" />
+      <zipfileset dir=".." includes="launcher_rc.rb" prefix="archivesspace" filemode="644" />
       <zipfileset dir="../clustering" prefix="archivesspace/clustering" filemode="755" />
       <zipfileset dir="../reports" prefix="archivesspace/reports" filemode="755" />
       <zipfileset dir="../launcher" includes="archivesspace.sh" prefix="archivesspace" filemode="755" />


### PR DESCRIPTION
Fixes #440.