### PR TITLE
Change op to q.op for ANW-427

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ build/shared
 backend/tests/ladle-server*
 webdriver-profile*
 common/ARCHIVESSPACE_VERSION
+common/asconstants.rb
 .yardoc
 API.md
 endpoint_examples*

--- a/backend/spec/model_solr_spec.rb
+++ b/backend/spec/model_solr_spec.rb
@@ -168,16 +168,16 @@ describe 'Solr model' do
                         pagination(1, 10).
                         set_repo_id(@repo_id) }
 
-    it 'does not include op parameter in solr url when not configured' do
+    it 'does not include q.op parameter in solr url when not configured' do
         AppConfig[:solr_params] = { }
         url = query.to_solr_url
-        expect(url.query).not_to include('&op=')
+        expect(url.query).not_to include('&q.op=')
     end
 
-    it 'includes op parameter in solr url when configured' do
-      AppConfig[:solr_params] = { "op" => "AND" }
+    it 'includes q.op parameter in solr url when configured' do
+      AppConfig[:solr_params] = { "q.op" => "AND" }
       url = query.to_solr_url
-      expect(url.query).to include('&op=AND')
+      expect(url.query).to include('&q.op=AND')
     end
   end
 

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -77,7 +77,7 @@ AppConfig[:mysql_binlog] = false
 AppConfig[:solr_backup_schedule] = "0 * * * *"
 AppConfig[:solr_backup_number_to_keep] = 1
 AppConfig[:solr_backup_directory] = proc { File.join(AppConfig[:data_directory], "solr_backups") }
-# add default solr params, i.e. use AND for search: AppConfig[:solr_params] = { "op" => "AND" }
+# add default solr params, i.e. use AND for search: AppConfig[:solr_params] = { "q.op" => "AND" }
 # Another example below sets the boost query value (bq) to boost the relevancy for the query string in the title,
 # sets the phrase fields parameter (pf) to boost the relevancy for the title when the query terms are in close proximity to
 # each other, and sets the phrase slop (ps) parameter for the pf parameter to indicate how close the proximity should be
@@ -87,7 +87,7 @@ AppConfig[:solr_backup_directory] = proc { File.join(AppConfig[:data_directory],
 #      "ps" => 0,
 #    }
 # Configuring search operator to be AND by default - ANW-427
-AppConfig[:solr_params] = { "op" => "AND" }
+AppConfig[:solr_params] = { "q.op" => "AND" }
 
 # Set the application's language (see the .yml files in
 # https://github.com/archivesspace/archivesspace/tree/master/common/locales for


### PR DESCRIPTION
Addresses issues discussed in the comments for https://github.com/archivesspace/archivesspace/pull/1128

## Description
Changes "op" to "q.op" in default and example solr param config, and updates tests to reflect this change.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-427
https://archivesspace.atlassian.net/browse/ANW-762

## Motivation and Context
Defaults staff-side search (including type aheads) to AND searches.  This change *does not* impact public search.

## How Has This Been Tested?
Passing backend tests, deveserver and built release behave as anticipated.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
