### PR TITLE
Make sure array is compact before using it to create Hash

### DIFF
--- a/common/json_schema_utils.rb
+++ b/common/json_schema_utils.rb
@@ -312,26 +312,22 @@ module JSONSchemaUtils
     result
   end
 
-
-
-  def self.is_blank?(obj)
-    obj.nil? || obj == "" || obj == {}
+  def self.blank?(obj)
+    obj.nil? || obj == '' || obj == {}
   end
-
 
   def self.drop_empty_elements(obj)
     if obj.is_a?(Hash)
       Hash[obj.map do |k, v|
              v = drop_empty_elements(v)
-             [k, v] if !is_blank?(v)
-           end]
+             [k, v] unless blank?(v)
+           end.compact]
     elsif obj.is_a?(Array)
-      obj.map {|elt| drop_empty_elements(elt)}.reject {|elt| is_blank?(elt)}
+      obj.map { |elt| drop_empty_elements(elt) }.reject { |elt| blank?(elt) }
     else
       obj
     end
   end
-
 
   # Drop any keys from 'hash' that aren't defined in the JSON schema.
   #


### PR DESCRIPTION
There seems to be some small issues with making a hash like:
Hash[[['key', 'value'], nil, ['anotherkey', 'anothervalue']]]

MRI ruby will actually give an error warning if you do this and the
newer version of jruby will do the same. This simply compacts the array
before it gets passed to Hash[].
i.e:
Hash[[['key', 'value'], nil, ['anotherkey', 'anothervalue']].compact]