### PR TITLE
Make search header message configurable

### DIFF
--- a/public/app/views/shared/_search.html.erb
+++ b/public/app/views/shared/_search.html.erb
@@ -5,7 +5,7 @@
 <div class="search" role="search">
   <a name="search" id="search"></a>
   <% if show_header %>
-  <h<%= header_size %>><%=  t('actions.search') %>  <%= title %> </h<%= header_size %>>
+  <h<%= header_size %>><%=  t('actions.search_header') %></h<%= header_size %>>
   <% end %>
   <% @search = Search.new unless defined?(@search) %>
   <%= form_tag(app_prefix("#{search_url}"), method: 'get', :id => 'advanced_search') do %>

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
 
   actions:
     search: Search
+    search_header: Search The Archives
     search_within: Search within results
     search_in: "Search %{type}"
     new_search: New Search


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The current header on the `/search?reset=true` search page wasn't easily customized. This changes that with a new locale and a change to the _search.html.erb file.

<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Trying to change "Search The Archives" was nearly impossible. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Brought up build locally and tested. The message is unchanged from the original, but it is now easily changed via en.yml

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
