### PR TITLE
ANW-238: Since NULL is valid value for publish and suppress columns in the archival_objects table, include it as an option in filters for large trees

### DIFF
--- a/backend/app/model/large_tree.rb
+++ b/backend/app/model/large_tree.rb
@@ -74,8 +74,8 @@ class LargeTree
   def published_filter
     filter = {}
 
-    filter[:publish] = @published_only ? [1] : [0, 1]
-    filter[:suppressed] = @published_only ? [0] : [0, 1]
+    filter[:publish] = @published_only ? [1] : [NULL, 0, 1]
+    filter[:suppressed] = @published_only ? [0] : [NULL, 0, 1]
 
     filter
   end


### PR DESCRIPTION
Fixes https://archivesspace.atlassian.net/browse/ANW-238