### PR TITLE
.[@label] should be changed to @label because Saxon 9.7 at least throws an error

### DIFF
--- a/stylesheets/as-ead-html.xsl
+++ b/stylesheets/as-ead-html.xsl
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet
     xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-    xmlns:xlink="http://www.w3.org/1999/xlink" 
-    xmlns:ns2="http://www.w3.org/1999/xlink" 
-    xmlns:local="http://www.yoursite.org/namespace" 
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:ns2="http://www.w3.org/1999/xlink"
+    xmlns:local="http://www.yoursite.org/namespace"
     xmlns:ead="urn:isbn:1-931666-22-9" version="2.0"  exclude-result-prefixes="#all">
     <!--
         *******************************************************************
@@ -22,17 +22,17 @@
         *                                                                 *
         *******************************************************************
     -->
-    <xsl:output indent="yes" method="xml" 
-        doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"  
+    <xsl:output indent="yes" method="xml"
+        doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"
         doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"
         exclude-result-prefixes="#all"
         omit-xml-declaration="yes"
         encoding="utf-8"/>
-    
+
     <xsl:strip-space elements="*"/>
     <!-- Calls a stylesheet with local functions and lists for languages and subject authorities -->
-    <xsl:include href="as-helper-functions.xsl"/>   
-    
+    <xsl:include href="as-helper-functions.xsl"/>
+
     <!-- HTML metadata tags -->
     <xsl:template name="metadata">
         <meta http-equiv="Content-Type" name="dc.title" content="{/ead:ead/ead:eadheader/ead:filedesc/ead:titlestmt/ead:titleproper}"/>
@@ -44,7 +44,7 @@
         <meta http-equiv="Content-Type" name="dc.format" content="manuscripts" />
         <meta http-equiv="Content-Type" name="dc.format" content="finding aids" />
     </xsl:template>
-    
+
     <!-- CSS styles -->
     <xsl:template name="css">
         <style type="text/css">
@@ -59,7 +59,7 @@
             */
             html {
                 margin: 0;
-                padding: 0; 
+                padding: 0;
             }
             body{
                 color: #333;
@@ -67,7 +67,7 @@
                 font-family: Verdana, Arial, Helvetica, sans-serif;
                 background-color: #f0f0f0;
            }
-            
+
             /* layout */
             #main {
                 font-size: .87em;
@@ -79,7 +79,7 @@
             }
             /* header*/
             #header {margin-left:1em;}
-            
+
             /*Fixed position table of contents*/
             #toc {
                 margin: 0;
@@ -91,15 +91,15 @@
                 position:fixed;
                 max-height: 600px;
                 overflow:scroll;
-                
+
             }
             #toc ul {
                 background-color: #ffffff;
                 border:1px solid #e1e1e8;
-                margin:0; 
-                padding:0; 
-            }   
-            #toc li { 
+                margin:0;
+                padding:0;
+            }
+            #toc li {
                 list-style: none;
                 border-bottom: 1px solid #e1e1e8;
                 overflow:hidden;
@@ -109,13 +109,13 @@
                 color:#14a6dc;
                 display:block;
                 /*height:25px;*/
-                line-height: 2em;                   
+                line-height: 2em;
                 text-decoration:none;
             }
             #toc ul li a:hover, #toc ul li .current {background:#f9f9f9;}
             #toc li.submenu {margin-left: 1.75em;}
             #toc li.submenu2 {margin-left: 2.5em;}
-            
+
             /* Main content div*/
             #content {
                 border:1px solid #e1e1e8;
@@ -123,7 +123,7 @@
                 margin: 1em 0 0 25%;
                 padding: 0;
             }
-            
+
             .section {
                 background-color: #fafafa;
                 border:1px solid #e1e1e8;
@@ -136,7 +136,7 @@
                 margin:.5em;
                 padding:.25em .5em;
             }
-            
+
             dl.summary {
                 width:100%;
                 overflow:hidden;
@@ -144,7 +144,7 @@
             }
             dl.summary dt {
                 float:left;
-                width:25%; 
+                width:25%;
                 text-align:right;
                 clear:left;
             }
@@ -153,7 +153,7 @@
                 width:70%;
                 clear:right;
             }
-            
+
             /* typography */
             #header h1 {
                 font-size: 1.75em;
@@ -161,8 +161,8 @@
                 padding-bottom:0;
             }
             #header h2 {
-                background-color:#ffffff; 
-                margin:0; 
+                background-color:#ffffff;
+                margin:0;
                 padding:0;
                 border:none;
             }
@@ -187,19 +187,19 @@
                 color:#666666;
                 margin: 0;
             }
-            
+
             dt {}
             dd {margin-bottom:1em;}
             .block {display:block;}
             .list {margin:.5em; padding-left:.5em;}
