### PR TITLE
Address potential for nil ancestors in found in column

### DIFF
--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -222,7 +222,7 @@ module SearchHelper
     when result['primary_type'] == 'digital_object_component'
       ancestors = result['digital_object'].split
     else
-      ancestors = nil
+      ancestors = ['']
     end
   end
 

--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -222,7 +222,7 @@ module SearchHelper
     when result['primary_type'] == 'digital_object_component'
       ancestors = result['digital_object'].split
     else
-      ancestors = ['']
+      ancestors = nil
     end
   end
 

--- a/frontend/app/views/search/_context.html.erb
+++ b/frontend/app/views/search/_context.html.erb
@@ -1,5 +1,5 @@
 <% ancestors = context_ancestor(result) %>
-<% if ancestors != [''] %>
+<% if ancestors != nil %>
   <% ancestors.reverse.each_with_index do |ancestor, i| %>
     <%= resolve_readonly_link_to((get_ancestor_title(ancestor).html_safe), ancestor) %>
     <% if i < ancestors.length - 1 %>

--- a/frontend/app/views/search/_context.html.erb
+++ b/frontend/app/views/search/_context.html.erb
@@ -1,5 +1,5 @@
 <% ancestors = context_ancestor(result) %>
-<% if ancestors != nil %>
+<% if ancestors != [''] && ancestors != nil %>
   <% ancestors.reverse.each_with_index do |ancestor, i| %>
     <%= resolve_readonly_link_to((get_ancestor_title(ancestor).html_safe), ancestor) %>
     <% if i < ancestors.length - 1 %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some staff side searches fail because the context partial was not built to account for a `nil` ancestor.  This changes the fallback value of context_ancestor to `nil` instead of an empty array to avoid a "Something went wrong error" when ancestors = `nil`.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Address error page that is returned when a nil value is present in ancestors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran locally against several different databases and confirmed searches successfully complete.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
