### PR TITLE
Fixes to preferences based upon permissions

### DIFF
--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -1814,9 +1814,9 @@ en:
     global_message: Edit these values to set system-wide user preference defaults. These values can be overridden by repository defaults or a user's own preferences.
     repo: User Preference Defaults
     repo_message: Edit these values to set user preference defaults for the current repository. These values can be overridden by a user's own preferences.
-    user_global: My Global Preferences
+    user_global: Global Preferences
     user_global_message: Edit these values to set your system-wide user preferences. These values can be overridden by repository defaults or by your own preferences for a repository.
-    user_repo: My Repository Preferences
+    user_repo: Repository Preferences
     user_repo_message: Edit these values to set your user preferences for this repository. These values cannot be overridden.
     _singular: Preferences
     _plural: Preferences

--- a/common/locales/es.yml
+++ b/common/locales/es.yml
@@ -1758,7 +1758,7 @@
     repo_message: Editar estos valores para establecer valores predeterminados de preferencia de usuario para el repositorio actual. Estos valores pueden ser reemplazados por un usuario propias preferencias.
     user_global: Mis preferencias globales
     user_global_message: Editar estos valores para definir las preferencias de usuario de todo el sistema. Estos valores pueden ser anulados por el repositorio por defecto o por sus propias preferencias para un repositorio.
-    user_repo: Mis preferencias de repositorio
+    user_repo: Preferencias de repositorio
     user_repo_message: Editar estos valores para definir las preferencias de usuario de este repositorio. Estos valores no se pueden sustituir.
     _singular: Preferencias
     _plural: Preferencias

--- a/common/locales/fr.yml
+++ b/common/locales/fr.yml
@@ -1775,7 +1775,7 @@ fr:
     repo_message: Editez ces valeurs pour définir les préférences utilisateur par défaut pour le service d'archives actif. Ces valeurs peuvent être écrasées par les préférences propres d'un utilisateur.
     user_global: Mes préférences globales
     user_global_message: Editez ces valeurs pour définir vos préférences utilisateur à l'échelle du système. Ces valeurs peuvent être écrasées par les valeurs par défauts du service d'archives ou par vos propres préférences pour un service d'archives.
-    user_repo: Mes préférences Service
+    user_repo: Préférences Service
     user_repo_message: Editez ces valeurs pour définir vos préférences utilisateur pour ce service d'archives. Ces valeurs ne peuvent pas être écrasées.
     _singular: Préférences
     _plural: Préférences

--- a/frontend/app/views/shared/_header_repository.html.erb
+++ b/frontend/app/views/shared/_header_repository.html.erb
@@ -135,7 +135,6 @@
                     <% found_an_item = true %>
                     <li><%= link_to I18n.t("navbar.manage_groups"), :controller => :groups, :action => :index %></li>
                     <li><%= link_to I18n.t("user._frontend.section.manage_access"), :controller => :users, :action => :manage_access %></li>
-                    <li><%= link_to I18n.t("navbar.repo_preferences"), :controller => :preferences, :action => :edit, :id => 0, :repo => true %></li>
                   <% end %>
                   <% if user_can?('manage_assessment_attributes') %>
                     <li><%= link_to I18n.t("navbar.manage_assessment_attributes"), :controller => :assessment_attributes, :action => :edit %></li>

--- a/frontend/app/views/shared/_header_user.html.erb
+++ b/frontend/app/views/shared/_header_user.html.erb
@@ -74,10 +74,13 @@
         <a class="btn btn-default navbar-btn dropdown-toggle last" data-toggle="dropdown" href="#"><span class="caret"></span></a>
         <ul class="dropdown-menu pull-right">
 
-          <li><%= link_to I18n.t("navbar.user_global_preferences"), :controller => :preferences, :action => :edit, :id => 0, :global => true %></li>
-          <% if session[:repo_id] %>
+          <% if user_can?('administer_system') %>
+            <li><%= link_to I18n.t("navbar.global_preferences"), :controller => :preferences, :action => :edit, :id => 0, :global => true %></li>
+          <% end %>
+          <% if user_can?('administer_system') || user_can?('manage_repository') %>
             <li><%= link_to I18n.t("navbar.user_repo_preferences"), :controller => :preferences, :action => :edit, :id => 0 %></li>
           <% end %>
+          <li><%= link_to I18n.t("navbar.repo_preferences"), :controller => :preferences, :action => :edit, :id => 0, :repo => true %></li>
           <li class="divider"></li>
 
           <% if user_can?('become_user') %>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -295,9 +295,9 @@ en:
     manage_location_profiles: Manage Location Profiles
     manage_top_containers: Manage Top Containers
     manage_enumerations: Manage Controlled Value Lists
-    user_global_preferences: My Global Preferences
-    user_repo_preferences: My Repository Preferences
-    repo_preferences: User Preference Defaults
+    global_preferences: Global Preferences
+    user_repo_preferences: Repository Preferences
+    repo_preferences: User Preferences
     manage_user_access: Manage User Access
     logout: Logout
     login: Sign In

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -270,8 +270,8 @@
     manage_location_profiles: Gestionar Location Profiles
     manage_top_containers: Gestionar Top Containers
     manage_enumerations: Administrar listas de valores controlados
-    user_global_preferences: Mis preferencias globales
-    user_repo_preferences: Mis preferencias de repositorio
+    global_preferences: Preferencias globales
+    user_repo_preferences: Preferencias de repositorio
     repo_preferences: Valores predeterminados de preferencia de usuario
     manage_user_access: Administrar el acceso de usuario
     logout: Salir

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -280,8 +280,8 @@ fr:
     manage_location_profiles: Gérer profils de localisations
     manage_top_containers: Gérer Top conditionnements
     manage_enumerations: Gérer listes de valeurs contrôlées
-    user_global_preferences: Mes préférences globales
-    user_repo_preferences: Mes préférences de service d'archives
+    global_preferences: Préférences globales
+    user_repo_preferences: Préférences de service d'archives
     repo_preferences: Préférences par défaut de l'utilisateur
     manage_user_access: Gérer accès utilisateur
     logout: Déconnexion


### PR DESCRIPTION
Global Preferences - should appear for system admin permissions only
Repository Preferences - should appear for repository managers and system admins only
User Preference Defaults (should perhaps be renamed to User Preferences to match others) - should appear for all users