-            
+
             /* Table styles */
             table {width: 98%; margin:1em 2em; background-color:#f0f0f0;}
             td {background-color:#ffffff; padding:.25em .75em; vertical-align:top;}
             .thead td {background-color:#f0f0f0;}
             .tlist {width: 50%;}
             .even td{background-color:#f7f7f9;}
-            
+
             /* List styles */
             .simple{list-style-type: none;}
             .arabic {list-style-type: decimal}
@@ -207,18 +207,18 @@
             .loweralpha{list-style-type: lower-alpha}
             .upperroman{list-style-type: upper-roman}
             .lowerroman{list-style-type: lower-roman}
-            
+
             /* Render styles */
             .smcaps {font-variant: small-caps;}
             .underline {text-decoration: underline;}
             .strong {font-weight: 600;}
-            
+
             /* Address line */
             .addressLine {display:block;}
-            
+
             /* publication statement*/
             .publication {display:block; float: right; margin-right:2em; font-size:.75em;}
-            
+
             /* Collection Inventory */
             table.dsc {text-align:left; margin:.5em; padding:0; font-size: .85em;}
             .dsc th {text-align:left; padding:.5em; font-weight:normal;  border-top: 2px solid #ccc; border-bottom:1px dotted #ccc; vertical-align:top;}
@@ -231,11 +231,11 @@
             .dscSeries p {margin: 0 .5em .5em;}
             table.dsc td p {margin: 0 .5em .5em}
             .dscHeaders {text-decoration: underline;}
-            
+
             /*--- Clevel Margins ---*/
             table td.c{padding-left: 0;}
             table td.c01{padding-left: 0;}
-            table td.c02{padding-left: 1em;}                
+            table td.c02{padding-left: 1em;}
             table td.c03{padding-left: 2em;}
             table td.c04{padding-left: 3em;}
             table td.c05{padding-left: 4em;}
@@ -248,12 +248,12 @@
             table td.c12{padding-left: 11em;}
         </style>
     </xsl:template>
-    
+
     <!-- Named template for a generic p element with a link back to the the top of the page  -->
     <xsl:template name="top">
         <p class="top"><a href="#main"><strong>^</strong> Top</a></p>
     </xsl:template>
-    
+
     <!-- Build html page -->
     <xsl:template match="/">
         <html xmlns="http://www.w3.org/1999/xhtml">
@@ -272,7 +272,7 @@
             </body>
         </html>
     </xsl:template>
-    
+
     <!-- Build table of contents -->
     <xsl:template match="ead:archdesc" mode="toc">
         <div id="toc">
@@ -281,63 +281,63 @@
                     <li><a href="#{local:buildID(ead:did)}"><xsl:value-of select="local:tagName(ead:did)"/></a></li>
                 </xsl:if>
                 <xsl:if test="ead:bioghist">
-                    <li><a href="#{local:buildID(ead:bioghist[1])}"><xsl:value-of select="local:tagName(ead:bioghist[1])"/></a></li>   
+                    <li><a href="#{local:buildID(ead:bioghist[1])}"><xsl:value-of select="local:tagName(ead:bioghist[1])"/></a></li>
                 </xsl:if>
                 <xsl:if test="ead:scopecontent">
-                    <li><a href="#{local:buildID(ead:scopecontent[1])}"><xsl:value-of select="local:tagName(ead:scopecontent[1])"/></a></li>  
+                    <li><a href="#{local:buildID(ead:scopecontent[1])}"><xsl:value-of select="local:tagName(ead:scopecontent[1])"/></a></li>
                 </xsl:if>
                 <xsl:if test="ead:arrangement">
-                    <li><a href="#{local:buildID(ead:arrangement[1])}"><xsl:value-of select="local:tagName(ead:arrangement[1])"/></a></li>  
+                    <li><a href="#{local:buildID(ead:arrangement[1])}"><xsl:value-of select="local:tagName(ead:arrangement[1])"/></a></li>
                 </xsl:if>
                 <xsl:if test="ead:fileplan">
-                    <li><a href="#{local:buildID(ead:fileplan[1])}"><xsl:value-of select="local:tagName(ead:fileplan[1])"/></a></li>   
+                    <li><a href="#{local:buildID(ead:fileplan[1])}"><xsl:value-of select="local:tagName(ead:fileplan[1])"/></a></li>
                 </xsl:if>
-                
+
                 <!-- Administrative Information  -->
                 <xsl:if test="ead:accessrestrict or ead:userestrict or
-                    ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or 
-                    ead:processinfo or ead:appraisal or ead:originalsloc or 
+                    ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or
+                    ead:processinfo or ead:appraisal or ead:originalsloc or
                     /ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt or /ead:ead/ead:eadheader/ead:revisiondesc">
                     <li><a href="#adminInfo">Administrative Information</a></li>
                 </xsl:if>
-                
+
                 <!-- Related Materials -->
                 <xsl:if test="ead:relatedmaterial or ead:separatedmaterial">
                     <li><a href="#relMat">Related Materials</a></li>
                 </xsl:if>
-                
+
                 <xsl:if test="ead:controlaccess">
-                    <li><a href="#{local:buildID(ead:controlaccess[1])}"><xsl:value-of select="local:tagName(ead:controlaccess[1])"/></a></li>   
+                    <li><a href="#{local:buildID(ead:controlaccess[1])}"><xsl:value-of select="local:tagName(ead:controlaccess[1])"/></a></li>
                 </xsl:if>
                 <xsl:if test="ead:otherfindaid">
-                    <li><a href="#{local:buildID(ead:otherfindaid[1])}"><xsl:value-of select="local:tagName(ead:otherfindaid[1])"/></a></li>   
+                    <li><a href="#{local:buildID(ead:otherfindaid[1])}"><xsl:value-of select="local:tagName(ead:otherfindaid[1])"/></a></li>
                 </xsl:if>
                 <xsl:if test="ead:phystech">
-                    <li><a href="#{local:buildID(ead:phystech[1])}"><xsl:value-of select="local:tagName(ead:phystech[1])"/></a></li>   
+                    <li><a href="#{local:buildID(ead:phystech[1])}"><xsl:value-of select="local:tagName(ead:phystech[1])"/></a></li>
                 </xsl:if>
                 <xsl:if test="ead:odd">
-                    <li><a href="#{local:buildID(ead:odd[1])}"><xsl:value-of select="local:tagName(ead:odd[1])"/></a></li>   
+                    <li><a href="#{local:buildID(ead:odd[1])}"><xsl:value-of select="local:tagName(ead:odd[1])"/></a></li>
                 </xsl:if>
                 <xsl:if test="ead:bibliography">
-                    <li><a href="#{local:buildID(ead:bibliography[1])}"><xsl:value-of select="local:tagName(ead:bibliography[1])"/></a></li>   
+                    <li><a href="#{local:buildID(ead:bibliography[1])}"><xsl:value-of select="local:tagName(ead:bibliography[1])"/></a></li>
                 </xsl:if>
                 <xsl:if test="ead:index">
-                    <li><a href="#{local:buildID(ead:index[1])}"><xsl:value-of select="local:tagName(ead:index[1])"/></a></li>   
-                </xsl:if> 
-               
+                    <li><a href="#{local:buildID(ead:index[1])}"><xsl:value-of select="local:tagName(ead:index[1])"/></a></li>
+                </xsl:if>
+
                <!-- Build Container List menu and submenu -->
                 <xsl:for-each select="ead:dsc">
                     <xsl:if test="child::*">
-                        <li><a href="#{local:buildID(.)}"><xsl:value-of select="local:tagName(.)"/></a></li>                   
+                        <li><a href="#{local:buildID(.)}"><xsl:value-of select="local:tagName(.)"/></a></li>
                     </xsl:if>
                     <!--Creates a submenu for collections, record groups and series and fonds-->
-                    <xsl:for-each select="child::*[@level = 'collection'] 
+                    <xsl:for-each select="child::*[@level = 'collection']
                         | child::*[@level = 'recordgrp']  | child::*[@level = 'series'] | child::*[@level = 'fonds']">
                         <li class="submenu">
                             <a href="#{local:buildID(.)}">
                                 <xsl:choose>
                                     <xsl:when test="ead:head">
-                                        <xsl:apply-templates select="child::*/ead:head"/>        
+                                        <xsl:apply-templates select="child::*/ead:head"/>
                                     </xsl:when>
                                     <xsl:otherwise>
                                         <xsl:apply-templates select="child::*/ead:unittitle"/>
@@ -345,13 +345,13 @@
                                 </xsl:choose>
                             </a>
                         </li>
-                        <!-- Creates a submenu for subfonds, subgrp or subseries -->    
+                        <!-- Creates a submenu for subfonds, subgrp or subseries -->
                         <xsl:for-each select="child::*[@level = 'subfonds'] | child::*[@level = 'subgrp']  | child::*[@level = 'subseries']">
                             <li class="submenu2">
                                 <a href="#{local:buildID(.)}">
                                     <xsl:choose>
                                         <xsl:when test="ead:head">
-                                            <xsl:apply-templates select="child::*/ead:head"/>        
+                                            <xsl:apply-templates select="child::*/ead:head"/>
                                         </xsl:when>
                                         <xsl:otherwise>
                                             <xsl:apply-templates select="child::*/ead:unittitle"/>
@@ -365,13 +365,13 @@
             </ul>
         </div>
     </xsl:template>
-    
-    <!-- 
-        Formats children of archdesc. This template orders the children of the archdesc, 
+
+    <!--
+        Formats children of archdesc. This template orders the children of the archdesc,
         if order is changed, remeber to also change it in the table of contents as well.
     -->
     <!-- Calls and organizes children of the archdesc -->
-    <xsl:template match="ead:archdesc">  
+    <xsl:template match="ead:archdesc">
         <div id="content">
             <xsl:apply-templates select="/ead:ead/ead:eadheader/ead:filedesc/ead:titlestmt"/>
             <xsl:apply-templates select="ead:did"/>
@@ -379,22 +379,22 @@
             <xsl:apply-templates select="ead:scopecontent"/>
             <xsl:apply-templates select="ead:arrangement"/>
             <xsl:apply-templates select="ead:fileplan"/>
-            
+
             <!-- Administrative Information  -->
             <xsl:if test="ead:accessrestrict or ead:userestrict or
-                ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or 
-                ead:processinfo or ead:appraisal or ead:originalsloc or 
+                ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or
+                ead:processinfo or ead:appraisal or ead:originalsloc or
                 /ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt or /ead:ead/ead:eadheader/ead:revisiondesc">
                 <div class="section">
                     <h2 id="adminInfo">Administrative Information</h2>
                     <xsl:apply-templates select="ead:accessrestrict | ead:userestrict |
-                        ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |  
-                        ead:processinfo | ead:appraisal | ead:originalsloc | 
+                        ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |
+                        ead:processinfo | ead:appraisal | ead:originalsloc |
                         /ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt | /ead:ead/ead:eadheader/ead:revisiondesc"/>
                     <xsl:call-template name="top"/>
                 </div>
             </xsl:if>
-            
+
             <!-- Related Materials -->
             <xsl:if test="ead:relatedmaterial or ead:separatedmaterial">
                 <div class="section">
@@ -403,18 +403,18 @@
                     <xsl:call-template name="top"/>
                 </div>
             </xsl:if>
-            
+
             <xsl:apply-templates select="ead:controlaccess"/>
             <xsl:apply-templates select="ead:otherfindaid"/>
             <xsl:apply-templates select="ead:phystech"/>
             <xsl:apply-templates select="ead:odd"/>
             <xsl:apply-templates select="ead:bibliography"/>
             <xsl:apply-templates select="ead:index"/>
-            <xsl:apply-templates select="ead:dsc"/>        
-            
+            <xsl:apply-templates select="ead:dsc"/>
+
         </div>
     </xsl:template>
-    
+
     <!-- Finding aid title -->
     <xsl:template match="ead:titlestmt">
         <div id="header">
@@ -430,34 +430,34 @@
             </h1>
             <xsl:if test="ead:subtitle">
                 <h2><xsl:apply-templates select="ead:subtitle"/></h2>
-            </xsl:if>            
+            </xsl:if>
         </div>
     </xsl:template>
-    
+
     <!-- Formats archdesc did -->
     <xsl:template match="ead:archdesc/ead:did">
         <div class="section">
             <h2 id="{local:buildID(.)}">Summary Information</h2>
             <div class="sectionContent">
-                <!-- 
-                    Determines the order in wich elements from the archdesc did appear, 
+                <!--
+                    Determines the order in wich elements from the archdesc did appear,
                     to change the order of appearance for the children of did
                     by changing the order of the following statements.
                 -->
                 <dl class="summary">
                     <xsl:apply-templates select="ead:repository" mode="overview"/>
                     <xsl:apply-templates select="ead:origination" mode="overview"/>
-                    <xsl:apply-templates select="ead:unittitle" mode="overview"/>    
+                    <xsl:apply-templates select="ead:unittitle" mode="overview"/>
                     <xsl:apply-templates select="ead:unitid" mode="overview"/>
                     <xsl:apply-templates select="ead:unitdate" mode="overview"/>
-                    <xsl:apply-templates select="ead:physdesc" mode="overview"/>        
-                    <xsl:apply-templates select="ead:physloc" mode="overview"/> 
+                    <xsl:apply-templates select="ead:physdesc" mode="overview"/>
+                    <xsl:apply-templates select="ead:physloc" mode="overview"/>
                     <xsl:apply-templates select="ead:dao" mode="overview"/>
                     <xsl:apply-templates select="ead:daogrp" mode="overview"/>
                     <xsl:apply-templates select="ead:langmaterial" mode="overview"/>
                     <xsl:apply-templates select="ead:materialspec" mode="overview"/>
                     <xsl:apply-templates select="ead:container" mode="overview"/>
-                    <xsl:apply-templates select="ead:abstract" mode="overview"/> 
+                    <xsl:apply-templates select="ead:abstract" mode="overview"/>
                     <xsl:apply-templates select="ead:note" mode="overview"/>
                 </dl>
                 <xsl:apply-templates select="../ead:prefercite" mode="overview"/>
@@ -465,7 +465,7 @@
             <xsl:call-template name="top"/>
         </div>
     </xsl:template>
-    
+
     <!-- Formats prefercite in the summary -->
     <xsl:template match="ead:prefercite" mode="overview">
         <div class="citation">
@@ -475,12 +475,12 @@
                 <xsl:apply-templates/>
                 </div>
             </div>
-        </div>    
+        </div>
     </xsl:template>
-    
+
     <!-- Formats children of arcdesc/did -->
-    <xsl:template match="ead:repository | ead:origination | ead:unittitle | ead:unitdate | ead:unitid  
-        | ead:physdesc | ead:physloc | ead:dao | ead:daogrp | ead:langmaterial | ead:materialspec | ead:container 
+    <xsl:template match="ead:repository | ead:origination | ead:unittitle | ead:unitdate | ead:unitid
+        | ead:physdesc | ead:physloc | ead:dao | ead:daogrp | ead:langmaterial | ead:materialspec | ead:container
         | ead:abstract | ead:note" mode="overview">
         <dt>
             <xsl:choose>
@@ -494,7 +494,7 @@
                                 - <xsl:value-of select="substring-before(ead:persname/@role,' (')"/>
                             </xsl:when>
                             <xsl:when test="ead:persname[@role != '']">
-                                - <xsl:value-of select="ead:persname/@role"/>  
+                                - <xsl:value-of select="ead:persname/@role"/>
                             </xsl:when>
                             <xsl:otherwise/>
                         </xsl:choose>
@@ -505,15 +505,15 @@
                     <!-- Test for type attribute used by unitdate -->
                     <xsl:if test="@type"> [<xsl:value-of select="@type"/>]</xsl:if>
                 </xsl:otherwise>
-            </xsl:choose>: 
+            </xsl:choose>:
         </dt>
         <dd><xsl:apply-templates/></dd>
     </xsl:template>
     <!-- Adds space between extents -->
-    <xsl:template match="ead:extent"><xsl:apply-templates/><xsl:text> </xsl:text></xsl:template>  
-    
+    <xsl:template match="ead:extent"><xsl:apply-templates/><xsl:text> </xsl:text></xsl:template>
+
     <!-- Formats children of arcdesc -->
-    <xsl:template match="ead:bibliography | ead:odd | ead:phystech | ead:otherfindaid | 
+    <xsl:template match="ead:bibliography | ead:odd | ead:phystech | ead:otherfindaid |
         ead:bioghist | ead:scopecontent | ead:arrangement | ead:fileplan">
         <div class="section">
             <h2 id="{local:buildID(.)}"><xsl:value-of select="local:tagName(.)"/></h2>
@@ -526,7 +526,7 @@
 
     <!-- Formats children of arcdesc in administrative and related materials sections -->
     <xsl:template match="ead:relatedmaterial | ead:separatedmaterial | ead:accessrestrict | ead:userestrict |
-        ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |  
+        ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |
         ead:processinfo | ead:appraisal | ead:originalsloc">
         <div class="section">
             <h3 id="{local:buildID(.)}"><xsl:value-of select="local:tagName(.)"/></h3>
@@ -535,7 +535,7 @@
             </div>
         </div>
     </xsl:template>
-    
+
     <!-- Publication statement included in administrative information section -->
     <xsl:template match="ead:publicationstmt">
         <div class="section">
@@ -543,12 +543,12 @@
             <div class="sectionContent">
                 <p><xsl:apply-templates select="ead:publisher"/>
                     <xsl:if test="ead:date"><xsl:text> </xsl:text><xsl:apply-templates select="ead:date"/></xsl:if>
-                </p>    
+                </p>
                 <xsl:apply-templates select="ead:address"/>
             </div>
         </div>
     </xsl:template>
-    
+
     <!-- Formats address elements -->
     <xsl:template match="ead:address">
         <p>
@@ -569,7 +569,7 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
+
     <!-- Formats revision description  -->
     <xsl:template match="ead:revisiondesc">
         <div class="section">
@@ -590,11 +590,11 @@
             <div class="sectionContent">
                     <ul>
                         <xsl:apply-templates/>
-                    </ul>    
+                    </ul>
             </div>
             <xsl:call-template name="top"/>
         </div>
-        <!-- 
+        <!--
             To sort by type change the above to:
             <xsl:for-each-group select="child::*" group-by="name(.)">
                 <xsl:sort select="current-grouping-key()"/>
@@ -612,16 +612,16 @@
     <xsl:template match="ead:controlaccess/child::*">
         <li><xsl:apply-templates/></li>
     </xsl:template>
-    
+
     <!-- Formats index and child elements, groups indexentry elements by type (i.e. corpname, subject...)    -->
     <xsl:template match="ead:index">
-        <div class="section">        
+        <div class="section">
             <h2 id="{local:buildID(.)}"><xsl:value-of select="local:tagName(.)"/></h2>
             <div class="sectionContent">
                 <xsl:apply-templates select="child::*[not(self::ead:indexentry)]"/>
                     <ul>
                         <xsl:apply-templates select="ead:indexentry"/>
-                    </ul>    
+                    </ul>
             </div>
             <xsl:call-template name="top"/>
         </div>
@@ -631,8 +631,8 @@
     </xsl:template>
     <xsl:template match="ead:indexentry/ead:ref">
         <span class="ref"><xsl:apply-templates/></span>
-    </xsl:template> 
-       
+    </xsl:template>
+
     <!--Formats a simple table. The width of each column is defined by the colwidth attribute in a colspec element. -->
     <xsl:template match="ead:table">
             <xsl:apply-templates/>
@@ -663,7 +663,7 @@
     <xsl:template match="ead:entry">
         <td><xsl:apply-templates/></td>
     </xsl:template>
-    
+
     <!--Bibref citation inline, if there is a p parent element.-->
     <xsl:template match="ead:p/ead:bibref">
         <xsl:choose>
@@ -688,7 +688,7 @@
             </xsl:choose>
         </p>
     </xsl:template>
-    
+
     <!-- Output for a variety of list types -->
     <xsl:template match="ead:list">
         <xsl:apply-templates select="ead:head"/>
@@ -715,7 +715,7 @@
             </xsl:when>
             <xsl:when test="@type = 'marked'">
                 <ul>
-                    <xsl:apply-templates select="ead:item"/>                    
+                    <xsl:apply-templates select="ead:item"/>
                 </ul>
             </xsl:when>
             <xsl:when test="@type = 'ordered'">
@@ -732,7 +732,7 @@
                 </ul>
             </xsl:otherwise>
         </xsl:choose>
-    </xsl:template> 
+    </xsl:template>
     <xsl:template match="ead:list/ead:item">
         <li><xsl:apply-templates/></li>
     </xsl:template>
@@ -740,15 +740,15 @@
         <dt><xsl:apply-templates select="ead:label"/></dt>
         <dd><xsl:apply-templates select="ead:item"/></dd>
     </xsl:template>
-    
-    <!-- Formats list as tabel if list has listhead element  -->         
+
+    <!-- Formats list as tabel if list has listhead element  -->
     <xsl:template match="ead:defitem" mode="listTable">
         <tr>
             <td><xsl:apply-templates select="ead:label"/></td>
             <td><xsl:apply-templates select="ead:item"/></td>
         </tr>
     </xsl:template>
-    
+
     <!-- Output chronlist and children in a table -->
     <xsl:template match="ead:chronlist">
         <table>
@@ -789,7 +789,7 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
+
     <!-- Formats notestmt and notes -->
     <xsl:template match="ead:notestmt">
         <h4>Note</h4>
@@ -808,19 +808,19 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
+
     <!-- Formats legalstatus -->
     <xsl:template match="ead:legalstatus">
         <p><span class="strong"><xsl:value-of select="local:tagName(.)"/>:</span><xsl:text> </xsl:text><xsl:apply-templates/></p>
     </xsl:template>
-    
+
     <!-- General headings -->
-    <!-- Most head tags are handled by local:tagName function --> 
+    <!-- Most head tags are handled by local:tagName function -->
     <xsl:template match="ead:head[parent::*/parent::ead:archdesc]"/>
     <xsl:template match="ead:head">
         <h4 id="{local:buildID(parent::*)}"><xsl:apply-templates/></h4>
     </xsl:template>
-    
+
    <!-- Linking elmenets -->
     <xsl:template match="ead:ref">
         <a href="#{@target}">
@@ -887,13 +887,13 @@
                 </xsl:otherwise>
             </xsl:choose>
         </a>
-    </xsl:template>    
+    </xsl:template>
     <xsl:template match="ead:extptr[@*:entityref]">
         <a href="{@*:entityref}">
             <xsl:choose>
                 <xsl:when test="@*:title"><xsl:value-of select="@*:title"/></xsl:when>
                 <xsl:otherwise><xsl:value-of select="@*:entityref"/></xsl:otherwise>
-            </xsl:choose>        
+            </xsl:choose>
         </a>
     </xsl:template>
     <xsl:template match="ead:extptr[@*:href]">
@@ -901,7 +901,7 @@
             <xsl:choose>
                 <xsl:when test="@*:title"><xsl:value-of select="@*:title"/></xsl:when>
                 <xsl:otherwise><xsl:value-of select="@*:href"/></xsl:otherwise>
-            </xsl:choose>        
+            </xsl:choose>
         </a>
     </xsl:template>
     <xsl:template match="ead:dao">
@@ -924,7 +924,7 @@
     </xsl:template>
     <xsl:template match="ead:daogrp">
         <div>
-            <xsl:apply-templates/>            
+            <xsl:apply-templates/>
         </div>
     </xsl:template>
     <xsl:template match="ead:daoloc">
@@ -942,7 +942,7 @@
             </xsl:choose>
         </a>
     </xsl:template>
-    
+
     <!--Render elements -->
     <xsl:template match="*[@render = 'bold'] | *[@altrender = 'bold'] ">
         <xsl:if test="preceding-sibling::*"> <xsl:text> </xsl:text></xsl:if><strong><xsl:apply-templates/></strong>
@@ -983,7 +983,7 @@
     <xsl:template match="*[@render = 'underline'] | *[@altrender = 'underline']">
         <xsl:if test="preceding-sibling::*"> <xsl:text> </xsl:text></xsl:if><span class="underline"><xsl:apply-templates/></span>
     </xsl:template>
-   
+
     <!-- formatting elements -->
     <xsl:template match="ead:p">
         <p><xsl:apply-templates/></p>
@@ -993,10 +993,10 @@
         <blockquote><xsl:apply-templates/></blockquote>
     </xsl:template>
     <xsl:template match="ead:emph[not(@render)]"><em><xsl:apply-templates/></em></xsl:template>
-    
+
     <!-- Collection Inventory (dsc) templates -->
     <xsl:template match="ead:archdesc/ead:dsc">
-        <div class="section">        
+        <div class="section">
             <h2 id="{local:buildID(.)}"><xsl:value-of select="local:tagName(.)"/></h2>
                 <table class="dsc">
                     <xsl:if test="child::*[@level][1][@level='item' or @level='file' or @level='otherlevel']">
@@ -1012,7 +1012,7 @@
                 </table>
         </div>
     </xsl:template>
-    
+
     <!--
         Calls the clevel template passes the calculates the level of current component in xml tree and passes it to clevel template via the level parameter
         Adds a row to with a link to top if level series
@@ -1027,14 +1027,14 @@
                 <td colspan="4">
                     <xsl:call-template name="top"/>
                 </td>
-            </tr>    
+            </tr>
         </xsl:if>
     </xsl:template>
 
     <!--This is a named template that processes all the components  -->
     <xsl:template name="clevel">
-        <!-- 
-            Establishes which level is being processed in order to provided indented displays. 
+        <!--
+            Establishes which level is being processed in order to provided indented displays.
             Indents handled by CSS margins
         -->
         <xsl:param name="level" />
@@ -1056,19 +1056,19 @@
         </xsl:variable>
             <xsl:choose>
                 <!--Formats Series and Groups  -->
-                <xsl:when test="@level='subcollection' or @level='subgrp' or @level='series' 
-                    or @level='subseries' or @level='collection'or @level='fonds' or 
+                <xsl:when test="@level='subcollection' or @level='subgrp' or @level='series'
+                    or @level='subseries' or @level='collection'or @level='fonds' or
                     @level='recordgrp' or @level='subfonds' or @level='class' or (@level='otherlevel' and not(child::ead:did/ead:container))">
                     <tr id="{local:buildID(.)}">
                         <xsl:attribute name="class">
                             <xsl:choose>
                                 <xsl:when test="@level='subcollection' or @level='subgrp' or @level='subseries' or @level='subfonds'">subseries</xsl:when>
                                 <xsl:otherwise>series</xsl:otherwise>
-                            </xsl:choose>    
+                            </xsl:choose>
                         </xsl:attribute>
                         <th class="{$clevelMargin}" rowspan="{count(ead:did/ead:container[@label]) + 1}">
                             <xsl:if test="not(ead:did/ead:container)">
-                                <xsl:attribute name="colspan">4</xsl:attribute>  
+                                <xsl:attribute name="colspan">4</xsl:attribute>
                             </xsl:if>
                             <xsl:apply-templates select="ead:did" mode="dscSeriesTitle"/>
                             <div class="dscSeries">
@@ -1078,7 +1078,7 @@
                         </th>
                     </tr>
                     <!-- Adds grouped instances if they exist -->
-                    <xsl:for-each-group select="ead:did/ead:container" group-starting-with=".[@label]">
+                    <xsl:for-each-group select="ead:did/ead:container" group-starting-with="@label">
                         <tr>
                             <xsl:apply-templates select="current-group()" mode="series"/>
                             <xsl:choose>
@@ -1101,15 +1101,15 @@
                 <xsl:when test="ead:did/ead:container[@label]">
                     <tr class="item">
                         <td class="{$clevelMargin}" rowspan="{count(ead:did/ead:container[@label]) + 1}">
-                            <xsl:apply-templates select="ead:did" mode="dsc"/>  
-                            <xsl:apply-templates mode="dsc" select="*[not(self::ead:did) and 
+                            <xsl:apply-templates select="ead:did" mode="dsc"/>
+                            <xsl:apply-templates mode="dsc" select="*[not(self::ead:did) and
                                 not(self::ead:c) and not(self::ead:c02) and not(self::ead:c03) and
                                 not(self::ead:c04) and not(self::ead:c05) and not(self::ead:c06) and not(self::ead:c07)
-                                and not(self::ead:c08) and not(self::ead:c09) and not(self::ead:c10) and not(self::ead:c11) and not(self::ead:c12)]"/>          
+                                and not(self::ead:c08) and not(self::ead:c09) and not(self::ead:c10) and not(self::ead:c11) and not(self::ead:c12)]"/>
                         </td>
                     </tr>
                     <!-- Groups instances by label attribute, the way they are grouped in ArchivesSpace -->
-                    <xsl:for-each-group select="ead:did/ead:container" group-starting-with=".[@label]">
+                    <xsl:for-each-group select="ead:did/ead:container" group-starting-with="@label">
                         <tr>
                             <xsl:apply-templates select="current-group()" />
                             <xsl:choose>
@@ -1128,11 +1128,11 @@
                 <xsl:otherwise>
                     <tr class="item">
                         <td class="{$clevelMargin}" rowspan="{count(ead:did/ead:container[@label]) + 1}">
-                            <xsl:apply-templates select="ead:did" mode="dsc"/>  
-                            <xsl:apply-templates mode="dsc" select="*[not(self::ead:did) and 
+                            <xsl:apply-templates select="ead:did" mode="dsc"/>
+                            <xsl:apply-templates mode="dsc" select="*[not(self::ead:did) and
                                 not(self::ead:c) and not(self::ead:c02) and not(self::ead:c03) and
                                 not(self::ead:c04) and not(self::ead:c05) and not(self::ead:c06) and not(self::ead:c07)
-                                and not(self::ead:c08) and not(self::ead:c09) and not(self::ead:c10) and not(self::ead:c11) and not(self::ead:c12)]"/>          
+                                and not(self::ead:c08) and not(self::ead:c09) and not(self::ead:c10) and not(self::ead:c11) and not(self::ead:c12)]"/>
                         </td>
                         <td>
                             <span class="containerType"><xsl:value-of select="ead:did/ead:container[1]/@type"/></span><xsl:text> </xsl:text><xsl:value-of select="ead:did/ead:container[1]"/>
@@ -1172,7 +1172,7 @@
     <xsl:template match="ead:did" mode="dscSeriesTitle">
         <div id="{local:buildID(.)}">
             <h3>
-<!--                
+<!--
             <xsl:if test="ead:unitid">
                 <xsl:choose>
                     <xsl:when test="../@level='series'">Series <xsl:value-of select="ead:unitid"/>: </xsl:when>
@@ -1199,45 +1199,45 @@
         (<xsl:apply-templates/>)
     </xsl:template>
     <xsl:template match="ead:unitdate" mode="did"><xsl:apply-templates/></xsl:template>
-    
+
     <!-- Series child elements -->
-    <xsl:template match="ead:did" mode="dscSeries">            
-        <xsl:apply-templates select="ead:repository" mode="dsc"/>            
-        <xsl:apply-templates select="ead:origination" mode="dsc"/>            
-        <xsl:apply-templates select="ead:unitdate" mode="dsc"/>            
-        <xsl:apply-templates select="ead:physdesc" mode="dsc"/>                    
-        <xsl:apply-templates select="ead:physloc" mode="dsc"/>             
-        <xsl:apply-templates select="ead:dao" mode="dsc"/>            
-        <xsl:apply-templates select="ead:daogrp" mode="dsc"/>            
-        <xsl:apply-templates select="ead:langmaterial" mode="dsc"/>            
-        <xsl:apply-templates select="ead:materialspec" mode="dsc"/>            
-        <xsl:apply-templates select="ead:abstract" mode="dsc"/>             
+    <xsl:template match="ead:did" mode="dscSeries">
+        <xsl:apply-templates select="ead:repository" mode="dsc"/>
+        <xsl:apply-templates select="ead:origination" mode="dsc"/>
+        <xsl:apply-templates select="ead:unitdate" mode="dsc"/>
+        <xsl:apply-templates select="ead:physdesc" mode="dsc"/>
+        <xsl:apply-templates select="ead:physloc" mode="dsc"/>
+        <xsl:apply-templates select="ead:dao" mode="dsc"/>
+        <xsl:apply-templates select="ead:daogrp" mode="dsc"/>
+        <xsl:apply-templates select="ead:langmaterial" mode="dsc"/>
+        <xsl:apply-templates select="ead:materialspec" mode="dsc"/>
+        <xsl:apply-templates select="ead:abstract" mode="dsc"/>
         <xsl:apply-templates select="ead:note" mode="dsc"/>
     </xsl:template>
-    
+
     <!-- Unittitles and all other clevel elements -->
     <xsl:template match="ead:did" mode="dsc">
            <span class="didTitle">
                <xsl:apply-templates select="ead:unittitle"/>
                <xsl:if test="(string-length(ead:unittitle[1]) &gt; 1) and (string-length(ead:unitdate[1]) &gt; 1)">, </xsl:if>
-               <xsl:apply-templates select="ead:unitdate" mode="did"/>   
-           </span> 
-        <xsl:apply-templates select="ead:repository" mode="dsc"/>            
-        <xsl:apply-templates select="ead:origination" mode="dsc"/>            
-        <xsl:apply-templates select="ead:unitdate" mode="dsc"/>            
-        <xsl:apply-templates select="ead:physdesc" mode="dsc"/>                    
-        <xsl:apply-templates select="ead:physloc" mode="dsc"/>             
-        <xsl:apply-templates select="ead:dao" mode="dsc"/>            
-        <xsl:apply-templates select="ead:daogrp" mode="dsc"/>            
-        <xsl:apply-templates select="ead:langmaterial" mode="dsc"/>            
-        <xsl:apply-templates select="ead:materialspec" mode="dsc"/>            
-        <xsl:apply-templates select="ead:abstract" mode="dsc"/>             
+               <xsl:apply-templates select="ead:unitdate" mode="did"/>
+           </span>
+        <xsl:apply-templates select="ead:repository" mode="dsc"/>
+        <xsl:apply-templates select="ead:origination" mode="dsc"/>
+        <xsl:apply-templates select="ead:unitdate" mode="dsc"/>
+        <xsl:apply-templates select="ead:physdesc" mode="dsc"/>
+        <xsl:apply-templates select="ead:physloc" mode="dsc"/>
+        <xsl:apply-templates select="ead:dao" mode="dsc"/>
+        <xsl:apply-templates select="ead:daogrp" mode="dsc"/>
+        <xsl:apply-templates select="ead:langmaterial" mode="dsc"/>
+        <xsl:apply-templates select="ead:materialspec" mode="dsc"/>
+        <xsl:apply-templates select="ead:abstract" mode="dsc"/>
         <xsl:apply-templates select="ead:note" mode="dsc"/>
     </xsl:template>
-   
+
     <!-- Special formatting for elements in the collection inventory list -->
-    <xsl:template match="ead:repository | ead:origination | ead:unitdate | ead:unitid  
-        | ead:physdesc | ead:physloc | ead:daogrp | ead:langmaterial | ead:materialspec | ead:container 
+    <xsl:template match="ead:repository | ead:origination | ead:unitdate | ead:unitid
+        | ead:physdesc | ead:physloc | ead:daogrp | ead:langmaterial | ead:materialspec | ead:container
         | ead:abstract | ead:note" mode="dsc">
         <xsl:if test="child::*">
             <p>
@@ -1253,7 +1253,7 @@
                                     - <xsl:value-of select="substring-before(ead:persname/@role,' (')"/>
                                 </xsl:when>
                                 <xsl:when test="ead:persname[@role != '']">
-                                    - <xsl:value-of select="ead:persname/@role"/>  
+                                    - <xsl:value-of select="ead:persname/@role"/>
                                 </xsl:when>
                                 <xsl:otherwise/>
                             </xsl:choose>
@@ -1265,11 +1265,11 @@
                         <xsl:if test="@type"> [<xsl:value-of select="@type"/>]</xsl:if>
                     </xsl:otherwise>
                 </xsl:choose></span>: <xsl:apply-templates/>
-            </p>            
+            </p>
         </xsl:if>
     </xsl:template>
     <xsl:template match="ead:relatedmaterial | ead:separatedmaterial | ead:accessrestrict | ead:userestrict |
-        ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |  
+        ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |
         ead:processinfo | ead:appraisal | ead:originalsloc" mode="dsc">
         <p>
             <span class="dscHeaders"><xsl:value-of select="local:tagName(.)"/>: </span>
@@ -1278,15 +1278,15 @@
     </xsl:template>
     <xsl:template match="ead:index" mode="dsc">
         <xsl:apply-templates select="child::*[not(self::ead:indexentry)]"/>
-            <ul>                
-                <xsl:apply-templates select="ead:indexentry"/>                    
-            </ul>    
+            <ul>
+                <xsl:apply-templates select="ead:indexentry"/>
+            </ul>
     </xsl:template>
     <xsl:template match="ead:controlaccess" mode="dsc">
         <p class="dscHeaders"><xsl:value-of select="local:tagName(.)"/>:</p>
             <ul>
                    <xsl:apply-templates/>
-            </ul>    
+            </ul>
     </xsl:template>
     <xsl:template match="ead:dao" mode="dsc">
         <p>
@@ -1307,7 +1307,7 @@
                     </xsl:otherwise>
                 </xsl:choose>
             </a>
-        </p> 
+        </p>
     </xsl:template>
     <!-- Formats all other children of the dsc -->
     <xsl:template mode="dsc" match="*">

--- a/stylesheets/as-ead-pdf.xsl
+++ b/stylesheets/as-ead-pdf.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:ns2="http://www.w3.org/1999/xlink" xmlns:local="http://www.yoursite.org/namespace" 
+    xmlns:ns2="http://www.w3.org/1999/xlink" xmlns:local="http://www.yoursite.org/namespace"
     xmlns:ead="urn:isbn:1-931666-22-9" xmlns:fo="http://www.w3.org/1999/XSL/Format" version="2.0"  exclude-result-prefixes="#all">
     <!--
         *******************************************************************
@@ -19,12 +19,12 @@
         *******************************************************************
     -->
     <xsl:output method="xml" encoding="utf-8" indent="yes"/>
-    
+
     <!-- Calls a stylesheet with local functions and lookup lists for languages and subject authorities -->
-    <xsl:include href="as-helper-functions.xsl"/>  
-    
+    <xsl:include href="as-helper-functions.xsl"/>
+
     <xsl:strip-space elements="*"/>
-   
+
     <!-- The following attribute sets are reusabe styles used throughout the stylesheet. -->
     <!-- Headings -->
     <xsl:attribute-set name="h1">
@@ -32,7 +32,7 @@
         <xsl:attribute name="font-weight">bold</xsl:attribute>
         <xsl:attribute name="margin-top">16pt</xsl:attribute>
         <xsl:attribute name="margin-bottom">8pt</xsl:attribute>
-    </xsl:attribute-set>    
+    </xsl:attribute-set>
     <xsl:attribute-set name="h2">
         <xsl:attribute name="font-size">16pt</xsl:attribute>
         <xsl:attribute name="font-weight">bold</xsl:attribute>
@@ -43,14 +43,14 @@
         <xsl:attribute name="padding-top">8pt</xsl:attribute>
         <xsl:attribute name="padding-bottom">8pt</xsl:attribute>
         <xsl:attribute name="keep-with-next.within-page">always</xsl:attribute>
-    </xsl:attribute-set>    
+    </xsl:attribute-set>
     <xsl:attribute-set name="h3">
         <xsl:attribute name="font-size">14pt</xsl:attribute>
         <xsl:attribute name="font-weight">bold</xsl:attribute>
         <xsl:attribute name="margin-bottom">4pt</xsl:attribute>
         <xsl:attribute name="padding-bottom">0</xsl:attribute>
         <xsl:attribute name="keep-with-next.within-page">always</xsl:attribute>
-    </xsl:attribute-set>    
+    </xsl:attribute-set>
     <xsl:attribute-set name="h4">
         <xsl:attribute name="font-size">12pt</xsl:attribute>
         <xsl:attribute name="font-weight">bold</xsl:attribute>
@@ -58,53 +58,53 @@
         <xsl:attribute name="padding-bottom">0</xsl:attribute>
         <xsl:attribute name="keep-with-next.within-page">always</xsl:attribute>
     </xsl:attribute-set>
-    
+
     <!-- Headings with id attribute -->
     <xsl:attribute-set name="h1ID" use-attribute-sets="h1">
         <xsl:attribute name="id"><xsl:value-of select="local:buildID(.)"/></xsl:attribute>
-    </xsl:attribute-set>    
+    </xsl:attribute-set>
     <xsl:attribute-set name="h2ID" use-attribute-sets="h2">
         <xsl:attribute name="id"><xsl:value-of select="local:buildID(.)"/></xsl:attribute>
-    </xsl:attribute-set>    
+    </xsl:attribute-set>
     <xsl:attribute-set name="h3ID" use-attribute-sets="h3">
         <xsl:attribute name="id"><xsl:value-of select="local:buildID(.)"/></xsl:attribute>
-    </xsl:attribute-set>    
+    </xsl:attribute-set>
     <xsl:attribute-set name="h4ID" use-attribute-sets="h4">
         <xsl:attribute name="id"><xsl:value-of select="local:buildID(.)"/></xsl:attribute>
     </xsl:attribute-set>
-    
+
     <!-- Linking attributes styles -->
     <xsl:attribute-set name="ref">
         <xsl:attribute name="color">#14A6DC</xsl:attribute>
         <xsl:attribute name="text-decoration">underline</xsl:attribute>
     </xsl:attribute-set>
-    
+
     <!-- Standard margin and padding for most fo:block elements, including paragraphs -->
     <xsl:attribute-set name="smp">
         <xsl:attribute name="margin">4pt</xsl:attribute>
         <xsl:attribute name="padding">4pt</xsl:attribute>
     </xsl:attribute-set>
-   
+
     <!-- Standard margin and padding for elements with in the dsc table -->
     <xsl:attribute-set name="smpDsc">
         <xsl:attribute name="margin">2pt</xsl:attribute>
         <xsl:attribute name="padding">2pt</xsl:attribute>
     </xsl:attribute-set>
-    
+
     <!-- Styles for main sections -->
     <xsl:attribute-set name="section">
         <xsl:attribute name="margin">4pt</xsl:attribute>
         <xsl:attribute name="padding">4pt</xsl:attribute>
     </xsl:attribute-set>
-    
+
     <!-- Table attributes for tables with borders -->
     <xsl:attribute-set name="tableBorder">
         <xsl:attribute name="table-layout">fixed</xsl:attribute>
         <xsl:attribute name="width">100%</xsl:attribute>
         <xsl:attribute name="border">.5pt solid #ccc</xsl:attribute>
         <xsl:attribute name="border-collapse">seperate</xsl:attribute>
-        <xsl:attribute name="space-after">12pt</xsl:attribute>        
-    </xsl:attribute-set>    
+        <xsl:attribute name="space-after">12pt</xsl:attribute>
+    </xsl:attribute-set>
     <!-- Table headings -->
     <xsl:attribute-set name="th">
         <xsl:attribute name="background-color">#ccc</xsl:attribute>
@@ -116,48 +116,48 @@
         <xsl:attribute name="border">.5pt solid #ccc</xsl:attribute>
         <xsl:attribute name="border-collapse">seperate</xsl:attribute>
     </xsl:attribute-set>
-    
+
     <!--  Start main page design and layout -->
     <xsl:template match="/">
         <fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format" font-size="12pt" font-family="serif">
             <!-- Set up page types and page layouts -->
             <fo:layout-master-set>
                 <!-- Page master for Cover Page -->
-                <fo:simple-page-master master-name="cover-page" page-width="8.5in" page-height="11in" margin="0.5in">                
-                    <fo:region-body margin="0.5in 0.5in 1in 0.5in"/>                 
-                    <fo:region-before extent="0.2in"/>                    
-                    <fo:region-after extent="2in"/>                    
-                </fo:simple-page-master>                
-                <!-- Page master for Table of Contents -->                
-                <fo:simple-page-master master-name="toc" page-width="8.5in" page-height="11in" margin="0.5in">          
-                    <fo:region-body margin-top="0.25in" margin-bottom="0.25in"/>                
-                    <fo:region-before extent="0.5in"/>                    
-                    <fo:region-after extent="0.2in"/>                    
-                </fo:simple-page-master>                  
-                <!-- Page master for Finding Aid Contents -->
-                <fo:simple-page-master master-name="contents" page-width="8.5in" page-height="11in" margin="0.5in">  
+                <fo:simple-page-master master-name="cover-page" page-width="8.5in" page-height="11in" margin="0.5in">
+                    <fo:region-body margin="0.5in 0.5in 1in 0.5in"/>
+                    <fo:region-before extent="0.2in"/>
+                    <fo:region-after extent="2in"/>
+                </fo:simple-page-master>
+                <!-- Page master for Table of Contents -->
+                <fo:simple-page-master master-name="toc" page-width="8.5in" page-height="11in" margin="0.5in">
                     <fo:region-body margin-top="0.25in" margin-bottom="0.25in"/>
-                    <fo:region-before extent="0.5in"/>                    
+                    <fo:region-before extent="0.5in"/>
                     <fo:region-after extent="0.2in"/>
                 </fo:simple-page-master>
-            </fo:layout-master-set>              
+                <!-- Page master for Finding Aid Contents -->
+                <fo:simple-page-master master-name="contents" page-width="8.5in" page-height="11in" margin="0.5in">
+                    <fo:region-body margin-top="0.25in" margin-bottom="0.25in"/>
+                    <fo:region-before extent="0.5in"/>
+                    <fo:region-after extent="0.2in"/>
+                </fo:simple-page-master>
+            </fo:layout-master-set>
             <!-- Builds PDF bookmarks for all major sections  -->
             <xsl:apply-templates select="/ead:ead/ead:archdesc" mode="bookmarks"/>
-            <!-- The fo:page-sequence establishes headers, footers and the body of the page.-->            
-            <!-- Cover page layout -->            
+            <!-- The fo:page-sequence establishes headers, footers and the body of the page.-->
+            <!-- Cover page layout -->
             <fo:page-sequence master-reference="cover-page">
                 <xsl:if test="/ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt">
                   <fo:static-content flow-name="xsl-region-after">
                         <xsl:apply-templates select="/ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt" mode="coverPage"/>
                     </fo:static-content>
-               </xsl:if>   
-                <fo:flow flow-name="xsl-region-body">                                   
+               </xsl:if>
+                <fo:flow flow-name="xsl-region-body">
                     <xsl:apply-templates select="/ead:ead/ead:eadheader/ead:filedesc/ead:titlestmt" mode="coverPage"/>
-                </fo:flow>               
-            </fo:page-sequence> 
-            <!-- Table of Contents layout -->            
-            <fo:page-sequence master-reference="toc">            
-                <!-- Page header -->                
+                </fo:flow>
+            </fo:page-sequence>
+            <!-- Table of Contents layout -->
+            <fo:page-sequence master-reference="toc">
+                <!-- Page header -->
                 <fo:static-content flow-name="xsl-region-before" margin-top=".15in">
                     <fo:block color="gray" font-size="8pt" text-align="center">
                         <xsl:apply-templates select="ead:ead/ead:eadheader/ead:filedesc/ead:titlestmt" mode="pageHeader"/>
@@ -166,16 +166,16 @@
                 <!-- Page footer-->
                 <fo:static-content flow-name="xsl-region-after">
                     <fo:block text-align="center" color="gray">
-                        <xsl:text>- Page </xsl:text>                        
+                        <xsl:text>- Page </xsl:text>
                         <fo:page-number/>
                         <xsl:text> -</xsl:text>
                     </fo:block>
                 </fo:static-content>
                 <!-- Content of page -->
-                <fo:flow flow-name="xsl-region-body">    
+                <fo:flow flow-name="xsl-region-body">
                     <xsl:apply-templates select="/ead:ead/ead:archdesc" mode="toc"/>
-                </fo:flow>    
-            </fo:page-sequence>         
+                </fo:flow>
+            </fo:page-sequence>
             <!-- All the rest -->
             <fo:page-sequence master-reference="contents">
                 <!-- Page header -->
@@ -186,27 +186,27 @@
                 </fo:static-content>
                 <!-- Page footer-->
                 <fo:static-content flow-name="xsl-region-after">
-                    <fo:block text-align="center">        
-                        <xsl:text>- Page </xsl:text> 
+                    <fo:block text-align="center">
+                        <xsl:text>- Page </xsl:text>
                         <fo:page-number/>
                         <xsl:text>- </xsl:text>
                     </fo:block>
                 </fo:static-content>
                 <!-- Content of page -->
-                <fo:flow flow-name="xsl-region-body">    
+                <fo:flow flow-name="xsl-region-body">
                     <xsl:apply-templates select="/ead:ead/ead:archdesc"/>
                 </fo:flow>
             </fo:page-sequence>
         </fo:root>
     </xsl:template>
-    
+
     <!-- Named template to link back to the table of contents  -->
-    <xsl:template name="toc">    
+    <xsl:template name="toc">
         <fo:block font-size="11pt" margin-top="12pt" margin-bottom="18pt">
             <fo:basic-link text-decoration="none" internal-destination="toc" color="#14A6DC"><fo:inline font-weight="bold">^</fo:inline> Return to Table of Contents </fo:basic-link>
-        </fo:block>        
+        </fo:block>
     </xsl:template>
-    
+
     <!-- Cover page templates -->
     <!-- Builds title -->
     <xsl:template match="ead:titlestmt" mode="pageHeader">
@@ -235,9 +235,9 @@
                 </xsl:choose>
             </fo:block>
             <xsl:if test="ead:subtitle">
-                <fo:block font-size="16" font-weight="bold"><xsl:apply-templates select="ead:subtitle"/></fo:block>    
-            </xsl:if>    
-        </fo:block> 
+                <fo:block font-size="16" font-weight="bold"><xsl:apply-templates select="ead:subtitle"/></fo:block>
+            </xsl:if>
+        </fo:block>
         <fo:block margin-top="8pt">
             <xsl:apply-templates select="/ead:ead/ead:eadheader/ead:profiledesc"/>
         </fo:block>
@@ -253,14 +253,14 @@
             </fo:block>
             <xsl:apply-templates select="ead:address"/>
         </fo:block>
-    </xsl:template>   
+    </xsl:template>
     <xsl:template match="ead:profiledesc/child::*">
         <fo:block><xsl:apply-templates/></fo:block>
     </xsl:template>
     <xsl:template match="ead:profiledesc/ead:language"> <xsl:value-of select="."/></xsl:template>
     <xsl:template match="ead:profiledesc/ead:creation/ead:date">
-        <!-- 
-            Uses local function to format date into Month, day year. 
+        <!--
+            Uses local function to format date into Month, day year.
             To print date as seen in xml change to select="."
         -->
         <xsl:apply-templates select="local:parseDate(.)"/>
@@ -276,7 +276,7 @@
             <fo:external-graphic src="archivesspace.small.png" content-height="75%" content-width="75%"/>
         </fo:block>
     </xsl:template>
-    
+
     <!-- Generates PDF Bookmarks -->
     <xsl:template match="ead:archdesc" mode="bookmarks">
         <fo:bookmark-tree>
@@ -286,12 +286,12 @@
             <xsl:if test="ead:did">
                 <fo:bookmark internal-destination="{local:buildID(ead:did)}">
                     <fo:bookmark-title><xsl:value-of select="local:tagName(ead:did)"/></fo:bookmark-title>
-                </fo:bookmark>    
+                </fo:bookmark>
             </xsl:if>
-            <xsl:if test="ead:bioghist"> 
+            <xsl:if test="ead:bioghist">
                 <fo:bookmark internal-destination="{local:buildID(ead:bioghist[1])}">
-                    <fo:bookmark-title><xsl:value-of select="local:tagName(ead:bioghist[1])"/></fo:bookmark-title>    
-                </fo:bookmark>                        
+                    <fo:bookmark-title><xsl:value-of select="local:tagName(ead:bioghist[1])"/></fo:bookmark-title>
+                </fo:bookmark>
             </xsl:if>
             <xsl:if test="ead:scopecontent">
                 <fo:bookmark internal-destination="{local:buildID(ead:scopecontent[1])}">
@@ -301,31 +301,31 @@
             <xsl:if test="ead:arrangement">
                 <fo:bookmark internal-destination="{local:buildID(ead:arrangement[1])}">
                     <fo:bookmark-title><xsl:value-of select="local:tagName(ead:arrangement[1])"/></fo:bookmark-title>
-                </fo:bookmark>               
+                </fo:bookmark>
             </xsl:if>
             <xsl:if test="ead:fileplan">
                 <fo:bookmark internal-destination="{local:buildID(ead:fileplan[1])}">
                     <fo:bookmark-title><xsl:value-of select="local:tagName(ead:fileplan[1])"/></fo:bookmark-title>
-                </fo:bookmark>   
+                </fo:bookmark>
             </xsl:if>
-            
+
             <!-- Administrative Information  -->
             <xsl:if test="ead:accessrestrict or ead:userestrict or
-                ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or 
-                ead:processinfo or ead:appraisal or ead:originalsloc or 
+                ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or
+                ead:processinfo or ead:appraisal or ead:originalsloc or
                 /ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt or /ead:ead/ead:eadheader/ead:revisiondesc">
                 <fo:bookmark internal-destination="adminInfo">
                     <fo:bookmark-title>Administrative Information</fo:bookmark-title>
                 </fo:bookmark>
             </xsl:if>
-            
+
             <!-- Related Materials -->
             <xsl:if test="ead:relatedmaterial or ead:separatedmaterial">
                 <fo:bookmark internal-destination="relMat">
                     <fo:bookmark-title>Related Materials</fo:bookmark-title>
                 </fo:bookmark>
             </xsl:if>
-            
+
             <xsl:if test="ead:controlaccess">
                 <fo:bookmark internal-destination="{local:buildID(ead:controlaccess[1])}">
                     <fo:bookmark-title><xsl:value-of select="local:tagName(ead:controlaccess[1])"/></fo:bookmark-title>
@@ -350,46 +350,46 @@
                 <fo:bookmark internal-destination="{local:buildID(ead:bibliography[1])}">
                     <fo:bookmark-title><xsl:value-of select="local:tagName(ead:bibliography[1])"/></fo:bookmark-title>
                 </fo:bookmark>
-            </xsl:if>            
+            </xsl:if>
             <xsl:if test="ead:index">
                 <fo:bookmark internal-destination="{local:buildID(ead:index[1])}">
                     <fo:bookmark-title><xsl:value-of select="local:tagName(ead:index[1])"/></fo:bookmark-title>
                 </fo:bookmark>
-            </xsl:if> 
-            
-            <!-- Build Container List menu and submenu -->            
-            <xsl:for-each select="ead:dsc">            
+            </xsl:if>
+
+            <!-- Build Container List menu and submenu -->
+            <xsl:for-each select="ead:dsc">
                 <xsl:if test="child::*">
                     <fo:bookmark internal-destination="{local:buildID(.)}">
                         <fo:bookmark-title><xsl:value-of select="local:tagName(.)"/></fo:bookmark-title>
                     </fo:bookmark>
-                </xsl:if>                
-                <!--Creates a submenu for collections, record groups and series and fonds-->                
+                </xsl:if>
+                <!--Creates a submenu for collections, record groups and series and fonds-->
                 <xsl:for-each select="child::*[@level = 'collection']  | child::*[@level = 'recordgrp']  | child::*[@level = 'series'] | child::*[@level = 'fonds']">
                     <fo:bookmark internal-destination="{local:buildID(.)}">
                         <fo:bookmark-title>
                             <xsl:choose>
                                 <xsl:when test="ead:head">
-                                    <xsl:apply-templates select="child::*/ead:head"/>        
+                                    <xsl:apply-templates select="child::*/ead:head"/>
                                 </xsl:when>
                                 <xsl:otherwise>
                                     <xsl:value-of select="ead:did/ead:unittitle"/>
                                 </xsl:otherwise>
-                            </xsl:choose>    
+                            </xsl:choose>
                         </fo:bookmark-title>
                     </fo:bookmark>
-                    <!-- Creates a submenu for subfonds, subgrp or subseries -->    
+                    <!-- Creates a submenu for subfonds, subgrp or subseries -->
                     <xsl:for-each select="child::*[@level = 'subfonds'] | child::*[@level = 'subgrp']  | child::*[@level = 'subseries']">
                         <fo:bookmark internal-destination="{local:buildID(.)}">
                             <fo:bookmark-title>
                                 <xsl:choose>
                                     <xsl:when test="ead:head">
-                                        <xsl:apply-templates select="child::*/ead:head"/>        
+                                        <xsl:apply-templates select="child::*/ead:head"/>
                                     </xsl:when>
                                     <xsl:otherwise>
                                         <xsl:value-of select="ead:did/ead:unittitle"/>
                                     </xsl:otherwise>
-                                </xsl:choose>    
+                                </xsl:choose>
                             </fo:bookmark-title>
                         </fo:bookmark>
                     </xsl:for-each>
@@ -397,243 +397,243 @@
             </xsl:for-each>
         </fo:bookmark-tree>
     </xsl:template>
-   
+
     <!-- Table of Contents -->
     <xsl:template match="ead:archdesc" mode="toc">
         <fo:block line-height="18pt" margin-top="0.25in">
             <fo:block xsl:use-attribute-sets="h2" id="toc">Table of Contents</fo:block>
-            <fo:block xsl:use-attribute-sets="section">                
-                <xsl:if test="ead:did">            
-                    <fo:block text-align-last="justify"> 
-                        <fo:basic-link internal-destination="{local:buildID(ead:did)}"><xsl:value-of select="local:tagName(ead:did)"/></fo:basic-link>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:leader leader-pattern="dots"/>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:page-number-citation ref-id="{local:buildID(ead:did)}"/>                    
-                    </fo:block>                
+            <fo:block xsl:use-attribute-sets="section">
+                <xsl:if test="ead:did">
+                    <fo:block text-align-last="justify">
+                        <fo:basic-link internal-destination="{local:buildID(ead:did)}"><xsl:value-of select="local:tagName(ead:did)"/></fo:basic-link>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:leader leader-pattern="dots"/>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:page-number-citation ref-id="{local:buildID(ead:did)}"/>
+                    </fo:block>
                 </xsl:if>
                 <xsl:if test="ead:bioghist">
-                    <fo:block text-align-last="justify"> 
-                        <fo:basic-link internal-destination="{local:buildID(ead:bioghist[1])}"><xsl:value-of select="local:tagName(ead:bioghist[1])"/></fo:basic-link>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:leader leader-pattern="dots"/>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:page-number-citation ref-id="{local:buildID(ead:bioghist[1])}"/>                    
-                    </fo:block>                               
+                    <fo:block text-align-last="justify">
+                        <fo:basic-link internal-destination="{local:buildID(ead:bioghist[1])}"><xsl:value-of select="local:tagName(ead:bioghist[1])"/></fo:basic-link>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:leader leader-pattern="dots"/>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:page-number-citation ref-id="{local:buildID(ead:bioghist[1])}"/>
+                    </fo:block>
                 </xsl:if>
                 <xsl:if test="ead:scopecontent">
-                    <fo:block text-align-last="justify"> 
-                        <fo:basic-link internal-destination="{local:buildID(ead:scopecontent[1])}"><xsl:value-of select="local:tagName(ead:scopecontent[1])"/></fo:basic-link>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:leader leader-pattern="dots"/>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:page-number-citation ref-id="{local:buildID(ead:scopecontent[1])}"/>                    
-                    </fo:block>                             
+                    <fo:block text-align-last="justify">
+                        <fo:basic-link internal-destination="{local:buildID(ead:scopecontent[1])}"><xsl:value-of select="local:tagName(ead:scopecontent[1])"/></fo:basic-link>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:leader leader-pattern="dots"/>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:page-number-citation ref-id="{local:buildID(ead:scopecontent[1])}"/>
+                    </fo:block>
                 </xsl:if>
                 <xsl:if test="ead:arrangement">
-                    <fo:block text-align-last="justify"> 
-                        <fo:basic-link internal-destination="{local:buildID(ead:arrangement[1])}"><xsl:value-of select="local:tagName(ead:arrangement[1])"/></fo:basic-link>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:leader leader-pattern="dots"/>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:page-number-citation ref-id="{local:buildID(ead:arrangement[1])}"/>                    
-                    </fo:block>                               
+                    <fo:block text-align-last="justify">
+                        <fo:basic-link internal-destination="{local:buildID(ead:arrangement[1])}"><xsl:value-of select="local:tagName(ead:arrangement[1])"/></fo:basic-link>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:leader leader-pattern="dots"/>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:page-number-citation ref-id="{local:buildID(ead:arrangement[1])}"/>
+                    </fo:block>
                 </xsl:if>
                 <xsl:if test="ead:fileplan">
-                    <fo:block text-align-last="justify"> 
-                        <fo:basic-link internal-destination="{local:buildID(ead:fileplan[1])}"><xsl:value-of select="local:tagName(ead:fileplan[1])"/></fo:basic-link>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:leader leader-pattern="dots"/>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:page-number-citation ref-id="{local:buildID(ead:fileplan[1])}"/>                    
-                    </fo:block>   
+                    <fo:block text-align-last="justify">
+                        <fo:basic-link internal-destination="{local:buildID(ead:fileplan[1])}"><xsl:value-of select="local:tagName(ead:fileplan[1])"/></fo:basic-link>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:leader leader-pattern="dots"/>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:page-number-citation ref-id="{local:buildID(ead:fileplan[1])}"/>
+                    </fo:block>
                 </xsl:if>
-                    
+
                 <!-- Administrative Information  -->
                 <xsl:if test="ead:accessrestrict or ead:userestrict or
-                              ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or 
-                              ead:processinfo or ead:appraisal or ead:originalsloc or 
+                              ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or
+                              ead:processinfo or ead:appraisal or ead:originalsloc or
                               /ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt or /ead:ead/ead:eadheader/ead:revisiondesc">
-                        <fo:block text-align-last="justify"> 
-                            <fo:basic-link internal-destination="adminInfo">Administrative Information</fo:basic-link>                    
-                            <xsl:text>&#160;&#160;</xsl:text>                    
-                            <fo:leader leader-pattern="dots"/>                    
-                            <xsl:text>&#160;&#160;</xsl:text>                    
-                            <fo:page-number-citation ref-id="adminInfo"/>                    
-                        </fo:block>    
+                        <fo:block text-align-last="justify">
+                            <fo:basic-link internal-destination="adminInfo">Administrative Information</fo:basic-link>
+                            <xsl:text>&#160;&#160;</xsl:text>
+                            <fo:leader leader-pattern="dots"/>
+                            <xsl:text>&#160;&#160;</xsl:text>
+                            <fo:page-number-citation ref-id="adminInfo"/>
+                        </fo:block>
                 </xsl:if>
-                        
+
                 <!-- Related Materials -->
                 <xsl:if test="ead:relatedmaterial or ead:separatedmaterial">
-                    <fo:block text-align-last="justify"> 
-                        <fo:basic-link internal-destination="relMat">Related Materials</fo:basic-link>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:leader leader-pattern="dots"/>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:page-number-citation ref-id="relMat"/>                    
-                    </fo:block> 
+                    <fo:block text-align-last="justify">
+                        <fo:basic-link internal-destination="relMat">Related Materials</fo:basic-link>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:leader leader-pattern="dots"/>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:page-number-citation ref-id="relMat"/>
+                    </fo:block>
                 </xsl:if>
-                    
+
                 <xsl:if test="ead:controlaccess">
-                    <fo:block text-align-last="justify"> 
-                        <fo:basic-link internal-destination="{local:buildID(ead:controlaccess[1])}"><xsl:value-of select="local:tagName(ead:controlaccess[1])"/></fo:basic-link>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:leader leader-pattern="dots"/>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:page-number-citation ref-id="{local:buildID(ead:controlaccess[1])}"/>                    
-                    </fo:block>  
+                    <fo:block text-align-last="justify">
+                        <fo:basic-link internal-destination="{local:buildID(ead:controlaccess[1])}"><xsl:value-of select="local:tagName(ead:controlaccess[1])"/></fo:basic-link>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:leader leader-pattern="dots"/>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:page-number-citation ref-id="{local:buildID(ead:controlaccess[1])}"/>
+                    </fo:block>
                 </xsl:if>
                 <xsl:if test="ead:otherfindaid">
-                    <fo:block text-align-last="justify"> 
-                        <fo:basic-link internal-destination="{local:buildID(ead:otherfindaid[1])}"><xsl:value-of select="local:tagName(ead:otherfindaid[1])"/></fo:basic-link>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:leader leader-pattern="dots"/>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:page-number-citation ref-id="{local:buildID(ead:otherfindaid[1])}"/>                    
+                    <fo:block text-align-last="justify">
+                        <fo:basic-link internal-destination="{local:buildID(ead:otherfindaid[1])}"><xsl:value-of select="local:tagName(ead:otherfindaid[1])"/></fo:basic-link>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:leader leader-pattern="dots"/>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:page-number-citation ref-id="{local:buildID(ead:otherfindaid[1])}"/>
                     </fo:block>
                 </xsl:if>
                 <xsl:if test="ead:phystech">
-                    <fo:block text-align-last="justify"> 
-                        <fo:basic-link internal-destination="{local:buildID(ead:phystech[1])}"><xsl:value-of select="local:tagName(ead:phystech[1])"/></fo:basic-link>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:leader leader-pattern="dots"/>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:page-number-citation ref-id="{local:buildID(ead:phystech[1])}"/>                    
+                    <fo:block text-align-last="justify">
+                        <fo:basic-link internal-destination="{local:buildID(ead:phystech[1])}"><xsl:value-of select="local:tagName(ead:phystech[1])"/></fo:basic-link>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:leader leader-pattern="dots"/>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:page-number-citation ref-id="{local:buildID(ead:phystech[1])}"/>
                     </fo:block>
                 </xsl:if>
                 <xsl:if test="ead:odd">
-                    <fo:block text-align-last="justify"> 
-                        <fo:basic-link internal-destination="{local:buildID(ead:odd[1])}"><xsl:value-of select="local:tagName(ead:odd[1])"/></fo:basic-link>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:leader leader-pattern="dots"/>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:page-number-citation ref-id="{local:buildID(ead:odd[1])}"/>                    
-                    </fo:block> 
+                    <fo:block text-align-last="justify">
+                        <fo:basic-link internal-destination="{local:buildID(ead:odd[1])}"><xsl:value-of select="local:tagName(ead:odd[1])"/></fo:basic-link>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:leader leader-pattern="dots"/>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:page-number-citation ref-id="{local:buildID(ead:odd[1])}"/>
+                    </fo:block>
                 </xsl:if>
                 <xsl:if test="ead:bibliography">
-                    <fo:block text-align-last="justify"> 
-                        <fo:basic-link internal-destination="{local:buildID(ead:bibliography[1])}"><xsl:value-of select="local:tagName(ead:bibliography[1])"/></fo:basic-link>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:leader leader-pattern="dots"/>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:page-number-citation ref-id="{local:buildID(ead:bibliography[1])}"/>                    
-                    </fo:block>    
-                </xsl:if>            
+                    <fo:block text-align-last="justify">
+                        <fo:basic-link internal-destination="{local:buildID(ead:bibliography[1])}"><xsl:value-of select="local:tagName(ead:bibliography[1])"/></fo:basic-link>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:leader leader-pattern="dots"/>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:page-number-citation ref-id="{local:buildID(ead:bibliography[1])}"/>
+                    </fo:block>
+                </xsl:if>
                 <xsl:if test="ead:index">
-                    <fo:block text-align-last="justify"> 
-                        <fo:basic-link internal-destination="{local:buildID(ead:index[1])}"><xsl:value-of select="local:tagName(ead:index[1])"/></fo:basic-link>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:leader leader-pattern="dots"/>                    
-                        <xsl:text>&#160;&#160;</xsl:text>                    
-                        <fo:page-number-citation ref-id="{local:buildID(ead:index[1])}"/>                    
-                    </fo:block>   
-                </xsl:if> 
-    
-                <!-- Build Container List menu and submenu -->            
-                <xsl:for-each select="ead:dsc">            
+                    <fo:block text-align-last="justify">
+                        <fo:basic-link internal-destination="{local:buildID(ead:index[1])}"><xsl:value-of select="local:tagName(ead:index[1])"/></fo:basic-link>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:leader leader-pattern="dots"/>
+                        <xsl:text>&#160;&#160;</xsl:text>
+                        <fo:page-number-citation ref-id="{local:buildID(ead:index[1])}"/>
+                    </fo:block>
+                </xsl:if>
+
+                <!-- Build Container List menu and submenu -->
+                <xsl:for-each select="ead:dsc">
                     <xsl:if test="child::*">
-                        <fo:block text-align-last="justify"> 
-                            <fo:basic-link internal-destination="{local:buildID(.)}"><xsl:value-of select="local:tagName(.)"/></fo:basic-link>                    
-                            <xsl:text>&#160;&#160;</xsl:text>                    
-                            <fo:leader leader-pattern="dots"/>                    
-                            <xsl:text>&#160;&#160;</xsl:text>                    
-                            <fo:page-number-citation ref-id="{local:buildID(.)}"/>                    
-                        </fo:block>             
-                    </xsl:if>                
-                    <!--Creates a submenu for collections, record groups and series and fonds-->                
+                        <fo:block text-align-last="justify">
+                            <fo:basic-link internal-destination="{local:buildID(.)}"><xsl:value-of select="local:tagName(.)"/></fo:basic-link>
+                            <xsl:text>&#160;&#160;</xsl:text>
+                            <fo:leader leader-pattern="dots"/>
+                            <xsl:text>&#160;&#160;</xsl:text>
+                            <fo:page-number-citation ref-id="{local:buildID(.)}"/>
+                        </fo:block>
+                    </xsl:if>
+                    <!--Creates a submenu for collections, record groups and series and fonds-->
                     <xsl:for-each select="child::*[@level = 'collection']  | child::*[@level = 'recordgrp']  | child::*[@level = 'series'] | child::*[@level = 'fonds']">
-                        <fo:block text-align-last="justify" margin-left="8pt"> 
+                        <fo:block text-align-last="justify" margin-left="8pt">
                             <fo:basic-link internal-destination="{local:buildID(.)}">
                                 <xsl:choose>
                                     <xsl:when test="ead:head">
-                                        <xsl:apply-templates select="child::*/ead:head"/>        
+                                        <xsl:apply-templates select="child::*/ead:head"/>
                                     </xsl:when>
                                     <xsl:otherwise>
                                         <xsl:apply-templates select="child::*/ead:unittitle"/>
                                     </xsl:otherwise>
-                                </xsl:choose>    
-                            </fo:basic-link>                    
-                            <xsl:text>&#160;&#160;</xsl:text>                    
-                            <fo:leader leader-pattern="dots"/>                    
-                            <xsl:text>&#160;&#160;</xsl:text>                    
-                            <fo:page-number-citation ref-id="{local:buildID(.)}"/>                    
-                        </fo:block>   
-                        <!-- Creates a submenu for subfonds, subgrp or subseries -->    
+                                </xsl:choose>
+                            </fo:basic-link>
+                            <xsl:text>&#160;&#160;</xsl:text>
+                            <fo:leader leader-pattern="dots"/>
+                            <xsl:text>&#160;&#160;</xsl:text>
+                            <fo:page-number-citation ref-id="{local:buildID(.)}"/>
+                        </fo:block>
+                        <!-- Creates a submenu for subfonds, subgrp or subseries -->
                         <xsl:for-each select="child::*[@level = 'subfonds'] | child::*[@level = 'subgrp']  | child::*[@level = 'subseries']">
-                            <fo:block text-align-last="justify" margin-left="16pt"> 
+                            <fo:block text-align-last="justify" margin-left="16pt">
                                 <fo:basic-link internal-destination="{local:buildID(.)}">
                                     <xsl:choose>
                                         <xsl:when test="ead:head">
-                                            <xsl:apply-templates select="child::*/ead:head"/>        
+                                            <xsl:apply-templates select="child::*/ead:head"/>
                                         </xsl:when>
                                         <xsl:otherwise>
                                             <xsl:apply-templates select="child::*/ead:unittitle"/>
                                         </xsl:otherwise>
-                                    </xsl:choose>    
-                                </fo:basic-link>                    
-                                <xsl:text>&#160;&#160;</xsl:text>                    
-                                <fo:leader leader-pattern="dots"/>                    
-                                <xsl:text>&#160;&#160;</xsl:text>                    
-                                <fo:page-number-citation ref-id="{local:buildID(.)}"/>                    
-                            </fo:block>   
+                                    </xsl:choose>
+                                </fo:basic-link>
+                                <xsl:text>&#160;&#160;</xsl:text>
+                                <fo:leader leader-pattern="dots"/>
+                                <xsl:text>&#160;&#160;</xsl:text>
+                                <fo:page-number-citation ref-id="{local:buildID(.)}"/>
+                            </fo:block>
                         </xsl:for-each>
                     </xsl:for-each>
                 </xsl:for-each>
             </fo:block>
             </fo:block>
     </xsl:template>
-    
-    <!-- 
-        Formats children of archdesc. This template orders the children of the archdesc, 
+
+    <!--
+        Formats children of archdesc. This template orders the children of the archdesc,
         if order is changed it must also be changed in the table of contents.
     -->
-    <xsl:template match="ead:archdesc">  
+    <xsl:template match="ead:archdesc">
             <xsl:apply-templates select="ead:did"/>
             <xsl:apply-templates select="ead:bioghist"/>
             <xsl:apply-templates select="ead:scopecontent"/>
             <xsl:apply-templates select="ead:arrangement"/>
             <xsl:apply-templates select="ead:fileplan"/>
-            
+
             <!-- Administrative Information  -->
             <xsl:if test="ead:accessrestrict or ead:userestrict or
-                ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or 
-                ead:processinfo or ead:appraisal or ead:originalsloc or 
+                ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or
+                ead:processinfo or ead:appraisal or ead:originalsloc or
                 /ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt or /ead:ead/ead:eadheader/ead:revisiondesc">
                 <fo:block xsl:use-attribute-sets="section">
                     <fo:block xsl:use-attribute-sets="h2" id="adminInfo">Administrative Information</fo:block>
                     <xsl:apply-templates select="ead:accessrestrict | ead:userestrict |
-                        ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |  
-                        ead:processinfo | ead:appraisal | ead:originalsloc | 
+                        ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |
+                        ead:processinfo | ead:appraisal | ead:originalsloc |
                         /ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt | /ead:ead/ead:eadheader/ead:revisiondesc"/>
                     <xsl:call-template name="toc"/>
                 </fo:block>
             </xsl:if>
-            
+
             <!-- Related Materials -->
             <xsl:if test="ead:relatedmaterial or ead:separatedmaterial">
                 <fo:block xsl:use-attribute-sets="section">
-                    <fo:block xsl:use-attribute-sets="h2" id="relMat">Related Materials</fo:block> 
+                    <fo:block xsl:use-attribute-sets="h2" id="relMat">Related Materials</fo:block>
                     <xsl:apply-templates select="ead:relatedmaterial | ead:separatedmaterial"/>
                     <xsl:call-template name="toc"/>
                 </fo:block>
             </xsl:if>
-            
+
             <xsl:apply-templates select="ead:controlaccess"/>
             <xsl:apply-templates select="ead:otherfindaid"/>
             <xsl:apply-templates select="ead:phystech"/>
             <xsl:apply-templates select="ead:odd"/>
             <xsl:apply-templates select="ead:bibliography"/>
             <xsl:apply-templates select="ead:index"/>
-            <xsl:apply-templates select="ead:dsc"/>        
+            <xsl:apply-templates select="ead:dsc"/>
     </xsl:template>
 
     <!-- Formats archdesc did -->
     <xsl:template match="ead:archdesc/ead:did">
         <fo:block xsl:use-attribute-sets="section">
         <fo:block xsl:use-attribute-sets="h2ID">Summary Information</fo:block>
-                <!-- 
-                    Determines the order in wich elements from the archdesc did appear, 
-                    to change the order of appearance change the order of the following 
+                <!--
+                    Determines the order in wich elements from the archdesc did appear,
+                    to change the order of appearance change the order of the following
                     apply-template statements.
                 -->
 
@@ -643,27 +643,27 @@
                 <fo:table-body>
                         <xsl:apply-templates select="ead:repository" mode="overview"/>
                         <xsl:apply-templates select="ead:origination" mode="overview"/>
-                        <xsl:apply-templates select="ead:unittitle" mode="overview"/>    
+                        <xsl:apply-templates select="ead:unittitle" mode="overview"/>
                         <xsl:apply-templates select="ead:unitid" mode="overview"/>
                         <xsl:apply-templates select="ead:unitdate" mode="overview"/>
-                        <xsl:apply-templates select="ead:physdesc" mode="overview"/>        
-                        <xsl:apply-templates select="ead:physloc" mode="overview"/> 
+                        <xsl:apply-templates select="ead:physdesc" mode="overview"/>
+                        <xsl:apply-templates select="ead:physloc" mode="overview"/>
                         <xsl:apply-templates select="ead:dao" mode="overview"/>
                         <xsl:apply-templates select="ead:daogrp" mode="overview"/>
                         <xsl:apply-templates select="ead:langmaterial" mode="overview"/>
                         <xsl:apply-templates select="ead:materialspec" mode="overview"/>
                         <xsl:apply-templates select="ead:container" mode="overview"/>
-                        <xsl:apply-templates select="ead:abstract" mode="overview"/> 
+                        <xsl:apply-templates select="ead:abstract" mode="overview"/>
                         <xsl:apply-templates select="ead:note" mode="overview"/>
                 </fo:table-body>
             </fo:table>
-            <!-- Adds prefered citation to summary information -->    
-            <xsl:apply-templates select="../ead:prefercite" mode="overview"/>   
+            <!-- Adds prefered citation to summary information -->
+            <xsl:apply-templates select="../ead:prefercite" mode="overview"/>
             <!-- Link back to table of contents -->
             <xsl:call-template name="toc"/>
         </fo:block>
     </xsl:template>
-    
+
     <!-- Formats prefercite in the summary -->
     <xsl:template match="ead:prefercite" mode="overview">
         <fo:block xsl:use-attribute-sets="section" border="1pt solid #333">
@@ -673,10 +673,10 @@
             </fo:block>
         </fo:block>
     </xsl:template>
-    
+
     <!-- Formats children of arcdesc/did -->
-    <xsl:template match="ead:repository | ead:origination | ead:unittitle | ead:unitdate | ead:unitid  
-        | ead:physdesc | ead:physloc | ead:dao | ead:daogrp | ead:langmaterial | ead:materialspec | ead:container 
+    <xsl:template match="ead:repository | ead:origination | ead:unittitle | ead:unitdate | ead:unitid
+        | ead:physdesc | ead:physloc | ead:dao | ead:daogrp | ead:langmaterial | ead:materialspec | ead:container
         | ead:abstract | ead:note" mode="overview">
         <fo:table-row>
             <fo:table-cell padding-bottom="8pt" padding-right="16pt" text-align="right" font-weight="bold">
@@ -692,7 +692,7 @@
                                     - <xsl:value-of select="substring-before(ead:persname/@role,' (')"/>
                                 </xsl:when>
                                 <xsl:when test="ead:persname[@role != '']">
-                                    - <xsl:value-of select="ead:persname/@role"/>  
+                                    - <xsl:value-of select="ead:persname/@role"/>
                                 </xsl:when>
                                 <xsl:otherwise/>
                             </xsl:choose>
@@ -703,7 +703,7 @@
                         <!-- Test for type attribute used by unitdate -->
                         <xsl:if test="@type"> [<xsl:value-of select="@type"/>]</xsl:if>
                     </xsl:otherwise>
-                </xsl:choose>: 
+                </xsl:choose>:
                 </fo:block>
             </fo:table-cell>
             <fo:table-cell padding-bottom="2pt">
@@ -714,40 +714,40 @@
         </fo:table-row>
     </xsl:template>
     <!-- Adds space between extents -->
-    <xsl:template match="ead:extent"><xsl:apply-templates/>&#160;</xsl:template>      
-        
+    <xsl:template match="ead:extent"><xsl:apply-templates/>&#160;</xsl:template>
+
     <!-- Formats children of arcdesc not in administrative or related materials sections-->
-    <xsl:template match="ead:bibliography | ead:odd | ead:phystech | ead:otherfindaid | 
+    <xsl:template match="ead:bibliography | ead:odd | ead:phystech | ead:otherfindaid |
         ead:bioghist | ead:scopecontent | ead:arrangement | ead:fileplan">
-        <fo:block xsl:use-attribute-sets="section">  
-            <fo:block xsl:use-attribute-sets="h2ID"><xsl:value-of select="local:tagName(.)"/></fo:block> 
-                <xsl:apply-templates/>                
+        <fo:block xsl:use-attribute-sets="section">
+            <fo:block xsl:use-attribute-sets="h2ID"><xsl:value-of select="local:tagName(.)"/></fo:block>
+                <xsl:apply-templates/>
             <xsl:call-template name="toc"/>
         </fo:block>
     </xsl:template>
 
     <!-- Formats children of arcdesc in administrative and related materials sections -->
     <xsl:template match="ead:relatedmaterial | ead:separatedmaterial | ead:accessrestrict | ead:userestrict |
-        ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |  
+        ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |
         ead:processinfo | ead:appraisal | ead:originalsloc">
         <fo:block xsl:use-attribute-sets="section">
             <fo:block xsl:use-attribute-sets="h3ID"><xsl:value-of select="local:tagName(.)"/></fo:block>
                 <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
-    
+
     <!-- Publication statement included in administrative information section -->
     <xsl:template match="ead:publicationstmt">
         <fo:block xsl:use-attribute-sets="section">
             <fo:block xsl:use-attribute-sets="h3"><xsl:value-of select="local:tagName(.)"/></fo:block>
             <fo:block xsl:use-attribute-sets="smp">
-                <xsl:apply-templates select="ead:publisher"/>             
-                <xsl:if test="ead:date">&#160;<xsl:apply-templates select="ead:date"/></xsl:if>                
+                <xsl:apply-templates select="ead:publisher"/>
+                <xsl:if test="ead:date">&#160;<xsl:apply-templates select="ead:date"/></xsl:if>
             </fo:block>
             <xsl:apply-templates select="ead:address"/>
         </fo:block>
     </xsl:template>
-    
+
     <!-- Formats Address elements -->
     <xsl:template match="ead:address">
         <fo:block xsl:use-attribute-sets="smp">
@@ -770,7 +770,7 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
+
     <!-- Templates for revision description  -->
     <xsl:template match="ead:revisiondesc">
         <fo:block xsl:use-attribute-sets="section">
@@ -779,13 +779,13 @@
             <xsl:if test="ead:change/ead:date">&#160;<xsl:value-of select="ead:change/ead:date"/></xsl:if>
         </fo:block>
     </xsl:template>
-    
+
     <!-- Formats controlled access terms -->
     <xsl:template match="ead:controlaccess">
-        <fo:block xsl:use-attribute-sets="section">         
+        <fo:block xsl:use-attribute-sets="section">
             <fo:block xsl:use-attribute-sets="h2ID"><xsl:value-of select="local:tagName(.)"/></fo:block>
             <fo:list-block xsl:use-attribute-sets="smp">
-                <xsl:apply-templates/>    
+                <xsl:apply-templates/>
             </fo:list-block>
         </fo:block>
     </xsl:template>
@@ -801,10 +801,10 @@
             </fo:list-item-body>
         </fo:list-item>
     </xsl:template>
-    
+
     <!-- Formats index and child elements, groups indexentry elements by type (i.e. corpname, subject...) -->
     <xsl:template match="ead:index">
-        <fo:block xsl:use-attribute-sets="section">          
+        <fo:block xsl:use-attribute-sets="section">
             <fo:block xsl:use-attribute-sets="h2ID"><xsl:value-of select="local:tagName(.)"/></fo:block>
             <xsl:apply-templates select="child::*[not(self::ead:indexentry)]"/>
             <fo:list-block xsl:use-attribute-sets="smp">
@@ -824,9 +824,9 @@
             </fo:list-item-body>
         </fo:list-item>
     </xsl:template>
-     
+
     <!-- Formats a simple table. The width of each column is defined by the colwidth attribute in a colspec element. -->
-    <xsl:template match="ead:table">  
+    <xsl:template match="ead:table">
         <xsl:apply-templates/>
     </xsl:template>
     <xsl:template match="ead:table/ead:thead">
@@ -836,7 +836,7 @@
         <fo:table xsl:use-attribute-sets="tableBorder">
             <xsl:apply-templates/>
             <fo:table-body>
-                <xsl:apply-templates select="*[not(ead:colspec)]"/>    
+                <xsl:apply-templates select="*[not(ead:colspec)]"/>
             </fo:table-body>
         </fo:table>
     </xsl:template>
@@ -860,11 +860,11 @@
     <xsl:template match="ead:entry">
         <fo:table-cell xsl:use-attribute-sets="tdBorder">
             <fo:block xsl:use-attribute-sets="smp">
-                <xsl:apply-templates/>                
+                <xsl:apply-templates/>
             </fo:block>
         </fo:table-cell>
     </xsl:template>
-    
+
     <!--Bibref citation  inline, if there is a parent element.-->
     <xsl:template match="ead:p/ead:bibref">
         <xsl:choose>
@@ -891,7 +891,7 @@
             </xsl:choose>
         </fo:block>
     </xsl:template>
-    
+
     <!-- Lists -->
     <!-- Lists with listhead element are output as tables -->
     <xsl:template match="ead:list[ead:listhead]">
@@ -901,12 +901,12 @@
                 <fo:table-row xsl:use-attribute-sets="th">
                     <fo:table-cell xsl:use-attribute-sets="tdBorder">
                         <fo:block xsl:use-attribute-sets="smp">
-                            <xsl:value-of select="ead:listhead/ead:head01"/>                            
+                            <xsl:value-of select="ead:listhead/ead:head01"/>
                         </fo:block>
                     </fo:table-cell>
                     <fo:table-cell xsl:use-attribute-sets="tdBorder">
                         <fo:block>
-                            <xsl:value-of select="ead:listhead/ead:head02"/>    
+                            <xsl:value-of select="ead:listhead/ead:head02"/>
                         </fo:block>
                     </fo:table-cell>
                 </fo:table-row>
@@ -927,7 +927,7 @@
                 </xsl:otherwise>
             </xsl:choose>
         </fo:list-block>
-    </xsl:template>   
+    </xsl:template>
     <xsl:template match="ead:item">
         <fo:list-item>
             <fo:list-item-label  end-indent="label-end()">
@@ -951,7 +951,7 @@
                         <xsl:when test="../@type='ordered' and not(../@numeration)">
                             <xsl:number format="1"/>
                         </xsl:when>
-                        <xsl:otherwise>&#x2022;</xsl:otherwise>                        
+                        <xsl:otherwise>&#x2022;</xsl:otherwise>
                     </xsl:choose>
                 </fo:block>
             </fo:list-item-label>
@@ -977,13 +977,13 @@
             </fo:list-item-body>
         </fo:list-item>
     </xsl:template>
-    
-    <!-- Formats list as table if list has listhead element  -->         
+
+    <!-- Formats list as table if list has listhead element  -->
     <xsl:template match="ead:defitem" mode="listTable">
         <fo:table-row>
             <fo:table-cell xsl:use-attribute-sets="tdBorder">
                 <fo:block xsl:use-attribute-sets="smp">
-                    <xsl:apply-templates select="ead:label"/>                    
+                    <xsl:apply-templates select="ead:label"/>
                 </fo:block>
             </fo:table-cell>
             <fo:table-cell xsl:use-attribute-sets="tdBorder">
@@ -993,7 +993,7 @@
             </fo:table-cell>
         </fo:table-row>
     </xsl:template>
-    
+
     <!-- Output chronlist and children in a table -->
     <xsl:template match="ead:chronlist">
         <fo:table xsl:use-attribute-sets="tableBorder">
@@ -1006,12 +1006,12 @@
         <fo:table-row xsl:use-attribute-sets="th">
             <fo:table-cell xsl:use-attribute-sets="tdBorder">
                 <fo:block xsl:use-attribute-sets="smp">
-                    <xsl:apply-templates select="ead:head01"/>                    
+                    <xsl:apply-templates select="ead:head01"/>
                 </fo:block>
             </fo:table-cell>
             <fo:table-cell xsl:use-attribute-sets="tdBorder">
                 <fo:block xsl:use-attribute-sets="smp">
-                    <xsl:apply-templates select="ead:head02"/>                    
+                    <xsl:apply-templates select="ead:head02"/>
                 </fo:block>
             </fo:table-cell>
         </fo:table-row>
@@ -1020,7 +1020,7 @@
         <fo:table-row>
             <fo:table-cell number-columns-spanned="2" xsl:use-attribute-sets="th">
                 <fo:block xsl:use-attribute-sets="smp">
-                    <xsl:apply-templates/>                    
+                    <xsl:apply-templates/>
                 </fo:block>
             </fo:table-cell>
         </fo:table-row>
@@ -1036,7 +1036,7 @@
             </xsl:attribute>
             <fo:table-cell  xsl:use-attribute-sets="tdBorder">
                 <fo:block xsl:use-attribute-sets="smp">
-                    <xsl:apply-templates select="ead:date"/>                    
+                    <xsl:apply-templates select="ead:date"/>
                 </fo:block>
             </fo:table-cell>
             <fo:table-cell  xsl:use-attribute-sets="tdBorder">
@@ -1056,11 +1056,11 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
+
     <!-- Formats notestmt and notes -->
     <xsl:template match="ead:notestmt">
         <fo:block xsl:use-attribute-sets="section">
-            <fo:block xsl:use-attribute-sets="h4ID">Note</fo:block>    
+            <fo:block xsl:use-attribute-sets="h4ID">Note</fo:block>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -1077,7 +1077,7 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
+
     <!-- Formats legalstatus -->
     <xsl:template match="ead:legalstatus">
         <fo:block xsl:use-attribute-sets="smp">
@@ -1085,7 +1085,7 @@
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
-    
+
     <!-- General headings -->
     <!-- Children of the archdesc are handled by the local:tagName function -->
     <xsl:template match="ead:head[parent::*/parent::ead:archdesc]"/>
@@ -1093,7 +1093,7 @@
     <xsl:template match="ead:head">
         <fo:block xsl:use-attribute-sets="h4" id="{local:buildID(parent::*)}"><xsl:apply-templates/></fo:block>
     </xsl:template>
-    
+
    <!-- Linking elmenets -->
     <xsl:template match="ead:ref">
         <fo:basic-link internal-destination="{@target}" xsl:use-attribute-sets="ref">
@@ -1154,7 +1154,7 @@
             <xsl:choose>
                 <xsl:when test="@*:title"><xsl:value-of select="@*:title"/></xsl:when>
                 <xsl:otherwise><xsl:value-of select="@*:entityref"/></xsl:otherwise>
-            </xsl:choose>        
+            </xsl:choose>
         </fo:basic-link>
     </xsl:template>
     <xsl:template match="ead:extptr[@*:href]">
@@ -1162,7 +1162,7 @@
             <xsl:choose>
                 <xsl:when test="@*:title"><xsl:value-of select="@*:title"/></xsl:when>
                 <xsl:otherwise><xsl:value-of select="@*:href"/></xsl:otherwise>
-            </xsl:choose>        
+            </xsl:choose>
         </fo:basic-link>
     </xsl:template>
     <xsl:template match="ead:dao">
@@ -1200,7 +1200,7 @@
             </xsl:choose>
         </fo:basic-link>
     </xsl:template>
-   
+
     <!--Render elements -->
     <xsl:template match="*[@render = 'bold'] | *[@altrender = 'bold'] ">
         <fo:inline font-weight="bold">
@@ -1265,7 +1265,7 @@
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
-   
+
     <!-- Formatting elements -->
     <xsl:template match="ead:p">
         <fo:block xsl:use-attribute-sets="smp"><xsl:apply-templates/></fo:block>
@@ -1275,7 +1275,7 @@
         <fo:block margin="4pt 18pt"><xsl:apply-templates/></fo:block>
     </xsl:template>
     <xsl:template match="ead:emph[not(@render)]"><fo:inline font-style="italic"><xsl:apply-templates/></fo:inline></xsl:template>
-    
+
     <!-- Collection Inventory (dsc) templates -->
     <xsl:template match="ead:archdesc/ead:dsc">
         <xsl:if test="count(child::*) >= 1">
@@ -1292,9 +1292,9 @@
 			    </xsl:if>
 			    <xsl:apply-templates select="*[not(self::ead:head)]"/>
 			</fo:table-body>
-		    </fo:table> 
-		</fo:block>        
-	</xsl:if> 
+		    </fo:table>
+		</fo:block>
+	</xsl:if>
     </xsl:template>
 
     <!--
@@ -1309,7 +1309,7 @@
         <xsl:if test="@level='series'">
             <fo:table-row>
                 <fo:table-cell number-columns-spanned="3"><xsl:call-template name="toc"/></fo:table-cell>
-            </fo:table-row>  
+            </fo:table-row>
         </xsl:if>
     </xsl:template>
     <!--This is a named template that processes all the components  -->
@@ -1334,8 +1334,8 @@
         </xsl:variable>
             <xsl:choose>
                 <!--Formats Series and Groups  -->
-                <xsl:when test="@level='subcollection' or @level='subgrp' or @level='series' 
-                    or @level='subseries' or @level='collection'or @level='fonds' or 
+                <xsl:when test="@level='subcollection' or @level='subgrp' or @level='series'
+                    or @level='subseries' or @level='collection'or @level='fonds' or
                     @level='recordgrp' or @level='subfonds' or @level='class' or (@level='otherlevel' and not(child::ead:did/ead:container))">
                     <fo:table-row background-color="#f0f0f0" border-bottom="1px dotted #ccc" border-top="3pt solid #ccc" keep-with-next.within-page="always">
                         <fo:table-cell margin-left="{$clevelMargin}" padding-top="4pt">
@@ -1350,16 +1350,16 @@
                                     </xsl:choose>
                                 </xsl:attribute>
                             </xsl:if>
-                            <xsl:apply-templates select="ead:did" mode="dscSeriesTitle"/>    
-                            <xsl:apply-templates select="ead:did" mode="dscSeries"/>                            
-                            <xsl:apply-templates select="child::*[not(ead:did) and not(self::ead:did)]" mode="dsc"/>                                        
+                            <xsl:apply-templates select="ead:did" mode="dscSeriesTitle"/>
+                            <xsl:apply-templates select="ead:did" mode="dscSeries"/>
+                            <xsl:apply-templates select="child::*[not(ead:did) and not(self::ead:did)]" mode="dsc"/>
                         </fo:table-cell>
                     </fo:table-row>
                     <!-- Adds grouped instances if they exist -->
                     <xsl:if test="ead:did/ead:container">
                         <xsl:choose>
                             <xsl:when test="ead:did/ead:container/@label">
-                                <xsl:for-each-group select="ead:did/ead:container" group-starting-with=".[@label]">
+                                <xsl:for-each-group select="ead:did/ead:container" group-starting-with="@label">
                                     <fo:table-row background-color="#f0f0f0" border-bottom="1px dotted #ccc" border-top="3pt solid #ccc" keep-with-next.within-page="always">
                                         <xsl:apply-templates select="current-group()"/>
                                         <xsl:choose>
@@ -1371,7 +1371,7 @@
                                                 <fo:table-cell><fo:block/></fo:table-cell>
                                             </xsl:when>
                                         </xsl:choose>
-                                    </fo:table-row>    
+                                    </fo:table-row>
                                 </xsl:for-each-group>
                             </xsl:when>
                             <xsl:otherwise>
@@ -1390,7 +1390,7 @@
                                     </xsl:choose>
                                 </fo:table-row>
                             </xsl:otherwise>
-                        </xsl:choose>                       
+                        </xsl:choose>
                     </xsl:if>
                     <!-- Adds column headings if series/subseries is followed by an item -->
                     <xsl:if test="child::*[@level][1][@level='item' or @level='file' or @level='otherlevel']">
@@ -1399,20 +1399,20 @@
                 </xsl:when>
                 <!-- Groups instances by label attribute, the way they are grouped in ArchivesSpace -->
                 <xsl:when test="ead:did/ead:container[@label]">
-                    <fo:table-row border-top="1px solid #ccc" keep-with-next.within-page="always"> 
+                    <fo:table-row border-top="1px solid #ccc" keep-with-next.within-page="always">
                         <fo:table-cell margin-left="{$clevelMargin}"  padding-top="4pt" number-rows-spanned="{count(ead:did/ead:container[@label]) + 1}">
                             <xsl:if test="not(ead:did/ead:container)">
                                 <xsl:attribute name="number-columns-spanned">4</xsl:attribute>
                             </xsl:if>
-                            <xsl:apply-templates select="ead:did" mode="dsc"/>  
-                            <xsl:apply-templates mode="dsc" select="*[not(self::ead:did) and 
+                            <xsl:apply-templates select="ead:did" mode="dsc"/>
+                            <xsl:apply-templates mode="dsc" select="*[not(self::ead:did) and
                                 not(self::ead:c) and not(self::ead:c02) and not(self::ead:c03) and
                                 not(self::ead:c04) and not(self::ead:c05) and not(self::ead:c06) and not(self::ead:c07)
-                                and not(self::ead:c08) and not(self::ead:c09) and not(self::ead:c10) and not(self::ead:c11) and not(self::ead:c12)]"/>          
+                                and not(self::ead:c08) and not(self::ead:c09) and not(self::ead:c10) and not(self::ead:c11) and not(self::ead:c12)]"/>
                         </fo:table-cell>
                     </fo:table-row>
                     <!-- Groups instances by label attribute, the way they are grouped in ArchivesSpace -->
