### PR TITLE
ANW-150: export label for physdesc notes in EAD

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -605,10 +605,16 @@ class EADSerializer < ASpaceExport::Serializer
 
       case note['type']
       when 'dimensions', 'physfacet'
+        att[:label] = note['label'] if note['label']
         xml.physdesc(audatt) {
           xml.send(note['type'], att) {
             sanitize_mixed_content( content, xml, fragments, ASpaceExport::Utils.include_p?(note['type'])  )
           }
+        }
+      when 'physdesc'
+        att[:label] = note['label'] if note['label']
+        xml.send(note['type'], att.merge(audatt)) {
+          sanitize_mixed_content(content, xml, fragments,ASpaceExport::Utils.include_p?(note['type']))
         }
       else
         xml.send(note['type'], att.merge(audatt)) {

--- a/backend/app/exporters/serializers/ead3.rb
+++ b/backend/app/exporters/serializers/ead3.rb
@@ -959,8 +959,14 @@ class EAD3Serializer < EADSerializer
 
       case note['type']
       when 'dimensions', 'physfacet'
+        atts[:label] = note['label'] if note['label']
         xml.physdesc(atts) {
           append_note_content.(note, xml, fragments, 'physdesc')
+        }
+      when 'physdesc'
+        atts[:label] = note['label'] if note['label']
+        xml.send(note['type'], atts) {
+          append_note_content.(note, xml, fragments, note['type'])
         }
       when 'langmaterial'
         xml.langmaterial(atts) {

--- a/backend/spec/export_ead3_spec.rb
+++ b/backend/spec/export_ead3_spec.rb
@@ -158,6 +158,7 @@ describe "EAD3 export mappings" do
     while !(note_types - notes.map {|note| note['type']}).empty? && brake < max do
       notes << build("json_note_#{['singlepart', 'multipart', 'multipart_gone_wilde', 'index', 'bibliography'].sample}".intern, {
                        :publish => true,
+                       :label => generate(:alphanumstr),
                        :persistent_id => [nil, generate(:alphanumstr)].sample
                      })
       brake += 1
@@ -613,18 +614,20 @@ describe "EAD3 export mappings" do
       end
 
 
-      # it "maps notes of type 'dimensions' to did/physdesc" do
-      #   notes.select {|n| n['type'] == 'dimensions'}.each_with_index do |note, i|
-      #     content = note_content(note)
-      #     path = "#{desc_path}/did/physdesc[text()='#{content}']"
-      #     mt(content.gsub("<p>",'').gsub("</p>", ""), path, :markup)
-      #     if note['persistent_id']
-      #       mt("aspace_" + note['persistent_id'], path, "id")
-      #     else
-      #       mt(nil, path, "id")
-      #     end
-      #   end
-      # end
+       it "maps notes of type 'dimensions' to did/physdesc" do
+         notes.select {|n| n['type'] == 'dimensions'}.each_with_index do |note, i|
+           content = note_content(note)
+           path = "#{desc_path}/did/physdesc[text()='#{content}']"
+           mt(content.gsub("<p>",'').gsub("</p>", ""), path, :markup)
+           if note['persistent_id']
+             mt("aspace_" + note['persistent_id'], path, "id")
+           else
+             mt(nil, path, "id")
+           end
+           
+          mt(note['label'], path, "label") if note['label']
+         end
+       end
 
 
       it "maps notes of type 'physdesc' to did/physdesc" do
@@ -636,6 +639,8 @@ describe "EAD3 export mappings" do
           else
             mt(nil, path, "id")
           end
+
+          mt(note['label'], path, "label") if note['label']
         end
       end
 
@@ -649,6 +654,8 @@ describe "EAD3 export mappings" do
           else
             mt(nil, path, "id")
           end
+
+          mt(note['label'], path, "label") if note['label']
         end
       end
 

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -163,6 +163,7 @@ describe "EAD export mappings" do
     while !(note_types - notes.map {|note| note['type']}).empty? && brake < max do
       notes << build("json_note_#{['singlepart', 'multipart', 'multipart_gone_wilde', 'index', 'bibliography'].sample}".intern, {
                        :publish => true,
+                       :label => generate(:alphanumstr),
                        :persistent_id => [nil, generate(:alphanumstr)].sample
                      })
       brake += 1
@@ -603,9 +604,10 @@ describe "EAD export mappings" do
           else
             mt(nil, path, "id")
           end
+          
+          mt(note['label'], path, "label") if note['label']
         end
       end
-
 
       it "maps notes of type 'physdesc' to did/physdesc" do
         notes.select {|n| n['type'] == 'physdesc'}.each do |note|
@@ -616,6 +618,8 @@ describe "EAD export mappings" do
           else
             mt(nil, path, "id")
           end
+
+          mt(note['label'], path, "label") if note['label']
         end
       end
 
@@ -669,6 +673,8 @@ describe "EAD export mappings" do
           else
             mt(nil, path, "id")
           end
+          
+          mt(note['label'], path, "label") if note['label']
         end
       end
     end


### PR DESCRIPTION
export label to label attr in physdesc tag for EAD and EAD3 exports for note types:

physdesc
physfacet
dimension

## Description
Updated serializer and specs to include value for label for these note types

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-150

## Motivation and Context
Missing data is now included in export.

## How Has This Been Tested?
I've updated the unit tests, and tested that the missing data is now present manually for both EAD and EAD3 exports

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
