### PR TITLE
fix accession show title bug

### DIFF
--- a/frontend/app/views/accessions/show.html.erb
+++ b/frontend/app/views/accessions/show.html.erb
@@ -1,4 +1,4 @@
-<%= setup_context(:object => @accession) %>
+<%= setup_context(:object => @accession, :title => @accession.display_string) %>
 
 <%= render_aspace_partial :partial => "transfer/transfer_failures", :locals => { :transfer_errors => @transfer_errors } %>
 


### PR DESCRIPTION
This PR fixes a bug that we discovered that results in accessions without titles having incomplete breadcrumb trails and HTML header titles. 

We do not assign titles to our accessions, only identifiers, resulting in the bug shown in the attached screenshot. This PR updates the accessions show template to pass a "title" parameter to setup_context using the accession's display string (title if it exists, identifier if not), similar to the [accessions edit template](https://github.com/archivesspace/archivesspace/blob/master/frontend/app/views/accessions/edit.html.erb).

![accession_show_bug](https://user-images.githubusercontent.com/11635158/36606436-b358907a-1891-11e8-801c-e0f8a2b6ad87.PNG)