-                    <xsl:for-each-group select="ead:did/ead:container" group-starting-with=".[@label]">
+                    <xsl:for-each-group select="ead:did/ead:container" group-starting-with="@label">
                         <fo:table-row keep-with-next.within-page="always">
                             <xsl:apply-templates select="current-group()"/>
                             <xsl:choose>
@@ -1424,18 +1424,18 @@
                                     <fo:table-cell><fo:block/></fo:table-cell>
                                 </xsl:when>
                             </xsl:choose>
-                        </fo:table-row>        
-                    </xsl:for-each-group>                    
+                        </fo:table-row>
+                    </xsl:for-each-group>
                 </xsl:when>
                 <!-- For finding aids with no @label attribute, only accounts for three containers -->
                 <xsl:otherwise>
-                    <fo:table-row border-top="1px solid #ccc"> 
+                    <fo:table-row border-top="1px solid #ccc">
                         <fo:table-cell margin-left="{$clevelMargin}"  padding-top="4pt" number-rows-spanned="{count(ead:did/ead:container[@label]) + 1}">
-                            <xsl:apply-templates select="ead:did" mode="dsc"/>  
-                            <xsl:apply-templates mode="dsc" select="*[not(self::ead:did) and 
+                            <xsl:apply-templates select="ead:did" mode="dsc"/>
+                            <xsl:apply-templates mode="dsc" select="*[not(self::ead:did) and
                                 not(self::ead:c) and not(self::ead:c02) and not(self::ead:c03) and
                                 not(self::ead:c04) and not(self::ead:c05) and not(self::ead:c06) and not(self::ead:c07)
