### PR TITLE
ANW-720 Show links between Staff and PUI when using localhost

### DIFF
--- a/frontend/app/views/site/_footer.html.erb
+++ b/frontend/app/views/site/_footer.html.erb
@@ -1,7 +1,7 @@
 <div class="container-fluid footer">
    <div class="row">
       <div class="col-md-12">
-        <p><% if AppConfig[:enable_public] and not proxy_localhost? %>View <a href="<%= AppConfig[:public_proxy_url] %>">Public Interface</a> | <% end %>Visit <a href="http://archivesspace.org">ArchivesSpace.org</a> | <%= ASConstants.VERSION %> |<% if AppConfig[:feedback_url] && !AppConfig[:feedback_url].blank? %> <a id='aspaceFeedbackLink' href='http://archivesspace.org/feedback' target='_blank'>Send Feedback or Report a Problem</a> <% end %></p>
+        <p><% if AppConfig[:enable_public] %>View <a href="<%= AppConfig[:public_proxy_url] %>">Public Interface</a> | <% end %>Visit <a href="http://archivesspace.org">ArchivesSpace.org</a> | <%= ASConstants.VERSION %> |<% if AppConfig[:feedback_url] && !AppConfig[:feedback_url].blank? %> <a id='aspaceFeedbackLink' href='http://archivesspace.org/feedback' target='_blank'>Send Feedback or Report a Problem</a> <% end %></p>
       </div>
    </div>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

This asdds a link to the public interface to the footer in the staff interface when you're running on localhost.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

This is for ANW-720. 
https://archivesspace.atlassian.net/browse/ANW-720

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In the standard application, the public interface footer includes a link back to the staff interface. The staff interface footer should do the same. Links on the staff interface footer should also be blue and underlined like on the PUI side. Basically, we want to have consistency of look and function of the footer on both sides of the application.

Most institutions in production will customize this footer, but this will improve the trial and testing experience.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran both source and created a build with the change, footer had links as exepected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
