### PR TITLE
ANW-794: Omit entities from OAI that have unpublished ancestors

### DIFF
--- a/backend/app/lib/oai/aspace_oai_repository.rb
+++ b/backend/app/lib/oai/aspace_oai_repository.rb
@@ -91,9 +91,21 @@ class ArchivesSpaceOAIRepository < OAI::Provider::Model
     RequestContext.open(:repo_id => repo_id) do
       obj = add_visibility_restrictions(model.filter(:id => parsed_ref[:id])).first
 
-      raise OAI::IdException.new unless obj
+      # ANW-794: In several places in this class, we're querying the database directly for an object. 
+      # add_visibility_restrictions is taking care of checking repository level restrictions, but it's not looking for unpublished ancestors.
+      # The process of getting JSON for a Sequel object automatically does this check. 
+      # So, here we rearrange things a bit so we can get the JSON before the ArchivesSpaceOAIRecord is created to see if it has an unpublished ancestor.
+      if obj
+        json = fetch_jsonmodels(model, [obj])[0]
 
-      ArchivesSpaceOAIRecord.new(obj, fetch_jsonmodels(model, [obj])[0])
+        if json && !json["has_unpublished_ancestor"]
+          ArchivesSpaceOAIRecord.new(obj, json)
+        else
+          raise OAI::IdException.new # because unpub ancestor found
+        end
+      else
+        raise OAI::IdException.new # because obj not found
+      end
     end
   end
 
@@ -228,7 +240,10 @@ class ArchivesSpaceOAIRepository < OAI::Provider::Model
       matches = matches.take(limit)
 
       matches.zip(fetch_jsonmodels(record_type, matches)).each do |obj, json|
-        matched_records << ArchivesSpaceOAIRecord.new(obj, json)
+        # ANW:794: Only include in record set if object does not have an unpublished ancestor
+        if json && !json["has_unpublished_ancestor"]
+          matched_records << ArchivesSpaceOAIRecord.new(obj, json)
+        end
       end
     end
 

--- a/backend/spec/model_oai_spec.rb
+++ b/backend/spec/model_oai_spec.rb
@@ -136,6 +136,16 @@ describe 'OAI handler' do
       end
     end
 
+    it "does not include an identifier in ListIdentifiers for an entity if that entity has an unpublished ancestor" do
+      first_ao = ArchivalObject.first
+      first_ao_root = Resource[first_ao.root_record_id]
+
+      expect(list_identifiers("oai_dc").include?("oai:archivesspace//repositories/#{first_ao.repo_id}/archival_objects/#{first_ao.id}")).to eq(true)
+
+      first_ao_root.update(:publish => 0)
+
+      expect(list_identifiers("oai_dc").include?("oai:archivesspace//repositories/#{first_ao.repo_id}/archival_objects/#{first_ao.id}")).to eq(false)
+    end
   end
 
   describe "ListRecords" do
@@ -158,6 +168,23 @@ describe 'OAI handler' do
     it "supports an unqualified ListRecords request" do
       response = oai_repo.find(:all, {:metadata_prefix => "oai_dc"})
       expect(response.records.length).to eq(page_size)
+    end
+
+    it "does not list a record in ListRecords if it has an unpublished ancestor" do
+      first_ao = ArchivalObject.first
+      first_ao_root = Resource[first_ao.root_record_id]
+
+      response = oai_repo.find(:all, {:metadata_prefix => "oai_dc"})
+      response_uris = response.records.map { |r| r.jsonmodel_record["uri"] }
+
+      expect(response_uris.include?("/repositories/#{first_ao.repo_id}/archival_objects/#{first_ao.id}")).to eq(true)
+
+      first_ao_root.update(:publish => 0)
+
+      response_2 = oai_repo.find(:all, {:metadata_prefix => "oai_dc"})
+      response_2_uris = response_2.records.map { |r| r.jsonmodel_record["uri"] }
+
+      expect(response_2_uris.include?("/repositories/#{first_ao.repo_id}/archival_objects/#{first_ao.id}")).to eq(false)
     end
 
     it "supports resumption tokens" do
@@ -406,6 +433,20 @@ describe 'OAI handler' do
       expect(response.body).not_to match(/note with unpublished parent node/)
     end
 
+    it "does not publish objects via GetRecord with if it has a unpublished ancestor" do
+      first_ao = ArchivalObject.first
+      first_ao_root = Resource[first_ao.root_record_id]
+
+      uri = "/oai?verb=GetRecord&identifier=oai:archivesspace/#{first_ao.uri}&metadataPrefix=oai_dc"
+
+      response = get uri
+      expect(response.body).to_not match(/<error code="idDoesNotExist">/)
+
+      first_ao_root.update(:publish => 0)
+
+      response2 = get uri
+      expect(response2.body).to match(/<error code="idDoesNotExist">/)
+    end
   end
 
   describe "respository with OAI harvesting disabled" do


### PR DESCRIPTION
## Description
Use has_unpublished_ancestor flag in JSON to determine if a record should be included in OAI result set for ListIdentifiers, ListRecords, and GetRecords.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-794

## Motivation and Context
OAI result sets were including entities with unpublished ancestors, which is incorrect behavior.

## How Has This Been Tested?
Tested on development instance by running an OAI ListIdentifier, ListRecord, and GetRecord query on an ArchivalObject. 

Verified that when the AO's root Resource was unpublished, the AO was omitted from all three queries.

Also verified that when AO's root Resource was REpublished, the AO was once again present in all three queries. 

Wrote unit tests for all three cases.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