-                                and not(self::ead:c08) and not(self::ead:c09) and not(self::ead:c10) and not(self::ead:c11) and not(self::ead:c12)]"/>          
+                                and not(self::ead:c08) and not(self::ead:c09) and not(self::ead:c10) and not(self::ead:c11) and not(self::ead:c12)]"/>
                         </fo:table-cell>
                         <fo:table-cell>
                             <fo:block margin="4pt 0"><xsl:value-of select="ead:did/ead:container[1]/@type"/><xsl:text> </xsl:text><xsl:value-of select="ead:did/ead:container[1]"/></fo:block>
@@ -1473,7 +1473,7 @@
             <fo:block margin="4pt 0"><xsl:value-of select="@type"/><xsl:text> </xsl:text><xsl:value-of select="."/></fo:block>
         </fo:table-cell>
     </xsl:template>
-    
+
     <!-- Series titles -->
     <xsl:template match="ead:did" mode="dscSeriesTitle">
         <fo:block font-weight="bold" font-size="14" margin-bottom="0" margin-top="4" id="{local:buildID(parent::*)}">
@@ -1499,42 +1499,42 @@
             <xsl:apply-templates select="ead:unitdate" mode="did"/>
         </fo:block>
     </xsl:template>
-    
+
     <!-- Series child elements -->
