### PR TITLE
Change to Docker startup script

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -27,5 +27,13 @@ fi
 
 # clear out tmp pre-startup as it can build up if persisted
 rm -rf $DATA_TMP_DIR/*
+
 /archivesspace/scripts/setup-database.sh
+
+if [[ "$?" != 0 ]]; then
+  echo "Error running the database setup script."
+  exit 1
+fi
+
 exec /archivesspace/archivesspace.sh
+

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -36,4 +36,3 @@ if [[ "$?" != 0 ]]; then
 fi
 
 exec /archivesspace/archivesspace.sh
-

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -29,7 +29,6 @@ fi
 rm -rf $DATA_TMP_DIR/*
 
 /archivesspace/scripts/setup-database.sh
-
 if [[ "$?" != 0 ]]; then
   echo "Error running the database setup script."
   exit 1

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -8,12 +8,12 @@ if [[ -v ASPACE_DEPLOY_PKG_URL ]]; then
   if [[ "$?" != 0 ]]; then
     echo "Error downloading deploy package from: $ASPACE_DEPLOY_PKG_URL"
     exit 1
+  else
+    unzip -o /archivesspace/deploy_pkg.zip -d /archivesspace/tmp
+    cp /archivesspace/tmp/config/config.rb /archivesspace/config/config.rb || true
+    cp -r /archivesspace/tmp/plugins/* /archivesspace/plugins/ || true
+    cp /archivesspace/tmp/stylesheets/* /archivesspace/stylesheets/ || true
   fi
-
-  unzip -o /archivesspace/deploy_pkg.zip -d /archivesspace/tmp
-  cp /archivesspace/tmp/config/config.rb /archivesspace/config/config.rb || true
-  cp -r /archivesspace/tmp/plugins/* /archivesspace/plugins/ || true
-  cp /archivesspace/tmp/stylesheets/* /archivesspace/stylesheets/ || true
 fi
 
 # INITIALIZE PLUGINS (optional): ASPACE_INITIALIZE_PLUGINS=plugin1,plugin2,plugin3

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -8,12 +8,12 @@ if [[ -v ASPACE_DEPLOY_PKG_URL ]]; then
   if [[ "$?" != 0 ]]; then
     echo "Error downloading deploy package from: $ASPACE_DEPLOY_PKG_URL"
     exit 1
-  else
-    unzip -o /archivesspace/deploy_pkg.zip -d /archivesspace/tmp
-    cp /archivesspace/tmp/config/config.rb /archivesspace/config/config.rb || true
-    cp -r /archivesspace/tmp/plugins/* /archivesspace/plugins/ || true
-    cp /archivesspace/tmp/stylesheets/* /archivesspace/stylesheets/ || true
   fi
+
+  unzip -o /archivesspace/deploy_pkg.zip -d /archivesspace/tmp
+  cp /archivesspace/tmp/config/config.rb /archivesspace/config/config.rb || true
+  cp -r /archivesspace/tmp/plugins/* /archivesspace/plugins/ || true
+  cp /archivesspace/tmp/stylesheets/* /archivesspace/stylesheets/ || true
 fi
 
 # INITIALIZE PLUGINS (optional): ASPACE_INITIALIZE_PLUGINS=plugin1,plugin2,plugin3


### PR DESCRIPTION
Addresses #1456 

This change causes ArchivesSpace containers to exit if `/archivesspace/scripts/setup-database.sh` fails, allowing Docker to restart the service if the container is running as part of a `docker-compose up` or a `docker stack deploy`.

## How has this been tested?

I am currently substituting this version of the `docker-startup.sh` into my production ArchivesSpace containers. I'll gladly take a crack at adding a test for this to Travis if you feel it is necessary.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
