### PR TITLE
Add aria labels to empty buttons and empty link in the collection organization section

### DIFF
--- a/frontend/app/assets/javascripts/largetree.js.erb
+++ b/frontend/app/assets/javascripts/largetree.js.erb
@@ -740,8 +740,11 @@
                 title.append($('<a class="record-title" />').prop('href', TreeIds.link_url(node.uri)).text(node.title));
                 title.attr('title', strippedTitle);
 
+                var ex = row.find('.expandme');
+                ex.attr('aria-label', 'expand element');
                 if (node.child_count === 0) {
-                    row.find('.expandme').css('visibility', 'hidden');
+                    ex.css('visibility', 'hidden');
+                    ex.attr('aria-hidden', 'true');
                 }
 
                 self.renderer.add_node_columns(row, node);

--- a/public/app/assets/javascripts/resizable_sidebar.js
+++ b/public/app/assets/javascripts/resizable_sidebar.js
@@ -19,6 +19,7 @@ function ResizableSidebar($sidebar) {
 ResizableSidebar.prototype.add_handle = function() {
     var $handle = $('<a>').attr('href', 'javascript:void(0);');
     $handle.attr('aria-hidden', 'true');
+    $handle.attr('aria-label', 'resizable sidebar handle');
     $handle.addClass('resizable-sidebar-handle');
 
     this.$sidebar.append($handle);

--- a/public/vendor/assets/javascripts/largetree.js.erb
+++ b/public/vendor/assets/javascripts/largetree.js.erb
@@ -742,8 +742,11 @@
                 title.append($('<a class="record-title" />').prop('href', TreeIds.link_url(node.uri)).text(node.title));
                 title.attr('title', strippedTitle);
 
+                var ex = row.find('.expandme');
+                ex.attr('aria-label', 'expand element');
                 if (node.child_count === 0) {
-                    row.find('.expandme').css('visibility', 'hidden');
+                    ex.css('visibility', 'hidden');
+                    ex.attr('aria-hidden', 'true');
                 }
 
                 self.renderer.add_node_columns(row, node);


### PR DESCRIPTION
For accessibility, the empty buttons and empty link on the collection organization of the PUI need labels. NOTE: This adds labels to those parts only - there is more to be done.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-704

## Motivation and Context
Improves accessibility

## Screenshots (if appropriate):
<img width="1410" alt="screen shot 2018-09-26 at 3 56 05 pm" src="https://user-images.githubusercontent.com/3585151/46113861-eb395300-c1a4-11e8-982d-388770fd2396.png">

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
