### PR TITLE
Use correct field to ensure research value note will not be included in assessments reports

### DIFF
--- a/reports/assessments/assessment_list_report/assessment_list_report.rb
+++ b/reports/assessments/assessment_list_report/assessment_list_report.rb
@@ -143,9 +143,9 @@ class AssessmentListReport < AbstractReport
       unless ratings_hash.nil?
         ratings_hash.each do | ra |
           rate_label = ra[:field] + ' Rating'
-          note_label = ra[:field] + ' Note' if ra[:label] != "Research Value"
+          note_label = ra[:field] + ' Note' if ra[:field] != "Research Value"
           row[ReportUtils.normalize_label(rate_label).to_sym] = ra[:rating]
-          row[ReportUtils.normalize_label(note_label).to_sym] = ra[:note] if ra[:label] != "Research Value"
+          row[ReportUtils.normalize_label(note_label).to_sym] = ra[:note] if ra[:field] != "Research Value"
         end
       end
     else


### PR DESCRIPTION
## Description
Wrong field was used to exclude non-existent Research Value Note

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-766
