### PR TITLE
Add alt text to staff side file version image

### DIFF
--- a/frontend/app/views/file_versions/_image.html.erb
+++ b/frontend/app/views/file_versions/_image.html.erb
@@ -2,8 +2,7 @@
   <div class="control-label col-sm-2"><%= I18n.t("file_version.file") %></div>
   <div class="controls label-only">
     <div class="image-container">
-      <img class="image-responsive" src="<%= file['file_uri'] %>" />
+      <img class="image-responsive" src="<%= file['file_uri'] %>" alt="<%= file['caption'] ? file['caption'] : @digital_object['title'] %>"/>
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
A little fix to address a portion of ANW-704.  This adds an alt attribute to images displayed on staff side digital object view records.  The attribute is set to the caption if present, and the digital object title if there is no caption.