### PR TITLE
Ensure response scoped to given repository

### DIFF
--- a/backend/app/controllers/id_lookup_controller.rb
+++ b/backend/app/controllers/id_lookup_controller.rb
@@ -17,7 +17,7 @@ class ArchivesSpaceService < Sinatra::Base
       end
     }.compact
 
-    refs = IDLookup.new.find_by_ids(Resource, :identifier => identifiers)
+    refs = IDLookup.new.find_by_ids(Resource, params, :identifier => identifiers)
     json_response(resolve_references({'resources' => refs}, params[:resolve]))
   end
 
@@ -30,7 +30,7 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \
   do
-    refs = IDLookup.new.find_by_ids(ArchivalObject, :ref_id => params[:ref_id], :component_id => params[:component_id])
+    refs = IDLookup.new.find_by_ids(ArchivalObject, params, :ref_id => params[:ref_id], :component_id => params[:component_id])
     json_response(resolve_references({'archival_objects' => refs}, params[:resolve]))
   end
 
@@ -43,7 +43,7 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \
   do
-    refs = IDLookup.new.find_by_ids(DigitalObjectComponent, :component_id => params[:component_id])
+    refs = IDLookup.new.find_by_ids(DigitalObjectComponent, params, :component_id => params[:component_id])
     json_response(resolve_references({'digital_object_components' => refs}, params[:resolve]))
   end
 
@@ -55,7 +55,7 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \
   do
-    refs = IDLookup.new.find_by_ids(DigitalObject, :digital_object_id => params[:digital_object_id])
+    refs = IDLookup.new.find_by_ids(DigitalObject, params, :digital_object_id => params[:digital_object_id])
     json_response(resolve_references({'digital_objects' => refs}, params[:resolve]))
   end
 

--- a/backend/app/controllers/id_lookup_controller.rb
+++ b/backend/app/controllers/id_lookup_controller.rb
@@ -8,16 +8,7 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \
   do
-    identifiers = Array(params[:identifier]).map {|identifier|
-      parsed = ASUtils.json_parse(identifier)
-
-      if parsed.is_a?(Array) && parsed.length > 0 && parsed.length <= 4
-        padded = (parsed + ([nil] * 3)).take(4)
-        ASUtils.to_json(padded)
-      end
-    }.compact
-
-    refs = IDLookup.new.find_by_ids(Resource, params, :identifier => identifiers)
+    refs = IDLookup.new.find_by_ids(Resource, params)
     json_response(resolve_references({'resources' => refs}, params[:resolve]))
   end
 
@@ -30,7 +21,7 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \
   do
-    refs = IDLookup.new.find_by_ids(ArchivalObject, params, :ref_id => params[:ref_id], :component_id => params[:component_id])
+    refs = IDLookup.new.find_by_ids(ArchivalObject, params)
     json_response(resolve_references({'archival_objects' => refs}, params[:resolve]))
   end
 
@@ -43,7 +34,7 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \
   do
-    refs = IDLookup.new.find_by_ids(DigitalObjectComponent, params, :component_id => params[:component_id])
+    refs = IDLookup.new.find_by_ids(DigitalObjectComponent, params)
     json_response(resolve_references({'digital_object_components' => refs}, params[:resolve]))
   end
 
@@ -55,7 +46,7 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \
   do
-    refs = IDLookup.new.find_by_ids(DigitalObject, params, :digital_object_id => params[:digital_object_id])
+    refs = IDLookup.new.find_by_ids(DigitalObject, params)
     json_response(resolve_references({'digital_objects' => refs}, params[:resolve]))
   end
 

--- a/backend/app/controllers/id_lookup_controller.rb
+++ b/backend/app/controllers/id_lookup_controller.rb
@@ -3,7 +3,7 @@ class ArchivesSpaceService < Sinatra::Base
   Endpoint.get('/repositories/:repo_id/find_by_id/resources')
     .description("Find Resources by their identifiers")
     .params(["repo_id", :repo_id],
-            ["identifier", [String], "A 4-part identifier expressed as JSON array (of up to 4 strings)", :optional => true],
+            ["identifier", [String], "A 4-part identifier expressed as a JSON array (of up to 4 strings) comprised of the id_0 to id_3 fields (though empty fields will be handled if not provided)", :optional => true],
             ["resolve", :resolve])
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \
@@ -15,8 +15,8 @@ class ArchivesSpaceService < Sinatra::Base
   Endpoint.get('/repositories/:repo_id/find_by_id/archival_objects')
     .description("Find Archival Objects by ref_id or component_id")
     .params(["repo_id", :repo_id],
-            ["ref_id", [String], "A set of record Ref IDs", :optional => true],
-            ["component_id", [String], "A set of record component IDs", :optional => true],
+            ["ref_id", [String], "An archival object's Ref ID (param may be repeated)", :optional => true],
+            ["component_id", [String], "An archival object's component ID (param may be repeated)", :optional => true],
             ["resolve", :resolve])
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \
@@ -25,11 +25,10 @@ class ArchivesSpaceService < Sinatra::Base
     json_response(resolve_references({'archival_objects' => refs}, params[:resolve]))
   end
 
