### PR TITLE
ANW-818: Store relative path for job files in stead of absolute

### DIFF
--- a/backend/app/controllers/job.rb
+++ b/backend/app/controllers/job.rb
@@ -216,7 +216,7 @@ class ArchivesSpaceService < Sinatra::Base
     file = JobFile.filter(  :id => params[:file_id], :job_id => params[:id] ).select(:file_path).first
     # ANW-267: Windows will corrupt PDFs with DOS line endings unless we return the file as a binary.
     content_type 'application/octect-stream'
-    IO.binread(file[:file_path])
+    IO.binread(file.full_file_path)
   end
 
   Endpoint.get('/repositories/:repo_id/jobs/:id/records')

--- a/backend/app/lib/job_runners/batch_import_runner.rb
+++ b/backend/app/lib/job_runners/batch_import_runner.rb
@@ -60,7 +60,7 @@ class BatchImportRunner < JobRunner
         begin
           @job.job_files.each_with_index do |input_file, i|
             ticker.log(("=" * 50) + "\n#{filenames[i]}\n" + ("=" * 50)) if filenames[i]
-            converter = Converter.for(@json.job['import_type'], input_file.file_path)
+            converter = Converter.for(@json.job['import_type'], input_file.full_file_path)
             begin
               RequestContext.open(:create_enums => true,
                                   :current_username => @job.owner.username,

--- a/backend/app/lib/job_runners/print_to_pdf_runner.rb
+++ b/backend/app/lib/job_runners/print_to_pdf_runner.rb
@@ -46,7 +46,7 @@ class PrintToPDFRunner < JobRunner
         end
 
         job_file = @job.add_file( pdf )
-        @job.write_output("File generated at #{job_file[:file_path].inspect} ")
+        @job.write_output("File generated at #{job_file.full_file_path.inspect} ")
 
         # pdf will be either a Tempfile or File object, depending on whether it was created externally.
         if pdf.class == Tempfile

--- a/backend/app/model/job.rb
+++ b/backend/app/model/job.rb
@@ -25,18 +25,20 @@ class Job < Sequel::Model(:job)
   class JobFileStore
 
     def initialize(name)
-      @job_path = File.join(AppConfig[:job_file_path], name)
+      @job_dir = name
+      @job_path = File.join(AppConfig[:job_file_path], @job_dir)
       FileUtils.mkdir_p(@job_path)
       @output_path = File.join(@job_path, "output.log")
     end
 
 
     def store(file)
-      target = File.join(@job_path, SecureRandom.hex)
+      filename = SecureRandom.hex
+      target = File.join(@job_path, filename)
 
       FileUtils.cp(file.path, target)
 
-      target
+      File.join(@job_dir, filename)
     end
 
 
@@ -68,6 +70,7 @@ class Job < Sequel::Model(:job)
     def unlink(path)
       File.unlink(path)
     end
+
 
   end
 

--- a/backend/app/model/job_files.rb
+++ b/backend/app/model/job_files.rb
@@ -1,2 +1,7 @@
+# require 'fileutils'
+
 class JobFile < Sequel::Model(:job_input_file)
+	def full_file_path
+		File.absolute_path(file_path, dir_string = AppConfig[:job_file_path])
+	end
 end

--- a/backend/app/model/job_files.rb
+++ b/backend/app/model/job_files.rb
@@ -1,5 +1,3 @@
-# require 'fileutils'
-
 class JobFile < Sequel::Model(:job_input_file)
 	def full_file_path
 		File.absolute_path(file_path, dir_string = AppConfig[:job_file_path])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When saving the path to job files, only the path relative to the base job files directory gets written to the database. When accessing job files, the absolute path will be created (if it's not already the absolute path) from the stored relative path and the job files directory defined in config.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-818](https://archivesspace.atlassian.net/browse/ANW-818)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In the table 'job_input_file' the file paths for job files were being stored as absolute file paths rather than as relative paths. This caused problems when the root path for ArchivesSpace changed (i.e. when upgrading).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running all the different job types and making sure the files could be downloaded and looked correct and that the appropriate relative file path was stored in the database. Also tested that job files from before this change (i.e. ones with the absolute file path stored) could still be downloaded.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
