### PR TITLE
fix static asset finder so it works for plugins.  #1111

### DIFF
--- a/backend/app/lib/static_asset_finder.rb
+++ b/backend/app/lib/static_asset_finder.rb
@@ -4,9 +4,8 @@ class StaticAssetFinder
     static_dir = File.join(ASUtils.find_base_directory, base)
     plugins_dir = File.join(ASUtils.find_base_directory, 'plugins' )
 
-    @valid_paths = (Dir[File.join(static_dir, "**", "*")] +
-        ( AppConfig[:plugins].map { |p| Dir[File.join(plugins_dir, p, base, "**", "*")] }).reduce(:+)).
-                            select {|path| File.exist?(path) && File.file?(path)}
+    @valid_paths = ( (AppConfig[:plugins].map { |p| Dir[File.join(plugins_dir, p, base, "**", "*")] }).reduce(:+) +
+                      Dir[File.join(static_dir, "**", "*")] ).select {|path| File.exist?(path) && File.file?(path)}
 
   end
 

--- a/backend/app/lib/static_asset_finder.rb
+++ b/backend/app/lib/static_asset_finder.rb
@@ -2,9 +2,12 @@ class StaticAssetFinder
 
   def initialize(base)
     static_dir = File.join(ASUtils.find_base_directory, base)
+    plugins_dir = File.join(ASUtils.find_base_directory, 'plugins' )
 
-    @valid_paths = Dir[File.join(static_dir, "**", "*")].
+    @valid_paths = (Dir[File.join(static_dir, "**", "*")] +
+        ( AppConfig[:plugins].map { |p| Dir[File.join(plugins_dir, p, base, "**", "*")] }).reduce(:+)).
                             select {|path| File.exist?(path) && File.file?(path)}
+
   end
 
 


### PR DESCRIPTION
#1111 
My suggestion: 
deprecate  plugins/AppConfig[:plugins]/backend/model/reports  

classes are still loaded from those directories in:
https://github.com/archivesspace/archivesspace/blob/master/backend/app/main.rb#L132
but that can be removed after deprecation warning. 

Besides fixing the template loading problem, this will now also find  files in AppConfig[:plugins]/reports/static, AppConfig[:plugins]/stylesheets

Will document in https://github.com/archivesspace/archivesspace/blob/master/plugins/PLUGINS_README.md 
if this seems like a reasonable solution. 




