### PR TITLE
Fix "Failed to clean XML" in PDF due to raw HTML in archival object

### DIFF
--- a/public/app/views/pdf/_archival_object.html.erb
+++ b/public/app/views/pdf/_archival_object.html.erb
@@ -14,7 +14,7 @@ end
 
 <div class="avoid-break">
     <div class="print-record-border print-record level-<%= level %>">
-        <h3><a class="record-title" id="<%= record.uri %>"><%== record.display_string %></a></h3>
+        <h3><a class="record-title" id="<%= record.uri %>"><%= record.display_string %></a></h3>
 
         <% Array(record.instances).each do |instance| %>
             <% if instance['sub_container'] %>


### PR DESCRIPTION
This is a proposed fix for #972.

Note: In `public/app/views/pdf/_archival_object.html.erb`, there are two more occurrences of unescaped HTML, both in the note text field (`<%== note['note_text'] %>`). I'm not sure if unescaped HTML is supposed to be allowed in the note text, so I didn't patch those two occurrences.

Thanks for reviewing this PR.