### PR TITLE
Improve API documentation

### DIFF
--- a/_yard/API.erb
+++ b/_yard/API.erb
@@ -178,29 +178,31 @@ As of <%= @time.inspect %> the following REST endpoints exist in the master bran
 <% if e[:method][0] == :get %>
   <% if e[:paginated] %>
 # return first 10 records    
-curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>?page=1&page_size=10"
+curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1").gsub(":repo_id", "2") %>?page=1&page_size=10"
 # return first 5 records in the Fibonacci sequence
-curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>?id_set=1,2,3,5,8"
+curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1").gsub(":repo_id", "2") %>?id_set=1,2,3,5,8"
 # return an array of all the ids 
-curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>?all_ids=true"
+curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1").gsub(":repo_id", "2") %>?all_ids=true"
   <% else %> 
-curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>"
+curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1").gsub(":repo_id", "2") %>"
   <% end %>
 <% elsif e[:method][0] == :post %>
   <% example.each_pair do |k,v| %>  
-  <% next if k == "id" %>   
+  <% next if k == "id" %>
+  <% next if k == "repo_id" %>
 curl -H "X-ArchivesSpace-Session: $SESSION" \
   -d '<%= v.to_json.gsub("{", "{ ").gsub(",", ",\n") %>' \
-  "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>"
+  "http://localhost:8089<%= e[:uri].gsub(":id", "1").gsub(":repo_id", "2") %>"
   <% end %>
 <% elsif e[:method][0] == :delete %>
-curl -H "X-ArchivesSpace-Session: $SESSION" -X DELETE "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>"
+curl -H "X-ArchivesSpace-Session: $SESSION" -X DELETE "http://localhost:8089<%= e[:uri].gsub(":id", "1").gsub(":repo_id", "2") %>"
 <% else %>
   <% example.each_pair do |k,v| %>  
-  <% next if k == "id" %>   
+  <% next if k == "id" %>
+  <% next if k == "repo_id" %>   
 curl -H "X-ArchivesSpace-Session: $SESSION" \
   -d '<%= v.to_json.gsub("{", "{ ").gsub(",", ",\n") %>' \
-  "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>"
+  "http://localhost:8089<%= e[:uri].gsub(":id", "1").gsub(":repo_id", "2") %>"
   <% end %>
 <% end %>
 