-
   Endpoint.get('/repositories/:repo_id/find_by_id/digital_object_components')
     .description("Find Digital Object Components by component_id")
     .params(["repo_id", :repo_id],
-            ["component_id", [String], "A set of record component IDs", :optional => true],
+            ["component_id", [String], "A digital object component's component ID (param may be repeated)", :optional => true],
             ["resolve", :resolve])
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \
@@ -41,7 +40,7 @@ class ArchivesSpaceService < Sinatra::Base
   Endpoint.get('/repositories/:repo_id/find_by_id/digital_objects')
     .description("Find Digital Objects by digital_object_id")
     .params(["repo_id", :repo_id],
-            ["digital_object_id", [String], "A set of digital object IDs", :optional => true],
+            ["digital_object_id", [String], "A digital object's digital object ID (param may be repeated)", :optional => true],
             ["resolve", :resolve])
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \

--- a/backend/app/model/idlookup.rb
+++ b/backend/app/model/idlookup.rb
@@ -1,12 +1,27 @@
 class IDLookup
 
-  def find_by_ids(model, params, id_maps)
+  def find_by_ids(model, params)
     filters = {:repo_id => params[:repo_id]}
 
-    id_maps.each do |column, ids|
-      if !Array(ids).empty?
-        filters[column] = Array(ids)
-
+    params.each do |key, values|
+      unless key == :repo_id
+        # The identifier for a resource needs to be massaged to match the db
+        if !Array(values).empty? && key == :identifier
+            identifiers = Array(values).map {|identifier|
+              parsed = ASUtils.json_parse(identifier)
+              if parsed.is_a?(Array) && parsed.length > 0 && parsed.length <= 4
+                padded = (parsed + ([nil] * 3)).take(4)
+                ASUtils.to_json(padded)
+              end
+            }.compact
+            filters[key] = Array(identifiers)
+        # For cases other than resources
+        elsif !Array(values).empty?
+          identifiers = Array(values).map {|identifier|
+            ASUtils.json_parse(identifier)
+          }.compact
+          filters[key] = Array(identifiers)
+        end
       end
     end
 

--- a/backend/app/model/idlookup.rb
+++ b/backend/app/model/idlookup.rb
@@ -1,7 +1,7 @@
 class IDLookup
 
-  def find_by_ids(model, id_maps)
-    filters = {}
+  def find_by_ids(model, params, id_maps)
+    filters = {:repo_id => params[:repo_id]}
 
     id_maps.each do |column, ids|
       if !Array(ids).empty?

--- a/backend/app/model/idlookup.rb
+++ b/backend/app/model/idlookup.rb
@@ -4,23 +4,20 @@ class IDLookup
     filters = {:repo_id => params[:repo_id]}
 
     params.each do |key, values|
-      unless key == :repo_id
+      unless key == :repo_id || key == :resolve
         # The identifier for a resource needs to be massaged to match the db
         if !Array(values).empty? && key == :identifier
-            identifiers = Array(values).map {|identifier|
-              parsed = ASUtils.json_parse(identifier)
-              if parsed.is_a?(Array) && parsed.length > 0 && parsed.length <= 4
-                padded = (parsed + ([nil] * 3)).take(4)
-                ASUtils.to_json(padded)
-              end
-            }.compact
-            filters[key] = Array(identifiers)
-        # For cases other than resources
-        elsif !Array(values).empty?
           identifiers = Array(values).map {|identifier|
-            ASUtils.json_parse(identifier)
+            parsed = ASUtils.json_parse(identifier)
+            if parsed.is_a?(Array) && parsed.length > 0 && parsed.length <= 4
+              padded = (parsed + ([nil] * 3)).take(4)
+              ASUtils.to_json(padded)
+            end
           }.compact
           filters[key] = Array(identifiers)
+        # For cases other than resources
+        elsif !Array(values).empty?
+          filters[key] = Array(values)
         end
       end
     end

--- a/backend/spec/controller_idlookup_spec.rb
+++ b/backend/spec/controller_idlookup_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'ID Lookup controller' do
 
   let (:archival_objects) {(0..5).map {|_| create(:json_archival_object, :component_id => SecureRandom.hex)}}
+  let (:resources) {(0..5).map {|_| create(:json_resource, :id_0 => SecureRandom.hex)}}
   let (:digital_object_components) {(0..5).map {|_| create(:json_digital_object_component, :component_id => SecureRandom.hex)}}
 
   it "lets you find archival objects by ref_id or component_id" do
@@ -36,6 +37,16 @@ describe 'ID Lookup controller' do
     ao_lookup = ASUtils.json_parse(last_response.body)
 
     ao_lookup['archival_objects'][0]['_resolved']['title'].should eq(ao['title'])
+  end
+
+  it "only returns one resource for a given identifier" do
+    resources.each do |resource|
+      get "#{$repo}/find_by_id/resources", {"identifier[]" => ["#{resource['id_0'].split}"]}
+      last_response.should be_ok
+      res_lookup = ASUtils.json_parse(last_response.body)
+
+      expect(res_lookup['resources'].count).to eq(1)
+    end
   end
 
 end


### PR DESCRIPTION
## Description
Addresses bug described in ANW-781.  Response returned from the `repositories/:repo_id/find_by_id/resources` API endpoint now only returns matches from the repository provided.

More work needs to be done to address noted issues with the equivalent endpoints for digital_objects, digital_object_components, and archival_objects.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-781

## Motivation and Context
User identified bug in the `repositories/:repo_id/find_by_id/resources` endpoint.

## How Has This Been Tested?
Existing automated tests passed, and a new relevant test was added.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
