### PR TITLE
Remove skip_before_filter from controllers

### DIFF
--- a/public/app/controllers/accessions_controller.rb
+++ b/public/app/controllers/accessions_controller.rb
@@ -3,7 +3,6 @@ class AccessionsController <  ApplicationController
  
   include TreeApis
 
-  skip_before_filter  :verify_authenticity_token
 
   DEFAULT_AC_TYPES = %w{accession}
   DEFAULT_AC_FACET_TYPES = %w{primary_type subjects published_agents repository}

--- a/public/app/controllers/agents_controller.rb
+++ b/public/app/controllers/agents_controller.rb
@@ -2,8 +2,6 @@ class AgentsController <  ApplicationController
   include ResultInfo
   include TreeApis
 
-  skip_before_filter  :verify_authenticity_token
-
   DEFAULT_AG_TYPES = %w{repository resource accession archival_object digital_object}
   DEFAULT_AG_FACET_TYPES = %w{primary_type subjects}
   DEFAULT_AG_SEARCH_OPTS = {

--- a/public/app/controllers/classifications_controller.rb
+++ b/public/app/controllers/classifications_controller.rb
@@ -3,8 +3,6 @@ class ClassificationsController <  ApplicationController
   include ResultInfo
   include TreeApis
 
-  skip_before_filter  :verify_authenticity_token
-
   IDENTIFIER_SORT_ASC = 'identifier_sort asc, repo_sort asc, title_sort asc'
   IDENTIFIER_SORT_DESC = 'identifier_sort desc, repo_sort desc, title_sort desc'
 

--- a/public/app/controllers/objects_controller.rb
+++ b/public/app/controllers/objects_controller.rb
@@ -7,7 +7,6 @@ class ObjectsController <  ApplicationController
   helper_method :process_digital
   helper_method :process_digital_instance
 
-  skip_before_filter  :verify_authenticity_token
   
   DEFAULT_OBJ_FACET_TYPES = %w(repository primary_type subjects published_agents)
   DEFAULT_OBJ_SEARCH_OPTS = {

--- a/public/app/controllers/repositories_controller.rb
+++ b/public/app/controllers/repositories_controller.rb
@@ -1,7 +1,6 @@
 class RepositoriesController < ApplicationController
   include ResultInfo
   helper_method :process_repo_info
-  skip_before_filter  :verify_authenticity_token  
 
   DEFAULT_SEARCH_FACET_TYPES = ['primary_type', 'subjects', 'published_agents']
   DEFAULT_REPO_SEARCH_OPTS = {

--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -6,7 +6,6 @@ class ResourcesController <  ApplicationController
 
   include TreeApis
 
-  skip_before_filter  :verify_authenticity_token
 
 
   DEFAULT_RES_FACET_TYPES = %w{primary_type subjects published_agents}

--- a/public/app/controllers/subjects_controller.rb
+++ b/public/app/controllers/subjects_controller.rb
@@ -2,7 +2,6 @@ class SubjectsController <  ApplicationController
 
   include ResultInfo
 
-  skip_before_filter  :verify_authenticity_token
   DEFAULT_SUBJ_TYPES = %w{repository resource accession archival_object digital_object}
   DEFAULT_SUBJ_FACET_TYPES = %w{primary_type published_agents used_within_published_repository}
   DEFAULT_SUBJ_SEARCH_OPTS = {


### PR DESCRIPTION
This removes the skip_before_filter from the models, which was removed
in Rails a long time ago.. ( starting the app gives a depreciation warning )

Can't figure out why they want to skip verify_authenticity_token in the first place? 