### PR TITLE
Use literal to generate enum aq strings

### DIFF
--- a/frontend/app/helpers/enumeration_helper.rb
+++ b/frontend/app/helpers/enumeration_helper.rb
@@ -6,7 +6,7 @@ module EnumerationHelper
     query = AdvancedQueryBuilder.new
 
     relationships.each do |rel|
-      query.or("#{rel}_enum_s", value)
+      query.or("#{rel}_enum_s", value, 'text', true)
     end
 
     query.build.to_json


### PR DESCRIPTION
Without this the search string values are unquoted which does not
retrieve the correct results.

BEFORE:

[java] INFO: [collection1] webapp= path=/select params={facet.field=primary_type&facet.field=creators&facet.field=subjects&csv.escape=\&start=0&fq=repository:"/repositories/2"+OR+repository:global&fq=(-types:("pui_only")+AND+*:*)&fq=-exclude_by_default:true&sort=&rows=10&**q=(extent_type_enum_s:(Video-Digital+LTO7)+OR+(processing_total_extent_type_enum_s:(Video-Digital+LTO7)))**&facet.limit=100&csv.header=true&csv.encapsulator="&facet.mincount=0&wt=json&facet=true} hits=0 status=0 QTime=17 

AFTER:

[java] INFO: [collection1] webapp= path=/select params={facet.field=primary_type&facet.field=creators&facet.field=subjects&csv.escape=\&start=0&fq=repository:"/repositories/2"+OR+repository:global&fq=(-types:("pui_only")+AND+*:*)&fq=-exclude_by_default:true&sort=&rows=10&**q=(extent_type_enum_s:("Video\-Digital+LTO7")+OR+(processing_total_extent_type_enum_s:("Video\-Digital+LTO7")))**&facet.limit=100&csv.header=true&csv.encapsulator="&facet.mincount=0&wt=json&facet=true} hits=26 status=0 QTime=14 
