### PR TITLE
ANW-716: EAD exporter: Escape '&' chars properly

### DIFF
--- a/backend/app/exporters/lib/streaming_xml.rb
+++ b/backend/app/exporters/lib/streaming_xml.rb
@@ -14,7 +14,6 @@ module ASpaceExport
     def substitute_fragments(xml_string)
       @fragments.each do |id, fragment|
         xml_string.gsub!(/:aspace_fragment_#{id}/, fragment)
-        xml_string.gsub!(/[&]([^a])/, '&amp;\1')
       end
 
       xml_string

--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -47,8 +47,6 @@ class EADSerializer < ASpaceExport::Serializer
   # we want to leave the pre-escaped entities alone, and escape the loose & chars
 
   def escape_content(content)
-    puts "++++++++++++++++++++++++++++"
-    puts "ESCAPING: " + content
     # first, find any pre-escaped entities and "mark" them by replacing & with @@
     # so something like &lt; becomes @@lt;
     # and &#1234 becomes @@#1234
@@ -65,7 +63,6 @@ class EADSerializer < ASpaceExport::Serializer
     content.gsub!(/@@#\d{4}/) {|t| t.gsub('@@', '&')}
     content.gsub!(/@@#\d{3}/) {|t| t.gsub('@@', '&')}
 
-    puts "RESULT: " + content
     return content
   end
 
@@ -115,7 +112,7 @@ class EADSerializer < ASpaceExport::Serializer
 
     begin
       if ASpaceExport::Utils.has_html?(content)
-        context.text( fragments << content )
+        context.text (fragments << content )
       else
         context.text content.gsub("&amp;", "&") #thanks, Nokogiri
       end

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1144,6 +1144,7 @@ describe "EAD export mappings" do
     let(:note_with_linebreaks_but_something_xml_nazis_hate) { "Something, something,\n\n<prefercite>XML & How to Live it!</prefercite>\n\n" }
     let(:note_with_linebreaks_and_xml_namespaces) { "Something, something,\n\n<prefercite xlink:foo='one' ns2:bar='two' >XML, you so crazy!</prefercite>\n\n" }
     let(:note_with_smart_quotes) {"This note has “smart quotes” and ‘smart apostrophes’ from MSWord."}
+    let(:note_with_different_amps) {"The materials are arrange in folders. Mumford&Sons. Mumford & Sons. They are cool&hip. &lt;p&gt;foo, 2 & 2.&lt;/p&gt;"}
     let(:serializer) { EADSerializer.new }
 
     it "can strip <p> tags from content when disallowed" do
@@ -1174,11 +1175,15 @@ describe "EAD export mappings" do
       serializer.handle_linebreaks(note_with_linebreaks_and_xml_namespaces).should eq("<p>Something, something,</p><p><prefercite xlink:foo='one' ns2:bar='two' >XML, you so crazy!</prefercite></p>")
     end
 
+    it "will correctly handle content with & as punctuation as well as & as pre-escaped characters" do
+      serializer.handle_linebreaks(note_with_different_amps).should eq("<p>The materials are arrange in folders. Mumford&amp;Sons. Mumford &amp; Sons. They are cool&amp;hip. <p>foo, 2 &amp; 2.</p></p>")
+    end
+
     it "will replace MSWord-style smart quotes with ASCII characters" do
       serializer.remove_smart_quotes(note_with_smart_quotes).should eq("This note has \"smart quotes\" and \'smart apostrophes\' from MSWord.")
     end
-
   end
+
 
 
   describe "Test unpublished record EAD exports" do

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1176,7 +1176,7 @@ describe "EAD export mappings" do
     end
 
     it "will correctly handle content with & as punctuation as well as & as pre-escaped characters" do
-      serializer.handle_linebreaks(note_with_different_amps).should eq("<p>The materials are arrange in folders. Mumford&amp;Sons. Mumford &amp; Sons. They are cool&amp;hip. <p>foo, 2 &amp; 2.</p></p>")
+      serializer.handle_linebreaks(note_with_different_amps).should eq("<p>The materials are arrange in folders. Mumford&amp;Sons. Mumford &amp; Sons. They are cool&amp;hip. &lt;p&gt;foo, 2 &amp; 2.&lt;/p&gt;</p>")
     end
 
     it "will replace MSWord-style smart quotes with ASCII characters" do


### PR DESCRIPTION
Handle cases like "two&two" as well as "two & two" correctly,
while handling cases where there is pre-escaped content.