### PR TITLE
ANW-798 fix weird display issues

### DIFF
--- a/frontend/app/views/archival_objects/_form_container.html.erb
+++ b/frontend/app/views/archival_objects/_form_container.html.erb
@@ -1,13 +1,13 @@
 <%= link_to_help :topic => "archival_object" %>
 
-<h3>
+<h2>
   <% if @archival_object.display_string.blank? %>
     <%= I18n.t("archival_object._singular") %>
   <% else %>
     <%= clean_mixed_content(@archival_object.display_string) %>
   <% end %>
   <span class="label label-info"><%= I18n.t("archival_object._singular") %></span>
-</h3>
+</h2>
 
 <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:form => form} %>
 
@@ -20,10 +20,10 @@
 
   <% define_template("archival_object", jsonmodel_definition(:archival_object)) do |form| %>
     <section id="basic_information">
-      <h4>
+      <h3>
         <%= I18n.t("archival_object._frontend.section.basic_information") %>
         <%= link_to_help :topic => "archival_object_basic_information" %>
-      </h4>
+      </h3>
 
       <fieldset>
         <%= form.label_and_textarea("title", :required => :conditionally)%>

--- a/frontend/app/views/archival_objects/_show_inline.html.erb
+++ b/frontend/app/views/archival_objects/_show_inline.html.erb
@@ -6,10 +6,10 @@
     <%= render_aspace_partial :partial => "toolbar" %>
     <div class="record-pane">
       <% define_template "archival_object", jsonmodel_definition(:archival_object) do |readonly, archival_object| %>
-        <h3><%= clean_mixed_content(archival_object.display_string) %> <span class="label label-info"><%= I18n.t("archival_object._singular") %></span></h3>
+        <h2><%= clean_mixed_content(archival_object.display_string) %> <span class="label label-info"><%= I18n.t("archival_object._singular") %></span></h2>
         <%= render_aspace_partial :partial => "shared/flash_messages" %>
         <section id="basic_information">
-          <h4><%= I18n.t("archival_object._frontend.section.basic_information") %></h4>
+          <h3><%= I18n.t("archival_object._frontend.section.basic_information") %></h3>
           <%= readonly.label_and_textarea "title" , :field_opts => { :clean => true, :escape => false } %>
           <%= readonly.label_with_field "ref_id", "<div class='identifier-display'><div class='identifier-display-part'>#{readonly["ref_id"]}</div></div>" %>
           <%= readonly.label_and_textfield "component_id" %>

--- a/frontend/app/views/classification_terms/_form_container.html.erb
+++ b/frontend/app/views/classification_terms/_form_container.html.erb
@@ -1,9 +1,9 @@
 <%= link_to_help :topic => "classification_term" %>
 
-<h3>
+<h2>
   <%= @form_title ? @form_title : @classification_term.title.blank? ? I18n.t("classification_term._singular") : @classification_term.title %>
   <span class="label label-info"><%= I18n.t("classification_term._singular") %></span>
-</h3>
+</h2>
 
 <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:form => form} %>
 
@@ -17,7 +17,7 @@
 
   <% define_template("classification_term", jsonmodel_definition(:classification_term)) do |form| %>
     <section id="basic_information">
-      <h4><%= I18n.t("classification_term._frontend.section.basic_information") %></h4>
+      <h3><%= I18n.t("classification_term._frontend.section.basic_information") %></h3>
 
       <%= form.label_and_textfield "identifier" %>
       <%= form.label_and_textfield "title" %>

--- a/frontend/app/views/classification_terms/_show_inline.html.erb
+++ b/frontend/app/views/classification_terms/_show_inline.html.erb
@@ -6,11 +6,11 @@
     <%= render_aspace_partial :partial => "toolbar" %>
     <div class="record-pane">
       <%= readonly_context :classification_term, @classification_term do |readonly| %>