--- a/_yard/API.erb
+++ b/_yard/API.erb
@@ -209,7 +209,7 @@ __Returns__
 
 <% if example %>
 ```shell 
-<% if e[:method] == :get %>
+<% if e[:method][0] == :get %>
   <% if e[:paginated] %>
 # return first 10 records    
 curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>?page=1&page_size=10"
@@ -220,14 +220,14 @@ curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gs
   <% else %> 
 curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>"
   <% end %>
-<% elsif e[:method] == :post %>
+<% elsif e[:method][0] == :post %>
   <% example.each_pair do |k,v| %>  
   <% next if k == "id" %>   
 curl -H "X-ArchivesSpace-Session: $SESSION" \
   -d '<%= v.to_json.gsub("{", "{ ").gsub(",", ",\n") %>' \
   "http://localhost:8089/<%= e[:uri].gsub(":id", "1") %>"
   <% end %>
-<% elsif e[:method] == :delete %>
+<% elsif e[:method][0] == :delete %>
 curl -H "X-ArchivesSpace-Session: $SESSION" -X DELETE "http://localhost:8089/<%= e[:uri].gsub(":id", "1") %>"
 <% else %>
   <% example.each_pair do |k,v| %>  

--- a/_yard/API.erb
+++ b/_yard/API.erb
@@ -171,6 +171,41 @@ As of <%= @time.inspect %> the following REST endpoints exist in the master bran
 
 ## <%= e[:method].map &:upcase %> <%= e[:uri]%> 
 
+<% example =  @examples[e[:uri]][e[:method].to_s] %>
+
+<% if example %>
+```shell 
+<% if e[:method][0] == :get %>
+  <% if e[:paginated] %>
+# return first 10 records    
+curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>?page=1&page_size=10"
+# return first 5 records in the Fibonacci sequence
+curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>?id_set=1,2,3,5,8"
+# return an array of all the ids 
+curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>?all_ids=true"
+  <% else %> 
+curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>"
+  <% end %>
+<% elsif e[:method][0] == :post %>
+  <% example.each_pair do |k,v| %>  
+  <% next if k == "id" %>   
+curl -H "X-ArchivesSpace-Session: $SESSION" \
+  -d '<%= v.to_json.gsub("{", "{ ").gsub(",", ",\n") %>' \
+  "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>"
+  <% end %>
+<% elsif e[:method][0] == :delete %>
+curl -H "X-ArchivesSpace-Session: $SESSION" -X DELETE "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>"
+<% else %>
+  <% example.each_pair do |k,v| %>  
+  <% next if k == "id" %>   
+curl -H "X-ArchivesSpace-Session: $SESSION" \
+  -d '<%= v.to_json.gsub("{", "{ ").gsub(",", ",\n") %>' \
+  "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>"
+  <% end %>
+<% end %>
+
+```
+
 __Description__
 
 <%= e[:description]%>
@@ -205,40 +240,6 @@ __Returns__
 <%= "\t#{ret[0]} -- #{ret[1]}\n" %>
 <% end %>
 
-<% example =  @examples[e[:uri]][e[:method].to_s] %>
-
-<% if example %>
-```shell 
-<% if e[:method][0] == :get %>
-  <% if e[:paginated] %>
-# return first 10 records    
-curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>?page=1&page_size=10"
-# return first 5 records in the Fibonacci sequence
-curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>?id_set=1,2,3,5,8"
-# return an array of all the ids 
-curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>?all_ids=true"
-  <% else %> 
-curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1") %>"
-  <% end %>
-<% elsif e[:method][0] == :post %>
-  <% example.each_pair do |k,v| %>  
-  <% next if k == "id" %>   
-curl -H "X-ArchivesSpace-Session: $SESSION" \
-  -d '<%= v.to_json.gsub("{", "{ ").gsub(",", ",\n") %>' \
-  "http://localhost:8089/<%= e[:uri].gsub(":id", "1") %>"
-  <% end %>
-<% elsif e[:method][0] == :delete %>
-curl -H "X-ArchivesSpace-Session: $SESSION" -X DELETE "http://localhost:8089/<%= e[:uri].gsub(":id", "1") %>"
-<% else %>
-  <% example.each_pair do |k,v| %>  
-  <% next if k == "id" %>   
-curl -H "X-ArchivesSpace-Session: $SESSION" \
-  -d '<%= v.to_json.gsub("{", "{ ").gsub(",", ",\n") %>' \
-  "http://localhost:8089/<%= e[:uri].gsub(":id", "1") %>"
-  <% end %>
-<% end %>
-
-```
 <% end %>
 
 <% end %>

--- a/_yard/API.erb
+++ b/_yard/API.erb
@@ -174,35 +174,57 @@ As of <%= @time.inspect %> the following REST endpoints exist in the master bran
 <% example =  @examples[e[:uri]][e[:method].to_s] %>
 
 <% if example %>
+
+<% url_params = e[:params].map{|p| p[0] unless (e[:uri].include?("/:#{p[0]}") or (p[3] or {})[:body] or p[1] == :body_stream or ["repo_id", "id"].include?(p[0])) }.compact %>
+<% request_uri = "http://localhost:8089#{e[:uri].gsub(":repo_id", "2").gsub(":id", "1").gsub(/(?<=\/)(:.*?)(?=\/)/, "1").gsub(/(?<=\/):.*?$/, "1")}" %>
+<% if !url_params.empty? && !e[:paginated] %>
+  <% url_param_examples = [] %>
+  <% url_params.each do |param| %>
+    <% if param == "resolve" %>
+      <% url_param_examples << "#{param}[]=[record_types, to_resolve]" %>
+    <% elsif example[param] %>
+      <% if example[param] == "BooleanParam" %>
+        <% url_param_examples << "#{param}=true" %>
+      <% else %>
+        <% url_param_examples << "#{param}=#{example[param]}" %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <% request_uri += "?#{url_param_examples.join("&")}" %>
+<% end %>
+
+<% data_params = e[:params].map{|p| p[0] if ((p[3] or {})[:body] or p[1] == :body_stream)}.compact %>
+<% if !data_params.empty? %>
+  <% data_param = data_params[0] %>
+  <% data_example = example[data_param] ? example[data_param].to_json.gsub("{", "{ ").gsub(",", ",\n") : "Example Missing" %>
+<% else %>
+  <% data_example = "Example Missing" %>
+<% end %>
+
 ```shell 
-<% if e[:method][0] == :get %>
+<% if e[:method] == [:get] %>
   <% if e[:paginated] %>
 # return first 10 records    
-curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1").gsub(":repo_id", "2") %>?page=1&page_size=10"
+curl -H "X-ArchivesSpace-Session: $SESSION" "<%= request_uri %>?page=1&page_size=10"
 # return first 5 records in the Fibonacci sequence
-curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1").gsub(":repo_id", "2") %>?id_set=1,2,3,5,8"
+curl -H "X-ArchivesSpace-Session: $SESSION" "<%= request_uri %>?id_set=1,2,3,5,8"
 # return an array of all the ids 
-curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1").gsub(":repo_id", "2") %>?all_ids=true"
+curl -H "X-ArchivesSpace-Session: $SESSION" "<%= request_uri %>?all_ids=true"
   <% else %> 
