### PR TITLE
ANW-129 display the instance type for both digital object and container instances in the tree view

### DIFF
--- a/backend/app/model/large_tree_resource.rb
+++ b/backend/app/model/large_tree_resource.rb
@@ -5,9 +5,9 @@ class LargeTreeResource
 
     # Collect all container data
     Instance
-      .join(:sub_container, :sub_container__instance_id => :instance__id)
-      .join(:top_container_link_rlshp, :sub_container_id => :sub_container__id)
-      .join(:top_container, :id => :top_container_link_rlshp__top_container_id)
+      .left_join(:sub_container, :sub_container__instance_id => :instance__id)
+      .left_join(:top_container_link_rlshp, :sub_container_id => :sub_container__id)
+      .left_join(:top_container, :id => :top_container_link_rlshp__top_container_id)
       .left_join(Sequel.as(:enumeration_value, :top_container_type), :id => :top_container__type_id)
       .left_join(Sequel.as(:enumeration_value, :type_2), :id => :sub_container__type_2_id)
       .left_join(Sequel.as(:enumeration_value, :type_3), :id => :sub_container__type_3_id)
@@ -88,9 +88,9 @@ class LargeTreeResource
 
     # Display container information
     Instance
-      .join(:sub_container, :sub_container__instance_id => :instance__id)
-      .join(:top_container_link_rlshp, :sub_container_id => :sub_container__id)
-      .join(:top_container, :id => :top_container_link_rlshp__top_container_id)
+      .left_join(:sub_container, :sub_container__instance_id => :instance__id)
+      .left_join(:top_container_link_rlshp, :sub_container_id => :sub_container__id)
+      .left_join(:top_container, :id => :top_container_link_rlshp__top_container_id)
       .left_join(Sequel.as(:enumeration_value, :top_container_type), :id => :top_container__type_id)
       .left_join(Sequel.as(:enumeration_value, :type_2), :id => :sub_container__type_2_id)
       .left_join(Sequel.as(:enumeration_value, :type_3), :id => :sub_container__type_3_id)

--- a/frontend/app/assets/javascripts/tree_renderers.js.erb
+++ b/frontend/app/assets/javascripts/tree_renderers.js.erb
@@ -151,7 +151,9 @@ ResourceRenderer.prototype.build_container_summary = function(node) {
             if (container.type_3) {
                 summary_items.push(self.i18n('container_type', container.type_3) + ': ' + container.indicator_3);
             }
-            container_summaries.push(summary_items.join(', '));
+            if (summary_items.length > 0) {
+                container_summaries.push(summary_items.join(', '));
+            }
         });
 
         container_summary = container_summaries.join('; ');


### PR DESCRIPTION
As per pre-v2.0.0, this change adds the digital object instance type to a column in the resource record's tree view.  Here's the logic from v1.4.2: https://github.com/archivesspace/archivesspace/blob/v1.4.2/frontend/app/views/shared/_tree.html.erb#L124

Delivers https://archivesspace.atlassian.net/browse/ANW-129