### PR TITLE
Skip verify csrf token check on print to pdf

### DIFF
--- a/public/app/controllers/pdf_controller.rb
+++ b/public/app/controllers/pdf_controller.rb
@@ -2,6 +2,8 @@ require 'java'
 
 class PdfController <  ApplicationController
 
+  skip_before_action :verify_authenticity_token, only: :resource
+
   PDF_MUTEX = java.util.concurrent.Semaphore.new(AppConfig[:pui_max_concurrent_pdfs])
 
   def resource


### PR DESCRIPTION
This skips the token check on the print to pdf form. Since this is not
making database changes or doing any special request with user
information, this check is most likely not needed. This check can cause
issues when using a reverse proxy in some user agents.