### PR TITLE
Fixes JRuby issue with files being loaded into memory on #copy_stream

### DIFF
--- a/common/ashttp.rb
+++ b/common/ashttp.rb
@@ -2,6 +2,35 @@
 
 require 'net/http'
 
+# Using SSL, current version of jruby just reads the file instead of passing it
+# as a stream. This patch chunks the input manually if a SSLSocket is being
+# used. 
+# https://github.com/jruby/jruby/issues/4842
+class Net::HTTPGenericRequest                                                                                                                                                                
+  def send_request_with_body_stream(sock, ver, path, f)                                                                                                                                      
+    unless content_length() or chunked?                                                                                                                                                      
+      raise ArgumentError,                                                                                                                                                                   
+          "Content-Length not given and Transfer-Encoding is not `chunked'"                                                                                                                  
+    end                                                                                                                                                                                      
+    supply_default_content_type                                                                                                                                                              
+    write_header sock, ver, path                                                                                                                                                             
+    wait_for_continue sock, ver if sock.continue_timeout                                                                                                                                     
+    if chunked?                                                                                                                                                                              
+      chunker = Chunker.new(sock)                                                                                                                                                            
+      IO.copy_stream(f, chunker)                                                                                                                                                             
+      chunker.finish                                                                                                                                                                         
+    else                                                                                                                                                                                     
+      # copy_stream can sendfile() to sock.io unless we use SSL.                                                                                                                             
+      # If sock.io is an SSLSocket, copy_stream will hit SSL_write()                                                                                                                         
+      if  sock.io.is_a? OpenSSL::SSL::SSLSocket                                                                                                                                              
+        IO.copy_stream(f, sock.io, 16 * 1024 * 1024) until f.eof?                                                                                                                            
+      else                                                                                                                                                                                   
+        IO.copy_stream(f, sock.io)                                                                                                                                                           
+      end                                                                                                                                                                                    
+    end                                                                                                                                                                                      
+  end                                                                                                                                                                                        
+end 
+
 class ASHTTP
 
   def self.start_uri(uri, opts = {})

--- a/common/ashttp.rb
+++ b/common/ashttp.rb
@@ -1,35 +1,6 @@
 # Small wrapper for common net/http functions.  Just to give us a central place to set parameters.
-
 require 'net/http'
-
-# Using SSL, current version of jruby just reads the file instead of passing it
-# as a stream. This patch chunks the input manually if a SSLSocket is being
-# used. 
-# https://github.com/jruby/jruby/issues/4842
-class Net::HTTPGenericRequest                                                                                                                                                                
-  def send_request_with_body_stream(sock, ver, path, f)                                                                                                                                      
-    unless content_length() or chunked?                                                                                                                                                      
-      raise ArgumentError,                                                                                                                                                                   
-          "Content-Length not given and Transfer-Encoding is not `chunked'"                                                                                                                  
-    end                                                                                                                                                                                      
-    supply_default_content_type                                                                                                                                                              
-    write_header sock, ver, path                                                                                                                                                             
-    wait_for_continue sock, ver if sock.continue_timeout                                                                                                                                     
-    if chunked?                                                                                                                                                                              
-      chunker = Chunker.new(sock)                                                                                                                                                            
-      IO.copy_stream(f, chunker)                                                                                                                                                             
-      chunker.finish                                                                                                                                                                         
-    else                                                                                                                                                                                     
-      # copy_stream can sendfile() to sock.io unless we use SSL.                                                                                                                             
-      # If sock.io is an SSLSocket, copy_stream will hit SSL_write()                                                                                                                         
-      if  sock.io.is_a? OpenSSL::SSL::SSLSocket                                                                                                                                              
-        IO.copy_stream(f, sock.io, 16 * 1024 * 1024) until f.eof?                                                                                                                            
-      else                                                                                                                                                                                   
-        IO.copy_stream(f, sock.io)                                                                                                                                                           
-      end                                                                                                                                                                                    
-    end                                                                                                                                                                                      
-  end                                                                                                                                                                                        
-end 
+require 'http_generic_request'
 
 class ASHTTP
 

--- a/common/http_generic_request.rb
+++ b/common/http_generic_request.rb
@@ -1,0 +1,30 @@
+require 'net/http'
+# Using SSL, current version of jruby just reads the file instead of passing it
+# as a stream. This patch chunks the input manually if a SSLSocket is being
+# used. 
+# https://github.com/jruby/jruby/issues/4842
+class Net::HTTPGenericRequest                                                                                                                                                                
+  def send_request_with_body_stream(sock, ver, path, f)                                                                                                                                      
+    unless content_length() or chunked?                                                                                                                                                      
+      raise ArgumentError,                                                                                                                                                                   
+          "Content-Length not given and Transfer-Encoding is not `chunked'"                                                                                                                  
+    end                                                                                                                                                                                      
+    supply_default_content_type                                                                                                                                                              
+    write_header sock, ver, path                                                                                                                                                             
+    wait_for_continue sock, ver if sock.continue_timeout                                                                                                                                     
+    if chunked?                                                                                                                                                                              
+      chunker = Chunker.new(sock)                                                                                                                                                            
+      IO.copy_stream(f, chunker)                                                                                                                                                             
+      chunker.finish                                                                                                                                                                         
+    else                                                                                                                                                                                     
+      # copy_stream can sendfile() to sock.io unless we use SSL.                                                                                                                             
+      # If sock.io is an SSLSocket, copy_stream will hit SSL_write()                                                                                                                         
+      if  sock.io.is_a? OpenSSL::SSL::SSLSocket                                                                                                                                              
+        IO.copy_stream(f, sock.io, 16 * 1024 * 1024) until f.eof?                                                                                                                            
+      else                                                                                                                                                                                   
+        puts "sending stream... "
+        IO.copy_stream(f, sock.io)                                                                                                                                                           
+      end                                                                                                                                                                                    
+    end                                                                                                                                                                                      
+  end                                                                                                                                                                                        
+end 


### PR DESCRIPTION
There's a JRuby issue ( https://github.com/jruby/jruby/issues/4842 )
that causes IOs to be read into memory if using SSL. This causes big
problems if, for instance, you're using Solr or the backend with an SSL socket.
This adds a patch to chunk the IO manually, rather then just reading the
whole thing in.