### PR TITLE
AR-1882 Weight resources and accessions in search relevancy

### DIFF
--- a/solr/solrconfig.xml
+++ b/solr/solrconfig.xml
@@ -354,9 +354,13 @@
          will be overridden by parameters in the request
       -->
      <lst name="defaults">
+       <str name="defType">edismax</str>
        <str name="echoParams">explicit</str>
        <int name="rows">10</int>
-       <str name="df">text</str>
+       <str name="df">fullrecord</str>
+       <str name="pf">four_part_id^50</str>
+       <str name="qf">title^25 four_part_id^50 fullrecord</str>
+       <str name="bq">primary_type:resource^100 primary_type:accession^100 primary_type:subject^50 primary_type:agent_person^50 primary_type:agent_corporate_entity^30 primary_type:agent_family^30</str>
      </lst>
   </requestHandler>
 


### PR DESCRIPTION
@lmcglohon First pass attempt at fixing https://archivesspace.atlassian.net/browse/AR-1882 and, to a small degree, https://archivesspace.atlassian.net/browse/ANW-201 (admin data not removed from results in PUI, but is lower ranked).

Following fields are boosted (based on local testing):

- primary_type of resource, accession, subject, and the 3 agent types
- four_part_id
- title

Reworking/feedback welcome.