### PR TITLE
Use four_part_id field instead of identifier field for searching identifiers

### DIFF
--- a/common/search_definitions.rb
+++ b/common/search_definitions.rb
@@ -1,6 +1,6 @@
 AdvancedSearch.define_field(:name => 'keyword', :type => :text, :visibility => [:staff, :public], :solr_field => 'fullrecord')
 AdvancedSearch.define_field(:name => 'title', :type => :text, :visibility => [:staff, :public], :solr_field => 'title')
-AdvancedSearch.define_field(:name => 'identifier', :type => :text, :visibility => [:staff, :public], :solr_field => 'identifier')
+AdvancedSearch.define_field(:name => 'identifier', :type => :text, :visibility => [:staff, :public], :solr_field => 'four_part_id')
 AdvancedSearch.define_field(:name => 'creators', :type => :text, :visibility => [:staff, :public], :solr_field => 'creators_text')
 AdvancedSearch.define_field(:name => 'notes', :type => :text, :visibility => [:staff, :public], :solr_field => 'notes')
 AdvancedSearch.define_field(:name => 'subjects', :type => :text, :visibility => [:staff, :public], :solr_field => 'subjects_text')

--- a/public/app/views/repositories/show.html.erb
+++ b/public/app/views/repositories/show.html.erb
@@ -25,5 +25,5 @@
             ["#{t('search_results.filter.creators')}",'creators_text'],
             ["#{t('search_results.filter.subjects')}",'subjects_text'],
             ["#{t('search_results.filter.notes')}", 'notes'],
-            ["#{t('search_results.filter.identifier')}", 'identifier'] ] } %>
+            ["#{t('search_results.filter.identifier')}", 'four_part_id'] ] } %>
 </div>

--- a/public/app/views/search/search_results.html.erb
+++ b/public/app/views/search/search_results.html.erb
@@ -17,7 +17,7 @@
                                                                        ["#{t('search_results.filter.creators')}",'creators_text'],
                                                                        ["#{t('search_results.filter.subjects')}",'subjects_text'],
                                                                        ["#{t('search_results.filter.notes')}", 'notes'],
-                                                                       ["#{t('search_results.filter.identifier')}", 'identifier'] ],
+                                                                       ["#{t('search_results.filter.identifier')}", 'four_part_id'] ],
                                                     :header_size => '1',
                                                     :show_header => true } %>
   <% else %>
@@ -44,7 +44,7 @@
                                                                          ["#{t('search_results.filter.creators')}",'creators_text'],
                                                                          ["#{t('search_results.filter.subjects')}",'subjects_text'],
                                                                          ["#{t('search_results.filter.notes')}", 'notes'],
-                                                                         ["#{t('search_results.filter.identifier')}", 'identifier'] ],
+                                                                         ["#{t('search_results.filter.identifier')}", 'four_part_id'] ],
                                                       :show_header => false } %>
       </div>
     </div>

--- a/public/app/views/welcome/show.html.erb
+++ b/public/app/views/welcome/show.html.erb
@@ -20,6 +20,6 @@
             ["#{t('search_results.filter.creators')}",'creators_text'],
             ["#{t('search_results.filter.subjects')}",'subjects_text'],
             ["#{t('search_results.filter.notes')}", 'notes'],
-            ["#{t('search_results.filter.identifier')}", 'identifier']
+            ["#{t('search_results.filter.identifier')}", 'four_part_id']
            ]
     } %>

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -57,17 +57,17 @@ en:
     search_remove_row: Remove the row below
     staff_link: Staff Only
 
-  page_actions: Page Actions    
+  page_actions: Page Actions
 
   request:
     required: required
     user_name: Your name
     user_email: Your email address
     date: Anticipated arrival date
-    note: Note to the staff 
+    note: Note to the staff
     visit: "Submit a request to visit %{repo_name} to view <strong>%{archival_object}</strong>"
     submit: Submit Request
-    submitted: Thank you, your request has been submitted.  You will soon receive an email with a copy of your request. 
+    submitted: Thank you, your request has been submitted.  You will soon receive an email with a copy of your request.
     errors:
       name: Please enter your name
       email: Please enter a valid email address
@@ -119,6 +119,7 @@ en:
     creators_text_contain: "the <strong>creator</strong> contains <span class='searchterm'>%{kw}</span>"
     subjects_text_contain: "the <strong>subject</strong> contains <span class='searchterm'>%{kw}</span>"
     identifier_contain: "the <strong>identifier</strong> contains <span class='searchterm'>%{kw}</span>"
+    four_part_id_contain: "the <strong>identifier</strong> contains <span class='searchterm'>%{kw}</span>"
     in_repository: " in <strong>%{name}</strong>"
     year_range: " from <strong>%{from_year}</strong> to <strong>%{to_year}</strong>"
     anything: "*"
@@ -224,7 +225,7 @@ en:
     recordgrp: Record Group
     subfonds: Sub-Fonds
     subgrp: Sub-Group
- 
+
   errors:
     error_404: "%{type} Record Not Found"
     error_404_message: "The %{type} record you've tried to access does not exist or may have been removed."
@@ -269,10 +270,10 @@ en:
 
   contains: "Contains %{count} %{type}"
   found: "Found in %{count} %{type}"
-  coll_obj: 
+  coll_obj:
     _singular: Collection or Record
     _plural: Collections and/or Records
