### PR TITLE
Add Capybara + Selenium test to PUI

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -864,7 +864,7 @@
 
   </target>
 
-  <target name="public:test" depends="set-classpath" description="Run the unit test suite">
+  <target name="public:test" depends="set-classpath, public:copy-shared-resources" description="Run the unit test suite">
     <property name="spec" value=""/>
     <property name="example" value=""/>
     <condition property="example-arg" value="-e &quot;${example}&quot;" else="">

--- a/public/Gemfile
+++ b/public/Gemfile
@@ -73,4 +73,6 @@ group :test do
   gem 'simplecov', "0.7.1"
   gem "factory_bot_rails"
   gem "fog-aws", "2.0.0", :require => false
+  gem 'selenium-webdriver'
+  gem 'capybara'
 end

--- a/public/Gemfile.lock
+++ b/public/Gemfile.lock
@@ -38,15 +38,24 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (7.1.4)
     ast (2.4.0)
     atomic (1.0.1-java)
-    autoprefixer-rails (8.2.0)
+    autoprefixer-rails (8.5.0)
       execjs
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     builder (3.2.3)
+    capybara (3.1.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     choice (0.2.0)
@@ -93,7 +102,7 @@ GEM
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     ipaddress (0.8.3)
-    jquery-rails (4.3.1)
+    jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -133,7 +142,8 @@ GEM
       pry (>= 0.9.10, < 0.11.0)
     pry-rails (0.3.6)
       pry (>= 0.10.4)
-    rack (2.0.4)
+    public_suffix (3.0.2)
+    rack (2.0.5)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.1)
@@ -198,6 +208,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
+    rubyzip (1.2.1)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -209,6 +220,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.12.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
@@ -234,14 +248,16 @@ GEM
     turbolinks-source (5.1.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2018.4)
+    tzinfo-data (1.2018.5)
       tzinfo (>= 1.0.0)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.3.2)
     websocket-driver (0.6.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    xpath (3.0.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   java
@@ -249,6 +265,7 @@ PLATFORMS
 DEPENDENCIES
   atomic (= 1.0.1)
   bootstrap-sass (~> 3.3.6)
+  capybara
   clipboard-rails
   coffee-rails (= 4.2.1)
   factory_bot_rails
@@ -271,6 +288,7 @@ DEPENDENCIES
   rspec-rails
   rubocop (~> 0.54.0)
   sass-rails (~> 5.0, >= 5.0.6)
+  selenium-webdriver
   simplecov (= 0.7.1)
   sprockets-rails (= 2.3.3)
   therubyrhino

--- a/public/spec/controllers/accessions_controller_spec.rb
+++ b/public/spec/controllers/accessions_controller_spec.rb
@@ -27,6 +27,7 @@ describe AccessionsController, type: :controller do
       rec_with_deaccession = results.records.find {|x| x["title"] == @acc_with_deaccession["title"]}
       expect( rec_with_deaccession.deaccessions ).not_to be_empty
     end
+    
     it 'does not show deaccessions when AppConfig[:pui_display_deaccessions] is false' do
       AppConfig[:pui_display_deaccessions] = false
       expect(get :index).to have_http_status(200)

--- a/public/spec/features/resources_spec.rb
+++ b/public/spec/features/resources_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Resources', js: true do
+  before(:all) do
+    @repo = create(:repo, repo_code: "resource_test_#{Time.now.to_i}",
+                          publish: true)
+    set_repo @repo
+    @resource = create(:resource, publish: true)
+    @aos = (0..5).map do
+      create(:archival_object,
+             resource: { 'ref' => @resource.uri }, publish: true)
+    end
+    run_all_indexers
+  end
+
+  it 'Should be able to see resources in a repository' do
+    visit('/')
+    click_link 'Collections'
+    click_link @resource.title
+    click_link 'Collection Organization'
+    finished_all_ajax_requests?
+    page.go_back
+    finished_all_ajax_requests?
+    expect(page).not_to(
+      have_content(
+        'Your request could not be completed due to an unexpected error'
+      )
+    )
+  end
+end

--- a/public/spec/rails_helper.rb
+++ b/public/spec/rails_helper.rb
@@ -1,0 +1,53 @@
+require 'capybara/rails'
+
+# Headless chrome
+Capybara.register_driver(:selenium_chrome) do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w[headless disable-gpu] }
+  )
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    desired_capabilities: capabilities
+  )
+end
+
+# Heady Chrome
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
+# We can use Headless Chrome, Regular Chrome, of FF (using geckodriver)
+if ENV['SELENIUM_CHROME']
+  Capybara.javascript_driver = :selenium_chrome
+elsif ENV['SELENIUM_HEADY_CHROME']
+  Capybara.javascript_driver = :chrome
+else
+  ENV['PATH'] = "#{File.join(ASUtils.find_base_directory,
+                             'selenium', 'bin', 'geckodriver',
+                             'linux')}:#{ENV['PATH']}"
+end
+
+# This should change once the app gets to a point where it's not just throwing
+# tons of errors...
+Capybara.raise_server_errors = false
+
+RSpec.configure do |config|
+  config.infer_spec_type_from_file_location!
+  config.include Capybara::DSL
+end
+
+# We use the Mizuno server.
+Capybara.register_server :mizuno do |app, port, host|
+  require 'rack/handler/mizuno'
+  Rack::Handler.get('mizuno').run(app, port: port, host: host)
+end
+Capybara.server = :mizuno
+
+def finished_all_ajax_requests?
+  request_count = page.evaluate_script('$.active').to_i
+  request_count && request_count.zero?
+rescue Timeout::Error
+  puts 'timeout..'
+end

