### PR TITLE
fix report orientation bug

### DIFF
--- a/backend/app/views/reports/report.erb
+++ b/backend/app/views/reports/report.erb
@@ -1,11 +1,11 @@
 <% if layout? %>
 
-<%
-if @report.template == 'generic_listing.erb'
-  # Listing template should be printed as landscape to fit on the page.
-  @report.orientation = 'landscape'
-end
-%>
+<% if @report.template == 'generic_listing.erb' %>
+  <!-- Listing template should be printed as landscape to fit on the page. -->
+  <% orientation = 'landscape' %>
+<% else %>
+  <% orientation = @report.orientation %>
+<% end %>
 
 <!DOCTYPE html>
 <html>
@@ -156,7 +156,7 @@ end
       }
 
       @page {
-        size: <%= @report.layout %> <%= @report.orientation %>;
+        size: <%= @report.layout %> <%= orientation %>;
         -fs-flow-bottom: "footer";
       }
 


### PR DESCRIPTION
`@report.orientation` is a method, not an attribute: https://github.com/archivesspace/archivesspace/blob/master/backend/app/model/reports/abstract_report.rb#L50

Attempting to set the value returned by `orientation` was generating the error described in ANW-265: https://archivesspace.atlassian.net/browse/ANW-265