### PR TITLE
Fix ampersands in notes to make valid XML

### DIFF
--- a/public/app/views/pdf/_archival_object.html.erb
+++ b/public/app/views/pdf/_archival_object.html.erb
@@ -51,7 +51,7 @@ end
                             <%= I18n.t("enumerations._note_types.#{note_type}") %>
                         <% end %>
                     </h3>
-                    <p><%== note['note_text'] %></p>
+                    <p><%== note['note_text'].gsub(/&(?!amp;)/,'&amp;') %></p>
                 <% end %>
             <% end %>
 
@@ -74,7 +74,7 @@ end
 
                 <% record.notes.each do |note_type, note| %>
                     <% if note_type == 'physdesc' && !note['is_inherited'] %>
-                        <dt><%= I18n.t('resource._public.physdesc') %></dt><dd><%== note['note_text'] %></dd>
+                        <dt><%= I18n.t('resource._public.physdesc') %></dt><dd><%== note['note_text'].gsub(/&(?!amp;)/,'&amp;') %></dd>
                     <% end %>
                 <% end %>
 

--- a/public/app/views/pdf/_resource.html.erb
+++ b/public/app/views/pdf/_resource.html.erb
@@ -29,7 +29,7 @@
     <% record.notes.each do |note_type, note| %>
         <% if note_type == 'physdesc' %>
             <a id="note-<%= note_type %>"></a>
-            <dt><%= I18n.t("enumerations._note_types.#{note_type}") %></dt><dd><%== note['note_text'] %></dd>
+            <dt><%= I18n.t("enumerations._note_types.#{note_type}") %></dt><dd><%== note['note_text'].gsub(/&(?!amp;)/,'&amp;') %></dd>
         <% end %>
     <% end %>
 
@@ -52,7 +52,7 @@
             <%= I18n.t("enumerations._note_types.#{note_type}") %>
         <% end %>
     </h3>
-    <p><%== note['note_text'] %></p>
+    <p><%== note['note_text'].gsub(/&(?!amp;)/,'&amp;') %></p>
 <% end %>
 
 <a id="administrative-information"></a>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
XMLCLEAN fails when it is fed invalid XML. Anything with an ampersand in a string is not valid XML, so we need to make sure we clean those up before sending anything through xmlclean.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-831

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A single & character causes failures like this:
RuntimeError (Failed to clean XML: The reference to entity "ix" must end with the ';' delimiter.):

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
