### PR TITLE
Return 404 when no record is found in Tree-releated controller actions

### DIFF
--- a/public/app/controllers/classifications_controller.rb
+++ b/public/app/controllers/classifications_controller.rb
@@ -155,26 +155,32 @@ class ClassificationsController <  ApplicationController
 
   def tree_root
     @root_uri = "/repositories/#{params[:rid]}/classifications/#{params[:id]}"
-
-    render :json => archivesspace.get_raw_record(@root_uri + '/tree/root')
+    render json: archivesspace.get_raw_record(@root_uri + '/tree/root')
+  rescue RecordNotFound
+    render json: {}, status: 404
   end
 
   def tree_node
     @root_uri = "/repositories/#{params[:rid]}/classifications/#{params[:id]}"
-
-    render :json => archivesspace.get_raw_record(@root_uri + '/tree/node_' + params[:node])
+    render json:
+       archivesspace.get_raw_record(@root_uri + '/tree/node_' + params[:node])
+  rescue RecordNotFound
+    render json: {}, status: 404
   end
 
   def tree_waypoint
     @root_uri = "/repositories/#{params[:rid]}/classifications/#{params[:id]}"
-
-    render :json => archivesspace.get_raw_record(@root_uri + '/tree/waypoint_' + params[:node] + '_' + params[:offset])
+    url = @root_uri + '/tree/waypoint_' + params[:node] + '_' + params[:offset]
+    render json: archivesspace.get_raw_record(url)
+  rescue RecordNotFound
+    render json: {}, status: 404
   end
 
   def tree_node_from_root
     @root_uri = "/repositories/#{params[:rid]}/classifications/#{params[:id]}"
-
-    render :json => archivesspace.get_raw_record(@root_uri + '/tree/node_from_root_' + params[:node_ids].first)
+    url = @root_uri + '/tree/node_from_root_' + params[:node_ids].first
+    render json: archivesspace.get_raw_record(url)
+  rescue RecordNotFound
+    render json: {}, status: 404
   end
-
 end

--- a/public/app/controllers/digital_objects_controller.rb
+++ b/public/app/controllers/digital_objects_controller.rb
@@ -1,25 +1,32 @@
 class DigitalObjectsController < ApplicationController
   def tree_root
     @root_uri = "/repositories/#{params[:rid]}/digital_objects/#{params[:id]}"
-
-    render :json => archivesspace.get_raw_record(@root_uri + '/tree/root')
+    render json: archivesspace.get_raw_record(@root_uri + '/tree/root')
+  rescue RecordNotFound
+    render json: {}, status: 404
   end
 
   def tree_node
     @root_uri = "/repositories/#{params[:rid]}/digital_objects/#{params[:id]}"
-
-    render :json => archivesspace.get_raw_record(@root_uri + '/tree/node_' + params[:node])
+    url = @root_uri + '/tree/node_' + params[:node]
+    render json: archivesspace.get_raw_record(url)
+  rescue RecordNotFound
+    render json: {}, status: 404
   end
 
   def tree_waypoint
     @root_uri = "/repositories/#{params[:rid]}/digital_objects/#{params[:id]}"
-
-    render :json => archivesspace.get_raw_record(@root_uri + '/tree/waypoint_' + params[:node] + '_' + params[:offset])
+    url = @root_uri + '/tree/waypoint_' + params[:node] + '_' + params[:offset]
+    render json: archivesspace.get_raw_record(url)
+  rescue RecordNotFound
+    render json: {}, status: 404
   end
 
   def tree_node_from_root
     @root_uri = "/repositories/#{params[:rid]}/digital_objects/#{params[:id]}"
-
-    render :json => archivesspace.get_raw_record(@root_uri + '/tree/node_from_root_' + params[:node_ids].first)
+    url = @root_uri + '/tree/node_from_root_' + params[:node_ids].first
+    render json: archivesspace.get_raw_record(url)
+  rescue RecordNotFound
+    render json: {}, status: 404
   end
 end

