### PR TITLE
REALLY fix clicking on the Search(magnif. glass) tab

### DIFF
--- a/public/app/views/shared/_navigation.html.erb
+++ b/public/app/views/shared/_navigation.html.erb
@@ -15,11 +15,10 @@
             <li><a href="<%= app_prefix(link[0]) %>"><%= t(link[1]) %></a></li>
           <% end %>
           <% unless AppConfig[:pui_hide][:search_tab] %>
-            <li>
-              <%= link_to({:controller => :search, :action => :search, :reset => 'true'}, {:title => I18n.t('search_tab', :target => t('archive._plural'))}) do %>
+            <li><a href="<%=  app_prefix('/search?reset=true') %>" title="<%= I18n.t('search_tab', :target => t('archive._plural'))%>">
                 <span class="fa fa-search" aria-hidden="true"></span>
                 <span class="sr-only"><%= I18n.t('search_tab', :target => t('archive._plural')) %></span>
-              <% end %>
+              </a>
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
The logic in public/app/controllers/search_controller.rb is faulty, as it does not remove the repo_id from the base_search_url when reset=true.  I obviate this by explicitly setting the magnifying glass link **/search/reset=true**, rather than relying on the *link_to* syntax, which is dicey.