### PR TITLE
Implement a 'touch' functionality to bump related record system_mtime

### DIFF
--- a/backend/app/model/archival_object.rb
+++ b/backend/app/model/archival_object.rb
@@ -25,6 +25,7 @@ class ArchivalObject < Sequel::Model(:archival_object)
   include RightsRestrictionNotes
   include RepresentativeImages
   include Assessments::LinkedRecord
+  include TouchRecords
 
   enable_suppression
 
@@ -96,6 +97,10 @@ class ArchivalObject < Sequel::Model(:archival_object)
     end
 
     result
+  end
+
+  def self.touch_records(obj)
+    [{ type: Resource, ids: [obj.root_record_id] }]
   end
 
 end

--- a/backend/app/model/digital_object_component.rb
+++ b/backend/app/model/digital_object_component.rb
@@ -16,6 +16,7 @@ class DigitalObjectComponent < Sequel::Model(:digital_object_component)
   include ComponentsAddChildren
   include Events
   include Publishable
+  include TouchRecords
 
   enable_suppression
 
@@ -51,6 +52,10 @@ class DigitalObjectComponent < Sequel::Model(:digital_object_component)
                      :message => "A Digital Object Component ID must be unique to its Digital Object")
     map_validation_to_json_property([:root_record_id, :component_id], :component_id)
     super
+  end
+
+  def self.touch_records(obj)
+    [{ type: DigitalObject, ids: [obj.root_record_id] }]
   end
 
 end

--- a/backend/app/model/mixins/touch_records.rb
+++ b/backend/app/model/mixins/touch_records.rb
@@ -3,7 +3,7 @@ module TouchRecords
   # Implement 'touch' functionality to bump related records system_mtime values
   # as 'this' record is modified in the system.
 
-  # To implmenent a model should include the mixin and define the class method:
+  # To implement a model should include the mixin and define the class method:
   # `touch_records`: [ { type: Resource, ids: [1, 3, 10] } ]
 
   # NOTE: this does not apply to _rlshp records which update related records

--- a/backend/app/model/mixins/touch_records.rb
+++ b/backend/app/model/mixins/touch_records.rb
@@ -1,0 +1,57 @@
+module TouchRecords
+
+  # Implement 'touch' functionality to bump related records system_mtime values
+  # as 'this' record is modified in the system.
+
+  # To implmenent a model should include the mixin and define the class method:
+  # `touch_records`: [ { type: Resource, ids: [1, 3, 10] } ]
+
+  # NOTE: this does not apply to _rlshp records which update related records
+  # system_mtime via the trigger_reindex_of_dependants path, i.e. for
+  # agents and subjects et al. using defined relationships
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  def set_parent_and_position(*)
+    super
+    self.class.touch(self)
+  end
+
+  def set_root(*)
+    super
+    self.class.touch(self)
+  end
+
+  def delete
+    self.class.touch(self)
+    super
+  end
+
+  def update_from_json(json, opts = {}, apply_nested_records = true)
+    result = super
+    self.class.touch(self)
+    result
+  end
+
+  module ClassMethods
+
+    def create_from_json(json, opts = {})
+      obj = super
+      touch(obj)
+      obj
+    end
+
+    def touch(obj)
+      return unless obj.class.respond_to? :touch_records
+      records = obj.class.touch_records(obj)
+      return unless records.any?
+      records.each do |record_set|
+        record_set[:type].update_mtime_for_ids(record_set[:ids])
+      end
+    end
+
+  end
+
+end

--- a/backend/spec/mixin_touch_records_spec.rb
+++ b/backend/spec/mixin_touch_records_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe 'Touch Records mixin' do
+
+  let(:resource) { create_resource({title: generate(:generic_title)}) }
+  let(:digital_object) { create_digital_object({title: generate(:generic_title)}) }
+
+  def gimme_ao(uri)
+    create_archival_object({
+      'resource' => {
+        'ref' => uri
+      }
+    })
+  end
+
+  def gimme_doc(uri)
+    create_digital_object_component({
+      'digital_object' => {
+        'ref' => uri
+      }
+    })
+  end
+
+  it 'can update resource system_mtime value when related ao created' do
+    resource_mt = resource.system_mtime
+    obj = gimme_ao(resource.uri)
+
+    resource.refresh
+
+    resource.system_mtime.should_not eq(resource_mt)
+    resource.system_mtime.utc.round.should be >= obj.system_mtime.utc.round
+  end
+
+  it 'can update resource system_mtime value when related ao updated' do
+    obj = gimme_ao(resource.uri)
+    obj_mt = obj.system_mtime
+    obj.system_mtime = Time.now + 120
+    obj.save
+
+    resource.refresh
+
+    obj.system_mtime.should_not eq(obj_mt)
+    resource.system_mtime.utc.round.should be >= obj.system_mtime.utc.round
+  end
+
+  it 'can update resource system_mtime value when related ao deleted' do
+    obj = gimme_ao(resource.uri)
+    resource.system_mtime = Time.now - 3600 # reset resource mtime after ao create
+    resource.save
+
+    obj_mt = obj.system_mtime
+    obj.delete
+
+    resource.refresh
+
+    resource.system_mtime.utc.round.should be >= obj_mt.utc.round
+  end
+
+  it 'works the same for digital objects and components' do
+    doc = gimme_doc(digital_object.uri)
+    doc_mt = doc.system_mtime
+    doc.system_mtime = Time.now + 120
+    doc.save
+
+    digital_object.refresh
+
+    doc.system_mtime.should_not eq(doc_mt)
+    digital_object.system_mtime.utc.round.should be >= doc.system_mtime.utc.round
+  end
+
+end

--- a/backend/spec/spec_helper_methods.rb
+++ b/backend/spec/spec_helper_methods.rb
@@ -34,6 +34,14 @@ module SpecHelperMethods
   end
 
 
+  def create_archival_object(opts = {})
+    ArchivalObject.create_from_json(
+      build(:json_archival_object, opts),
+      :repo_id => $repo_id
+    )
+  end
+
+
   def create_event(opts = {})
     Event.create_from_json(build(:json_event, opts),
                            :repo_id => $repo_id)
@@ -47,6 +55,13 @@ module SpecHelperMethods
 
   def create_digital_object(opts = {})
     DigitalObject.create_from_json(build(:json_digital_object, opts), :repo_id => $repo_id)
+  end
+
+
+  def create_digital_object_component(opts = {})
+    DigitalObjectComponent.create_from_json(
+      build(:json_digital_object_component, opts), :repo_id => $repo_id
+    )
   end
 
 


### PR DESCRIPTION
## Description
Provide a generic mixin that allows a model to define a method to update the `system_mtime` value for one or more related records.

## Related JIRA Ticket or GitHub Issue
https://github.com/archivesspace/archivesspace/issues/856

## Motivation and Context
Particularly for EAD serialization a resource "full record" is the resource + many of its related records. Updates to some related records do not propagate an update to resources (only those that link via a relationship mixin do currently), which is inconsistent, and makes requesting resources updated "since" or "from" a certain date difficult, requiring a chain of api calls to archival objects, top containers etc. OAI EAD requests are scoped by record type (resource) and therefore updates to archival objects or containers are not factored into results when using dates, which greatly limits the usefulness of that very useful feature.

Issue #856 describes some other possible approaches, but this one slots in without introducing anything new (like a dedicated endpoint).

## How Has This Been Tested?
1. Manual testing.
2. `./build/run backend:test -Dexample='Touch Records mixin'`
3. `./build/run backend:test`

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
