### PR TITLE
Fix for sort submenu partially off-screen with fluid width

### DIFF
--- a/frontend/app/views/shared/_pagination_summary.html.erb
+++ b/frontend/app/views/shared/_pagination_summary.html.erb
@@ -2,56 +2,10 @@
   <div class="pull-left">
     <%= I18n.t "pagination.summary_prefix" %> <strong><%= @search_data["offset_first"] %></strong> <%= I18n.t "pagination.summary_offset_connector" %> <strong><%= @search_data["offset_last"] %></strong> <%= I18n.t "pagination.summary_total_connector" %> <strong><%= @search_data["total_hits"] %></strong> <%= I18n.t "pagination.summary_suffix" %>
   </div>
-  <% if @search_data.sorted? %>
-    <div class="pull-right" style="position: relative">
-      <span class="btn-group">
-        <label style="float: left;">&#160;<%= I18n.t("search_sorting.and") %>&#160;</label>
-        <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-          <div class="btn-group">
-            <span class="btn btn-xs btn-default"><%= @search_data.sorted_by_label(title_sort_label, 1) %></span>
-            <span class="btn btn-xs btn-default last"><span class="caret"></span></span>
-          </div>
-        </a>
-        <ul class="dropdown-menu pull-right">
-          <% if show_record_type? %>
-            <li class="dropdown-submenu"><%= link_to I18n.t("search_sorting.primary_type"), build_search_params("sort2" => @search_data.sort_filter_for("primary_type", "desc")) %>
-              <ul class="dropdown-menu">
-                <li><%= link_to I18n.t("search_sorting.asc"), build_search_params("sort2" => "primary_type asc") %></li>
-                <li><%= link_to I18n.t("search_sorting.desc"), build_search_params("sort2" => "primary_type desc") %></li>
-              </ul>
-            </li>
-          <% end %>
-          <% if @search_data.weightable? %>
-            <li><%= link_to I18n.t("search_sorting.relevance"), build_search_params("sort2" => "") %></li>
-          <% end %>
-          <% if show_title_column? && !@search_data.sorted_by?('title_sort') %>
-            <li class="dropdown-submenu">
-              <%= link_to title_sort_label, build_search_params("sort2" => @search_data.sort_filter_for("title_sort")) %>
-                <ul class="dropdown-menu">
-                  <li><%= link_to I18n.t("search_sorting.asc"), build_search_params("sort2" => "title_sort asc") %></li>
-                  <li><%= link_to I18n.t("search_sorting.desc"), build_search_params("sort2" => "title_sort desc") %></li>
-              </ul>
-            </li>
-          <% end %>
-          <% @search_data.sort_fields.each do |field| %>
-            <% if !@search_data.sorted_by?(field) %>
-              <li class="dropdown-submenu">
-                <%= link_to I18n.t("search_sorting.#{field}"), build_search_params("sort2" => @search_data.sort_filter_for(field, "desc")) %>
-                <ul class="dropdown-menu">
-                  <li><%= link_to I18n.t("search_sorting.asc"), build_search_params("sort2" => "#{field} asc") %></li>
-                  <li><%= link_to I18n.t("search_sorting.desc"), build_search_params("sort2" => "#{field} desc") %></li>
-                </ul>
-             </li>
-           <% end %>
-         <% end %>
-        </ul>
-      </span>
-    </div>
-  <% end %>
 
-  <div class="pull-right" style="position: relative">
+  <div class="pull-left" style="position: relative">
     <span class="btn-group">
-      <label style="float: left;"><%= I18n.t("search_sorting.sort_by") %>&#160;</label>
+      <label style="float: left;">,&#160;<%= I18n.t("search_sorting.sort_by") %>&#160;</label>
       <a class="dropdown-toggle" data-toggle="dropdown" href="#">
         <div class="btn-group">
           <span class="btn btn-default btn btn-xs"><%= @search_data.sorted_by_label(title_sort_label) %></span>
@@ -91,4 +45,51 @@
       </ul>
     </span>
  </div>
+
+ <% if @search_data.sorted? %>
+   <div class="pull-left" style="position: relative">
+     <span class="btn-group">
+       <label style="float: left;">&#160;<%= I18n.t("search_sorting.and") %>&#160;</label>
+       <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+         <div class="btn-group">
+           <span class="btn btn-xs btn-default"><%= @search_data.sorted_by_label(title_sort_label, 1) %></span>
+           <span class="btn btn-xs btn-default last"><span class="caret"></span></span>
+         </div>
+       </a>
+       <ul class="dropdown-menu pull-right">
+         <% if show_record_type? %>
+           <li class="dropdown-submenu"><%= link_to I18n.t("search_sorting.primary_type"), build_search_params("sort2" => @search_data.sort_filter_for("primary_type", "desc")) %>
+             <ul class="dropdown-menu">
+               <li><%= link_to I18n.t("search_sorting.asc"), build_search_params("sort2" => "primary_type asc") %></li>
+               <li><%= link_to I18n.t("search_sorting.desc"), build_search_params("sort2" => "primary_type desc") %></li>
+             </ul>
+           </li>
+         <% end %>
+         <% if @search_data.weightable? %>
+           <li><%= link_to I18n.t("search_sorting.relevance"), build_search_params("sort2" => "") %></li>
+         <% end %>
+         <% if show_title_column? && !@search_data.sorted_by?('title_sort') %>
+           <li class="dropdown-submenu">
+             <%= link_to title_sort_label, build_search_params("sort2" => @search_data.sort_filter_for("title_sort")) %>
+               <ul class="dropdown-menu">
+                 <li><%= link_to I18n.t("search_sorting.asc"), build_search_params("sort2" => "title_sort asc") %></li>
+                 <li><%= link_to I18n.t("search_sorting.desc"), build_search_params("sort2" => "title_sort desc") %></li>
+             </ul>
+           </li>
+         <% end %>
+         <% @search_data.sort_fields.each do |field| %>
+           <% if !@search_data.sorted_by?(field) %>
+             <li class="dropdown-submenu">
+               <%= link_to I18n.t("search_sorting.#{field}"), build_search_params("sort2" => @search_data.sort_filter_for(field, "desc")) %>
+               <ul class="dropdown-menu">
+                 <li><%= link_to I18n.t("search_sorting.asc"), build_search_params("sort2" => "#{field} asc") %></li>
+                 <li><%= link_to I18n.t("search_sorting.desc"), build_search_params("sort2" => "#{field} desc") %></li>
+               </ul>
+            </li>
+          <% end %>
+        <% end %>
+       </ul>
+     </span>
+   </div>
+ <% end %>
 <% end %>


### PR DESCRIPTION
Looks like a lot but it's actually just re-ordered with a couple of pull-left vs. right updates.