### PR TITLE
Protect against newline only and newline prefixed fa titles

### DIFF
--- a/public/app/models/finding_aid_pdf.rb
+++ b/public/app/models/finding_aid_pdf.rb
@@ -16,8 +16,9 @@ class FindingAidPDF
     @resource = archivesspace.get_record("/repositories/#{repo_id}/resources/#{resource_id}")
     @ordered_records = archivesspace.get_record("/repositories/#{repo_id}/resources/#{resource_id}/ordered_records")
 
-    if @resource.finding_aid['title']
-      @short_title = @resource.finding_aid['title'].split("\n")[0].strip
+    # make sure finding aid title isn't only like /^\n$/
+    if @resource.finding_aid['title'] and @resource.finding_aid['title'] =~ /\w/
+      @short_title = @resource.finding_aid['title'].lstrip.split("\n")[0].strip
     end
   end
 


### PR DESCRIPTION
Make sure the "to be" short title has a regex word char in it and remove left leading newlines or else they become the short title by index selection.