### PR TITLE
Return valid updated json_response when updating the position

### DIFF
--- a/backend/app/controllers/enumeration.rb
+++ b/backend/app/controllers/enumeration.rb
@@ -88,7 +88,7 @@ class ArchivesSpaceService < Sinatra::Base
   do
     obj = EnumerationValue.get_or_die(params[:enum_val_id])
     obj.update_position_only(params[:position])
-    json_response(EnumerationValue.to_jsonmodel(params[:enum_val_id]))
+    updated_response( obj.refresh )
   end
   
   Endpoint.post('/config/enumeration_values/:enum_val_id/suppressed')

--- a/backend/app/controllers/enumeration.rb
+++ b/backend/app/controllers/enumeration.rb
@@ -88,7 +88,7 @@ class ArchivesSpaceService < Sinatra::Base
   do
     obj = EnumerationValue.get_or_die(params[:enum_val_id])
     obj.update_position_only(params[:position])
-    json_response(obj)
+    json_response(EnumerationValue.to_jsonmodel(params[:enum_val_id]))
   end
   
   Endpoint.post('/config/enumeration_values/:enum_val_id/suppressed')

--- a/backend/spec/controller_enumeration_spec.rb
+++ b/backend/spec/controller_enumeration_spec.rb
@@ -187,16 +187,18 @@ describe "Enumeration controller" do
 
   it "can change positions of  values" do
     obj = JSONModel(:enumeration).find(@enum_id)
-    
     val = obj.enumeration_values[0]
-   
+    position = obj.enumeration_values.length 
+
     enum_val = JSONModel(:enumeration_value).find(val['id'])
-    JSONModel::HTTP.post_form("#{enum_val.uri}/position", :position => obj.enumeration_values.length ) 
-    
+    response = JSON.parse( JSONModel::HTTP.post_form("#{enum_val.uri}/position", :position => position ).body )  
+   
+    response["position"].should eq(position)
+    response["value"].should eq(val["value"])
+
     obj = nil
     obj = JSONModel(:enumeration).find(@enum_id)
     obj.values.last.should eq(val["value"])
-    
   end
     
 

--- a/backend/spec/controller_enumeration_spec.rb
+++ b/backend/spec/controller_enumeration_spec.rb
@@ -193,10 +193,9 @@ describe "Enumeration controller" do
     enum_val = JSONModel(:enumeration_value).find(val['id'])
     response = JSON.parse( JSONModel::HTTP.post_form("#{enum_val.uri}/position", :position => position ).body )  
    
-    response["position"].should eq(position)
-    response["value"].should eq(val["value"])
+    response["id"].should eq(val["id"])
+    response["status"].should eq("Updated")
 
-    obj = nil
     obj = JSONModel(:enumeration).find(@enum_id)
     obj.values.last.should eq(val["value"])
   end


### PR DESCRIPTION
Currently the update position end-point tries to return the object as
json without calling to_jsonmodel, which just returns the name of the
instance. Call to_jsonmodel and adds test.

Fixes #1163 