### PR TITLE
Quit trying to interpolate 'limit' variable in search-limit i18n

### DIFF
--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -76,7 +76,7 @@ en:
 
   search-button:
     label: Search
-  search-limit: "Limit to %{limit}"
+  search-limit: "Limit Search"
   search-limiting: "limited to %{limit}"
   search-limits:
     all: all record types

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -76,7 +76,7 @@ fr:
 
   search-button:
     label: Chercher
-  search-limit: "Limité à %{limit}"
+  search-limit: "Limité Chercher"
   search-limiting: "Limité à %{limit}"
   search-limits:
     all: tous types de notices


### PR DESCRIPTION
Newer version of i18n ( 0.8.* ) gem freaks out if you try and interpolate a
variable that isn't set. This seems to be happening with the
'search-limit' label. Assuming that the variable is for the
'search-limiting' label, so this removed the 'limit' variable.

This is related to the issues with #925 / #896 