### PR TITLE
Give defined relationship classes names.

### DIFF
--- a/backend/app/model/mixins/relationships.rb
+++ b/backend/app/model/mixins/relationships.rb
@@ -535,6 +535,11 @@ module Relationships
           model.include(Relationships)
           model.add_relationship_dependency(opts[:name], base)
         end
+
+        # Give the new relationship class a name to help with debugging
+        # Example: Relationships::ResourceSubject
+        Relationships.const_set(self.name + opts[:name].to_s.camelize, clz)
+
       end
     end
 

--- a/backend/spec/model_relationships_spec.rb
+++ b/backend/spec/model_relationships_spec.rb
@@ -59,6 +59,11 @@ describe 'Relationships' do
     $testdb.drop_table(:cherry)
     $testdb.drop_table(:fruit_salad_rlshp)
     $testdb.drop_table(:friends_rlshp)
+
+    Relationships.send(:remove_const, :BananaFruitSalad)
+    Relationships.send(:remove_const, :BananaFriends)
+    Relationships.send(:remove_const, :AppleFruitSalad)
+    Relationships.send(:remove_const, :AppleFriends)
   end
 
 
@@ -430,4 +435,13 @@ describe 'Relationships' do
     archival_object.refresh
     expect((archival_object.system_mtime.to_f * 1000).to_i).not_to eq(start_time)
   end
+
+
+  it "gives defined relationship classes names" do
+    expect{Relationships::BananaFruitSalad}.to_not raise_error
+    expect{Relationships::BananaFriends}.to_not raise_error
+    expect{Relationships::AppleFruitSalad}.to_not raise_error
+    expect{Relationships::AppleFriends}.to_not raise_error
+  end
+
 end


### PR DESCRIPTION
Previously these have been anonymous clasees which can make them
tricky to identify when debugging. This change gives each relationship
class a name in the `Relationships` module. For example:

```
  Relationships::ResourceSubject
```

Where the first part `Resource` is the name of the model on which
the relationship is defined, and the second part `Subject` is the
name of the defined relationship.

## Description
See above

## Related JIRA Ticket or GitHub Issue
None

## Motivation and Context
See above

## How Has This Been Tested?
Ran the tests - they passed
Provided a test for the change

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
