### PR TITLE
Fixes some backend tests that need a specific fixtures

### DIFF
--- a/backend/spec/controller_digital_object_component_spec.rb
+++ b/backend/spec/controller_digital_object_component_spec.rb
@@ -51,8 +51,8 @@ describe 'Digital Object Component controller' do
   it "lets you reorder sibling digital object components" do
     digital_object = create(:json_digital_object)
 
-    doc_1 = create(:json_digital_object_component, :digital_object => {:ref => digital_object.uri}, :title=> "DOC1")
-    doc_2 = create(:json_digital_object_component, :digital_object => {:ref => digital_object.uri}, :title=> "DOC2")
+    doc_1 = create(:json_digital_object_component, :digital_object => {:ref => digital_object.uri}, :title=> "DOC1", :position => 0)
+    doc_2 = create(:json_digital_object_component, :digital_object => {:ref => digital_object.uri}, :title=> "DOC2", :position => 1)
 
     tree = JSONModel(:digital_object_tree).find(nil, :digital_object_id => digital_object.id)
 
@@ -132,8 +132,8 @@ describe 'Digital Object Component controller' do
     digital_object = create(:json_digital_object)
     parent_component = create(:json_digital_object_component, :digital_object => {:ref => digital_object.uri})
 
-    doc_1 = build(:json_digital_object_component)
-    doc_2 = build(:json_digital_object_component)
+    doc_1 = build(:json_digital_object_component, :position => nil )
+    doc_2 = build(:json_digital_object_component, :position => nil )
 
     children = JSONModel(:digital_record_children).from_hash({
                                                                 "children" => [doc_1, doc_2]

--- a/backend/spec/factories.rb
+++ b/backend/spec/factories.rb
@@ -370,6 +370,14 @@ FactoryGirl.define do
     dates { few_or_none(:json_date) }
   end
 
+  factory :json_digital_object_component, class: JSONModel(:digital_object_component) do
+    component_id { generate(:alphanumstr) }
+    title { "Digital Object Component #{generate(:generic_title)}" }
+    digital_object { {'ref' => create(:json_digital_object).uri} }
+    position { rand(0..10) }
+    has_unpublished_ancestor { rand(2) == 0 }
+  end
+
   factory :json_digital_object_component_pub_ancestor, class: JSONModel(:digital_object_component) do
     component_id { generate(:alphanumstr) }
     title { "Digital Object Component #{generate(:generic_title)}" }

--- a/backend/spec/model_digital_object_component_spec.rb
+++ b/backend/spec/model_digital_object_component_spec.rb
@@ -8,8 +8,7 @@ describe 'DigitalObjectComponent model' do
     bib_note = build(:json_note_bibliography)
     do_note = build(:json_note_digital_object)
     doc.notes = [bib_note, do_note]
-
-    DigitalObjectComponent[doc.id].title.should eq("Digital Object Component Title: 1")
+    DigitalObjectComponent[doc.id].title.should eq(doc.title)
   end
 
 end


### PR DESCRIPTION
The digital object component fixtures changed a bit, which caused some
tests to break. This re-adds the generic DOC fixtures.