### PR TITLE
Remove Duplicate Enumeration Locale

### DIFF
--- a/common/locales/enums/en.yml
+++ b/common/locales/enums/en.yml
@@ -1353,7 +1353,6 @@ en:
       phystech: Physical Characteristics and Technical Requirements
       prefercite: Preferred Citation
       processinfo: Processing Information
-      relatedmaterial: Related Archival Materials
       scopecontent: Scope and Contents
       separatedmaterial: Separated Materials
       userestrict: Conditions Governing Use

--- a/common/locales/enums/es.yml
+++ b/common/locales/enums/es.yml
@@ -1331,7 +1331,6 @@
       phystech: Nota de características físicas y requisitos técnicos
       prefercite: Nota de cita preferida
       processinfo: Nota de información del proceso
-      relatedmaterial: Nota de material relacionado
       scopecontent: Nota de alcance y contenido
       separatedmaterial: Nota de documentos separados
       userestrict: Nota de restricciones de uso

--- a/common/locales/enums/fr.yml
+++ b/common/locales/enums/fr.yml
@@ -1355,7 +1355,6 @@
       phystech: Caractéristiques matérielles et contraintes techniques
       prefercite: Référence privilégiée
       processinfo: Information sur le traitement
-      relatedmaterial: Documents en relation
       scopecontent: Présentation du contenu
       separatedmaterial: Documents séparés
       userestrict: Conditions d'utilisation


### PR DESCRIPTION
The `(language).enumerations._note_types.relatedmaterial` locale appears to have been duplicated across all 3 of currently available languages.