### PR TITLE
Improve basic alignment for all record types

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -232,6 +232,10 @@ a {
   }
 }
 
+#main-content.accessions, #main-content.objects {
+  padding: 0 1em;
+}
+
 #sidebar {
   border: 1px solid $border;
   padding: rem-calc(10);
@@ -547,6 +551,12 @@ ul.no-bullets {
 }
 
 /* search results */
+.result_context {
+  padding-top: 1em;
+  strong {
+    padding-right: 0.5em;
+  }
+}
 
 .recordrow {
 

--- a/public/app/views/accessions/show.html.erb
+++ b/public/app/views/accessions/show.html.erb
@@ -1,4 +1,4 @@
-<div id="main-content" class="row">
+<div id="main-content" class="row accessions">
 
   <div class="row" id="info_row">
     <div class="information col-sm-7">
@@ -9,9 +9,7 @@
     </div>
   </div>
 
-  <div class="row">
-    <%= render partial: 'shared/breadcrumbs' %>
-  </div>
+  <%= render partial: 'shared/breadcrumbs' %>
 
   <div class="col-sm-9">
 

--- a/public/app/views/agents/show.html.erb
+++ b/public/app/views/agents/show.html.erb
@@ -1,5 +1,4 @@
-<div id="main-content">
-<div class="row">
+<div id="main-content" class="agents">
 
   <div class="row" id="info_row">
     <div class="information col-sm-7">
@@ -9,8 +8,6 @@
       <%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %>
     </div>
   </div>
-
-</div>
 
 <div class="row">
   <div class="col-sm-9">

--- a/public/app/views/classifications/show.html.erb
+++ b/public/app/views/classifications/show.html.erb
@@ -1,4 +1,4 @@
-<div id="main-content" class="row">
+<div id="main-content" class="classifications">
   <div class="row">
     <div class="information col-sm-7">
       <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %>

--- a/public/app/views/containers/show.html.erb
+++ b/public/app/views/containers/show.html.erb
@@ -1,4 +1,4 @@
-<div id="main-content">
+<div id="main-content" class="containers">
 <div class="row">
   <div class="information col-sm-7">
     <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %>

--- a/public/app/views/objects/show.html.erb
+++ b/public/app/views/objects/show.html.erb
@@ -1,5 +1,5 @@
 <a name="main" title="<%= t('internal_links.main') %>"></a>
-<div id="main-content" class="row">
+<div id="main-content" class="row objects">
   <div class="row" id="info_row">
     <div class="information col-sm-7">
       <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %>
@@ -8,9 +8,8 @@
     <%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath, :cite => @result.cite } %>
     </div>
   </div>
-  <div class="row">
-     <%= render partial: 'shared/breadcrumbs' %>
-  </div>
+
+   <%= render partial: 'shared/breadcrumbs' %>
 
   <div class="row" id="notes_row">
    <div class="col-sm-9">

--- a/public/app/views/repositories/show.html.erb
+++ b/public/app/views/repositories/show.html.erb
@@ -1,9 +1,9 @@
-<div id="main-content">
-  <div class="abstract row">
+<div id="main-content" class="repositories">
+  <div class="abstract">
     <%= render partial: 'repositories/repository', locals: {:result => @result,  :full => true} %>
   </div>
 
-  <div id="whats-in-container" class="row">
+  <div id="whats-in-container">
     <h3><%= t('repository.what') %> </h3>
     <div>
       <ul class="list-inline">

--- a/public/app/views/resources/show.html.erb
+++ b/public/app/views/resources/show.html.erb
@@ -1,5 +1,5 @@
 <a name="main" title="<%= t('internal_links.main') %>"></a>
-<div id="main-content" class="row">
+<div id="main-content" class="row resources">
   <div class="row" id="info_row">
   <% unless defined?(@no_statement) || !defined?(@search) %>
   <div class="searchstatement"><%= @search[:search_statement].html_safe %></div>


### PR DESCRIPTION
The fundamental layout isn't consistent for each record type so a record
type class has been added to each record page to make it easier to make
changes that don't fix one thing, break another.