### PR TITLE
URI value in agent_[type] schema doesn't match routes.rb.

### DIFF
--- a/common/schemas/agent_corporate_entity.rb
+++ b/common/schemas/agent_corporate_entity.rb
@@ -4,7 +4,7 @@
     "version" => 1,
     "type" => "object",
     "parent" => "abstract_agent",
-    "uri" => "/agents/corporate_entities",
+    "uri" => "/agents/agent_corporate_entity",
     "properties" => {
       "names" => {
         "type" => "array",

--- a/common/schemas/agent_family.rb
+++ b/common/schemas/agent_family.rb
@@ -4,7 +4,7 @@
     "version" => 1,
     "type" => "object",
     "parent" => "abstract_agent",
-    "uri" => "/agents/families",
+    "uri" => "/agents/agent_family",
     "properties" => {
       "names" => {
         "type" => "array",

--- a/common/schemas/agent_person.rb
+++ b/common/schemas/agent_person.rb
@@ -4,7 +4,7 @@
     "version" => 1,
     "type" => "object",
     "parent" => "abstract_agent",
-    "uri" => "/agents/people",
+    "uri" => "/agents/agent_person",
     "properties" => {
       "names" => {
         "type" => "array",

--- a/common/schemas/agent_software.rb
+++ b/common/schemas/agent_software.rb
@@ -4,7 +4,7 @@
     "version" => 1,
     "type" => "object",
     "parent" => "abstract_agent",
-    "uri" => "/agents/software",
+    "uri" => "/agents/agent_software",
     "properties" => {
       "display_name" => {
         "type" => "JSONModel(:name_software) object",


### PR DESCRIPTION
I believe the URI value in agent_[type] schema should match the route defined in frontend/config/routes.rb.

Line 182 of routes.rb
`match` 'agents/:agent_type/:id' => 'agents#show', :via => [:get]

Which means the route pattern on line 182 will only match against following URI values:

- /agents/agent_corporate_entity/######
- /agents/agent_family/######
- /agents/agent_person/######
- /agents/agent_software/######

All other values will get a 404. All existing URI values don't conform to above route pattern.


