### PR TITLE
Return total count in paginated response

### DIFF
--- a/backend/app/lib/crud_helpers.rb
+++ b/backend/app/lib/crud_helpers.rb
@@ -117,6 +117,7 @@ module CrudHelpers
         :first_page => dataset.page_range.first,
         :last_page => dataset.page_range.last,
         :this_page => dataset.current_page,
+        :total => dataset.pagination_record_count,
         :results => results
       }
     else


### PR DESCRIPTION
https://github.com/jeremyevans/sequel/blob/master/lib/sequel/extensions/pagination.rb#L87-L90

Provides db count for record type (don't believe this is conveniently 
exposed any other way).