### PR TITLE
ar-1869: defaults on fetch in case of no title

### DIFF
--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -50,7 +50,7 @@
           <% result.ancestors.each do |ancestor| %>
             /
             <span class="ancestor">
-            <%= link_to process_mixed_content(ancestor.fetch('title')).html_safe, app_prefix(ancestor.fetch('uri')) %>
+            <%= link_to process_mixed_content(ancestor.fetch('title', "[#{ ancestor.fetch('level', 'untitled')}]" )).html_safe, app_prefix(ancestor.fetch('uri')) %>
             </span>
           <% end %>
         <% else %>


### PR DESCRIPTION
A better fix would be to always generate and add display_string to PUI index, but I'm putting this in as an interim fix. ( We may have accumulated enough bugs to warrant a 2.1.2 bug fix release soon, so this is in the queue if we don't get around to a better fix. ) 

https://archivesspace.atlassian.net/browse/AR-1869