### PR TITLE
Object graph filtering

### DIFF
--- a/backend/app/model/ASModel_object_graph.rb
+++ b/backend/app/model/ASModel_object_graph.rb
@@ -142,7 +142,7 @@ module ObjectGraph
           if association[:type] != :many_to_many
             nested_model = Kernel.const_get(association[:class_name])
 
-            ids = nested_model.filter(association[:key] => object_graph.ids_for(model)).
+            ids = opts.fetch(nested_model, nested_model).filter(association[:key] => object_graph.ids_for(model)).
                                select(:id).map {|row|
               row[:id]
             }

--- a/backend/app/model/mixins/agent_names.rb
+++ b/backend/app/model/mixins/agent_names.rb
@@ -35,13 +35,13 @@ module AgentNames
 
   module ClassMethods
 
-    def calculate_object_graph(object_graph, opts = {})
+    def calculate_object_graph(object_graph, filters = {})
       super
 
       # Add the rows for authority IDs too
       column = "#{self.table_name}_id".intern
 
-      ids = opts.fetch(NameAuthorityId, NameAuthorityId).filter(column => object_graph.ids_for(self)).
+      ids = filters.fetch(NameAuthorityId, NameAuthorityId).filter(column => object_graph.ids_for(self)).
                             map {|row| row[:id]}
 
       object_graph.add_objects(NameAuthorityId, ids)

--- a/backend/app/model/mixins/agent_names.rb
+++ b/backend/app/model/mixins/agent_names.rb
@@ -41,7 +41,7 @@ module AgentNames
       # Add the rows for authority IDs too
       column = "#{self.table_name}_id".intern
 
-      ids = NameAuthorityId.filter(column => object_graph.ids_for(self)).
+      ids = opts.fetch(NameAuthorityId, NameAuthorityId).filter(column => object_graph.ids_for(self)).
                             map {|row| row[:id]}
 
       object_graph.add_objects(NameAuthorityId, ids)

--- a/backend/app/model/mixins/notes.rb
+++ b/backend/app/model/mixins/notes.rb
@@ -313,13 +313,13 @@ module Notes
     end
 
 
-    def calculate_object_graph(object_graph, opts = {})
+    def calculate_object_graph(object_graph, filters = {})
       super
 
       column = "#{self.table_name}_id".intern
 
-      ids = opts.fetch(Note, Note).filter(column => object_graph.ids_for(self)).
-                 map {|row| row[:id]}
+      ids = filters.fetch(Note, Note).filter(column => object_graph.ids_for(self)).
+                    map {|row| row[:id]}
 
       object_graph.add_objects(Note, ids)
     end

--- a/backend/app/model/mixins/notes.rb
+++ b/backend/app/model/mixins/notes.rb
@@ -318,7 +318,7 @@ module Notes
 
       column = "#{self.table_name}_id".intern
 
-      ids = Note.filter(column => object_graph.ids_for(self)).
+      ids = opts.fetch(Note, Note).filter(column => object_graph.ids_for(self)).
                  map {|row| row[:id]}
 
       object_graph.add_objects(Note, ids)

--- a/backend/app/model/mixins/relationships.rb
+++ b/backend/app/model/mixins/relationships.rb
@@ -201,14 +201,14 @@ AbstractRelationship = Class.new(Sequel::Model) do
 
   # Return the list of relationships involving any of the records named in
   # 'participant_ids'
-  def self.find_by_participant_ids(participant_model, participant_ids)
+  def self.find_by_participant_ids(participant_model, participant_ids, opts = {})
     result = []
 
     return result if participant_ids.empty?
     reference_columns = self.reference_columns_for(participant_model)
 
     reference_columns.each do |col|
-      self.filter(col => participant_ids).each do |relationship|
+      opts.fetch(self, self).filter(col => participant_ids).each do |relationship|
         result << relationship
       end
     end
@@ -456,7 +456,7 @@ module Relationships
         object_graph.each do |model, id_list|
           next unless relationship_defn.participating_models.include?(model)
 