--- a/public/spec/controllers/classifications_controller_spec.rb
+++ b/public/spec/controllers/classifications_controller_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+describe ClassificationsController, type: :controller do
+  before(:all) do
+    @repo = create(:repo, repo_code: "classification_test_#{Time.now.to_i}",
+                          publish: true)
+    set_repo @repo
+
+    @creator = create(:agent_person)
+    @classification = create(:classification, creator: { ref: @creator.uri },
+                                              publish: true)
+
+    @term1 = create(:classification_term,
+                    publish: true, classification: { ref: @classification.uri })
+    @term2 = create(:classification_term,
+                    publish: true, classification: { ref: @classification.uri })
+    @term3 = create(:classification_term,
+                    publish: true, classification: { ref: @classification.uri })
+
+    @grandchildren = (0..10).map do
+      create(:classification_term,
+             publish: true,
+             classification: { ref: @classification.uri },
+             parent: { ref: [@term1, @term2, @term3].sample.uri })
+    end
+
+    @great_grandchildren = @grandchildren.map do |gc|
+      (0..3).map do
+        create(:classification_term,
+               publish: true,
+               classification: { ref: @classification.uri },
+               parent: { ref: gc.uri })
+      end
+    end.flatten
+
+    run_all_indexers
+  end
+
+  it 'should show the published classification' do
+    expect(get(:index)).to have_http_status(200)
+    results = assigns(:results)
+    expect(results['total_hits']).to eq(1)
+    expect(results.records.first['title']).to eq(@classification['title'])
+  end
+
+  describe 'Tree Node Actions' do
+    it 'should get the tree root' do
+      get(:tree_root, params: { rid: @repo.id, id: @classification.id })
+      expect(response.status).to eq(200)
+    end
+
+    it 'should return a 404 when it cannot find the tree root' do
+      get(:tree_root, params: { rid: @repo.id, id: 'notaId' })
+      expect(response.status).to eq(404)
+    end
+
+    it 'should get the tree node for an classification term' do
+      get(:tree_node, params: { rid: @repo.id, id: @classification.id,
+                                node: @term1.uri })
+      expect(response.status).to eq(200)
+    end
+
+    it 'should return a 404 when it cannot find the Node' do
+      get(:tree_node, params: { rid: @repo.id, id: @classification.id,
+                                node: @classification.uri })
+      expect(response.status).to eq(404)
+    end
+
+    it 'should get the tree waypoint for an classification' do
+      get(:tree_waypoint, params: { rid: @repo.id, id: @classification.id,
+                                    node: nil, offset: 0 })
+      expect(response.status).to eq(200)
+    end
+
+    it 'should return a 404 when it cannot find the tree waypoint' do
+      get(:tree_waypoint, params: { rid: @repo.id, id: @classification.id,
+                                    node: @classification.uri, offset: 100 })
+      expect(response.status).to eq(404)
+    end
+
+    it 'should get the tree node from the root ' do
+      get(:tree_node_from_root, params: { rid: @repo.id, id: @classification.id,
+                                          node_ids: [@term1, @term2, @term3]
+                                          .map(&:id) })
+      expect(response.status).to eq(200)
+    end
+
+    it 'should return a 404 when it cannot find the tree node from root' do
+      get(:tree_node_from_root, params: { rid: @repo.id, id: @classification.id,
+                                          node_ids: ['notaId'] })
+      expect(response.status).to eq(404)
+    end
+  end
+end

