### PR TITLE
Fixes add config param to show/hide container inventory on  resource page #1030

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -432,6 +432,8 @@ AppConfig[:pui_hide][:subject_badge] = false
 AppConfig[:pui_hide][:agent_badge] = false
 AppConfig[:pui_hide][:classification_badge] = false
 AppConfig[:pui_hide][:counts] = false
+# The following determines globally whether the 'container inventory' navigation tab/pill is hidden on resource/collection page
+AppConfig[:pui_hide][:container_inventory] = false
 # Other usage examples:
 # Don't display the accession ("unprocessed material") link on the main navigation menu
 # AppConfig[:pui_hide][:accessions] = true

--- a/public/app/views/resources/_resource_alltabs.erb
+++ b/public/app/views/resources/_resource_alltabs.erb
@@ -1,0 +1,12 @@
+<div class="row" id="tabs">
+  <div class="col-sm-9 text-center tabbing navbar navbar-default">
+    <ul class="tabbing nav nav-pills">
+      <%= render partial: 'resources/resource_tab', locals: {:action => :show, :text => t('actions.collection_overview'),
+                                                             :enabled => true, :hidden => false } %>
+      <%= render partial: 'resources/resource_tab', locals: {:action => :infinite, :text => t('actions.hierarch'),
+                                                             :enabled => @has_children, :hidden => false } %>
+      <%= render partial: 'resources/resource_tab', locals: {:action => :inventory, :text => t('actions.numeric'),
+                                                             :enabled => @has_containers, :hidden => AppConfig[:pui_hide][:container_inventory] } %>
+    </ul>
+  </div>
+</div>

--- a/public/app/views/resources/_resource_tab.erb
+++ b/public/app/views/resources/_resource_tab.erb
@@ -1,0 +1,12 @@
+<% active = (action.to_s == controller.action_name) %>
+<% unless hidden && !active %>
+  <li <% unless enabled %>class="disabled"<% end %>>
+    <%=
+      link_to_unless active || !enabled, text, { :action => action } do
+        link_to_if active, text, '#', :class => "active" do
+          link_to text, "#"
+        end
+      end
+    %>
+  </li>
+<% end %>

--- a/public/app/views/resources/infinite.html.erb
+++ b/public/app/views/resources/infinite.html.erb
@@ -13,18 +13,7 @@
   <%= render partial: 'shared/breadcrumbs' %>
 </div>
 
-<div class="row" id="tabs">
-  <div class="col-sm-9 text-center tabbing navbar navbar-default">
-    <ul class="tabbing nav nav-pills">
-      <%= render partial: 'resources/resource_tab', locals: {:action => :show, :text => t('actions.collection_overview'),
-                                                             :enabled => true, :hidden => false } %>
-      <%= render partial: 'resources/resource_tab', locals: {:action => :infinite, :text => t('actions.hierarch'),
-                                                             :enabled => @has_children, :hidden => false } %>
-      <%= render partial: 'resources/resource_tab', locals: {:action => :inventory, :text => t('actions.numeric'),
-                                                             :enabled => @has_containers, :hidden => AppConfig[:pui_hide][:container_inventory] } %>
-    </ul>
-  </div>
-</div>
+<%= render partial: 'resources/resource_alltabs' %>
 
 <%= javascript_include_tag 'treesync' %>
 <%= javascript_include_tag 'infinite_scroll' %>

--- a/public/app/views/resources/infinite.html.erb
+++ b/public/app/views/resources/infinite.html.erb
@@ -18,7 +18,11 @@
     <ul class="tabbing nav nav-pills">
       <li><%= link_to t('actions.collection_overview'), :action => :show %></li>
       <li><a class='active' href='#'><%= t('actions.hierarch') %></a></li>
-      <li <% unless @has_containers %>class="disabled"<% end %>><a <% if @has_containers %> href="<%= url_for(:action => :inventory) %>"<% end %>><%= t('actions.numeric') %></a></li>
+      <% unless AppConfig[:pui_hide][:container_inventory] %>
+        <li <% unless @has_containers %>class="disabled"<% end %>>
+          <a <% if @has_containers %> href="<%= url_for(:action => :inventory) %>"<% end %>><%= t('actions.numeric') %></a>
+        </li>
+      <% end %>
     </ul>
   </div>
 </div>