--- a/public/spec/spec_helper.rb
+++ b/public/spec/spec_helper.rb
@@ -28,7 +28,7 @@ if ENV['COVERAGE_REPORTS'] == 'true'
     add_filter '/spec'
   end
   SimpleCov.command_name 'spec'
-end 
+end
 
 require 'aspace_gems'
 
@@ -41,7 +41,7 @@ $solr_port = TestUtils::free_port_from(2989)
 $backend = "http://localhost:#{$backend_port}"
 $frontend = "http://localhost:#{$frontend_port}"
 $expire = 30000
-  
+
 AppConfig[:backend_url] = $backend
 AppConfig[:solr_url] = "http://localhost:#{$solr_port}"
 
@@ -62,11 +62,12 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 include FactoryBot::Syntax::Methods
 
+
 RSpec.configure do |config|
-  
+
   config.include FactoryBot::Syntax::Methods
   config.include BackendClientMethods
-  
+
   [:controller, :view, :request].each do |type|
     config.include ::Rails::Controller::Testing::TestProcess, :type => type
     config.include ::Rails::Controller::Testing::TemplateAssertions, :type => type
@@ -83,16 +84,17 @@ RSpec.configure do |config|
       $period = PeriodicIndexer.new($backend, nil, "periodic_indexer", false)
       $pui = PUIIndexer.new($backend, nil, "pui_periodic_indexer")
     end
-    FactoryBot.reload 
+    FactoryBot.reload
     AspaceFactories.init
-     
   end
 
   config.after(:suite) do
     $server_pids.each do |pid|
       TestUtils::kill(pid)
     end
+    # For some reason we have to manually shutdown mizuno for the test suite to
+    # quit.
+    Rack::Handler.get('mizuno').instance_variable_get(:@server).stop
   end
 
 end
-


### PR DESCRIPTION
This adds Capybara/Selenium tests to the PUI.

The capybara test suite runs with the public:test task.
Tests can be added to the features directory. Included in one to test
for the back button issue that was causing the flash to incorrectly
display that there's a general error.

It is configured to allow for Firefox (default), Chrome, and Headless
Chrome. To use Headless chrome, set an environment variable of
SELENIUM_CHROME. To use regular chrome, set an environment variable of
SELENIUM_HEADY_CHROME.