### PR TITLE
by default: allow all robots

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -14,6 +14,11 @@ file, with the relevant configuration options are prefixed with
 To see the full list of available options, see the file
 [`app/archivesspace-public/app/lib/config_defaults.rb`](app/archivesspace-public/app/lib/config_defaults.rb)
 
+## robots.txt
+The default, the robots.txt file packaged in public.war file is open to the world so that it will be indexed by Google and other search sites. If you wish to restrict web spiders from crawling all or part of your public site, you can replace this file in the warfile with the command: `zip -uj archivesspace/wars/public.war  robots.txt`, or if you include a robots.txt file in the archivesspace/config directory, it will be used to replace the one packaged in the war file on startup.
+
+See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+
 ## Preserving Patron Privacy
 
 The **:block_referrer** key in the configuration file (default: **true**) determines whether the full referring URL is

--- a/public/config/initializers/public_new_defaults.rb
+++ b/public/config/initializers/public_new_defaults.rb
@@ -155,3 +155,13 @@ module PublicNewDefaults
   end
 
 end
+
+# config public robots.txt
+if Rails.root.basename.to_s == 'WEB-INF'  # only need to do this when running out of unpacked .war
+  robtxt = ((Pathname.new AppConfig.find_user_config).dirname + 'robots.txt' )
+  dest = Rails.root.dirname
+  if robtxt.exist? && robtxt.file?  && dest.directory? && dest.writable?
+    p "*********    #{robtxt} exists: copying to #{dest} ****** "
+    FileUtils.cp( robtxt, dest, :verbose => true  )
+  end
+end

--- a/public/public/robots.txt
+++ b/public/public/robots.txt
@@ -1,5 +1,5 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 #
 # To ban all spiders from the entire site uncomment the next two lines:
-User-agent: *
-Disallow: /
+#User-agent: *
+#Disallow: /


### PR DESCRIPTION

https://archivesspace.atlassian.net/browse/AR-1486

It would be nice to eventually make this more easily configurable, but until we figure out how to do that, lets have a better (open to crawling) default before next release. 