--- a/public/app/views/resources/infinite.html.erb
+++ b/public/app/views/resources/infinite.html.erb
@@ -16,13 +16,12 @@
 <div class="row" id="tabs">
   <div class="col-sm-9 text-center tabbing navbar navbar-default">
     <ul class="tabbing nav nav-pills">
-      <li><%= link_to t('actions.collection_overview'), :action => :show %></li>
-      <li><a class='active' href='#'><%= t('actions.hierarch') %></a></li>
-      <% unless AppConfig[:pui_hide][:container_inventory] %>
-        <li <% unless @has_containers %>class="disabled"<% end %>>
-          <a <% if @has_containers %> href="<%= url_for(:action => :inventory) %>"<% end %>><%= t('actions.numeric') %></a>
-        </li>
-      <% end %>
+      <%= render partial: 'resources/resource_tab', locals: {:action => :show, :text => t('actions.collection_overview'),
+                                                             :enabled => true, :hidden => false } %>
+      <%= render partial: 'resources/resource_tab', locals: {:action => :infinite, :text => t('actions.hierarch'),
+                                                             :enabled => @has_children, :hidden => false } %>
+      <%= render partial: 'resources/resource_tab', locals: {:action => :inventory, :text => t('actions.numeric'),
+                                                             :enabled => @has_containers, :hidden => AppConfig[:pui_hide][:container_inventory] } %>
     </ul>
   </div>
 </div>

--- a/public/app/views/resources/inventory.html.erb
+++ b/public/app/views/resources/inventory.html.erb
@@ -13,18 +13,7 @@
     <%= render partial: 'shared/breadcrumbs' %>
 </div>
 
-<div class="row" id="tabs">
-  <div class="col-sm-9 text-center tabbing navbar navbar-default">
-    <ul class="tabbing nav nav-pills">
-      <%= render partial: 'resources/resource_tab', locals: {:action => :show, :text => t('actions.collection_overview'),
-                                                             :enabled => true, :hidden => false } %>
-      <%= render partial: 'resources/resource_tab', locals: {:action => :infinite, :text => t('actions.hierarch'),
-                                                             :enabled => @has_children, :hidden => false } %>
-      <%= render partial: 'resources/resource_tab', locals: {:action => :inventory, :text => t('actions.numeric'),
-                                                             :enabled => @has_containers, :hidden => AppConfig[:pui_hide][:container_inventory] } %>
-    </ul>
-  </div>
-</div>
+<%= render partial: 'resources/resource_alltabs' %>
 
 <div class="row">
   <div class="col-sm-9">

--- a/public/app/views/resources/inventory.html.erb
+++ b/public/app/views/resources/inventory.html.erb
@@ -16,9 +16,12 @@
 <div class="row" id="tabs">
   <div class="col-sm-9 text-center tabbing navbar navbar-default">
     <ul class="tabbing nav nav-pills">
-      <li><%= link_to t('actions.collection_overview'), :action => :show %></li>
-      <li <% unless @has_children %>class="disabled"<% end %>><a <% if @has_children %> href="<%= url_for(:action => :infinite) %>"<% end %>><%= t('actions.hierarch') %></a></li>
-      <li><a class='active' href='#'><%= t('actions.numeric') %></a></li>
+      <%= render partial: 'resources/resource_tab', locals: {:action => :show, :text => t('actions.collection_overview'),
+                                                             :enabled => true, :hidden => false } %>
+      <%= render partial: 'resources/resource_tab', locals: {:action => :infinite, :text => t('actions.hierarch'),
+                                                             :enabled => @has_children, :hidden => false } %>
+      <%= render partial: 'resources/resource_tab', locals: {:action => :inventory, :text => t('actions.numeric'),
+                                                             :enabled => @has_containers, :hidden => AppConfig[:pui_hide][:container_inventory] } %>
     </ul>
   </div>
 </div>

