### PR TITLE
ANW-609 unresolved containers was causing errors on OAI getRecord EAD serializer

### DIFF
--- a/backend/app/lib/oai/aspace_oai_record.rb
+++ b/backend/app/lib/oai/aspace_oai_record.rb
@@ -7,7 +7,8 @@ class ArchivesSpaceOAIRecord
   attr_reader :sequel_record, :jsonmodel_record
 
   def initialize(sequel_record, jsonmodel_record)
-    @jsonmodel_record = jsonmodel_record
+    @jsonmodel_record = JSONModel::JSONModel(:resource).new(
+        URIResolver.resolve_references( jsonmodel_record, ['repository', 'linked_agents', 'subjects', 'digital_object', 'top_container', 'top_container::container_profile'] ))
     @sequel_record = sequel_record
   end
 


### PR DESCRIPTION
In my current failing samples, it is unresolved containers and container profiles that is causing the serializer errors.  

I don't know if it's necessary to resolve everything, but I referred to working code in backend/app/lib/export.rb.

Go ahead and trim that list of resources to be resolved  if you know more specifically what is required. 
( I will look for further failing examples to see if I can find a failure due to agents or subjects. ) 