### PR TITLE
Have indexer log Solr errors, not raise them

### DIFF
--- a/indexer/app/lib/fake_solr_timeout_response.rb
+++ b/indexer/app/lib/fake_solr_timeout_response.rb
@@ -1,0 +1,27 @@
+require 'net/http'
+# This is a faked response for a solr timeout. Why? In some cases, Solr will
+# timeout, but there will be no response. Instead Ruby will raise a
+# Timeout::Error, which the indexer does not handle, causing the indexer to
+# crash in the index round. Instead we will rescue the timeout error and return
+# this faked response.
+class FakeSolrTimeoutResponse < Net::HTTPRequestTimeOut
+
+    def initialize(req)
+      @req = req 
+      super('1.0', '408', 'SOLR TIMEOUT ERROR') 
+    end
+    
+    
+    # This needs to be added so Net::HTTP stream check passes.
+    def read_body(*args, &block)
+      @body = "
+Timeout error with #{@req.uri} #{@req.method} #{@req.body}.
+Please check your :indexer_solr_timeout_seconds, :indexer_thread_count, and :indexer_records_per_thread settings in 
+your config.rb file.
+Also check https://wiki.apache.org/solr/SolrPerformanceProblems for possible performance issues.
+      " 
+      yield @body if block_given?
+      @body
+    end
+
+end

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -821,13 +821,12 @@ class IndexerCommon
     req.body = delete_request.to_json
 
     response = do_http_request(solr_url, req)
-    Log.info "Deleted #{records.length} documents: #{response}"
 
 
-    if response.code == '408'
-      Log.error response.body
-    elsif response.code != '200'
-      raise "Error when deleting records: #{response.body}"
+    if response.code == '200'
+      Log.info "Deleted #{records.length} documents: #{response}"
+    else
+      Log.error "SolrIndexerError when deleting records: #{response.body}"
     end
   end
 
@@ -980,10 +979,8 @@ class IndexerCommon
         stream.close
         batch.destroy
 
-        if response.code == '408'
-          Log.error response.body
-        elsif response.code != '200'
-          raise "Error when indexing records: #{response.body}"
+        if response.code != '200'
+          Log.error "SolrIndexerError when indexing records: #{response.body}"
         end
       end
     end
@@ -997,13 +994,11 @@ class IndexerCommon
 
     response = do_http_request(solr_url, req)
 
-    if response.code == '408'
-      Log.error response.body
-    elsif response.code != '200'
+    if response.code != '200'
       if response.body =~ /exceeded limit of maxWarmingSearchers/
         Log.info "INFO: #{response.body}"
       else
-        raise "Error when committing: #{response.body}"
+        Log.error "SolrIndexerError when committing: #{response.body}"
       end
     end
   end

--- a/indexer/spec/indexer_common_spec.rb
+++ b/indexer/spec/indexer_common_spec.rb
@@ -341,10 +341,14 @@ describe "indexer common" do
     end
   end
   describe "do_http_request" do
-    it "does http request" do
-      # def do_http_request(url, req)
+    it "should report if there's a timeout but not fail" do
+      solr_url = @ic.solr_url
+      req = Net::HTTP::Post.new("#{solr_url.path}/update")
+      ASHTTP.should_receive(:start_uri).and_raise(Timeout::Error)
+      @ic.do_http_request(solr_url, req)
     end
   end
+
   describe "reset_session" do
     it "resets the session" do
       # def reset_session
@@ -396,8 +400,9 @@ describe "indexer common" do
     end
   end
   describe "send_commit" do
-    it "send commit" do
-      # def send_commit(type = :hard)
+    it "report if there's a timeout but not fail" do
+      ASHTTP.should_receive(:start_uri).and_raise(Timeout::Error)
+      @ic.send_commit
     end
   end
   describe "paused?" do


### PR DESCRIPTION
Redo of https://github.com/archivesspace/archivesspace/pull/1420

## Description

Sometime Solr will return an error, especially if it's under resourced. This will just log the error and not raise it, which allows the indexer to attempt to complete the index round rather than abort and start from the beginning. 

People can search for SolrIndexingError in the logs for these issues. 

## Related JIRA Ticket or GitHub Issue


## Motivation and Context

If there's a solr error, the index round will abort. Then the indexer will start from the beginning, then run into another error, and abort. Then the indexer will start from the beginning, then run into another error, and abort. Etc. 


## How Has This Been Tested?

Tests included.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
