### PR TITLE
All the parameters were being stripped from the digital object link 

### DIFF
--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -6,7 +6,7 @@
    <% if !d_file['out'].blank? %>
     <% if d_file['thumb'].blank? %>
  <div class="objectimage">
-      <form id="larger" action="<%= d_file['out'] %>" method="get" target="new">
+      <form id="larger" action="<%= d_file['out'] %>" method="post" target="new">
        <button type="submit"  class="btn btn-default record-type-badge digital_object" title="<%= t('digital_object._public.link') %>" >
           <i class="fa fa-file-image-o fa-4x"></i><br/>
             <%= d_file['caption'].blank? ? "#{t('enumerations.instance_instance_type.digital_object')} #{d_file['material']}" : d_file['caption'].html_safe %>
@@ -17,7 +17,7 @@
     <% else %>
  <div class="objectimage">
    <div class="panel panel-default">
-        <a class="thumbnail" href="<%= d_file['out'] %>" target="new" 
+        <a class="thumbnail" href="<%= d_file['out'] %>" target="new"
 	   title="<%= t('digital_object._public.link')%>">
           <img src="<%= d_file['thumb'] %>" alt="<%= strip_mixed_content(d_file['caption'] || t('enumerations.instance_instance_type.digital_object')) %>" />
         </a>
@@ -35,4 +35,3 @@
  <% end %>
 </div>
 <% end %>
-


### PR DESCRIPTION
because a GET method was being used. Changing to a POST method retains the parameters so the URL returns the requested image