### PR TITLE
Ensure saxon-xslt version >= 0.8.2.1

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -13,7 +13,7 @@ gem "json-schema", "1.0.10"
 gem "jruby-jars", "= 9.1.8.0"
 gem 'nokogiri', '1.8.1' # because of https://github.com/sparklemotion/nokogiri/issues/1673
 gem "saxerator", "= 0.9.2"
-gem 'saxon-xslt'
+gem 'saxon-xslt', '~> 0.8', '>= 0.8.2.1'
 gem 'tzinfo'
 gem "rufus-scheduler", "~> 2.0.24"
 gem "rufus-lru", "1.0.5"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
       tzinfo (>= 0.3.22)
     saxerator (0.9.2)
       nokogiri (>= 1.4.0)
-    saxon-xslt (0.8.0-java)
+    saxon-xslt (0.8.2.1-java)
     sequel (4.20.0)
     simplecov (0.7.1)
       multi_json (~> 1.0)
@@ -134,7 +134,7 @@ DEPENDENCIES
   rufus-lru (= 1.0.5)
   rufus-scheduler (~> 2.0.24)
   saxerator (= 0.9.2)
-  saxon-xslt
+  saxon-xslt (~> 0.8, >= 0.8.2.1)
   sequel (~> 4.20.0)
   simplecov (= 0.7.1)
   sinatra (= 1.4.7)


### PR DESCRIPTION
In previous versions of `saxon-xslt` I included VCR HTTP fixtures
('cassettes') in the files included in the `.gem` package by mistake.

These fixtures have very long file names, which may well have been
causing problems with building on Windows systems, with their
maximum-complete-path-length restriction. Releases 0.7.2.1 and 0.8.2.1
remove the fixtures from the `.gem` package, with no code changes.

This will hopefully fix the Windows build problem @lmcglohon has reported.

(See fidothe/saxon-xslt#17)