### PR TITLE
Tweak _yard/API.erb to make TOC headings human readable

### DIFF
--- a/_yard/API.erb
+++ b/_yard/API.erb
@@ -17,13 +17,13 @@ search: true
 
 This is the documentation for the ArchivesSpace RESTful API. This documents the endpoints that are used by the backend server to edit records in the application.
 
-This example API documentation page was created with [Slate](http://github.com/tripit/slate). 
+This example API documentation page was created with [Slate](http://github.com/tripit/slate).
 
 # Authentication
 
 > To authorize, use this code:
 
-<!-- 
+<!--
 ```ruby
 require 'kittn'
 
@@ -154,7 +154,7 @@ curl -s -F password="admin" "http://localhost:8089/users/admin/login"
 }
 ```
 
-> It's a good idea to save the "session" id, since this will be used for later requests. 
+> It's a good idea to save the "session" id, since this will be used for later requests.
 
 
 Most requests to the ArchivesSpace backend requires a user to be authenticated.
@@ -169,7 +169,7 @@ As of <%= @time.inspect %> the following REST endpoints exist in the master bran
 
 <% @endpoints.each do | e | %>
 
-## <%= e[:method].map &:upcase %> <%= e[:uri]%> 
+## <%= e[:description]%>
 
 <% example =  @examples[e[:uri]][e[:method].to_s] %>
 
@@ -201,16 +201,16 @@ As of <%= @time.inspect %> the following REST endpoints exist in the master bran
   <% data_example = "Example Missing" %>
 <% end %>
 
-```shell 
+```shell
 <% if e[:method] == [:get] %>
   <% if e[:paginated] %>
-# return first 10 records    
+# return first 10 records
 curl -H "X-ArchivesSpace-Session: $SESSION" "<%= request_uri %>?page=1&page_size=10"
 # return first 5 records in the Fibonacci sequence
 curl -H "X-ArchivesSpace-Session: $SESSION" "<%= request_uri %>?id_set=1,2,3,5,8"
-# return an array of all the ids 
+# return an array of all the ids
 curl -H "X-ArchivesSpace-Session: $SESSION" "<%= request_uri %>?all_ids=true"
-  <% else %> 
+  <% else %>
 curl -H "X-ArchivesSpace-Session: $SESSION" "<%= request_uri %>"
   <% end %>
 <% elsif e[:method] == [:post] %>
@@ -220,8 +220,8 @@ curl -H "X-ArchivesSpace-Session: $SESSION" \
 <% elsif e[:method] == [:delete] %>
 curl -H "X-ArchivesSpace-Session: $SESSION" -X DELETE "<%= request_uri %>"
 <% else %>
-  <% example.each_pair do |k,v| %>  
-    <% next if e[:uri].include?("/:#{k}") %>  
+  <% example.each_pair do |k,v| %>
+    <% next if e[:uri].include?("/:#{k}") %>
 curl -H "X-ArchivesSpace-Session: $SESSION" \
   -d '<%= v.to_json.gsub("{", "{ ").gsub(",", ",\n") %>' \
   "<%= request_uri %>"
@@ -229,6 +229,10 @@ curl -H "X-ArchivesSpace-Session: $SESSION" \
 <% end %>
 
 ```
+
+__Endpoint__
+
+```<%= e[:method].map &:upcase %> <%= e[:uri]%> ```
 
 __Description__
 
@@ -245,10 +249,10 @@ This endpoint is paginated. :page, :id_set, or :all_ids is required
   <li>Integer page_size &ndash; The size of the set to be returned ( Optional. default set in AppConfig )</li>
   <li>Comma seperated list id_set &ndash; A list of ids to request resolved objects ( Must be smaller than default page_size )</li>
   <li>Boolean all_ids &ndash; Return a list of all object ids</li>
-</ul>  
+</ul>
 </aside>
 <% end %>
-<% e[:params].each do |param| 
+<% e[:params].each do |param|
   opts = (param[3] or {})
   vs = opts[:validation] ? " -- #{opts[:validation][0]}" : ""
   optional = opts[:optional] ? " (Optional)" : "" %>
@@ -268,5 +272,3 @@ __Returns__
 <% end %>
 
 <% end %>
-
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes the construction of the Slate API docs table of contents left side column.  It replaces the table of contents heading formerly populated by the endpoint itself, with the contents of the `.description` parameter.  Additionally, since the endpoint is being removed from the left column, it has been added to the center column under the new Endpoint heading.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
First pass at making the API documentation more readable and beginner friendly.

Ultimately, I suggest adding an additional `.short_heading` param that can be used to populate the table of contents, as some `.description`s may be too long to be of much use as a table of contents heading.  This change does not address the fact that the table of contents column is a fixed width and longer text will be truncated if it is present in that column.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15144646/46556008-3e9d5680-c8b3-11e8-934d-8634a0d29fd4.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
