### PR TITLE
Travis dropped support for oraclejdk7 awhile ago

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk:
 - openjdk7
-- oraclejdk7
+- openjdk8
 - oraclejdk8
 matrix:
   fast_finish: true


### PR DESCRIPTION
Looks like Travis doesn't support oraclejdk7
https://docs.travis-ci.com/user/reference/trusty/#JVM-(Clojure%2C-Groovy%2C-Java%2C-Scala)-images

Funny tho bc it still runs with a label of "oraclejdk7" ( but if you
look at the log you'll see it's actually running 8. :confused: )