### PR TITLE
ANW-269: Fix finding aid PDF Collection Inventory record display string rendering

### DIFF
--- a/public/app/views/pdf/_archival_object.html.erb
+++ b/public/app/views/pdf/_archival_object.html.erb
@@ -14,7 +14,7 @@ end
 
 <div class="avoid-break">
     <div class="print-record-border print-record level-<%= level %>">
-        <p><a class="record-title" id="<%= record.uri %>"><%= record.display_string %></a></p>
+        <p><a class="record-title" id="<%= record.uri %>"><%== record.display_string %></a></p>
 
         <% Array(record.instances).each do |instance| %>
             <% if instance['sub_container'] %>


### PR DESCRIPTION
## Description
Updated PDF template to use the raw record display string, rather than the (now default) HTML escaped form, so that the tags are 1) not visible and 2) available for CSS styling.

## Related JIRA Ticket or GitHub Issue
[ANW-269](https://archivesspace.atlassian.net/browse/ANW-269) HTML tags are inappropriately generated from the HTML to PDF process for the PUI, but only at the Collection Inventory level.

## Motivation and Context
Fixes problem described in ANW-269. Tags in "Collection Inventory" record display strings were displayed as such, rather than being rendered into the appropriate style by the PDF CSS.

For example, the string: 
`<span class="italic title">Zeniada</span> Notes, 1981`
rendered as
`<span class="italic title">Zeniada</span> Notes, 1981`
rather than
_Zeniada_ Notes, 1981

## How Has This Been Tested?
Generated multiple PDF files that triggered the original error and verified that they render correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
