### PR TITLE
ANW-85 include the public url of the record in an identifier tag

### DIFF
--- a/backend/app/lib/oai/mappers/oai_dcterms.rb
+++ b/backend/app/lib/oai/mappers/oai_dcterms.rb
@@ -29,6 +29,11 @@ class OAIDCTermsMapper
           xml['dcterms'].identifier(merged_identifier)
         end
 
+        # And a second identifier containing the public url - if public is running
+        if AppConfig[:enable_public]
+          xml['dcterms'].identifier(AppConfig[:public_proxy_url] + jsonmodel['uri'])
+        end
+
         # Creator -- agents linked with role 'creator' that don't have a relator of 'contributor' or 'publisher'
         Array(jsonmodel['linked_agents']).each do |link|
           next unless link['_resolved']['publish']


### PR DESCRIPTION
if public is running for oai dcterms