### PR TITLE
ANW-766 Made improvements/adjustments based upon comments in JIRA ticket

### DIFF
--- a/backend/app/lib/reports/report_utils.rb
+++ b/backend/app/lib/reports/report_utils.rb
@@ -115,4 +115,9 @@ module ReportUtils
     label.strip.downcase.gsub(/[^a-z0-9]+/, '_').gsub(/_+$/, '')
   end
 
+  def self.fix_id(row)
+    row[:record_id] = normalize_label(row[:linked_record_type].to_s) + '_' + row[:record_id].to_s
+    row.delete(:linked_record_type)
+  end
+
 end

--- a/reports/assessments/assessment_linked_records_subreport/assessment_linked_records_subreport.rb
+++ b/reports/assessments/assessment_linked_records_subreport/assessment_linked_records_subreport.rb
@@ -7,6 +7,7 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
 
   def query_string
     "(select
+      resource.id as record_id,
       'Resource' as linked_record_type,
       resource.title as record_title,
       resource.identifier as identifier
@@ -17,6 +18,7 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
     union
 
     (select
+      resource.id as record_id,
       'Archival Object' as linked_record_type,
       ifnull(archival_object.title, archival_object.display_string) as record_title,
       resource.identifier as identifier
@@ -28,6 +30,7 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
     union
 
     (select
+      accession.id as record_id,
       'Accession' as linked_record_type,
       accession.title as record_title,
       accession.identifier as identifier
@@ -38,6 +41,7 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
     union
 
     (select
+      digital_object.id as record_id,
       'Digital Object' as linked_record_type,
       digital_object.title as record_title,
       digital_object.digital_object_id as identifier
@@ -48,6 +52,7 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
 
   def fix_row(row)
     ReportUtils.fix_identifier_format(row) unless row[:linked_record_type] == 'Digital Object'
+    ReportUtils.fix_id(row)
   end
 
 end

--- a/reports/static/translation_defaults/en.yml
+++ b/reports/static/translation_defaults/en.yml
@@ -94,6 +94,7 @@ en:
       purpose: Purpose of Assessment
       rating: Rating
       ratings: Ratings
+      record_id: Record ID
       linked_record_type: Record Type
       related_eac_records: Related EAC Record(s)
       repository: Repository

--- a/reports/static/translation_defaults/es.yml
+++ b/reports/static/translation_defaults/es.yml
@@ -94,6 +94,7 @@ es:
       purpose: Purpose of Assessment
       rating: Rating
       ratings: Ratings
+      record_id: ID de registro
       linked_record_type: Record Type
       related_eac_records: Related EAC Record(s)
       repository: Repository

--- a/reports/static/translation_defaults/fr.yml
+++ b/reports/static/translation_defaults/fr.yml
@@ -94,6 +94,7 @@ fr:
       purpose: Purpose of Assessment
       rating: Rating
       ratings: Ratings
+      record_id: ID d'enregistrement
       linked_record_type: Record Type
       related_eac_records: Related EAC Record(s)
       repository: Services d'archives


### PR DESCRIPTION
## Description
Made changes based upon comment from JIRA ticket:
1. The record id (resource_144 etc) seems to the only bit of info missing, which doesn't matter to our current workflows, but might matter to other people?
2. The report is pulling in a field called research value note, and there's actually no place to enter that note, so I'm not sure where that's coming from.
3. The report is pulling in inactive assessments, when the original functionality was designed to exclude inactive records from reports (that's what the inactive button was for).
4. It would be helpful if the assessment attributes (the user-defined fields) were grouped with their sections as they were in the original report.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-766

## How Has This Been Tested?
Using test data, all 5 formats of the Assessment List report were generated and examined

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