-curl -H "X-ArchivesSpace-Session: $SESSION" "http://localhost:8089<%= e[:uri].gsub(":id", "1").gsub(":repo_id", "2") %>"
+curl -H "X-ArchivesSpace-Session: $SESSION" "<%= request_uri %>"
   <% end %>
-<% elsif e[:method][0] == :post %>
-  <% example.each_pair do |k,v| %>  
-  <% next if k == "id" %>
-  <% next if k == "repo_id" %>
+<% elsif e[:method] == [:post] %>
 curl -H "X-ArchivesSpace-Session: $SESSION" \
-  -d '<%= v.to_json.gsub("{", "{ ").gsub(",", ",\n") %>' \
-  "http://localhost:8089<%= e[:uri].gsub(":id", "1").gsub(":repo_id", "2") %>"
-  <% end %>
-<% elsif e[:method][0] == :delete %>
-curl -H "X-ArchivesSpace-Session: $SESSION" -X DELETE "http://localhost:8089<%= e[:uri].gsub(":id", "1").gsub(":repo_id", "2") %>"
+  -d '<%= data_example %>' \
+  "<%= request_uri %>"
+<% elsif e[:method] == [:delete] %>
+curl -H "X-ArchivesSpace-Session: $SESSION" -X DELETE "<%= request_uri %>"
 <% else %>
   <% example.each_pair do |k,v| %>  
-  <% next if k == "id" %>
-  <% next if k == "repo_id" %>   
+    <% next if e[:uri].include?("/:#{k}") %>  
 curl -H "X-ArchivesSpace-Session: $SESSION" \
   -d '<%= v.to_json.gsub("{", "{ ").gsub(",", ",\n") %>' \
-  "http://localhost:8089<%= e[:uri].gsub(":id", "1").gsub(":repo_id", "2") %>"
+  "<%= request_uri %>"
   <% end %>
 <% end %>
 
@@ -228,11 +250,12 @@ This endpoint is paginated. :page, :id_set, or :all_ids is required
 <% end %>
 <% e[:params].each do |param| 
   opts = (param[3] or {})
-  vs = opts[:validation] ? " -- #{opts[:validation][0]}" : "" %>
+  vs = opts[:validation] ? " -- #{opts[:validation][0]}" : ""
+  optional = opts[:optional] ? " (Optional)" : "" %>
 <% if opts[:body] %>
 	<%= "#{param[1]} <request body> -- #{param[2]}#{vs}" %>
 <% else %>
-	<%= "#{param[1]} #{param[0]} -- #{param[2]}#{vs}" %>
+	<%= "#{param[1]} #{param[0]}#{optional} -- #{param[2]}#{vs}" %>
 <% end %>
 <% end %>
 


### PR DESCRIPTION
This PR started as an investigation of this issue: https://github.com/archivesspace/archivesspace/issues/1071

That particular issue was being caused by method checks being written like this:
```ruby
<% if e[:method] == :get %>
```

Methods are returned as an array, so every example in the API docs, regardless of method, was defaulting to the final `<% else %>` block that adds a -d flag regardless of method.  Method checks are now written as:
```ruby
<% if e[:method] == [:get] %>
```

Other changes included in this PR include:

1. Moving code samples to immediately below the heading, in line with the Slate markdown syntax guidelines: https://github.com/lord/slate/wiki/markdown-syntax#formatting-code-annotations-right-column-with-its-explanation-center-column

2. Parsing out endpoint parameters, URL parameters, and data parameters in an attempt to produce more accurate examples. Previous examples treated each URL parameter as a separate data parameter, so that endpoints like `[:POST] /users/:id`, with an optional `password` parameter and a `JSONModel(:user)` post body parameter were given examples like this:

```shell
curl -H "X-ArchivesSpace-Session: $SESSION" \
  -d '{ "jsonmodel_type":"user",
"groups":[],
"is_admin":false,
"username":"username_21",
"name":"Name Number 633"}' \
  "http://localhost:8089/users/1"

curl -H "X-ArchivesSpace-Session: $SESSION" \
  -d 'YOUTY' \
  "http://localhost:8089/users/1"
```

instead of:

```shell
curl -H "X-ArchivesSpace-Session: $SESSION" \
  -d '{ "jsonmodel_type":"user",
"groups":[],
"is_admin":false,
"username":"username_21",
"name":"Name Number 633"}' \
  "http://localhost:8089/users/1?password=YOUTY"
```

This PR is by no means perfect, as many endpoints still lack realistic examples, a number of [:POST] endpoints that do not require any data (e.g., `[:POST] /config/enumeration_values/:enum_val_id/position`) still contain a -d flag, etc., but it's a start!

I've built and pushed an updated version of the API docs to my fork of the gh-pages branch here, to give a sense of what the updated docs look like: http://djpillen.github.io/archivesspace/api/
