### PR TITLE
ANW-244 : Use repository image on title page: had to move logo within…

### DIFF
--- a/public/app/views/pdf/_header.html.erb
+++ b/public/app/views/pdf/_header.html.erb
@@ -5,6 +5,8 @@
         <style>
  .title-page {
      page-break-after: always;
+     position: relative;
+     height: 58em;
  }
 
  .toc-page {
@@ -68,10 +70,12 @@
  }
 
  .title-page .repository-information {
-     position: relative;
-     top: 24em;
-     left: 4em;
+     position: absolute;
+     bottom: 0;
+     border: solid 2px gray;
+      width: 95%;
      padding: 1em;
+
  }
 
  .repository-information > * {
@@ -198,4 +202,3 @@
     </head>
     <body>
 
-        <div class="logo"><%= image_tag(asset_url("archivesspace.small.png")) %></div>

--- a/public/app/views/pdf/_titlepage.html.erb
+++ b/public/app/views/pdf/_titlepage.html.erb
@@ -1,4 +1,5 @@
 <div class="title-page">
+    <div class="logo"><%= image_tag( record.resolved_repository['image_url'] || asset_url("Aspace-logo.png") ) %></div>
     <div class="title-block">
         <h1 class="title"><%= record.finding_aid['title'] %></h1>
         <h2 class="subtitle"><%= record.finding_aid['subtitle'] %></h2>

--- a/public/app/views/pdf/_titlepage.html.erb
+++ b/public/app/views/pdf/_titlepage.html.erb
@@ -1,5 +1,5 @@
 <div class="title-page">
-    <div class="logo"><%= image_tag( record.resolved_repository['image_url'] || asset_url("Aspace-logo.png") ) %></div>
+    <div class="logo"><%= image_tag( record.resolved_repository['image_url'] || asset_url("archivesspace.small.png") ) %></div>
     <div class="title-block">
         <h1 class="title"><%= record.finding_aid['title'] %></h1>
         <h2 class="subtitle"><%= record.finding_aid['subtitle'] %></h2>


### PR DESCRIPTION
… title-page div

and change styles to keep from overflowing/overwriting on next page
page sizing might still be a bit fragile. I tried 100%, but that didn't work, so I made it 58em;