-          linked_relationships = relationship_defn.find_by_participant_ids(model, id_list).map {|row|
+          linked_relationships = relationship_defn.find_by_participant_ids(model, id_list, opts).map {|row|
             row[:id]
           }
 

--- a/backend/app/model/mixins/relationships.rb
+++ b/backend/app/model/mixins/relationships.rb
@@ -201,14 +201,14 @@ AbstractRelationship = Class.new(Sequel::Model) do
 
   # Return the list of relationships involving any of the records named in
   # 'participant_ids'
-  def self.find_by_participant_ids(participant_model, participant_ids, opts = {})
+  def self.find_by_participant_ids(participant_model, participant_ids, filters = {})
     result = []
 
     return result if participant_ids.empty?
     reference_columns = self.reference_columns_for(participant_model)
 
     reference_columns.each do |col|
-      opts.fetch(self, self).filter(col => participant_ids).each do |relationship|
+      filters.fetch(self, self).filter(col => participant_ids).each do |relationship|
         result << relationship
       end
     end
@@ -447,7 +447,7 @@ module Relationships
   module ClassMethods
 
 
-    def calculate_object_graph(object_graph, opts = {})
+    def calculate_object_graph(object_graph, filters = {})
       # For each relationship involving a resource
       self.relationships.each do |relationship_defn|
         # Find any relationship of this type involving any record mentioned in
@@ -456,7 +456,7 @@ module Relationships
         object_graph.each do |model, id_list|
           next unless relationship_defn.participating_models.include?(model)
 
-          linked_relationships = relationship_defn.find_by_participant_ids(model, id_list, opts).map {|row|
+          linked_relationships = relationship_defn.find_by_participant_ids(model, id_list, filters).map {|row|
             row[:id]
           }
 

--- a/backend/app/model/mixins/tree_nodes.rb
+++ b/backend/app/model/mixins/tree_nodes.rb
@@ -456,8 +456,7 @@ module TreeNodes
     def calculate_object_graph(object_graph, opts = {})
       object_graph.each do |model, id_list|
         next if self != model
-
-        ids = self.any_repo.filter(:parent_id => id_list).
+        ids = self.any_repo(opts.fetch(self, nil)).filter(:parent_id => id_list).
                    select(:id).map {|row|
           row[:id]
         }

--- a/backend/app/model/mixins/tree_nodes.rb
+++ b/backend/app/model/mixins/tree_nodes.rb
@@ -453,10 +453,10 @@ module TreeNodes
     end
 
 
-    def calculate_object_graph(object_graph, opts = {})
+    def calculate_object_graph(object_graph, filters = {})
       object_graph.each do |model, id_list|
         next if self != model
-        ids = self.any_repo(opts.fetch(self, nil)).filter(:parent_id => id_list).
+        ids = self.any_repo(filters.fetch(self, nil)).filter(:parent_id => id_list).
                    select(:id).map {|row|
           row[:id]
         }

--- a/backend/app/model/mixins/trees.rb
+++ b/backend/app/model/mixins/trees.rb
@@ -355,10 +355,10 @@ module Trees
     end
 
 
-    def calculate_object_graph(object_graph, opts = {})
+    def calculate_object_graph(object_graph, filters = {})
       object_graph.each do |model, id_list|
         next if self != model
-        ids = node_model.any_repo(opts.fetch(node_model, nil)).filter(:root_record_id => id_list).
+        ids = node_model.any_repo(filters.fetch(node_model, nil)).filter(:root_record_id => id_list).
                          select(:id).map {|row|
           row[:id]
         }

--- a/backend/app/model/mixins/trees.rb
+++ b/backend/app/model/mixins/trees.rb
@@ -358,8 +358,7 @@ module Trees
     def calculate_object_graph(object_graph, opts = {})
       object_graph.each do |model, id_list|
         next if self != model
-
-        ids = node_model.any_repo.filter(:root_record_id => id_list).
+        ids = node_model.any_repo(opts.fetch(node_model, nil)).filter(:root_record_id => id_list).
                          select(:id).map {|row|
           row[:id]
         }

--- a/backend/spec/asmodel_object_graph_filtering_spec.rb
+++ b/backend/spec/asmodel_object_graph_filtering_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe 'Object graph filtering' do
+
+  let!(:resource) {
+    create(:json_resource, :publish => true)
+  }
+
+  let!(:series_1) {
+    create(:json_archival_object, :resource => {:ref => resource.uri}, :publish => true, :title => "Series 1")
+  }
+
+  let!(:series_2) {
+    create(:json_archival_object, :resource => {:ref => resource.uri}, :publish => true, :title => "Series 2")
+
+  }
+
+  let!(:series_1_child_1) {
+    create(:json_archival_object,
+           :resource => {:ref => resource.uri},
+           :parent => {:ref => series_1.uri},
+           :publish => true,
+           :title => "Series 1 Child 1")
+  }
+
+  let!(:series_1_child_2) {
+    create(:json_archival_object,
+           :resource => {:ref => resource.uri},
+           :parent => {:ref => series_1.uri},
+           :publish => true,
+           :title => "Series 1 Child 2")
+  }
+
+  let!(:series_2_child_1) {
+    create(:json_archival_object,
+           :resource => {:ref => resource.uri},
+           :parent => {:ref => series_2.uri},
+           :publish => true,
+           :title => "Series 2 Child 1")
+  }
+
+  let!(:series_2_child_2) {
+    create(:json_archival_object,
+           :resource => {:ref => resource.uri},
+           :parent => {:ref => series_2.uri},
+           :publish => true,
+           :ref_id => 'EXCLUDE',
+           :title => "Series 2 Child 2")
+  }
+
+  it "supports excluding items from the graph" do
+
+    filters = {}
+    filters[ArchivalObject] = ArchivalObject.exclude(:ref_id => 'EXCLUDE')
+
+    og = Resource[resource.id].object_graph(filters)
+
+    og.ids_for(ArchivalObject).should eq ([1,2,3,4,5])
+
+  end
+
+end

--- a/backend/spec/asmodel_object_graph_filtering_spec.rb
+++ b/backend/spec/asmodel_object_graph_filtering_spec.rb
@@ -3,11 +3,13 @@ require 'spec_helper'
 describe 'Object graph filtering' do
 
   let!(:resource) {
-    create(:json_resource, :publish => true)
+    create(:json_resource,
+           :publish => true,
+           :extents => [{"portion" => "whole", "number" => "BILLIONS", "extent_type" => "reels"}])
   }
 
   let!(:series_1) {
-    create(:json_archival_object, :resource => {:ref => resource.uri}, :publish => true, :title => "Series 1")
+    create(:json_archival_object, :resource => {:ref => resource.uri}, :publish => false, :title => "Series 1")
   }
 
   let!(:series_2) {
@@ -19,15 +21,16 @@ describe 'Object graph filtering' do
     create(:json_archival_object,
            :resource => {:ref => resource.uri},
            :parent => {:ref => series_1.uri},
-           :publish => true,
-           :title => "Series 1 Child 1")
+           :publish => false,
+           :title => "Series 1 Child 1",
+           :extents => [{"portion" => "whole", "number" => "ONE", "extent_type" => "reels"}])
   }
 
   let!(:series_1_child_2) {
     create(:json_archival_object,
            :resource => {:ref => resource.uri},
            :parent => {:ref => series_1.uri},
-           :publish => true,
+           :publish => false,
            :title => "Series 1 Child 2")
   }
 
@@ -48,15 +51,45 @@ describe 'Object graph filtering' do
            :title => "Series 2 Child 2")
   }
 