-        <h3><%= @classification_term.title %> <span class="label label-info"><%= I18n.t("classification_term._singular") %></span></h3>
+        <h2><%= @classification_term.title %> <span class="label label-info"><%= I18n.t("classification_term._singular") %></span></h2>
         <%= render_aspace_partial :partial => "shared/flash_messages" %>
         <% define_template "classification_term", jsonmodel_definition(:classification_term) do |form, classification_term| %>
         <section id="basic_information">
-          <h4><%= I18n.t("classification_term._frontend.section.basic_information") %></h4>
+          <h3><%= I18n.t("classification_term._frontend.section.basic_information") %></h3>
             <%= form.label_and_textarea "identifier" %>
             <%= form.label_and_textarea "title" %>
             <%= form.label_and_textarea "description" %>

--- a/frontend/app/views/classifications/_form_container.html.erb
+++ b/frontend/app/views/classifications/_form_container.html.erb
@@ -1,8 +1,8 @@
 <%= link_to_help :topic => "classification" %>
 
-<h3>
+<h2>
    <%= @form_title ? @form_title : @classification.title.blank? ? "#{I18n.t("actions.new_prefix")} #{I18n.t("classification._singular")}" : @classification.title %>  <span class="label label-info"><%= I18n.t("classification._singular") %></span>
-</h3>
+</h2>
 
 <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:form => form} %>
 
@@ -12,7 +12,7 @@
 <fieldset>
   <% define_template("classification", jsonmodel_definition(:classification)) do |form| %>
     <section id="basic_information">
-      <h4><%= I18n.t("classification._frontend.section.basic_information") %></h4>
+      <h3><%= I18n.t("classification._frontend.section.basic_information") %></h3>
 
       <%= form.label_and_textfield "identifier" %>
       <%= form.label_and_textfield "title" %>

--- a/frontend/app/views/classifications/_show_inline.html.erb
+++ b/frontend/app/views/classifications/_show_inline.html.erb
@@ -6,11 +6,11 @@
     <%= render_aspace_partial :partial => "toolbar" %>
     <div class="record-pane">
       <%= readonly_context :classification, @classification do |readonly| %>
-        <h3><%= @classification.title %> <span class="label label-info"><%= I18n.t("classification._singular") %></span></h3>
+        <h2><%= @classification.title %> <span class="label label-info"><%= I18n.t("classification._singular") %></span></h2>
 
         <% define_template "classification", jsonmodel_definition(:classification) do |form, classification| %>
           <section id="basic_information">
-            <h4><%= I18n.t("classification._frontend.section.basic_information") %></h4>
+            <h3><%= I18n.t("classification._frontend.section.basic_information") %></h3>
 
             <%= form.label_and_textarea "identifier" %>
             <%= form.label_and_textarea "title" %>

--- a/frontend/app/views/digital_object_components/_form_container.html.erb
+++ b/frontend/app/views/digital_object_components/_form_container.html.erb
@@ -1,13 +1,13 @@
 <%= link_to_help :topic => "digital_object_component" %>
 
-<h3>
+<h2>
   <% if @digital_object_component.display_string.blank? %>
     <%= I18n.t("digital_object_component._singular") %>
   <% else %>
     <%= clean_mixed_content(@digital_object_component.display_string) %>
   <% end %>
   <span class="label label-info"><%= I18n.t("digital_object_component._singular") %></span>
-</h3>
+</h2>
 
 <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:form => form} %>
 
@@ -21,10 +21,10 @@
 
   <% define_template("digital_object_component", jsonmodel_definition(:digital_object_component)) do |form| %>
     <section id="basic_information">
-      <h3>
+      <h2>
         <%= I18n.t("digital_object_component._frontend.section.basic_information") %>
         <%= link_to_help :topic => "digital_object_component_basic_information" %>
-      </h3>
+      </h2>
       <%= form.label_and_textfield "label", :required => :conditionally %>
       <%= form.label_and_textarea "title", :required => :conditionally %>
       <%= form.label_and_textfield "component_id" %>

