### PR TITLE
Update marc auth record import

### DIFF
--- a/backend/spec/lib_marcxml_converter_spec.rb
+++ b/backend/spec/lib_marcxml_converter_spec.rb
@@ -356,16 +356,28 @@ END
       converter = MarcXMLConverter.for_subjects_and_agents_only(john_davis)
       converter.run
       json = JSON(IO.read(converter.get_output_path))
+      # we should only get one agent record
+      json.count.should eq(1)
 
-      new_record = json.last
-
-      new_record['names'][0]['primary_name'].should eq("Davis")
-      new_record['names'][0]['rest_of_name'].should eq("John W.")
-      new_record['names'][0]['dates'].should eq("1873-1955")
+      agent = json.first
+      agent['publish'].should be_truthy
+      agent['names'][0]['authority_id'].should eq('n88218900')
+      agent['names'][0]['authorized'].should be_truthy
+      agent['names'][0]['is_display_name'].should be_truthy
+      agent['names'][0]['source'].should eq('naf')
+      agent['names'][0]['rules'].should eq('aacr')
+      agent['names'][0]['primary_name'].should eq("Davis")
+      agent['names'][0]['rest_of_name'].should eq("John W.")
+      agent['names'][0]['dates'].should eq("1873-1955")
 
       # Unauthorized names are added too
-      new_record['names'][1]['primary_name'].should eq("Davis")
-      new_record['names'][1]['rest_of_name'].should eq("John William,")
+      agent['names'][1]['authority_id'].should be_nil
+      agent['names'][1]['authorized'].should be_falsey
+      agent['names'][1]['source'].should eq('naf')
+      agent['names'][1]['rules'].should eq('aacr')
+      agent['names'][1]['is_display_name'].should be_falsey
+      agent['names'][1]['primary_name'].should eq("Davis")
+      agent['names'][1]['rest_of_name'].should eq("John William,")
     end
   end
 
@@ -377,14 +389,15 @@ END
       converter = MarcXMLConverter.for_subjects_and_agents_only(cyberpunk_file)
       converter.run
       json = JSON(IO.read(converter.get_output_path))
+      # we should only get one subject record
+      json.count.should eq(1)
 
-      # ensure we get them in a standard order
-      badass, cyberpunk = json.sort_by { |j| j['terms'][0]['term'] }
-      badass['terms'][0]['term'].should eq("Badass sci-fi")
-      badass['source'].should eq("Library of Congress Subject Headings")
-
-      cyberpunk['terms'][0]['term'].should eq("Cyberpunk")
-      cyberpunk['source'].should eq("Library of Congress Subject Headings")
+      subject = json.first
+      subject['publish'].should be_truthy
+      subject['authority_id'].should eq('no2006087900')
+      subject['source'].should eq("Library of Congress Subject Headings")
+      subject['terms'].count.should eq(1)
+      subject['terms'][0]['term'].should eq('Cyberpunk')
     end
   end
 


### PR DESCRIPTION
- Set authority id from 001 controlfield for agents / subjects
- Sets source and rules for name authority records (limited)
- Create 1 subject record per marc auth record ignoring 4XX fields

The latter update is not "good" just better than the current
behavior of creating 1 subject record for each 4XX variant heading
in an authority record. This is very undesirable as it pollutes the
database with unauthorized form subject headings.

In the future the subject / term data model should be updated to
support authorized vs. unauthorized forms and multiple headings
per subject (the equivalent is already possible for agents).