-    <xsl:template match="ead:did" mode="dscSeries">    
-        <fo:block margin-bottom="4pt" margin-top="0">        
-            <xsl:apply-templates select="ead:repository" mode="dsc"/>            
-            <xsl:apply-templates select="ead:origination" mode="dsc"/>            
-            <xsl:apply-templates select="ead:unitdate" mode="dsc"/>            
-            <xsl:apply-templates select="ead:physdesc" mode="dsc"/>                    
-            <xsl:apply-templates select="ead:physloc" mode="dsc"/>             
-            <xsl:apply-templates select="ead:dao"/>            
-            <xsl:apply-templates select="ead:daogrp"/>            
-            <xsl:apply-templates select="ead:langmaterial" mode="dsc"/>            
-            <xsl:apply-templates select="ead:materialspec" mode="dsc"/>            
-            <xsl:apply-templates select="ead:abstract" mode="dsc"/>             
+    <xsl:template match="ead:did" mode="dscSeries">
+        <fo:block margin-bottom="4pt" margin-top="0">
+            <xsl:apply-templates select="ead:repository" mode="dsc"/>
+            <xsl:apply-templates select="ead:origination" mode="dsc"/>
+            <xsl:apply-templates select="ead:unitdate" mode="dsc"/>
+            <xsl:apply-templates select="ead:physdesc" mode="dsc"/>
+            <xsl:apply-templates select="ead:physloc" mode="dsc"/>
+            <xsl:apply-templates select="ead:dao"/>
+            <xsl:apply-templates select="ead:daogrp"/>
+            <xsl:apply-templates select="ead:langmaterial" mode="dsc"/>
+            <xsl:apply-templates select="ead:materialspec" mode="dsc"/>
+            <xsl:apply-templates select="ead:abstract" mode="dsc"/>
             <xsl:apply-templates select="ead:note" mode="dsc"/>
         </fo:block>
     </xsl:template>