--- a/frontend/app/views/digital_object_components/_show_inline.html.erb
+++ b/frontend/app/views/digital_object_components/_show_inline.html.erb
@@ -6,12 +6,12 @@
     <%= render_aspace_partial :partial => "toolbar" %>
     <div class="record-pane">
       <% define_template "digital_object_component", jsonmodel_definition(:digital_object_component) do |readonly, digital_object_component| %>
-        <h3><%= clean_mixed_content(digital_object_component.display_string) %> <span class="label label-info"><%= I18n.t("digital_object_component._singular") %></span></h3>
+        <h2><%= clean_mixed_content(digital_object_component.display_string) %> <span class="label label-info"><%= I18n.t("digital_object_component._singular") %></span></h2>
 
         <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:form => readonly} %>
 
         <section id="basic_information">
-          <h4><%= I18n.t("digital_object_component._frontend.section.basic_information") %></h4>
+          <h3><%= I18n.t("digital_object_component._frontend.section.basic_information") %></h3>
 
           <%= readonly.label_and_textfield "label" %>
           <%= readonly.label_and_textarea "title" %>

--- a/frontend/app/views/digital_objects/_edit_inline.html.erb
+++ b/frontend/app/views/digital_objects/_edit_inline.html.erb
@@ -8,14 +8,14 @@
         <%= render_aspace_partial :partial => "toolbar" %>
         <div class="record-pane">
           <%= link_to_help :topic => "digital_object" %>
-          <h3>
+          <h2>
             <% if @digital_object.title.blank? %>
               <%= I18n.t("digital_object._singular") %>
             <% else %>
               <%= clean_mixed_content(@digital_object.title) %>
             <% end %>
             <span class="label label-info"><%= I18n.t("digital_object._singular") %></span>
-          </h3>
+          </h2>
           <%= render_aspace_partial :partial => "digital_objects/form_container", :locals => {:form => form} %>
            <div class="form-actions">
              <button type="submit" class="btn btn-primary"><%= I18n.t("digital_object._frontend.action.save") %></button>

--- a/frontend/app/views/digital_objects/_show_inline.html.erb
+++ b/frontend/app/views/digital_objects/_show_inline.html.erb
@@ -6,12 +6,12 @@
     <%= render_aspace_partial :partial => "toolbar" %>
     <div class="record-pane">
       <% define_template "digital_object", jsonmodel_definition(:digital_object) do |readonly, digital_object| %>
-        <h3><%= clean_mixed_content(digital_object.title) %> <span class="label label-info"><%= I18n.t("digital_object._singular") %></span></h3>
+        <h2><%= clean_mixed_content(digital_object.title) %> <span class="label label-info"><%= I18n.t("digital_object._singular") %></span></h2>
 
         <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:form => readonly} %>
 
         <section id="basic_information">
-          <h4><%= I18n.t("digital_object._frontend.section.basic_information") %></h4>
+          <h3><%= I18n.t("digital_object._frontend.section.basic_information") %></h3>
 
           <%= readonly.label_and_textarea "title" %>
           <%= readonly.label_and_textfield "digital_object_id" %>
@@ -41,7 +41,7 @@
 
         <% if digital_object.linked_instances.length > 0 %>
           <section id="digital_object_linked_instances" class="subrecord-form-dummy">
-            <h4><%= I18n.t("linked_record._plural") %></h4>
+            <h3><%= I18n.t("linked_record._plural") %></h3>
             <div class="subrecord-form-container">
               <div class="subrecord-form-fields">
                 <div class="row label-and-value">

--- a/frontend/app/views/resources/_form_container.html.erb
+++ b/frontend/app/views/resources/_form_container.html.erb
@@ -1,8 +1,8 @@
 <%= link_to_help :topic => "resource" %>
 
