### PR TITLE
Fixed references to a symbol that is not used

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -497,7 +497,7 @@ AppConfig[:pui_hide][:agents] = false
 AppConfig[:pui_hide][:classifications] = false
 AppConfig[:pui_hide][:search_tab] = false
 # The following determine globally whether the various "badges" appear on the Repository page
-# can be overriden at repository level below (e.g.:  AppConfig[:repos][{repo_code}][:hide][:counts] = true
+# can be overriden at repository level below (e.g.:  AppConfig[:pui_repos][{repo_code}][:hide][:counts] = true
 AppConfig[:pui_hide][:resource_badge] = false
 AppConfig[:pui_hide][:record_badge] = true # hide by default
 AppConfig[:pui_hide][:digital_object_badge] = false

--- a/docs/doc/file.configuration.html
+++ b/docs/doc/file.configuration.html
@@ -1117,7 +1117,7 @@ AppConfig[:pui_hide][:search_tab] = false
 
 <p>The following determine globally whether the various “badges” appear on the Repository page
 can be overriden at repository level below (e.g.:
-<code>AppConfig[:repos][{repo_code}][:hide][:counts] = true</code></p>
+<code>AppConfig[:pui_repos][{repo_code}][:hide][:counts] = true</code></p>
 
 <p><code>
 AppConfig[:pui_hide][:resource_badge] = false

--- a/docs/user/configuring-archivesspace.md
+++ b/docs/user/configuring-archivesspace.md
@@ -1121,7 +1121,7 @@ AppConfig[:pui_hide][:search_tab] = false
 
 The following determine globally whether the various "badges" appear on the Repository page
 can be overriden at repository level below (e.g.:
-`AppConfig[:repos][{repo_code}][:hide][:counts] = true`
+`AppConfig[:pui_repos][{repo_code}][:hide][:counts] = true`
 
 ```
 AppConfig[:pui_hide][:resource_badge] = false


### PR DESCRIPTION
Found all places where the `:repos` Ruby symbol was mentioned, and replaced it with `:pui_repos`. This was due to a mismatch between documentation and the operation of `Repository.badge_list(repo_code)`.

## Motivation

I spent a few hours looking through documentation and code to try to figure out how to hide the "Record Groups" badge for a repository. I eventually found where the AppConfig settings are used to control that display, and noticed that the documented symbol `:repos` was not actually used anywhere.

I hope that fixing the documentation will help save someone else some time.

## Related Quirk

Related to this, you can't directly set the configuration properties like:

```rb
AppConfig[:pui_repos]['{repo_code}'][:hide][:counts] = true
```

`AppConfig[:pui_repos]['{repo_code}']` is Nil by default. You instead have to initialize the Ruby hashes first, or use the implicit form of a Ruby hash.

```rb
AppConfig[:pui_repos]['{repo_code}'] = {}
AppConfig[:pui_repos]['{repo_code}'][:hide] = {}
AppConfig[:pui_repos]['{repo_code}'][:hide][:counts] = true

# alternatively

AppConfig[:pui_repos]['{repo_code}'] = { :hide => { :counts => true } }
```

## Related JIRA Ticket or GitHub Issue

Closes #1449

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation
