### PR TITLE
Fix public errors

### DIFF
--- a/common/exceptions.rb
+++ b/common/exceptions.rb
@@ -1,7 +1,3 @@
-class AccessDeniedException < StandardError
-end
-
-
 class ConflictException < StandardError
   attr_reader :conflicts
 
@@ -11,5 +7,7 @@ class ConflictException < StandardError
   end
 end
 
-class RecordNotFound < StandardError
-end
+class AccessDeniedException < StandardError; end
+class RecordNotFound < StandardError; end
+class LoginFailedException < StandardError; end
+class RequestFailedException < StandardError; end

--- a/public/app/controllers/accessions_controller.rb
+++ b/public/app/controllers/accessions_controller.rb
@@ -35,16 +35,8 @@ class AccessionsController <  ApplicationController
     page = Integer(params.fetch(:page, "1"))
     search_opts = default_search_opts( DEFAULT_AC_SEARCH_OPTS)
     search_opts['fq'] = ["repository:\"/repositories/#{@repo_id}\""] if @repo_id
-    begin
-      set_up_and_run_search( DEFAULT_AC_TYPES, DEFAULT_AC_FACET_TYPES,  search_opts, params)
-    rescue NoResultsError
-      flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
-    rescue Exception => error
-      flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/') and return
-    end
-#    @context = repo_context(repo_id, 'accession')
+    set_up_and_run_search( DEFAULT_AC_TYPES, DEFAULT_AC_FACET_TYPES,  search_opts, params)
+    
     if @results['total_hits'] > 1
       @search[:dates_within] = true if params.fetch(:filter_from_year,'').blank? && params.fetch(:filter_to_year,'').blank?
       @search[:text_within] = true

--- a/public/app/controllers/agents_controller.rb
+++ b/public/app/controllers/agents_controller.rb
@@ -32,15 +32,7 @@ class AgentsController <  ApplicationController
     default_facets = DEFAULT_AG_FACET_TYPES
     default_facets.push('used_within_published_repository') unless repo_id
     page = Integer(params.fetch(:page, "1"))
-    begin
-      set_up_and_run_search( DEFAULT_AG_TYPES, default_facets,  search_opts, params)
-    rescue NoResultsError
-      flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
-    rescue Exception => error
-      flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/') and return
-    end
+    set_up_and_run_search( DEFAULT_AG_TYPES, default_facets,  search_opts, params)
 
     @context = repo_context(repo_id, 'agent')
     if @results['total_hits'] > 1

--- a/public/app/controllers/application_controller.rb
+++ b/public/app/controllers/application_controller.rb
@@ -19,6 +19,9 @@ class ApplicationController < ActionController::Base
   helper_method :process_json_notes
 
   protect_from_forgery with: :exception
+  
+  rescue_from LoginFailedException, :with => :render_backend_failure
+  rescue_from RequestFailedException, :with => :render_backend_failure
 
   # Allow overriding of templates via the local folder(s)
   if not ASUtils.find_local_directories.blank?
@@ -32,5 +35,13 @@ class ApplicationController < ActionController::Base
   def archivesspace
     ArchivesSpaceClient.instance
   end
+
+  private
+
+  def render_backend_failure(exception)
+    Rails.logger.error(exception)
+    render :template => '/error/backend_request_failure', :status => 500 
+  end
+
 
 end

--- a/public/app/controllers/application_controller.rb
+++ b/public/app/controllers/application_controller.rb
@@ -19,10 +19,14 @@ class ApplicationController < ActionController::Base
   helper_method :process_json_notes
 
   protect_from_forgery with: :exception
+ 
   
+  rescue_from Exception, :with => :render_general_error
   rescue_from LoginFailedException, :with => :render_backend_failure
   rescue_from RequestFailedException, :with => :render_backend_failure
-
+  rescue_from NoResultsError, :with => :render_no_results_found
+  
+  
   # Allow overriding of templates via the local folder(s)
   if not ASUtils.find_local_directories.blank?
     ASUtils.find_local_directories.map{|local_dir| File.join(local_dir, 'public', 'views')}.reject { |dir| !Dir.exist?(dir) }.each do |template_override_directory|
@@ -43,5 +47,20 @@ class ApplicationController < ActionController::Base
     render :template => '/error/backend_request_failure', :status => 500 
   end
 
+  def render_no_results_found(exception)
+    Rails.logger.error(exception)
+    flash[:error] = I18n.t('search_results.no_results')
+    unless controller_name == 'repositories'
+      redirect_back(fallback_location: '/') and return
+    else
+      redirect_to('/')
+    end
+  end
+  
+  def render_general_error(exception)
+    Rails.logger.error(exception)
+    flash[:error] = I18n.t('errors.unexpected_error')
+    redirect_back(fallback_location: '/') and return
+  end
 
 end

--- a/public/app/controllers/classifications_controller.rb
+++ b/public/app/controllers/classifications_controller.rb
@@ -33,16 +33,8 @@ class ClassificationsController <  ApplicationController
 
     @base_search = repo_id ? "repositories/#{repo_id}/classifications?" : '/classifications?'
     page = Integer(params.fetch(:page, "1"))
-
-    begin
-      set_up_and_run_search( DEFAULT_CL_TYPES, DEFAULT_CL_FACET_TYPES,  search_opts, params)
-    rescue NoResultsError
-      flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
-    rescue Exception => error
-      flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/') and return
-    end
+    set_up_and_run_search( DEFAULT_CL_TYPES, DEFAULT_CL_FACET_TYPES,  search_opts, params)
+    
     if @results['total_hits'] > 1
       @search[:dates_within] = true if params.fetch(:filter_from_year,'').blank? && params.fetch(:filter_to_year,'').blank?
       @search[:text_within] = true

--- a/public/app/controllers/objects_controller.rb
+++ b/public/app/controllers/objects_controller.rb
@@ -27,16 +27,7 @@ class ObjectsController <  ApplicationController
     search_opts = default_search_opts(DEFAULT_OBJ_SEARCH_OPTS)
     search_opts['fq'] = ["repository:\"/repositories/#{repo_id}\""] if repo_id
     @base_search = repo_id ? "/repositories/#{repo_id}/objects?" : '/objects?'
-
-    begin
-      set_up_and_run_search( params[:limit].split(","), DEFAULT_OBJ_FACET_TYPES, search_opts,params)
-    rescue NoResultsError
-      flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
-    rescue Exception => error
-     flash[:error] = I18n.t('errors.unexpected_error')
-     redirect_back(fallback_location: '/') and return
-    end
+    set_up_and_run_search( params[:limit].split(","), DEFAULT_OBJ_FACET_TYPES, search_opts,params)
     @context = repo_context(repo_id, 'record')
     if @results['total_hits'] > 1
       @search[:dates_within] = true if params.fetch(:filter_from_year,'').blank? && params.fetch(:filter_to_year,'').blank?

--- a/public/app/controllers/repositories_controller.rb
+++ b/public/app/controllers/repositories_controller.rb
@@ -27,7 +27,6 @@ class RepositoriesController < ApplicationController
     @criteria['page_size'] = 100
     @search_data =  archivesspace.search(query, page, @criteria) || {}
     Rails.logger.debug("TOTAL HITS: #{@search_data['total_hits']}, last_page: #{@search_data['last_page']}")
-    Rails.logger.debug(@search_data.inspect) 
     @json = []
 
     if !@search_data['results'].blank?

--- a/public/app/controllers/repositories_controller.rb
+++ b/public/app/controllers/repositories_controller.rb
@@ -27,7 +27,9 @@ class RepositoriesController < ApplicationController
     @criteria['page_size'] = 100
     @search_data =  archivesspace.search(query, page, @criteria) || {}
     Rails.logger.debug("TOTAL HITS: #{@search_data['total_hits']}, last_page: #{@search_data['last_page']}")
+    Rails.logger.debug(@search_data.inspect) 
     @json = []
+
     if !@search_data['results'].blank?
       @pager =  Pager.new("/repositories?", @search_data['this_page'],@search_data['last_page'])
       @search_data['results'].each do |result| 
@@ -39,6 +41,8 @@ class RepositoriesController < ApplicationController
         end
       end
       Rails.logger.debug("First hash: #{@json[0]}")
+    else
+      raise NoResultsError.new("No repository records found!")
     end
     @json.sort_by!{|h| h['display_string'].upcase}
     @page_title = I18n.t('list', {:type => (@json.length > 1 ? I18n.t('repository._plural') : I18n.t('repository._singular'))})

--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -48,15 +48,7 @@ class ResourcesController <  ApplicationController
     page = Integer(params.fetch(:page, "1"))
     facet_types = DEFAULT_RES_FACET_TYPES
     facet_types.unshift('repository') if !@repo_id
-    begin
-      set_up_and_run_search(['resource'], facet_types,search_opts, params)
-    rescue NoResultsError
-      flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
-    rescue Exception => error
-      flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/' ) and return
-    end
+    set_up_and_run_search(['resource'], facet_types,search_opts, params)
     @context = repo_context(@repo_id, 'resource')
      if @results['total_hits'] > 1
         @search[:dates_within] = true if params.fetch(:filter_from_year,'').blank? && params.fetch(:filter_to_year,'').blank?

--- a/public/app/controllers/subjects_controller.rb
+++ b/public/app/controllers/subjects_controller.rb
@@ -28,15 +28,7 @@ class SubjectsController <  ApplicationController
     @base_search  =  repo_id ? "/repositories/#{repo_id}/subjects?" : '/subjects?' 
     default_facets = repo_id ? [] : ['used_within_published_repository']
     page = Integer(params.fetch(:page, "1"))
-    begin
-      set_up_and_run_search(['subject'],default_facets,search_opts, params)
-    rescue NoResultsError
-      flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
-    rescue Exception => error
-      flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/' ) and return
-    end
+    set_up_and_run_search(['subject'],default_facets,search_opts, params)
     @context = repo_context(repo_id, 'subject')
     if @results['total_hits'] > 1
       @search[:dates_within] = false

--- a/public/app/services/archives_space_client.rb
+++ b/public/app/services/archives_space_client.rb
@@ -139,9 +139,6 @@ class ArchivesSpaceClient
 
   private
   
-  class LoginFailedException < StandardError; end
-
-  class RequestFailedException < StandardError; end
 
   # perform the actual search, returning json-ized results, 
   # or raising an error

--- a/public/app/views/error/backend_request_failure.html.erb
+++ b/public/app/views/error/backend_request_failure.html.erb
@@ -1,0 +1,6 @@
+<div class='row'>
+  <div class="jumbotron text-center">
+    <h1><%= t('errors.backend_down') %></h1>
+    <p><%= t('errors.backend_down_message') %></p>
+  </div>
+</div>

--- a/public/app/views/shared/_pagination.html.erb
+++ b/public/app/views/shared/_pagination.html.erb
@@ -1,4 +1,4 @@
-<% if pager.pages.last > 1 %>
+<% if pager && pager.pages.last > 1 %>
 <div id="paging">
   
   <ul class="pagination">


### PR DESCRIPTION

Fixes #1090 and adds an error page when the Public UI cannot connect to the backend.
Tries to DRY out the exception rescue bits by moving it to the application controller

You might not see some of these pages in development unless you change the development.rb to

```
config.consider_all_requests_local = false
```
