### PR TITLE
ANW-285: unpublished file versions do not appear in EAD export

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -175,10 +175,11 @@ class EADSerializer < ASpaceExport::Serializer
 
             EADSerializer.run_serialize_step(data, xml, @fragments, :did)
 
-            data.digital_objects.each do |dob|
-                  serialize_digital_object(dob, xml, @fragments)
-            end
           }# </did>
+
+          data.digital_objects.each do |dob|
+            serialize_digital_object(dob, xml, @fragments)
+          end
 
           serialize_nondid_notes(data, xml, @fragments)
 

--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -175,11 +175,10 @@ class EADSerializer < ASpaceExport::Serializer
 
             EADSerializer.run_serialize_step(data, xml, @fragments, :did)
 
+            data.digital_objects.each do |dob|
+                  serialize_digital_object(dob, xml, @fragments)
+            end
           }# </did>
-
-          data.digital_objects.each do |dob|
-                serialize_digital_object(dob, xml, @fragments)
-          end
 
           serialize_nondid_notes(data, xml, @fragments)
 
@@ -463,12 +462,23 @@ class EADSerializer < ASpaceExport::Serializer
     end
   end
 
+  # set daoloc audience attr == 'internal' if this is an unpublished && include_unpublished is set
+  def get_audience_flag_for_file_version(file_version)
+    if file_version['file_uri'] && 
+       (file_version['publish'] == false && @include_unpublished)
+      return "internal"
+    else
+      return "external"
+    end
+  end
 
   def serialize_digital_object(digital_object, xml, fragments)
     return if digital_object["publish"] === false && !@include_unpublished
     return if digital_object["suppressed"] === true
 
-    file_versions = digital_object['file_versions']
+    # ANW-285: Only serialize file versions that are published, unless include_unpublished flag is set 
+    file_versions_to_display = digital_object['file_versions'].select {|fv| fv['publish'] == true || @include_unpublished }
+
     title = digital_object['title']
     date = digital_object['dates'][0] || {}
 
@@ -488,7 +498,7 @@ class EADSerializer < ASpaceExport::Serializer
     atts['xlink:title'] = digital_object['title'] if digital_object['title']
 
 
-    if file_versions.empty?
+    if file_versions_to_display.empty?
       atts['xlink:type'] = 'simple'
       atts['xlink:href'] = digital_object['digital_object_id']
       atts['xlink:actuate'] = 'onRequest'
@@ -496,39 +506,27 @@ class EADSerializer < ASpaceExport::Serializer
       xml.dao(atts) {
         xml.daodesc{ sanitize_mixed_content(content, xml, fragments, true) } if content
       }
-    elsif file_versions.length == 1
-      publish_file_uri = file_versions.first['file_uri'] && 
-                         (file_versions.first['publish'] == true || @include_unpublished)
+    elsif file_versions_to_display.length == 1
+      file_version = file_versions_to_display.first
 
       atts['xlink:type'] = 'simple'
-
-      if publish_file_uri
-        atts['xlink:href'] = file_versions.first['file_uri'] 
-      end
-
-      atts['xlink:actuate'] = file_versions.first['xlink_actuate_attribute'] || 'onRequest'
-      atts['xlink:show'] = file_versions.first['xlink_show_attribute'] || 'new'
-      atts['xlink:role'] = file_versions.first['use_statement'] if file_versions.first['use_statement']
+      atts['xlink:actuate'] = file_version['xlink_actuate_attribute'] || 'onRequest'
+      atts['xlink:show'] = file_version['xlink_show_attribute'] || 'new'
+      atts['xlink:role'] = file_version['use_statement'] if file_version['use_statement']
+      atts['xlink:href'] = file_version['file_uri'] 
+      atts['xlink:audience'] = get_audience_flag_for_file_version(file_version)
       xml.dao(atts) {
         xml.daodesc{ sanitize_mixed_content(content, xml, fragments, true) } if content
       }
     else
       xml.daogrp( atts.merge( { 'xlink:type' => 'extended'} ) ) {
         xml.daodesc{ sanitize_mixed_content(content, xml, fragments, true) } if content
-        file_versions.each do |file_version|
-
-
-          publish_file_uri = file_version['file_uri'] && 
-                             (file_version['publish'] == true || @include_unpublished)
-
+        file_versions_to_display.each do |file_version|
           atts['xlink:type'] = 'locator'
-
-          if publish_file_uri
-            atts['xlink:href'] = file_version['file_uri'] 
-          end
-
+          atts['xlink:href'] = file_version['file_uri'] 
           atts['xlink:role'] = file_version['use_statement'] if file_version['use_statement']
           atts['xlink:title'] = file_version['caption'] if file_version['caption']
+          atts['xlink:audience'] = get_audience_flag_for_file_version(file_version)
           xml.daoloc(atts)
         end
       }

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1033,11 +1033,11 @@ describe "EAD export mappings" do
         visible_file_versions = d['file_versions'].select {|fv| fv['publish'] == true }
 
         if visible_file_versions.length == 0