-    
+
     <!-- Unittitles and all other clevel elements -->
     <xsl:template match="ead:did" mode="dsc">
         <fo:block margin-bottom="0">
             <xsl:apply-templates select="ead:unittitle"/>
             <xsl:if test="(string-length(ead:unittitle[1]) &gt; 1) and (string-length(ead:unitdate[1]) &gt; 1)">, </xsl:if>
-            <xsl:apply-templates select="ead:unitdate" mode="did"/>    
-        </fo:block> 
+            <xsl:apply-templates select="ead:unitdate" mode="did"/>
+        </fo:block>
         <fo:block margin-bottom="4pt" margin-top="0">
-            <xsl:apply-templates select="ead:repository" mode="dsc"/>            
-            <xsl:apply-templates select="ead:origination" mode="dsc"/>            
-            <xsl:apply-templates select="ead:unitdate" mode="dsc"/>            
-            <xsl:apply-templates select="ead:physdesc" mode="dsc"/>                    
-            <xsl:apply-templates select="ead:physloc" mode="dsc"/>             
-            <xsl:apply-templates select="ead:dao" mode="dsc"/>            
-            <xsl:apply-templates select="ead:daogrp" mode="dsc"/>            
-            <xsl:apply-templates select="ead:langmaterial" mode="dsc"/>            
-            <xsl:apply-templates select="ead:materialspec" mode="dsc"/>            
-            <xsl:apply-templates select="ead:abstract" mode="dsc"/>             
+            <xsl:apply-templates select="ead:repository" mode="dsc"/>
+            <xsl:apply-templates select="ead:origination" mode="dsc"/>
+            <xsl:apply-templates select="ead:unitdate" mode="dsc"/>
+            <xsl:apply-templates select="ead:physdesc" mode="dsc"/>
+            <xsl:apply-templates select="ead:physloc" mode="dsc"/>
+            <xsl:apply-templates select="ead:dao" mode="dsc"/>
+            <xsl:apply-templates select="ead:daogrp" mode="dsc"/>
+            <xsl:apply-templates select="ead:langmaterial" mode="dsc"/>
+            <xsl:apply-templates select="ead:materialspec" mode="dsc"/>
+            <xsl:apply-templates select="ead:abstract" mode="dsc"/>
             <xsl:apply-templates select="ead:note" mode="dsc"/>
         </fo:block>
     </xsl:template>
