### PR TITLE
Allow multiple subfield b's and correctly punctuate

### DIFF
--- a/backend/spec/export_marc_spec.rb
+++ b/backend/spec/export_marc_spec.rb
@@ -125,7 +125,7 @@ end
     end
 
     it "maps primary_name to subfield 'a'" do
-      @marc.should have_tag "datafield[@tag='110']/subfield[@code='a']" => @name.primary_name
+      @marc.should have_tag "datafield[@tag='110']/subfield[@code='a']" => @name.primary_name + "." || @name.primary_name + ","
     end
   end
 
@@ -913,9 +913,14 @@ end
       df = @marcs[0].at("datafield[@tag='610'][@ind1='2'][@ind2='#{ind2}']")
 
       a_text = df.at("subfield[@code='a']").text
+      b_text = df.at("subfield[@code='b']").text
       n_text = df.at("subfield[@code='n']").text
 
-      expect(a_text[-1]).to eq(",")
+      if b_text.nil?
+        expect(a_text[-1]).to eq(",")
+      elsif !b_text.nil?
+        expect(a_text[-1]).to eq(".")
+      end
 
       expect(n_text[-1]).to eq(".")
       expect(n_text =~ /\(.*\)/).to_not eq(nil)


### PR DESCRIPTION
## Description

Continuing to improve/fix MARC export for the 110/610/710s.  

Changes sufield_b from a single subfield containing a concatenation of the two subordinate names into repeatable subfield_b's containing only one subordinate name.  Adjusts end punctuation for subfield's a and b depending on presence of subfield's b and e.

## Related JIRA Ticket or GitHub Issue

https://archivesspace.atlassian.net/browse/ANW-779

## Motivation and Context

Address bugs in MARC export.

## How Has This Been Tested?

Passed automated tests, and updated tests that failed.  Reviewed MARC exports for compliance with stated mappings.

## Screenshots (if appropriate):

110 with multiple subnames and subfields:

<img width="489" alt="multiple_subfields" src="https://user-images.githubusercontent.com/15144646/46907588-c94d0980-cee2-11e8-9408-7c225fb0ab5b.png">


710 with one subordinate name:

<img width="472" alt="one_subname" src="https://user-images.githubusercontent.com/15144646/46907589-d538cb80-cee2-11e8-8e72-332f8194d0bc.png">


710 with no subordinate names:

<img width="541" alt="no_subnames" src="https://user-images.githubusercontent.com/15144646/46907591-d9fd7f80-cee2-11e8-8aac-32f08bc60cfb.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
