### PR TITLE
EAD3Serializer requires EADSerializer so require it first

### DIFF
--- a/backend/app/exporters/serializers/ead3.rb
+++ b/backend/app/exporters/serializers/ead3.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
-require 'nokogiri'
-require 'securerandom'
+require_relative 'ead'
 class EAD3Serializer < EADSerializer
   serializer_for :ead3
 


### PR DESCRIPTION
Without this there's a load order issue between (at least) Mac OS
and Ubuntu. The latter loads ead3.rb before ead.rb and fails.