### PR TITLE
Add Option for Abstract Note Length

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -153,6 +153,10 @@ AppConfig[:solr_facet_limit] = 100
 AppConfig[:default_page_size] = 10
 AppConfig[:max_page_size] = 250
 
+# An option to change the length of the abstracts on the collections overview page
+# If your Scope & Contents notes are very long you can increase this to show more
+AppConfig[:abstract_note_length] = 500
+
 # A prefix added to cookies used by the application.
 #
 # Change this if you're running more than one instance of ArchivesSpace on the

--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -17,9 +17,9 @@
           end
 	  if !note_struct['note_text'].blank? %>
           <div class="abstract single_note"><span class='inline-label'><%= note_struct['label'] %></span>
-           <% if note_struct['note_text'].length > 500 %>
-             <% truncated_note = note_struct['note_text'][0..499] %>
-             <% end_index = truncated_note.rindex(' ') || 499 %>
+           <% if note_struct['note_text'].length > AppConfig[:abstract_note_length] %>
+             <% truncated_note = note_struct['note_text'][0..AppConfig[:abstract_note_length]-1] %>
+             <% end_index = truncated_note.rindex(' ') || AppConfig[:abstract_note_length]-1 %>
              <%= strip_tags(truncated_note[0..end_index - 1]) + '...' %>
            <% else %>
 	     <%= note_struct['note_text'].html_safe %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This adds a new config.rb variable to change the length of the text on the collection overview page. 

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Some sites have very long scope and contents notes because they have 2 or more languages and have a separate note for each language. Those longer notes need to be displayed even if they're longer than the default. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran from source

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
