### PR TITLE
Ar 1868

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -254,8 +254,7 @@ class EADSerializer < ASpaceExport::Serializer
           xml.unittitle {  sanitize_mixed_content( val,xml, fragments) }
         end
 
-        if !data.component_id.nil? && !data.component_id.empty? &&
-          !(data.external_ids.select {|x| x['external_id'] == data.component_id }).empty?
+        if !data.component_id.nil? && !data.component_id.empty?
           xml.unitid data.component_id
 
         end

--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -157,8 +157,10 @@ class EADSerializer < ASpaceExport::Serializer
 
             xml.unitid (0..3).map{|i| data.send("id_#{i}")}.compact.join('.')
 
-            data.external_ids.each do |exid|
-              xml.unitid  ({ "type" => exid['source'], "identifier" => exid['external_id']}) { xml.text exid['external_id']}
+            if @include_unpublished
+              data.external_ids.each do |exid|
+                xml.unitid  ({ "audience" => "internal", "type" => exid['source'], "identifier" => exid['external_id']}) { xml.text exid['external_id']}
+              end
             end
 
             serialize_extents(data, xml, @fragments)
@@ -256,11 +258,12 @@ class EADSerializer < ASpaceExport::Serializer
 
         if !data.component_id.nil? && !data.component_id.empty?
           xml.unitid data.component_id
-
         end
 
-        data.external_ids.each do |exid|
-          xml.unitid  ({ "type" => exid['source'], "identifier" => exid['external_id']}) { xml.text exid['external_id']}
+        if @include_unpublished
+          data.external_ids.each do |exid|
+            xml.unitid  ({ "audience" => "internal",  "type" => exid['source'], "identifier" => exid['external_id']}) { xml.text exid['external_id']}
+          end
         end
 
         serialize_origination(data, xml, fragments)


### PR DESCRIPTION
1. fix logic bug that was preventing export of primary id if there were also external ids.
2. Since external ids are for internal staff use only and are not displayed in the public view, we will consider them by default unpublished in the context of EAD export: not exported unless include_unpublished is true, and if exported, marked with audience="internal" attribute. 

The last point should be documented in the EAD import/export maps. 
Need to add spec tests for all cases. 

https://archivesspace.atlassian.net/browse/AR-1868