--- a/public/spec/controllers/digital_objects_controller_spec.rb
+++ b/public/spec/controllers/digital_objects_controller_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+describe DigitalObjectsController, type: :controller do
+  before(:all) do
+    @repo = create(:repo, repo_code: "do_test_#{Time.now.to_i}",
+                          publish: true)
+    set_repo @repo
+
+    @do = create(:digital_object, publish: true)
+    @unpublished_do = create(:digital_object)
+    @doc1 = create(:digital_object_component,
+                   publish: true, digital_object: { ref: @do.uri })
+    @doc2 = create(:digital_object_component,
+                   publish: true, digital_object: { ref: @do.uri })
+    @doc3 = create(:digital_object_component,
+                   publish: true, digital_object: { ref: @do.uri })
+
+    @grandchildren = (0..10).map do
+      create(:digital_object_component,
+             publish: true,
+             digital_object: { ref: @do.uri },
+             parent: { ref: [@doc1, @doc2, @doc3].sample.uri })
+    end
+
+    @great_grandchildren = @grandchildren.map do |gc|
+      (0..3).map do
+        create(:digital_object_component,
+               publish: true,
+               digital_object: { ref: @do.uri },
+               parent: { ref: gc.uri })
+      end
+    end.flatten
+
+    run_all_indexers
+  end
+
+
+  describe 'Tree Node Actions' do
+    it 'should get the tree root' do
+      get(:tree_root, params: { rid: @repo.id, id: @do.id })
+      expect(response.status).to eq(200)
+    end
+
+    it 'should return a 404 when it cannot find the tree root' do
+      get(:tree_root, params: { rid: @repo.id, id: 'notaId' })
+      expect(response.status).to eq(404)
+    end
+
+    it 'should get the tree node for an Digital Object Component' do
+      get(:tree_node, params: { rid: @repo.id, id: @do.id,
+                                node: @doc1.uri })
+      expect(response.status).to eq(200)
+    end
+
+    it 'should return a 404 when it cannot find the Node' do
+      get(:tree_node, params: { rid: @repo.id, id: @do.id,
+                                node: @do.uri })
+      expect(response.status).to eq(404)
+    end
+
+    it 'should get the tree waypoint for a digital object' do
+      get(:tree_waypoint, params: { rid: @repo.id, id: @do.id,
+                                    node: nil, offset: 0 })
+      expect(response.status).to eq(200)
+    end
+
+    it 'should return a 404 when it cannot find the tree waypoint' do
+      get(:tree_waypoint, params: { rid: @repo.id, id: @do.id,
+                                node: @do.uri, offset: 100 })
+      expect(response.status).to eq(404)
+    end
+
+    it 'should get the tree node from the root' do
+      get(:tree_node_from_root, params: { rid: @repo.id, id: @do.id,
+                                          node_ids: [@doc1,@doc2, @doc3].map(&:id) })
+      expect(response.status).to eq(200)
+    end
+
+    it 'should return a 404 when it cannot find the tree node from root' do
+      get(:tree_node_from_root, params: { rid: @repo.id, id: @do.id,
+                                          node_ids: ['notaId'] })
+      expect(response.status).to eq(404)
+    end
+  end
+end

--- a/public/spec/controllers/resources_controller_spec.rb
+++ b/public/spec/controllers/resources_controller_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+describe ResourcesController, type: :controller do
+  before(:all) do
+    @repo = create(:repo, repo_code: "resources_test_#{Time.now.to_i}",
+                          publish: true)
+    set_repo @repo
+    @accession = create(:accession,
+                        collection_management: build(:collection_management))
+
+    @resource = create(:resource, publish: true)
+    @unpublished_resource = create(:resource)
+
+    @a1 = create(:archival_object,
+                 publish: true, resource: { ref: @resource.uri })
+    @a2 = create(:archival_object,
+                 publish: true, resource: { ref: @resource.uri })
+    @a3 = create(:archival_object,
+                 publish: true, resource: { ref: @resource.uri })
+
+    @grandchildren = (0..10).map do
+      create(:archival_object,
+             publish: true,
+             resource: { ref: @resource.uri },
+             parent: { ref: [@a1, @a2, @a3].sample.uri })
+    end
+
+    @great_grandchildren = @grandchildren.map do |gc|
+      (0..3).map do
+        create(:archival_object,
+               publish: true,
+               resource: { ref: @resource.uri },
+               parent: { ref: gc.uri })
+      end
+    end.flatten
+
+    run_all_indexers
+  end
+
+  it 'should show the published resources' do
+    expect(get(:index)).to have_http_status(200)
+    results = assigns(:results)
+    expect(results['total_hits']).to eq(1)
+    expect(results.records.first['title']).to eq(@resource['title'])
+  end
+
+  describe 'Tree Node Actions' do
+    it 'should get the tree root' do
+      get(:tree_root, params: { rid: @repo.id, id: @resource.id })
+      expect(response.status).to eq(200)
+    end
+
+    it 'should return a 404 when it cannot find the tree root' do
+      get(:tree_root, params: { rid: @repo.id, id: 'notaId' })
+      expect(response.status).to eq(404)
+    end
+
+    it 'should get the tree node for an Archival Object' do
+      get(:tree_node, params: { rid: @repo.id, id: @resource.id,
+                                node: @a1.uri })
+      expect(response.status).to eq(200)
+    end
+
+    it 'should return a 404 when it cannot find the Node' do
+      get(:tree_node, params: { rid: @repo.id, id: @resource.id,
+                                node: @resource.uri })
+      expect(response.status).to eq(404)
+    end
+
+    it 'should get the tree waypoint for an Archival Object' do
+      get(:tree_waypoint, params: { rid: @repo.id, id: @resource.id,
+                                    node: nil, offset: 0 })
+      expect(response.status).to eq(200)
+    end
+
+    it 'should return a 404 when it cannot find the tree waypoint' do
+      get(:tree_waypoint, params: { rid: @repo.id, id: @resource.id,
+                                node: @resource.uri, offset: 100 })
+      expect(response.status).to eq(404)
+    end
+
+    it 'should get the tree node from the root ' do
+      get(:tree_node_from_root, params: { rid: @repo.id, id: @resource.id,
+                                          node_ids: [@a1,@a2,@a3].map(&:id) })
+      expect(response.status).to eq(200)
+    end
+
+    it 'should return a 404 when it cannot find the tree node from root' do
+      get(:tree_node_from_root, params: { rid: @repo.id, id: @resource.id,
+                                          node_ids: ['notaId'] })
+      expect(response.status).to eq(404)
+    end
+  end
+end

