### PR TITLE
Fixes Leading Spaces in File URI Break Links To Digital Objects PUI  

### DIFF
--- a/public/app/controllers/concerns/result_info.rb
+++ b/public/app/controllers/concerns/result_info.rb
@@ -164,7 +164,7 @@ module ResultInfo
       embed_caption = ''
       rep_caption = ''
       json['file_versions'].each do |version|
-        if version.dig('publish') != false && version['file_uri'].start_with?('http')
+        if version.dig('publish') != false && version['file_uri'].strip.start_with?('http')
           if version.dig('xlink_show_attribute') == 'embed'
             dig_f['thumb'] = version['file_uri']
             dig_f['represent'] = 'embed' if version['is_representative']

--- a/public/app/controllers/concerns/result_info.rb
+++ b/public/app/controllers/concerns/result_info.rb
@@ -164,7 +164,8 @@ module ResultInfo
       embed_caption = ''
       rep_caption = ''
       json['file_versions'].each do |version|
-        if version.dig('publish') != false && version['file_uri'].strip.start_with?('http')
+        version['file_uri'].strip!
+        if version.dig('publish') != false && version['file_uri'].start_with?('http')
           if version.dig('xlink_show_attribute') == 'embed'
             dig_f['thumb'] = version['file_uri']
             dig_f['represent'] = 'embed' if version['is_representative']


### PR DESCRIPTION
ANW-728 - If you somehow manage to accidentally put a space before the http in the "File URI" of a digital object, the PUI chokes and won't display the red icon thinger to link out the digital object to the url.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the `strip` to the `file_uri` so it displays even with a space in the record in the DB

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-728

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Sometimes someone just drops a space where it shouldn't be, we've all done that. This just cleans that up in the digital object page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in running source and making changes to a record to include a space and random other things to see if anything broke. Did not break.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