- 
+
   # I don't have a place for these, so I'm putting them here
   scope_note : Scope Note
   multiple_containers: Multiple Containers
@@ -443,7 +444,7 @@ en:
     identifier_separator: "/"
 
   all_agents: Names
-  
+
   an_agent: Name
 
   pui_agent:
@@ -471,7 +472,7 @@ en:
         dates_of_existence: Dates
         related_agent_description: Description
         related_agent_dates: Dates
-   
+
   agent_person:
     _singular: Person
 
@@ -509,7 +510,7 @@ en:
   parent_inst: Parent Institution
 
   email: Send email
- 
+
   fax: Fax
 
 #  The following are the enums for things like notes type, etc.
@@ -540,7 +541,7 @@ en:
       att: Attributed name
       auc: Auctioneer
       aut: Author
-      aqt: Author in quotations or text abstracts 
+      aqt: Author in quotations or text abstracts
       aft: Author of afterword, colophon, etc.
       aud: Author of dialog
       aui: Author of introduction, etc.
@@ -1914,7 +1915,7 @@ en:
     user_defined_enum_4:
       novalue: No value defined
     job_type:
-      print_to_pdf_job: Print To PDF 
+      print_to_pdf_job: Print To PDF
       import_job: Import Data
       find_and_replace_job: Batch Find and Replace (Beta)
       report_job: Reports
@@ -1990,7 +1991,7 @@ en:
     note_multipart_type: Note Multipart Type
     note_orderedlist_enumeration: Note Orderedlist Enumeration
     note_singlepart_type: Note Singlepart Type
-    telephone_number_type: Telephone Number Type 
+    telephone_number_type: Telephone Number Type
     resource_finding_aid_description_rules: Resource Finding Aid Description Rules
     resource_finding_aid_status: Resource Finding Aid Status
     resource_resource_type: Resource Resource Type

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -57,7 +57,7 @@ fr:
     search_remove_row: Supprimer une ligne dessous
     staff_link: Réservé au personnel
 
-  page_actions: Page Actions    
+  page_actions: Page Actions
 
   request:
     required: obligatoire
@@ -118,6 +118,7 @@ fr:
     notes_contain: "la <strong>note</strong> contient  <span class='searchterm'>%{kw}</span>"
     creators_text_contain: "le <strong>producteur</strong> contient <span class='searchterm'>%{kw}</span>"
     identifier_contain: "L'<strong>identifiant</strong> contient <span class='searchterm'>%{kw}</span>"
+    four_part_id_contain: "L'<strong>identifiant</strong> contient <span class='searchterm'>%{kw}</span>"
     in_repository: " dans <strong>%{name}</strong>"
     year_range: " entre <strong>%{from_year}</strong> et <strong>%{to_year}</strong>"
     anything: "*"
@@ -223,7 +224,7 @@ fr:
     recordgrp: Groupe d'archives
     subfonds: Sous-fonds
     subgrp: Sous-groupe
- 
+
   errors:
     error_404: "%{type} Record Not Found"
     error_404_message: "La notice %{type} à laquelle vous avez tenté d'accéder n'existe plus ou peut avoir été enlevée."
@@ -252,7 +253,7 @@ fr:
     collapse: Réduire tout
 
   advanced_search:
-    operator_label: Opérateur 
+    operator_label: Opérateur
     operator:
       AND: Et
       OR: Ou
@@ -268,10 +269,10 @@ fr:
 
   contains: "Contient %{count} %{type}"
   found: "Trouvé dans %{count} %{type}"
-  coll_obj: 
+  coll_obj:
     _singular: Collection ou document
     _plural: Collections et/ou documents
- 
+
   # I don't have a place for these, so I'm putting them here
   scope_note : Note de portée
   multiple_containers: Conditionnements divers
@@ -296,7 +297,7 @@ fr:
   linked_digital_objects: Objets numériques
 
   accession:
-   _singular: Non traitée 
+   _singular: Non traitée
    _plural: Instances de matériel non traité
    _public:
       section:
@@ -346,7 +347,7 @@ fr:
   context: Trouvé dans
   context_delimiter: "/"
   bulk:
-     _singular: "Majeure partie des documents trouvés en %{dates}" 
+     _singular: "Majeure partie des documents trouvés en %{dates}"
      _plural: "Majeure partie des documents trouvés entre %{dates}"
 
   resource:
@@ -442,7 +443,7 @@ fr:
     identifier_separator: "/"
 
   all_agents: Noms
-  
+
   an_agent: Nom
 
   pui_agent:
@@ -470,7 +471,7 @@ fr:
         dates_of_existence: Dates
         related_agent_description: Description
         related_agent_dates: Dates
-   
+
   agent_person:
     _singular: Personne
 
@@ -508,7 +509,7 @@ fr:
   parent_inst: Institution mère
 
   email: Envoyer courriel
- 
+
   fax: Fax
 
 #  The following are the enums for things like notes type, etc.
@@ -1503,7 +1504,7 @@ fr:
       expression: Expression
       single: Unique
       bulk: Dates de la majeure partie
-      inclusive: Dates extrêmes 
+      inclusive: Dates extrêmes
       range: Fourchette
     date_label:
       record_keeping: Maintenance


### PR DESCRIPTION
The identifier field is a sort_string field and the four_part_id field is a general text field so the parsing of the search term matches the parsing for the four_part_id field.

This also fixes ANW-290 and ANW-311.