--- a/public/spec/factories.rb
+++ b/public/spec/factories.rb
@@ -64,6 +64,7 @@ module AspaceFactories
       sequence(:ref_id) {|n| "aspace_#{n}"}
       sequence(:id_0) {|n| "#{Time.now.to_i}_#{n}"}
 
+      sequence(:number) { rand(1_000) }
       sequence(:accession_title) { |n| "Accession #{n}" }
       sequence(:resource_title) { |n| "Resource #{n}" }
       sequence(:archival_object_title) {|n| "Archival Object #{n}"}
@@ -71,6 +72,29 @@ module AspaceFactories
       sequence(:digital_object_component_title) {|n| "Digital Object #{n}"}
       sequence(:classification_title) {|n| "Classification #{n}"}
       sequence(:classification_term_title) {|n| "Classification Term #{n}"}
+
+      sequence(:use_statement) { ["application", "application-pdf", "audio-clip",
+                                  "audio-master", "audio-master-edited",
+                                  "audio-service", "image-master",
+                                  "image-master-edited","image-service",
+                                  "image-service-edited", "image-thumbnail",
+                                  "text-codebook","test-data",
+                                  "text-data_definition","text-georeference",
+                                  "text-ocr-edited","text-ocr-unedited",
+                                  "text-tei-transcripted","text-tei-translated",
+                                  "video-clip", "video-master",
+                                  "video-master-edited","video-service",
+                                  "video-streaming"].sample }
+      sequence(:checksum_method) { ["md5", "sha-1", "sha-256", "sha-384", "sha-512"].sample }
+      sequence(:xlink_actuate_attribute) {  ["none", "other", "onLoad", "onRequest"].sample } 
+      sequence(:xlink_show_attribute) {  ["new", "replace", "embed", "other", "none"].sample } 
+      sequence(:file_format) { %w[aiff avi gif jpeg mp3 pdf tiff txt].sample } 
+
+
+      sequence(:name_rule) {  ["local", "aacr", "dacs", "rda"].sample }
+      sequence(:name_source) { ["local", "naf", "nad", "ulan"].sample }
+      sequence(:generic_name) { SecureRandom.hex }
+      sequence(:sort_name) { SecureRandom.hex }
 
 
       sequence(:rde_template_name) {|n| "RDE Template #{n}_#{Time.now.to_i}"}
@@ -182,7 +206,7 @@ module AspaceFactories
         use_statement { generate(:use_statement) }
         xlink_actuate_attribute { generate(:xlink_actuate_attribute) }
         xlink_show_attribute { generate(:xlink_show_attribute) }
-        file_format_name { generate(:file_format_name) }
+        file_format_name { generate(:file_format) }
         file_format_version { generate(:alphanumstr) }
         file_size_bytes { generate(:number).to_i }
         checksum { generate(:alphanumstr) }
@@ -270,6 +294,7 @@ module AspaceFactories
 
       factory :classification, class: JSONModel(:classification) do
         identifier { generate(:alphanumstr) }
+        publish true
         title { generate(:classification_title) }
         description { generate(:alphanumstr) }
       end

--- a/public/spec/spec_helper.rb
+++ b/public/spec/spec_helper.rb
@@ -62,6 +62,7 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 include FactoryBot::Syntax::Methods
 
+
 RSpec.configure do |config|
   
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
Some of the tree-related actions in the Classification, Digital Object,
and Resources controllers were raising RecordNotFound errors, which
resulted in 500 errors to be returned.

Not sure why these URLs are being called, but this makes sure that
exception is handled by returning a 404 error instead.

Tests included.