### PR TITLE
Revert "ANW-238: Since NULL is valid value for publish and suppress columns in the archival_objects table, include it as an option in filters for large trees"

### DIFF
--- a/backend/app/model/large_tree.rb
+++ b/backend/app/model/large_tree.rb
@@ -74,8 +74,8 @@ class LargeTree
   def published_filter
     filter = {}
 
-    filter[:publish] = @published_only ? [1] : [NULL, 0, 1]
-    filter[:suppressed] = @published_only ? [0] : [NULL, 0, 1]
+    filter[:publish] = @published_only ? [1] : [0, 1]
+    filter[:suppressed] = @published_only ? [0] : [0, 1]
 
     filter
   end


### PR DESCRIPTION
Reverts archivesspace/archivesspace#1007

Instead of changing this in the published_filter, the default archival_object table should be changed to not accept NULL as a value. Also the default value should be set to 0 or 1. 0 means publish is false (not published), anything else (including 1) means publish is true (published). Need specification for what the default should be - not published or published.