### PR TITLE
app_prefix function not necessary since the public_proxy_url is already added on the line above

### DIFF
--- a/public/app/views/request_mailer/request_received_email.html.erb
+++ b/public/app/views/request_mailer/request_received_email.html.erb
@@ -4,7 +4,7 @@
   <h2>Record Requested</h2>
   <strong>Title</strong>: <%= @request.title %><br>
   <% url = "#{AppConfig[:public_proxy_url].sub(/\/^/, '')}#{@request.request_uri}" %>
-  <strong>URL</strong>: <%= link_to url, app_prefix(url) %>
+  <strong>URL</strong>: <%= link_to url, url %>
 </div>
 
 <div class="user">


### PR DESCRIPTION
Fixes #964 
url = "#{AppConfig[:public_proxy_url].sub(/\/^/, '')}#{@request.request_uri}"
so don't need app_prefix method around url in this line: 
<strong>URL</strong>: <%= link_to url, url %>

@archivesspace/archivesspace-core-committers Can someone review this for me?