### PR TITLE
Tree reorder mode multiselect fix for Mac

### DIFF
--- a/frontend/app/assets/javascripts/largetree_dragdrop.js.erb
+++ b/frontend/app/assets/javascripts/largetree_dragdrop.js.erb
@@ -184,7 +184,7 @@
         $(largetree.elt).on('mousedown', '.drag-handle', function (event) {
             var selection = $(this);
 
-            if (event.ctrlKey || event.metaKey) {
+            if (self.isMultiSelectKeyHeld(event)) {
                 return self.handleMultiSelect(selection);
             } else if (event.shiftKey) {
                 return self.handleShiftSelect(selection);
@@ -238,7 +238,8 @@
         });
 
         $(document).on('mousedown', function (event) {
-            if (!event.ctrlKey &&
+            if (!self.isMultiSelectKeyHeld(event) &&
+
                 /* Not clicking on a drag handle */
                 !$(event.target).hasClass('drag-handle') &&
 
@@ -392,6 +393,11 @@
 
             return true;
         });
+    };
+
+
+    LargeTreeDragDrop.prototype.isMultiSelectKeyHeld = function (mouseEvent) {
+        return (mouseEvent.ctrlKey || mouseEvent.metaKey);
     };
 
 

--- a/frontend/app/assets/javascripts/largetree_dragdrop.js.erb
+++ b/frontend/app/assets/javascripts/largetree_dragdrop.js.erb
@@ -32,7 +32,7 @@
         var self = this;
 
         /* If any of our rowsToMove selections are no longer visible, deselect them. */
-        var selectionToKeep = []
+        var selectionToKeep = [];
 
         $(self.rowsToMove).each(function (idx, selectedRow) {
             if ($(selectedRow).is(':visible')) {
@@ -137,7 +137,7 @@
         var self = this;
 
         var row = selection.closest('tr');
-        var lastSelection = self.rowsToMove[self.rowsToMove.length - 1]
+        var lastSelection = self.rowsToMove[self.rowsToMove.length - 1];
 
         if (lastSelection) {
             var start = $(lastSelection);
@@ -156,7 +156,7 @@
             rowsInRange.each(function (i, row) {
                 if ($(row).is('.largetree-node')) {
                     if (!$(row).is('.multiselected') && $(row).data('level') === targetLevel) {
-                        $(row).find('.drag-handle').addClass('multiselected')
+                        $(row).find('.drag-handle').addClass('multiselected');
                         self.rowsToMove.push(row);
                     }
                 }
@@ -420,7 +420,7 @@
         // blockout the page
         self.blockout = $('<div>').addClass('largetree-blockout');
         $(document.body).append(self.blockout);
-        
+
         // insert a menu!
         self.menu = $('<ul>').addClass('dropdown-menu largetree-dropdown-menu');
         if (!dropTarget.is('.root-row')) {
@@ -473,11 +473,11 @@
             });
         }).on('click', '.add-items-as-children', function() {
             self.largetree.reparentNodes(dropTarget, self.rowsToMove, dropTarget.data('child_count')).done(function() {
-                self.resetState()
+                self.resetState();
             });
         }).on('click', '.add-items-after', function() {
             self.largetree.reparentNodes(getParent(dropTarget), self.rowsToMove, dropTarget.data('position') + 1).done(function() {
-                self.resetState()
+                self.resetState();
             });
         });
     };
@@ -491,6 +491,6 @@
     };
 
     exports.LargeTreeDragDrop = LargeTreeDragDrop;
-    exports.DRAGDROP_HOTSPOT_HEIGHT = HOTSPOT_HEIGHT
+    exports.DRAGDROP_HOTSPOT_HEIGHT = HOTSPOT_HEIGHT;
 
 }(window));


### PR DESCRIPTION
When performing a multiselect in tree reorder mode, a misclick shouldn't clear the current selection.

## Description
To perform a multiselect in the tree reorder mode, you hold down the command key (on Mac) or control (everywhere else) and select the items you want by clicking their handles.  Clicking anywhere else would normally clear the current selection but, to be tolerant of misclicks, the selection is only cleared if you're not currently holding down the multiselect key.

This all works fine when you're holding the control key, but on Mac (where you hold the command key instead), a misclick will clear the current selection.  This commit unifies the behavior of the control and command keys and pulls the checking logic into a central spot to avoid future issues like this.

## Related JIRA Ticket or GitHub Issue
I couldn't find anyone reporting this issue (it's pretty minor), but just noticed it in my own usage and thought I'd send a fix.

## Motivation and Context
It's a small issue, but frustrating to lose your selection if you're bad at using your mouse like me.

## How Has This Been Tested?
Tested on Firefox under Linux, and Chrome and Safari under OS X.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
