### PR TITLE
ANW-745: nokogiri to 1.8.4

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -11,7 +11,7 @@ gem "bcrypt", "3.1.7"
 gem 'json', "1.8.6"
 gem "json-schema", "1.0.10"
 gem "jruby-jars", "= 9.1.8.0"
-gem 'nokogiri', '1.8.1' # because of https://github.com/sparklemotion/nokogiri/issues/1673
+gem 'nokogiri', '1.8.4' # because of https://github.com/sparklemotion/nokogiri/issues/1673
 gem "saxerator", "= 0.9.2"
 gem 'saxon-xslt', '~> 0.8', '>= 0.8.2.1'
 gem 'tzinfo'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     multipart-post (1.2.0)
     net-http-persistent (2.8)
     net-ldap (0.16.1)
-    nokogiri (1.8.1-java)
+    nokogiri (1.8.4-java)
     oai (0.4.0)
       builder (>= 3.1.0)
       faraday

--- a/backend/app/exporters/Gemfile
+++ b/backend/app/exporters/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'nokogiri', '1.8.1' # because of https://github.com/sparklemotion/nokogiri/issues/1673
+gem 'nokogiri', '1.8.4' # because of https://github.com/sparklemotion/nokogiri/issues/1673
 gem "factory_bot"
 gem "rufus-lru"
 gem "net-http-persistent"

--- a/backend/app/exporters/Gemfile.lock
+++ b/backend/app/exporters/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     multipart-post (2.0.0)
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
-    nokogiri (1.8.1-java)
+    nokogiri (1.8.4-java)
     rufus-lru (1.1.0)
     thread_safe (0.3.6-java)
     tzinfo (1.2.4)

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem "github-pages"
-gem 'nokogiri', '1.8.1' # because of https://github.com/sparklemotion/nokogiri/issues/1673
+gem 'nokogiri', '1.8.4' # because of https://github.com/sparklemotion/nokogiri/issues/1673

--- a/frontend/Gemfile
+++ b/frontend/Gemfile
@@ -55,7 +55,7 @@ gem 'multi_json', '~> 1.13.1'
 gem "rubyzip", "~> 1.2.1" # because of https://github.com/rubyzip/rubyzip/issues/315
 gem "zip-zip", "0.3"
 
-gem 'nokogiri', '1.8.1' # because of https://github.com/sparklemotion/nokogiri/issues/1673
+gem 'nokogiri', '1.8.4' # because of https://github.com/sparklemotion/nokogiri/issues/1673
 
 
 require 'asutils'

--- a/frontend/Gemfile.lock
+++ b/frontend/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     multipart-post (1.2.0)
     net-http-persistent (2.8)
     nio4r (1.2.1-java)
-    nokogiri (1.8.1-java)
+    nokogiri (1.8.4-java)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)

--- a/public/Gemfile.lock
+++ b/public/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     multipart-post (1.2.0)
     net-http-persistent (2.8)
     nio4r (1.2.1-java)
-    nokogiri (1.8.2-java)
+    nokogiri (1.8.4-java)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)

--- a/selenium/Gemfile
+++ b/selenium/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "i18n", "0.9.1"
-gem 'nokogiri', '1.8.1' # because of https://github.com/sparklemotion/nokogiri/issues/1673
+gem 'nokogiri', '1.8.4' # because of https://github.com/sparklemotion/nokogiri/issues/1673
 
 group :test do
   gem "json", "1.8.6"

--- a/selenium/Gemfile.lock
+++ b/selenium/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     multipart-post (1.2.0)
     net-http-digest_auth (1.4.1)
     net-http-persistent (2.8)
-    nokogiri (1.8.1-java)
+    nokogiri (1.8.4-java)
     ntlm-http (0.1.1)
     parallel (1.12.1)
     parallel_tests (2.14.3)


### PR DESCRIPTION
Please test.  I'm not entirely sure why things are set up so that I'd need to update the lock files to update the gem, but I also don't understand the lock files :) 

I've included one test record here https://archivesspace.atlassian.net/projects/ANW/issues/ANW-745 (this illustrates the problem, and in my local build upgrading to nokogiri 1.8.4 fixes that issue).

I believe that there are some issues with nokogiri 1.8.2 and jRuby.  There are a few issues in GitHub about this.  FWIW, we also had to downgrade the version of nokogiri earlier this year when updating the ArchivesSpace Export Plugin (see https://github.com/hudmol/archivesspace_export_service/commit/78abd61c088061d5dd601421988f23f26943e2d5). . At this point, it looks like upgrading to the newest release of nokogiri solves the issue.