### PR TITLE
ANW-793: OAI ListSets only returns sets that are included by at least one repo

### DIFF
--- a/backend/app/lib/oai/aspace_oai_repository.rb
+++ b/backend/app/lib/oai/aspace_oai_repository.rb
@@ -72,7 +72,9 @@ class ArchivesSpaceOAIRepository < OAI::Provider::Model
                               .select(:oai_sets_available)
                               .map {|r| JSON::parse(r[:oai_sets_available]) rescue [] }
 
-    # if oai_sets_enabled array is blank, then all sets are enabled for that repo
+    # if oai_sets_available array is blank, then all sets are enabled for that repository.
+    # if a repository is restricted to certain sets, then those set_ids will be in the oai_sets_available array.
+    # So, we're looking to see if there is at least one repository with an empty set OR this set_id in the oai_sets_available array.
     set_id = BackendEnumSource.id_for_value("archival_record_level", set.name).to_s
 
     repos_enabling_set = sets_in_repos.select {|r| r.length == 0 || r.include?(set_id)}

--- a/backend/app/lib/oai/aspace_oai_repository.rb
+++ b/backend/app/lib/oai/aspace_oai_repository.rb
@@ -62,7 +62,22 @@ class ArchivesSpaceOAIRepository < OAI::Provider::Model
       OAI::Set.new(:name => level, :spec => level)
     }
 
-    config_sets + level_sets
+    config_sets + level_sets.select {|s| set_enabled?(s) }
+  end
+
+  # returns true if set is enabled in at least one repository
+  def set_enabled?(set)
+    sets_in_repos = Repository.exclude(:publish => 0)
+                              .exclude(:oai_is_disabled => 1)
+                              .select(:oai_sets_available)
+                              .map {|r| JSON::parse(r[:oai_sets_available]) rescue [] }
+
+    # if oai_sets_enabled array is blank, then all sets are enabled for that repo
+    set_id = BackendEnumSource.id_for_value("archival_record_level", set.name).to_s
+
+    repos_enabling_set = sets_in_repos.select {|r| r.length == 0 || r.include?(set_id)}
+
+    return repos_enabling_set.length > 0
   end
 
   def fetch_single_record(uri, options = {})

--- a/backend/spec/model_oai_spec.rb
+++ b/backend/spec/model_oai_spec.rb
@@ -440,12 +440,16 @@ describe 'OAI handler' do
     before(:all) do
       # 891 is the enum_value_id for 'fonds'
       # add a set restriction for only 'fonds' objects
-      Repository.where(:id => 3).update(:oai_sets_available => ([891]).to_json)
+      Repository.all.each do |r|
+        r.update(:oai_sets_available => (["891"]).to_json)
+      end
     end
 
     after(:all) do
       # change things back: remove all set restrictions
-      Repository.where(:id => 3).update(:oai_sets_available => "[]")
+      Repository.all.each do |r|
+        r.update(:oai_sets_available => "[]")
+      end
     end
 
     it "does not return an object if set excluded from OAI in repo" do
@@ -465,6 +469,49 @@ describe 'OAI handler' do
 
         # should have at least 1 result in XML
         expect(doc.xpath("//xmlns:header[not(@status='deleted')]").length > 0).to be true
+    end
+
+    it "does not list a set in ListSets if that set is not enabled for at least one repository" do
+        uri = "/oai?verb=ListSets"
+        response = get uri
+        doc = Nokogiri::XML(response.body)
+
+        expect(doc.to_s).to match(/<set><setSpec>fonds<\/setSpec>/)
+
+        expect(doc.to_s).to_not match(/<set><setSpec>class<\/setSpec>/)
+        expect(doc.to_s).to_not match(/<set><setSpec>collection<\/setSpec>/)
+        expect(doc.to_s).to_not match(/<set><setSpec>file<\/setSpec>/)
+        expect(doc.to_s).to_not match(/<set><setSpec>item<\/setSpec>/)
+        expect(doc.to_s).to_not match(/<set><setSpec>otherlevel<\/setSpec>/)
+        expect(doc.to_s).to_not match(/<set><setSpec>recordgrp<\/setSpec>/)
+        expect(doc.to_s).to_not match(/<set><setSpec>series<\/setSpec>/)
+        expect(doc.to_s).to_not match(/<set><setSpec>subfonds<\/setSpec>/)
+        expect(doc.to_s).to_not match(/<set><setSpec>subgrp<\/setSpec>/)
+        expect(doc.to_s).to_not match(/<set><setSpec>subseries<\/setSpec>/)
+    end
+  end
+
+  describe "repository without sets disabled" do
+    it "does list a set in ListSets if that set is enabled for at least one repository" do
+        Repository.all.each do |r|
+          r.update(:oai_sets_available => "[]")
+        end
+
+        uri = "/oai?verb=ListSets"
+        response = get uri
+        doc = Nokogiri::XML(response.body)
+
+        expect(doc.to_s).to match(/<set><setSpec>fonds<\/setSpec>/)
+        expect(doc.to_s).to match(/<set><setSpec>class<\/setSpec>/)
+        expect(doc.to_s).to match(/<set><setSpec>collection<\/setSpec>/)
+        expect(doc.to_s).to match(/<set><setSpec>file<\/setSpec>/)
+        expect(doc.to_s).to match(/<set><setSpec>item<\/setSpec>/)
+        expect(doc.to_s).to match(/<set><setSpec>otherlevel<\/setSpec>/)
+        expect(doc.to_s).to match(/<set><setSpec>recordgrp<\/setSpec>/)
+        expect(doc.to_s).to match(/<set><setSpec>series<\/setSpec>/)
+        expect(doc.to_s).to match(/<set><setSpec>subfonds<\/setSpec>/)
+        expect(doc.to_s).to match(/<set><setSpec>subgrp<\/setSpec>/)
+        expect(doc.to_s).to match(/<set><setSpec>subseries<\/setSpec>/)
     end
   end
 end


### PR DESCRIPTION
## Description
Previously, ListSets just returned a list of all sets that are defined.

Changes add a check against the repositories defined, such that a set is only included in ListSets results if it is enabled in at least one repository.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-793

## Motivation and Context
This fix is necessary after the ability to turn off OAI for certain sets was added. 

## How Has This Been Tested?
This has been tested by setting all repos to only enable a single set, and then running an OAI ListSets query against it, affirming the correct result.

Also tested setting a repo to allow all sets, and affirming that correct result as well.

Unit test added to model_oai_spec.rb.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
