### PR TITLE
Add a .top_level? method to ASModels

### DIFF
--- a/backend/app/model/ASModel.rb
+++ b/backend/app/model/ASModel.rb
@@ -36,7 +36,16 @@ module ASModel
     base.include(ObjectGraph)
     base.include(Relationships)
 
+    base.extend(ClassMethods)
+
     @@all_models << base
+  end
+
+
+  module ClassMethods
+    def top_level?
+      respond_to?(:has_jsonmodel?) && has_jsonmodel? && my_jsonmodel.schema.has_key?('uri')
+    end
   end
 
 end

--- a/backend/app/model/ASModel_sequel.rb
+++ b/backend/app/model/ASModel_sequel.rb
@@ -11,7 +11,7 @@ module ASModel
     # top-level records upon save.  Pure-nested records don't need refreshing,
     # so skip them.
     def _save_refresh
-      if self.class.top_level?
+      if self.class.is_a?(ASModel) && self.class.top_level?
         _refresh(this.opts[:server] ? this : this.server(:default))
       end
     end

--- a/backend/app/model/ASModel_sequel.rb
+++ b/backend/app/model/ASModel_sequel.rb
@@ -11,7 +11,7 @@ module ASModel
     # top-level records upon save.  Pure-nested records don't need refreshing,
     # so skip them.
     def _save_refresh
-      if self.class.respond_to?(:has_jsonmodel?) && self.class.has_jsonmodel? && self.class.my_jsonmodel.schema['uri']
+      if self.class.top_level?
         _refresh(this.opts[:server] ? this : this.server(:default))
       end
     end

--- a/backend/spec/asmodel_spec.rb
+++ b/backend/spec/asmodel_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'ASModel' do
+
+  it "knows if it is a top level model" do
+    # some top level models
+    expect(Repository.top_level?).to eq(true)
+    expect(Accession.top_level?).to eq(true)
+    expect(Resource.top_level?).to eq(true)
+    expect(ArchivalObject.top_level?).to eq(true)
+    expect(DigitalObject.top_level?).to eq(true)
+    expect(DigitalObjectComponent.top_level?).to eq(true)
+    expect(TopContainer.top_level?).to eq(true)
+    expect(Location.top_level?).to eq(true)
+    expect(Subject.top_level?).to eq(true)
+    expect(Assessment.top_level?).to eq(true)
+
+    # some nested models
+    expect(Instance.top_level?).to eq(false)
+    expect(Extent.top_level?).to eq(false)
+    expect(UserDefined.top_level?).to eq(false)
+    expect(SubContainer.top_level?).to eq(false)
+    expect(ASDate.top_level?).to eq(false)
+  end
+
+end


### PR DESCRIPTION
This provides a consistent way to test whether a model is top level - as opposed to nested.

The test is that the model has a corresponding jsonmodel and the
jsonmodel's schema has a uri property.


## Description
See above

## Related JIRA Ticket or GitHub Issue
None

## Motivation and Context
See above

## How Has This Been Tested?
Implemented a unit test
Ran the tests

## Screenshots (if appropriate):
None

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.