### PR TITLE
Roll back DRY for error handling until it can be refactored. 

### DIFF
--- a/public/app/controllers/accessions_controller.rb
+++ b/public/app/controllers/accessions_controller.rb
@@ -33,8 +33,16 @@ class AccessionsController <  ApplicationController
     page = Integer(params.fetch(:page, "1"))
     search_opts = default_search_opts( DEFAULT_AC_SEARCH_OPTS)
     search_opts['fq'] = ["repository:\"/repositories/#{@repo_id}\""] if @repo_id
-    set_up_and_run_search( DEFAULT_AC_TYPES, DEFAULT_AC_FACET_TYPES,  search_opts, params)
-    
+    begin
+      set_up_and_run_search( DEFAULT_AC_TYPES, DEFAULT_AC_FACET_TYPES,  search_opts, params)
+    rescue NoResultsError
+      flash[:error] = I18n.t('search_results.no_results')
+      redirect_back(fallback_location: '/') and return
+    rescue Exception => error
+      flash[:error] = I18n.t('errors.unexpected_error')
+      redirect_back(fallback_location: '/') and return
+    end
+
     if @results['total_hits'] > 1
       @search[:dates_within] = true if params.fetch(:filter_from_year,'').blank? && params.fetch(:filter_to_year,'').blank?
       @search[:text_within] = true

--- a/public/app/controllers/agents_controller.rb
+++ b/public/app/controllers/agents_controller.rb
@@ -31,7 +31,16 @@ class AgentsController <  ApplicationController
     default_facets = DEFAULT_AG_FACET_TYPES.dup
     default_facets.push('used_within_published_repository') unless repo_id
     page = Integer(params.fetch(:page, "1"))
-    set_up_and_run_search( DEFAULT_AG_TYPES, default_facets,  search_opts, params)
+
+    begin
+      set_up_and_run_search( DEFAULT_AG_TYPES, default_facets, search_opts, params)
+    rescue NoResultsError
+      flash[:error] = I18n.t('search_results.no_results')
+      redirect_back(fallback_location: '/') and return
+    rescue Exception => error
+      flash[:error] = I18n.t('errors.unexpected_error')
+      redirect_back(fallback_location: '/agents') and return
+    end
 
     @context = repo_context(repo_id, 'agent')
     if @results['total_hits'] > 1

--- a/public/app/controllers/application_controller.rb
+++ b/public/app/controllers/application_controller.rb
@@ -19,14 +19,12 @@ class ApplicationController < ActionController::Base
   helper_method :process_json_notes
 
   protect_from_forgery with: :exception
- 
-  
-  rescue_from Exception, :with => :render_general_error
+
   rescue_from LoginFailedException, :with => :render_backend_failure
   rescue_from RequestFailedException, :with => :render_backend_failure
   rescue_from NoResultsError, :with => :render_no_results_found
-  
-  
+
+
   # Allow overriding of templates via the local folder(s)
   if not ASUtils.find_local_directories.blank?
     ASUtils.find_local_directories.map{|local_dir| File.join(local_dir, 'public', 'views')}.reject { |dir| !Dir.exist?(dir) }.each do |template_override_directory|
@@ -44,7 +42,7 @@ class ApplicationController < ActionController::Base
 
   def render_backend_failure(exception)
     Rails.logger.error(exception)
-    render :template => '/error/backend_request_failure', :status => 500 
+    render :template => '/error/backend_request_failure', :status => 500
   end
 
   def render_no_results_found(exception)
@@ -55,12 +53,6 @@ class ApplicationController < ActionController::Base
     else
       redirect_to('/')
     end
-  end
-  
-  def render_general_error(exception)
-    Rails.logger.error(exception)
-    flash[:error] = I18n.t('errors.unexpected_error')
-    redirect_back(fallback_location: '/') and return
   end
 
 end

--- a/public/app/controllers/classifications_controller.rb
+++ b/public/app/controllers/classifications_controller.rb
@@ -32,8 +32,17 @@ class ClassificationsController <  ApplicationController
 
     @base_search = repo_id ? "repositories/#{repo_id}/classifications?" : '/classifications?'
     page = Integer(params.fetch(:page, "1"))
-    set_up_and_run_search( DEFAULT_CL_TYPES, DEFAULT_CL_FACET_TYPES,  search_opts, params)
-    
+
+    begin
+      set_up_and_run_search( DEFAULT_CL_TYPES, DEFAULT_CL_FACET_TYPES, search_opts, params)
+    rescue NoResultsError
+      flash[:error] = I18n.t('search_results.no_results')
+      redirect_back(fallback_location: '/') and return
+    rescue Exception => error
+      flash[:error] = I18n.t('errors.unexpected_error')
+      redirect_back(fallback_location: '/') and return
+    end
+
     if @results['total_hits'] > 1
       @search[:dates_within] = true if params.fetch(:filter_from_year,'').blank? && params.fetch(:filter_to_year,'').blank?
       @search[:text_within] = true


### PR DESCRIPTION
Throwing an incorrect RecordNotFound error when browser back arrow is used

Fixes #1213