--- a/public/app/views/resources/show.html.erb
+++ b/public/app/views/resources/show.html.erb
@@ -19,8 +19,12 @@
   <div class="col-sm-9 text-center tabbing navbar navbar-default">
     <ul class="tabbing nav nav-pills">
       <li><a class="active" href="#"><%= t('actions.collection_overview') %></a></li><li <% unless @has_children %>class="disabled"<% end %>>
-      <a <% if @has_children %> href="<%= url_for(:action => :infinite) %>" <% end %>><%= t('actions.hierarch') %></a></li><li <% unless @has_containers %>class="disabled"<% end %>>
-      <a <% if @has_containers %> href="<%= url_for(:action => :inventory) %>" <% end %>><%= t('actions.numeric') %></a></li>
+      <a <% if @has_children %> href="<%= url_for(:action => :infinite) %>" <% end %>><%= t('actions.hierarch') %></a></li>
+      <% unless AppConfig[:pui_hide][:container_inventory] %>
+        <li <% unless @has_containers %>class="disabled"<% end %>>
+          <a <% if @has_containers %> href="<%= url_for(:action => :inventory) %>" <% end %>><%= t('actions.numeric') %></a>
+        </li>
+      <% end %>
     </ul>
   </div>
 </div>

--- a/public/app/views/resources/show.html.erb
+++ b/public/app/views/resources/show.html.erb
@@ -15,18 +15,9 @@
 <div class="row">
     <%= render partial: 'shared/breadcrumbs' %>
 </div>
-<div class="row" id="tabs">
-  <div class="col-sm-9 text-center tabbing navbar navbar-default">
-    <ul class="tabbing nav nav-pills">
-      <%= render partial: 'resources/resource_tab', locals: {:action => :show, :text => t('actions.collection_overview'),
-                                                             :enabled => true, :hidden => false } %>
-      <%= render partial: 'resources/resource_tab', locals: {:action => :infinite, :text => t('actions.hierarch'),
-                                                             :enabled => @has_children, :hidden => false } %>
-      <%= render partial: 'resources/resource_tab', locals: {:action => :inventory, :text => t('actions.numeric'),
-                                                             :enabled => @has_containers, :hidden => AppConfig[:pui_hide][:container_inventory] } %>
-    </ul>
-  </div>
-</div>
+
+<%= render partial: 'resources/resource_alltabs' %>
+
 <div class="row" id="notes_row">
   <div class="col-sm-9">
     <%= render partial: 'shared/digital', locals: {:dig_objs => @dig} %>

--- a/public/app/views/resources/show.html.erb
+++ b/public/app/views/resources/show.html.erb
@@ -18,13 +18,12 @@
 <div class="row" id="tabs">
   <div class="col-sm-9 text-center tabbing navbar navbar-default">
     <ul class="tabbing nav nav-pills">
-      <li><a class="active" href="#"><%= t('actions.collection_overview') %></a></li><li <% unless @has_children %>class="disabled"<% end %>>
-      <a <% if @has_children %> href="<%= url_for(:action => :infinite) %>" <% end %>><%= t('actions.hierarch') %></a></li>
-      <% unless AppConfig[:pui_hide][:container_inventory] %>
-        <li <% unless @has_containers %>class="disabled"<% end %>>
-          <a <% if @has_containers %> href="<%= url_for(:action => :inventory) %>" <% end %>><%= t('actions.numeric') %></a>
-        </li>
-      <% end %>
+      <%= render partial: 'resources/resource_tab', locals: {:action => :show, :text => t('actions.collection_overview'),
+                                                             :enabled => true, :hidden => false } %>
+      <%= render partial: 'resources/resource_tab', locals: {:action => :infinite, :text => t('actions.hierarch'),
+                                                             :enabled => @has_children, :hidden => false } %>
+      <%= render partial: 'resources/resource_tab', locals: {:action => :inventory, :text => t('actions.numeric'),
+                                                             :enabled => @has_containers, :hidden => AppConfig[:pui_hide][:container_inventory] } %>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
PR does the following:
- Fixes issue #1030 
- adds abstraction for a page tab, via partial
- DRYs up tab display on resource/collection overview, detail, and container inventory pages