### PR TITLE
Allow event outcome to be blank

### DIFF
--- a/frontend/app/views/events/index.html.erb
+++ b/frontend/app/views/events/index.html.erb
@@ -2,7 +2,7 @@
 
 <%
    add_column(I18n.t("event.event_type"), proc {|record| I18n.t("enumerations.event_event_type.#{record['event_type']}", :default => record['event_type'])}, :sortable => true, :sort_by => "event_type")
-   add_column(I18n.t("event.outcome"), proc {|record| I18n.t("enumerations.event_outcome.#{record['outcome']}", :default => record['outcome'])}, :sortable => true, :sort_by => "outcome")
+   add_column(I18n.t("event.outcome"), proc {|record| record['outcome'] ? I18n.t("enumerations.event_outcome.#{record['outcome']}", :default => record['outcome']) : ''}, :sortable => true, :sort_by => "outcome")
    add_column(I18n.t("linked_agent._plural"),
               proc {|record|
                 event = ASUtils.json_parse(record['json'])
@@ -34,7 +34,7 @@
           <% if user_can?('manage_repository') %>
               <%= link_to I18n.t("actions.edit_default_values"), {:controller => :events, :action => :defaults}, :class => "btn btn-sm btn-default" %>
           <% end %>
-          <%= link_to I18n.t("actions.export_csv"), request.parameters.merge({ :format => :csv}), id: "searchExport",  class:  "btn btn-sm btn-info" %> 
+          <%= link_to I18n.t("actions.export_csv"), request.parameters.merge({ :format => :csv}), id: "searchExport",  class:  "btn btn-sm btn-info" %>
           <%= link_to I18n.t("event._frontend.action.create"), {:controller => :events, :action => :new}, :class => "btn btn-sm btn-default" %>
         </div>
         <br style="clear:both" /> <!-- So dirty! -->

--- a/frontend/app/views/linked_events/_show.html.erb
+++ b/frontend/app/views/linked_events/_show.html.erb
@@ -18,7 +18,7 @@
             <% record = event['_resolved'] %>
             <tr>
               <td><%= I18n.t("enumerations.event_event_type.#{record['event_type']}", :default => record['event_type']) %></td>
-              <td><%= I18n.t("enumerations.event_outcome.#{record['outcome']}", :default => record['outcome']) %></td>
+              <td><%= record['outcome'] ? I18n.t("enumerations.event_outcome.#{record['outcome']}", :default => record['outcome']) : '' %></td>
               <td>
                 <% record['linked_agents'].each do |link| %>
                   <div><%= I18n.t("enumerations.linked_agent_event_roles.#{link['role']}", :default => link['role']) %>:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes linked record and Events > Browse views to account for event outcomes that are blank/NULL.  Added a ternary in the impacted views to confirm that a `record['outcome']` exists *before* attempting to display the translation for that outcome value in the table.  Additionally, I confirmed by pulling records out via the API that, when an outcome is not present in a record, the outcome key does not exist (e.g. it's just not there, not it's there but is blank).

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Partial fix for: https://archivesspace.atlassian.net/browse/ANW-778

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
An outcome is not a required field for an event record, so the outcome column in the staff UI should not assume that there will always be a value to display.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Backend tests passed looked, inspected visually on a local branch.

## Screenshots (if appropriate):

Before change:
<img width="1038" alt="before" src="https://user-images.githubusercontent.com/15144646/47856512-c8aae300-ddbd-11e8-863b-b4e26038a254.png">

After change: 
<img width="1033" alt="after" src="https://user-images.githubusercontent.com/15144646/47856500-c2b50200-ddbd-11e8-98f0-f64b929375bd.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
