### PR TITLE
Dup default facets instead of assigning

### DIFF
--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -46,7 +46,7 @@ class ResourcesController <  ApplicationController
       params[k] = v unless params.fetch(k, nil)
     end
     page = Integer(params.fetch(:page, "1"))
-    facet_types = DEFAULT_RES_FACET_TYPES
+    facet_types = DEFAULT_RES_FACET_TYPES.dup
     facet_types.unshift('repository') if !@repo_id
     set_up_and_run_search(['resource'], facet_types,search_opts, params)
     @context = repo_context(@repo_id, 'resource')


### PR DESCRIPTION
We noticed an issue where the default facets array (DEFAULT_RES_FACET_TYPES in public/app/controllers/resources_controller.rb) was being modified and in turn growing in length each time the resources (Collections) view was navigated to if a repository ID was not specified.
At some point the array grows to such a large size that the generated search URL is no longer able to be processed and causes the page to display an error. A service restart would temporarily resolve the issue as it would reset the default facet array.