-<h3>
+<h2>
    <%= @form_title ? @form_title : @resource.title.blank? ? "#{I18n.t("actions.new_prefix")} #{I18n.t("resource._singular")}" : clean_mixed_content( @resource.title)  %>  <span class="label label-info"><%= I18n.t("resource._singular") %></span>
-</h3>
+</h2>
 
 <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:form => form} %>
 
@@ -13,10 +13,10 @@
   <% define_template("resource", jsonmodel_definition(:resource)) do |form| %>
 
   <section id="basic_information">
-    <h4>
+    <h3>
       <%= I18n.t("resource._frontend.section.basic_information") %>
       <%= link_to_help :topic => "resource_basic_information" %>
-    </h4>
+    </h3>
 
     <fieldset>
       <%= form.label_and_textarea "title" %>
@@ -35,10 +35,10 @@
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "extents"} %>
 
   <section id="finding_aid" class="subrecord-form-dummy">
-    <h4>
+    <h3>
       <%= I18n.t("resource._frontend.section.finding_aid") %>
       <%= link_to_help :topic => "resource_finding_aid" %>
-    </h4>
+    </h3>
     <div class="subrecord-form-container">
       <div class="subrecord-form-fields">
         <fieldset>

--- a/frontend/app/views/resources/_show_inline.html.erb
+++ b/frontend/app/views/resources/_show_inline.html.erb
@@ -7,13 +7,13 @@
     <div class="record-pane">
       <%= readonly_context :resource, @resource do |readonly| %>
 
-        <h3><%= clean_mixed_content(@resource.title) %> <span class="label label-info"><%= I18n.t("resource._singular") %></span></h3>
+        <h2><%= clean_mixed_content(@resource.title) %> <span class="label label-info"><%= I18n.t("resource._singular") %></span></h2>
 
         <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:form => readonly} %>
 
         <% define_template "resource", jsonmodel_definition(:resource) do |readonly, resource| %>
           <section id="basic_information">
-            <h4><%= I18n.t("resource._frontend.section.basic_information") %></h4>
+            <h3><%= I18n.t("resource._frontend.section.basic_information") %></h3>
 
             <%= readonly.label_and_textarea "title", :field_opts => { :clean => true, :base_url => url_for(:root), :escape => false} %>
             <% if resource.id_0 %><%= readonly.label_and_fourpartid %><% end %>
@@ -34,7 +34,7 @@
           <%= render_aspace_partial :partial => "extents/show", :locals => { :extents => @resource.extents, :section_id => "resource_extents_" } %>
 
           <section id="finding_aid" class="subrecord-form-dummy">
-            <h4><%= I18n.t("resource._frontend.section.finding_aid") %></h4>
+            <h3><%= I18n.t("resource._frontend.section.finding_aid") %></h3>
             <div class="subrecord-form-container">
               <div class="subrecord-form-fields">
                 <% if resource.ead_id or resource.ead_location %>


### PR DESCRIPTION
## Description
The Basic Information heading and titles are smushed together and have the wrong font size/type for resources, archival objects, digital objects and classifications.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-798

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by navigating to appropriate pages on the staff interface.

## Screenshots (if appropriate):
<img width="1024" alt="screen shot 2018-10-25 at 3 38 33 pm" src="https://user-images.githubusercontent.com/3585151/47534436-3742ea80-d86c-11e8-9631-71d2f014a900.png">
<img width="680" alt="screen shot 2018-10-25 at 3 38 15 pm" src="https://user-images.githubusercontent.com/3585151/47534437-37db8100-d86c-11e8-9a0e-5d82c946d2f5.png">
<img width="965" alt="screen shot 2018-10-25 at 3 37 53 pm" src="https://user-images.githubusercontent.com/3585151/47534438-37db8100-d86c-11e8-8295-9d8a5b060353.png">
<img width="680" alt="screen shot 2018-10-25 at 3 37 34 pm" src="https://user-images.githubusercontent.com/3585151/47534439-37db8100-d86c-11e8-9aa3-c91a8c9980e5.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
