### PR TITLE
URLs for external documents do not need the ASpace application prefix added to them

### DIFF
--- a/public/app/views/agents/show.html.erb
+++ b/public/app/views/agents/show.html.erb
@@ -20,7 +20,7 @@
     <% end %>
 
     <%= render partial: 'shared/display_notes' %>
-  
+
  <% if !@results.blank? && @results['total_hits'] > 0 %>
      <h3><%= t('found', {:count => @results['total_hits'], :type => @results['total_hits'] == 1? t('coll_obj._singular') : t('coll_obj._plural')}) %>:</h3>
          <%= render partial: 'shared/pagination', locals: {:pager  => @pager}  %>
@@ -33,7 +33,7 @@
 
   </div>
   <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
-    <% if @result.json['names'].length > 1 || 
+    <% if @result.json['names'].length > 1 ||
           (@result.respond_to?(:related_agents) && !ASUtils.wrap(@result.related_agents).empty?) ||
           ASUtils.wrap(@result.external_documents).length > 0 %>
 
@@ -51,7 +51,7 @@
           <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('agent._public.section.related_agents'), :p_id => 'related_agents_list', :p_body => x} %>
         <% end %>
         <% unless @result.external_documents.blank? %>
-          <% x = render partial: 'shared/present_list', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
+          <% x = render partial: 'shared/present_list_external_docs', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
           <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('external_docs'), :p_id => 'ext_doc_list', :p_body => x} %>
         <% end %>
       </div>

--- a/public/app/views/shared/_present_list_external_docs.html.erb
+++ b/public/app/views/shared/_present_list_external_docs.html.erb
@@ -1,0 +1,49 @@
+<% if list.kind_of? Hash
+   list.each do |k,v| %>
+   <h4><%= k %></h4>
+   <ul class="present_list <%= list_clss %>">
+   <% v.each do |item | %>
+     <li>
+     <% unless item['inherit'].blank? %>
+	<%= item['inherit'].html_safe %>
+     <% end %>
+     <% unless item['uri'].blank? %>
+     <a href="<%= item['uri'] %>">
+     <% end %>
+     <%= item['title'] %>
+     <% unless item['uri'].blank? %>
+     </a>
+     <% end %>
+     </li>
+   <% end %>
+   </ul>
+  <% end %>
+<% else %>
+  <ul class="present_list <%= list_clss %>">
+    <% list.each do |item| %>
+     <li>
+       <% if list_clss == 'subjects_list' && item['jsonmodel_type'].start_with?('agent_') %>
+         <a href="<%= item['uri'] %>">
+           <%= item['title'] %>
+         </a>
+         <% if item['_relator'] %>
+           (<%= t("enumerations.linked_agent_archival_record_relators.#{item['_relator']}", :default => item['_relator'])  %>)
+         <% end %>
+         <%= item['_terms'].map{|t| " -- #{t['term']}"}.join %>
+       <% else %>
+       <% if item.kind_of? Hash %>
+        <% unless item['uri'].blank? %>
+         <a href="<%= item['uri'] %>">
+        <% end %>
+        <%= item['title'] %>
+        <% unless item['uri'].blank? %>
+         </a>
+        <% end %>
+       <% else %>
+         <%= item %>
+       <% end %>
+       <% end %>
+     </li>
+    <% end %>
+  </ul>
+ <% end %>

--- a/public/app/views/shared/_record_innards.html.erb
+++ b/public/app/views/shared/_record_innards.html.erb
@@ -4,7 +4,7 @@
 <div class="upper-record-details">
     <% over = @result.note('scopecontent') %>
     <% if over.blank?
-       over = @result.note('abstract') 
+       over = @result.note('abstract')
        folder.shift # remove abstract from in-folder notes
 
     end %>
@@ -33,8 +33,8 @@
 
     <% unless @result.extents.blank? %>
       <h4><%= t('resource._public.extent') %></h4>
-       <% @result.extents.each do |ext| %> 
-        <p class="extent"><%= inheritance(ext['_inherited']).html_safe %> 
+       <% @result.extents.each do |ext| %>
+        <p class="extent"><%= inheritance(ext['_inherited']).html_safe %>
 	  <%= ext['display']%>
 	</p>
       <% end %>
@@ -53,7 +53,7 @@
       <div class="panel-group" id="res_accordion">
 	<% x = render partial: 'shared/multi_notes', locals: {:types => folder} %>
 	<% unless x.blank? %>
-	<%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('resource._public.additional'), 
+	<%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('resource._public.additional'),
 	      :p_id => 'add_desc', :p_body => x } %>
 	<% end %>
         <% if @result.kind_of?(Accession) && !@result.deaccessions.blank? %>
@@ -94,12 +94,12 @@
     <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('linked_instances'), :p_id => 'linked_instances_list', :p_body => x} %>
   <% end %>
 	<% unless @result.external_documents.blank? %>
-	 <% x = render partial: 'shared/present_list', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
+	 <% x = render partial: 'shared/present_list_external_docs', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
 	  <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('external_docs'), :p_id => 'ext_doc_list', :p_body => x} %>
 	<% end %>
 	<% unless @repo_info.blank? || @repo_info['top']['name'].blank? %>
            <% x= render partial: 'repositories/repository_details' %>
-	    <%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('repository.details'), 
+	    <%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('repository.details'),
 	    :p_id => 'repo_deets', :p_body => x} %>
         <% end %>
         <% if @result.kind_of?(Resource) && !@result.related_accessions.blank? %>
@@ -117,4 +117,3 @@
     </div>
     <script type="text/javascript" >initialize_accordion(".note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>");
     </script>
-

--- a/public/app/views/subjects/show.html.erb
+++ b/public/app/views/subjects/show.html.erb
@@ -12,7 +12,7 @@
 <div class="row">
   <div class="information col-sm-9">
     <div class="clear">
-    <span class="inline-label clear"><%= t('enumeration_names.subject_source') %>: </span><%= t("enumerations.subject_source.#{@result['json']['source']}" ) %> 
+    <span class="inline-label clear"><%= t('enumeration_names.subject_source') %>: </span><%= t("enumerations.subject_source.#{@result['json']['source']}" ) %>
     </div>
 
 
@@ -51,7 +51,7 @@
           <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('subject_term_type'), :p_id => 'subject_terms', :p_body => x} %>
         <% end %>
         <% unless @result.external_documents.blank? %>
-          <% x = render partial: 'shared/present_list', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
+          <% x = render partial: 'shared/present_list_external_docs', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
           <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('external_docs'), :p_id => 'ext_doc_list', :p_body => x} %>
         <% end %>
       </div>


### PR DESCRIPTION
so now there is a present_list for external documents that does not add the prefix to the URL that is used for displaying external documents in the PUI. Fixes https://archivesspace.atlassian.net/browse/ANW-225

@archivesspace/archivesspace-core-committers