### PR TITLE
Clarify role of abstract_archival_object schema

### DIFF
--- a/common/schemas/abstract_archival_object.rb
+++ b/common/schemas/abstract_archival_object.rb
@@ -1,3 +1,5 @@
+# This is the parent schema for the four primary archival record types: resources, archival objects, digital objects, and digital object components.
+
 {
   :schema => {
     "$schema" => "http://www.archivesspace.org/archivesspace.json",

--- a/common/schemas/archival_object.rb
+++ b/common/schemas/archival_object.rb
@@ -1,3 +1,5 @@
+# Schema inherits from the abstract_archival_object schema, and must only include extensions/overrides unique to archival object records.
+
 {
   :schema => {
     "$schema" => "http://www.archivesspace.org/archivesspace.json",

--- a/common/schemas/digital_object.rb
+++ b/common/schemas/digital_object.rb
@@ -1,3 +1,5 @@
+# Schema inherits from the abstract_archival_object schema, and must only include extensions/overrides unique to digital object records.
+
 {
   :schema => {
     "$schema" => "http://www.archivesspace.org/archivesspace.json",

--- a/common/schemas/digital_object_component.rb
+++ b/common/schemas/digital_object_component.rb
@@ -1,3 +1,5 @@
+# Schema inherits from the abstract_archival_object schema, and must only include extensions/overrides unique to digital object component records.
+
 {
   :schema => {
     "$schema" => "http://www.archivesspace.org/archivesspace.json",
@@ -9,7 +11,7 @@
 
       "component_id" => {"type" => "string", "maxLength" => 255},
       "label" => {"type" => "string", "maxLength" => 255},
-      "title" => {"type" => "string", "maxLength" => 16384, "ifmissing" => nil},
+      "title" => {"type" => "string", "ifmissing" => nil},
       "display_string" => {"type" => "string", "maxLength" => 8192, "readonly" => true},
 
       "file_versions" => {"type" => "array", "items" => {"type" => "JSONModel(:file_version) object"}},

--- a/common/schemas/resource.rb
+++ b/common/schemas/resource.rb
@@ -1,3 +1,5 @@
+# Schema inherits from the abstract_archival_object schema, and must only include extensions/overrides unique to resource records.
+
 {
   :schema => {
     "$schema" => "http://www.archivesspace.org/archivesspace.json",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Minor tweak to clarify that abstract_archival_object is the parent schema for the four major archival record types: resources, archival objects, digital objects, and digital object components.

## Description
<!--- Describe your changes in detail -->
Also includes small tweak to remove duplicative information from digital object component schema.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It was not obvious by naming convention that this abstract schema applied to the four major record types.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Confirmed no changes were noticeable within the application.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