@@ -1543,10 +1543,10 @@
         (<xsl:apply-templates/>)
     </xsl:template>
     <xsl:template match="ead:unitdate" mode="did"><xsl:apply-templates/></xsl:template>
-    
+
     <!-- Special formatting for elements in the collection inventory list -->
-    <xsl:template match="ead:repository | ead:origination | ead:unitdate | ead:unitid  
-        | ead:physdesc | ead:physloc | ead:langmaterial | ead:materialspec | ead:container 
+    <xsl:template match="ead:repository | ead:origination | ead:unitdate | ead:unitid
+        | ead:physdesc | ead:physloc | ead:langmaterial | ead:materialspec | ead:container
         | ead:abstract | ead:note" mode="dsc">
         <xsl:if test="normalize-space()">
         <fo:block xsl:use-attribute-sets="smpDsc">
@@ -1562,7 +1562,7 @@
                                 - <xsl:value-of select="substring-before(ead:persname/@role,' (')"/>
                             </xsl:when>
                             <xsl:when test="ead:persname[@role != '']">
-                                - <xsl:value-of select="ead:persname/@role"/>  
+                                - <xsl:value-of select="ead:persname/@role"/>
                             </xsl:when>
                             <xsl:otherwise/>
                         </xsl:choose>
@@ -1580,7 +1580,7 @@
         </xsl:if>
     </xsl:template>
     <xsl:template match="ead:relatedmaterial | ead:separatedmaterial | ead:accessrestrict | ead:userestrict |