-          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:dao"
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:dao"
         elsif visible_file_versions.length == 1
-          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:dao"
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:dao"
         elsif visible_file_versions.length > 1
-          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:daogrp/xmlns:daoloc"
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:daogrp/xmlns:daoloc"
         end
 
 
@@ -1065,11 +1065,11 @@ describe "EAD export mappings" do
         file_versions = d['file_versions']
 
         if file_versions.length == 0
-          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:dao"
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:dao"
         elsif file_versions.length == 1
-          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:dao"
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:dao"
         elsif file_versions.length > 1
-          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:daogrp/xmlns:daoloc"
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:daogrp/xmlns:daoloc"
         end
 
         # for each file version in the digital object

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1030,21 +1030,27 @@ describe "EAD export mappings" do
       # for each digital object generated
       digital_objects.each do |d|
         digital_object_id = d['digital_object_id']
+        visible_file_versions = d['file_versions'].select {|fv| fv['publish'] == true }
 
-        if d['file_versions'].length == 1
-          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:dao"
-        elsif d['file_versions'].length > 1
-          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:daogrp/xmlns:daoloc"
+        if visible_file_versions.length == 0
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:dao"
+        elsif visible_file_versions.length == 1
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:dao"
+        elsif visible_file_versions.length > 1
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:daogrp/xmlns:daoloc"
         end
 
 
         # for each file version in the digital object
         d['file_versions'].each do |fv|
           file_uri = fv['file_uri']
+          next unless file_uri
+
           publish = fv['publish']
 
           if publish
             @doc_unpub.should have_node(basepath + "[@xlink:href='#{file_uri}']")
+            @doc.should have_node(basepath + "[@xlink:audience='external']")
           else
             @doc_unpub.should_not have_node(basepath + "[@xlink:href='#{file_uri}']")
           end
@@ -1055,17 +1061,31 @@ describe "EAD export mappings" do
     it "always displays file_uri in dao tags if EAD generated with include_unpublished = true" do
       # for each digital object generated
       digital_objects.each do |d|
-        if d['file_versions'].length == 1
-          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:dao"
-        elsif d['file_versions'].length > 1
-          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:daogrp/xmlns:daoloc"
+
+        file_versions = d['file_versions']
+
+        if file_versions.length == 0
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:dao"
+        elsif file_versions.length == 1
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:dao"
+        elsif file_versions.length > 1
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:daogrp/xmlns:daoloc"
         end
 
         # for each file version in the digital object
-        d['file_versions'].each do |fv|
+        file_versions.each do |fv|
           file_uri = fv['file_uri']
+          next unless file_uri
 
-          @doc.should have_node(basepath + "[@xlink:href='#{file_uri}']")
+          publish = fv['publish']
+
+          if publish
+            @doc.should have_node(basepath + "[@xlink:href='#{file_uri}']")
+            @doc.should have_node(basepath + "[@xlink:audience='external']")
+          else
+            @doc.should have_node(basepath + "[@xlink:href='#{file_uri}']")
+            @doc.should have_node(basepath + "[@xlink:audience='internal']")
+          end
         end
       end
     end


### PR DESCRIPTION
- daogrp only used if there is more than one visible file version
- 'audience' attribute is set correctly
- dao or daogrp tag nested inside of did tag