### PR TITLE
Ar 1877

### DIFF
--- a/frontend/app/controllers/jobs_controller.rb
+++ b/frontend/app/controllers/jobs_controller.rb
@@ -134,7 +134,7 @@ class JobsController < ApplicationController
 
     respond_to do |format|
       format.html {
-        self.response.headers["Content-Type"] ||= "application/#{params[:format]}" 
+        self.response.headers["Content-Type"] = "application/#{params[:format]}"
         self.response.headers["Content-Disposition"] = "attachment; filename=#{filename}"
         self.response.headers['Last-Modified'] = Time.now.ctime.to_s
 

--- a/frontend/app/controllers/jobs_controller.rb
+++ b/frontend/app/controllers/jobs_controller.rb
@@ -134,7 +134,7 @@ class JobsController < ApplicationController
 
     respond_to do |format|
       format.html {
-        self.response.headers["Content-Type"] = "application/#{params[:format]}"
+        self.response.headers["Content-Type"] = "application/#{params[:format]}" if params[:format]
         self.response.headers["Content-Disposition"] = "attachment; filename=#{filename}"
         self.response.headers['Last-Modified'] = Time.now.ctime.to_s
 


### PR DESCRIPTION
Safari seems to be the only browser in which this is a significant bug: 
Reports incorrectly download with  '.html' file type appended no matter what format. 
Content-Type overrides file name type in Safari. 

https://archivesspace.atlassian.net/browse/AR-1877