-        ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |  
+        ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |
         ead:processinfo | ead:appraisal | ead:originalsloc" mode="dsc">
         <xsl:if test="child::*">
             <fo:block xsl:use-attribute-sets="smpDsc">
@@ -1595,13 +1595,13 @@
             <xsl:apply-templates select="ead:indexentry"/>
         </fo:list-block>
     </xsl:template>
-    <xsl:template match="ead:controlaccess" mode="dsc">         
+    <xsl:template match="ead:controlaccess" mode="dsc">
         <fo:block xsl:use-attribute-sets="smpDsc" text-decoration="underline"><xsl:value-of select="local:tagName(.)"/>:</fo:block>
         <fo:list-block xsl:use-attribute-sets="smpDsc">
             <xsl:apply-templates/>
         </fo:list-block>
         <!--
-            To group controlled access terms by type 
+            To group controlled access terms by type
             <xsl:for-each-group select="child::*" group-by="name(.)">
                 <xsl:sort select="current-grouping-key()"/>
                 <fo:block margin-left="8pt" text-decoration="underline"><xsl:value-of select="local:tagName(.)"/></fo:block>
@@ -1619,7 +1619,7 @@
                         </fo:list-item>
                     </xsl:for-each>
                 </fo:list-block>
-            </xsl:for-each-group>    
+            </xsl:for-each-group>
         -->
     </xsl:template>
     <xsl:template match="ead:dao" mode="dsc">
@@ -1646,7 +1646,7 @@
                  <xsl:otherwise>
                      <xsl:value-of select="local:tagName(.)"/>
                  </xsl:otherwise>
-             </xsl:choose></fo:inline>:             
+             </xsl:choose></fo:inline>:
             <fo:basic-link external-destination="url('{@*:href}')" xsl:use-attribute-sets="ref">
                 <xsl:value-of select="$title"/>
             </fo:basic-link>


### PR DESCRIPTION
@fordmadox Is this what you were thinking needed to happen? Please excuse the weird spaces showing up in the difference below. The line numbers that I changed are in as-ead-html.xsl - 1081 and 1112; and in as-ead-pdf.xsl - 1362 and 1415.