-  it "supports excluding items from the graph" do
-
+  it "supports excluding items" do
     filters = {}
     filters[ArchivalObject] = ArchivalObject.exclude(:ref_id => 'EXCLUDE')
 
     og = Resource[resource.id].object_graph(filters)
 
-    og.ids_for(ArchivalObject).should eq ([1,2,3,4,5])
-
+    og.ids_for(ArchivalObject).length.should eq (5)
   end
 
+
+  it "supports excluding items based on multiple criteria" do
+    filters = {}
+    filters[ArchivalObject] = ArchivalObject.exclude(:ref_id => 'EXCLUDE')
+                                            .filter(:publish => 1)
+
+    og = Resource[resource.id].object_graph(filters)
+
+    og.ids_for(ArchivalObject).length.should eq (2)
+  end
+
+
+  it "supports excluding nested records" do
+    filters = {}
+    filters[Extent] = Extent.exclude(:number => 'BILLIONS')
+
+    og = Resource[resource.id].object_graph(filters)
+
+    og.ids_for(Extent).length.should eq (1)
+  end
+
+
+  it "supports multiple model filters" do
+    filters = {}
+    filters[Extent] = Extent.filter(:number => 'ONE')
+    filters[ArchivalObject] = ArchivalObject.filter(:publish => 0)
+
+    og = Resource[resource.id].object_graph(filters)
+
+    og.ids_for(ArchivalObject).length.should eq (3)
+    og.ids_for(Extent).length.should eq (1)
+  end
 end


### PR DESCRIPTION
Introducing the ability to provide filters to the .object_graph method.

## Description
The .object_graph method (and implementations of .calculate_object_graph)
now accepts an optional 'filters' argument.
This is a hash whose keys are model classes and whose values are datasets
on the respective model. This allows for filtering out objects from the graph.

For example:
   Resource[id].object_graph({ArchivalObject => ArchivalObject.filter(:publish => 1)})

This call to .object_graph will only return published ArchivalObjects. All other
models in the graph will be unaffected.

## Related JIRA Ticket or GitHub Issue
None

## Motivation and Context
Sometimes is it desirable to filter objects out of an object graph based on criteria.
Since .object_graph only returns arrays of ids there is no efficient way to do this after the fact.

## How Has This Been Tested?
Ran the tests - they passed.
Implemented tests specifically for this change.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.