### PR TITLE
ANW-675

### DIFF
--- a/backend/app/exporters/models/marc21.rb
+++ b/backend/app/exporters/models/marc21.rb
@@ -176,7 +176,7 @@ class MARCModel < ASpaceExport::ExportModel
     if date_codes.length > 0
       # we want to pass in all our date codes as separate subfield tags
       # e.g., with_sfs(['a', title], [code1, val1], [code2, val2]... [coden, valn])
-      df('245', ind1, '0').with_sfs(['a', title], *date_codes)
+      df('245', ind1, '0').with_sfs(['a', title + ","], *date_codes)
     else
       df('245', ind1, '0').with_sfs(['a', title])
     end

--- a/backend/spec/export_marc_spec.rb
+++ b/backend/spec/export_marc_spec.rb
@@ -127,6 +127,10 @@ describe 'MARC Export' do
       end
     end
 
+    it "adds a comma after $a if a date is defined" do
+      expect(@marc.at("datafield[@tag='245']/subfield[@code='a']/text()").to_s[-1]).to eq(",")
+    end
+
 
     it "maps the first bulk date to subfield 'g'" do
       date = @dates.find{|d| d.date_type == 'bulk'}
@@ -338,7 +342,8 @@ describe 'MARC Export' do
     end
 
     it "should strip out the mixed content in title" do
-      @marc.should have_tag "datafield[@tag='245']/subfield[@code='a']" => "Foo  BAR  Jones"
+      @marc.should have_tag "datafield[@tag='245']/subfield[@code='a']"
+      expect(@marc.at("datafield[@tag='245']/subfield[@code='a']/text()").to_s).to match(/Foo  BAR  Jones/)
     end
   end
 


### PR DESCRIPTION
MARCXML Export: In 245 title tag, $f or $g date subfields should be prececeded by a comma (in $a)