### PR TITLE
Allow for inline, manual documentation of Endpoints in definition.

### DIFF
--- a/_yard/API.erb
+++ b/_yard/API.erb
@@ -1,9 +1,17 @@
 ---
+<%
+# hateful hack to get additional highlighter tabs
+hilighters = @endpoints.each.map do |e| e[:examples].keys.reject(&->(k) {k == 'shell'}) end.flatten.to_set.to_a.sort
+
+%>
+
 title: API Reference
 
 language_tabs:
   - shell
-
+<% hilighters.each do |hl| %>
+  - <%= hl %>
+<% end %>
 toc_footers:
   - <a href='http://github.com/tripit/slate'>Documentation Powered by Slate</a>
 
@@ -200,7 +208,9 @@ As of <%= @time.inspect %> the following REST endpoints exist in the master bran
 <% else %>
   <% data_example = "Example Missing" %>
 <% end %>
-
+<% if e[:examples]['shell'] %>
+<%= e[:examples]['shell'] %>
+<% else %>
 ```shell
 <% if e[:method] == [:get] %>
   <% if e[:paginated] %>
@@ -227,8 +237,10 @@ curl -H "X-ArchivesSpace-Session: $SESSION" \
   "<%= request_uri %>"
   <% end %>
 <% end %>
-
 ```
+<% end %>
+
+<%= e[:examples].reject do |k,v| k == 'shell' end.to_h.values.join("\n\n") %>
 
 __Endpoint__
 
@@ -240,7 +252,7 @@ __Description__
 
 <%= e[:documentation] %>
 
-<%= if !e[:documentation] || e[:prepend_docs] %>
+<% if !e[:documentation] || e[:prepend_docs] %>
 
 __Parameters__
 

--- a/_yard/API.erb
+++ b/_yard/API.erb
@@ -169,7 +169,7 @@ As of <%= @time.inspect %> the following REST endpoints exist in the master bran
 
 <% @endpoints.each do | e | %>
 
-## <%= e[:description]%>
+## <%= e[:description] %>
 
 <% example =  @examples[e[:uri]][e[:method].to_s] %>
 
@@ -238,6 +238,9 @@ __Description__
 
 <%= e[:description]%>
 
+<%= e[:documentation] %>
+
+<%= if !e[:documentation] || e[:prepend_docs] %>
 
 __Parameters__
 
@@ -269,6 +272,7 @@ __Returns__
   <%= "\t#{ret[0]} -- #{ret[1]}\n" %>
 <% end %>
 
+<% end # end prepend check %>
 <% end %>
 
 <% end %>

--- a/_yard/API.erb
+++ b/_yard/API.erb
@@ -1,9 +1,6 @@
 ---
-<%
-# hateful hack to get additional highlighter tabs
-hilighters = @endpoints.each.map do |e| e[:examples].keys.reject(&->(k) {k == 'shell'}) end.flatten.to_set.to_a.sort
-
-%>
+<%# hateful hack to get additional highlighter tabs %>
+<% hilighters = @endpoints.each.map do |e| e[:examples].keys.reject(&->(k) {k == 'shell'}) end.flatten.to_set.to_a.sort %>
 
 title: API Reference
 
@@ -177,13 +174,21 @@ As of <%= @time.inspect %> the following REST endpoints exist in the master bran
 
 <% @endpoints.each do | e | %>
 
-## <%= e[:description] %>
+## <%= e[:description]%>
 
 <% example =  @examples[e[:uri]][e[:method].to_s] %>
 
 <% if example %>
 
-<% url_params = e[:params].map{|p| p[0] unless (e[:uri].include?("/:#{p[0]}") or (p[3] or {})[:body] or p[1] == :body_stream or ["repo_id", "id"].include?(p[0])) }.compact %>
+<% tmp = [] %>
+<% e[:params].each do |p| %>
+  <% if p.is_a? String %>
+    <% tmp << p %>
+  <% else %>
+    <% tmp << p[0] unless (e[:uri].include?("/:#{p[0]}") or (p[3] or {})[:body] or p[1] == :body_stream or ["repo_id", "id"].include?(p[0])) %>
+  <% end %>
+<% end %>
+<% url_params = tmp.compact %>
 <% request_uri = "http://localhost:8089#{e[:uri].gsub(":repo_id", "2").gsub(":id", "1").gsub(/(?<=\/)(:.*?)(?=\/)/, "1").gsub(/(?<=\/):.*?$/, "1")}" %>
 <% if !url_params.empty? && !e[:paginated] %>
   <% url_param_examples = [] %>
@@ -196,12 +201,22 @@ As of <%= @time.inspect %> the following REST endpoints exist in the master bran
       <% else %>
         <% url_param_examples << "#{param}=#{example[param]}" %>
       <% end %>
+        <% elsif param.is_a? String %>
+          <% url_param_examples << "#{param}=#{param}" %>
     <% end %>
   <% end %>
   <% request_uri += "?#{url_param_examples.join("&")}" %>
 <% end %>
 
-<% data_params = e[:params].map{|p| p[0] if ((p[3] or {})[:body] or p[1] == :body_stream)}.compact %>
+<% tmp = [] %>
+<% e[:params].each do |p| %>
+  <% if p.is_a? String %>
+    <% tmp << p %>
+  <% else %>
+    <% tmp << p[0] if ((p[3] or {})[:body] or p[1] == :body_stream) %>
+  <% end %>
+<% end %>
+<% data_params = tmp.compact %>
 <% if !data_params.empty? %>
   <% data_param = data_params[0] %>
   <% data_example = example[data_param] ? example[data_param].to_json.gsub("{", "{ ").gsub(",", ",\n") : "Example Missing" %>
@@ -209,20 +224,20 @@ As of <%= @time.inspect %> the following REST endpoints exist in the master bran
   <% data_example = "Example Missing" %>
 <% end %>
 <% if e[:examples]['shell'] %>
-<%= e[:examples]['shell'] %>
+  <% e[:examples]['shell'] %>
 <% else %>
 ```shell
 <% if e[:method] == [:get] %>
-  <% if e[:paginated] %>
+<% if e[:paginated] %>
 # return first 10 records
 curl -H "X-ArchivesSpace-Session: $SESSION" "<%= request_uri %>?page=1&page_size=10"
 # return first 5 records in the Fibonacci sequence
 curl -H "X-ArchivesSpace-Session: $SESSION" "<%= request_uri %>?id_set=1,2,3,5,8"
 # return an array of all the ids
 curl -H "X-ArchivesSpace-Session: $SESSION" "<%= request_uri %>?all_ids=true"
-  <% else %>
+<% else %>
 curl -H "X-ArchivesSpace-Session: $SESSION" "<%= request_uri %>"
-  <% end %>
+<% end %>
 <% elsif e[:method] == [:post] %>
 curl -H "X-ArchivesSpace-Session: $SESSION" \
   -d '<%= data_example %>' \
@@ -230,13 +245,14 @@ curl -H "X-ArchivesSpace-Session: $SESSION" \
 <% elsif e[:method] == [:delete] %>
 curl -H "X-ArchivesSpace-Session: $SESSION" -X DELETE "<%= request_uri %>"
 <% else %>
-  <% example.each_pair do |k,v| %>
-    <% next if e[:uri].include?("/:#{k}") %>
+<% example.each_pair do |k,v| %>
+  <% next if e[:uri].include?("/:#{k}") %>
 curl -H "X-ArchivesSpace-Session: $SESSION" \
   -d '<%= v.to_json.gsub("{", "{ ").gsub(",", ",\n") %>' \
   "<%= request_uri %>"
   <% end %>
 <% end %>
+
 ```
 <% end %>
 
@@ -262,19 +278,25 @@ This endpoint is paginated. :page, :id_set, or :all_ids is required
 <ul>
   <li>Integer page &ndash; The page set to be returned</li>
   <li>Integer page_size &ndash; The size of the set to be returned ( Optional. default set in AppConfig )</li>
-  <li>Comma seperated list id_set &ndash; A list of ids to request resolved objects ( Must be smaller than default page_size )</li>
+  <li>Comma separated list id_set &ndash; A list of ids to request resolved objects ( Must be smaller than default page_size )</li>
   <li>Boolean all_ids &ndash; Return a list of all object ids</li>
 </ul>
 </aside>
 <% end %>
-<% e[:params].each do |param|
-  opts = (param[3] or {})
-  vs = opts[:validation] ? " -- #{opts[:validation][0]}" : ""
-  optional = opts[:optional] ? " (Optional)" : "" %>
+<% e[:params].each do |param| %>
+  <% if param.is_a? String %>
+    <% opts = {} %>
+  <% else %>
+    <% opts = (param[3] or {}) %>
+  <% end %>
+  <% unless opts.empty? %>
+    <% vs = opts[:validation] ? " -- #{opts[:validation][0]}" : "" %>
+    <% optional = opts[:optional] ? " (Optional)" : "" %>
 <% if opts[:body] %>
 	<%= "#{param[1]} <request body> -- #{param[2]}#{vs}" %>
 <% else %>
 	<%= "#{param[1]} #{param[0]}#{optional} -- #{param[2]}#{vs}" %>
+<% end %>
 <% end %>
 <% end %>
 
@@ -284,7 +306,8 @@ __Returns__
   <%= "\t#{ret[0]} -- #{ret[1]}\n" %>
 <% end %>
 
-<% end # end prepend check %>
+<%# end prepend check %>
+<% end %>
 <% end %>
 
 <% end %>

--- a/_yard/API.erb
+++ b/_yard/API.erb
@@ -1,4 +1,6 @@
 ---
+<%# Note: Do not modify the indentation/white space in this file.  It matters! %>
+
 <%# hateful hack to get additional highlighter tabs %>
 <% hilighters = @endpoints.each.map do |e| e[:examples].keys.reject(&->(k) {k == 'shell'}) end.flatten.to_set.to_a.sort %>
 

--- a/backend/app/lib/rest.rb
+++ b/backend/app/lib/rest.rb
@@ -155,8 +155,10 @@ module RESTHelpers
       end
       if docs
         @documentation = docs
-        @prepend_to_autodoc = prepend
       end
+      
+      @prepend_to_autodoc = prepend
+      
       self
     end
 

--- a/backend/app/lib/rest.rb
+++ b/backend/app/lib/rest.rb
@@ -73,6 +73,9 @@ module RESTHelpers
       @methods = ASUtils.wrap(method)
       @uri = ""
       @description = "-- No description provided --"
+      @documentation = nil
+      @prepend_to_autodoc = true
+      @examples = {}
       @permissions = []
       @preconditions = []
       @required_params = []
@@ -95,6 +98,9 @@ module RESTHelpers
           {
             :uri => @uri,
             :description => @description,
+            :documentation => @documentation,
+            :prepend_docs => @prepend_to_autodoc,
+            :examples => @examples,
             :method => @methods,
             :params => @required_params,
             :paginated => @paginated,
@@ -124,6 +130,63 @@ module RESTHelpers
     def uri(uri); @uri = uri; self; end
     def description(description); @description = description; self; end
     def preconditions(*preconditions); @preconditions += preconditions; self; end
+
+    # For the following methods (documentation, example),  content can be provided via either
+    # argument or as the return value of a provided block.
+
+    # Add documentation for endpoint to be interpolated into the API docs.
+    # If "prepend" is true, the automated docs (e.g. pagination) will be
+    #   appended to this when API docs are generated, otherwise this will
+    #   replace the docs entirely.
+    #
+    # Recommended usage:
+    #
+    # endpoint.documentation do
+    #   <<~DOCS
+    #   # Header
+    #   Some content
+    #   - with maybe a list
+    #   - who doesn't like lists, right?
+    #   DOCS
+    # end
+    def documentation(docs = nil, prepend: true)
+      if block_given?
+        docs = yield docs, prepend
+      end
+      if docs
+        @documentation = docs
+        @prepend_to_autodoc = prepend
+      end
+      self
+    end
+
+    # Add an example to the example code tabs.
+    #
+    # The highlighter argument must be a language code understood by the rouge highlighting library
+    #   (https://github.com/jneen/rouge/wiki/List-of-supported-languages-and-lexers)
+    #
+    # Recommended usage:
+    #
+    # endpoint.example('shell') do
+    #   <<~CONTENTS
+    #   wget 'blah blah blah'
+    #   CONTENTS
+    # end
+    def example(highlighter, contents = nil)
+      if block_given?
+        contents = yield contents
+      end
+      if contents
+        contents = <<~TEMPLATE
+          ```#{highlighter}
+          #{contents}
+          ```
+        TEMPLATE
+
+        @examples[highlighter] = contents
+      end
+      self
+    end
 
 
     def permissions(permissions)
@@ -231,18 +294,18 @@ module RESTHelpers
             DB.open do |db|
               ensure_params(rp, paginated)
             end
-  
+
             Log.debug("Post-processed params: #{Log.filter_passwords(params).inspect}")
-  
+
             RequestContext.put(:repo_id, params[:repo_id])
             RequestContext.put(:is_high_priority, high_priority_request?)
-  
+
             if Endpoint.is_toplevel_request?(env) || Endpoint.is_potentially_destructive_request?(env)
               unless preconditions.all? { |precondition| self.instance_eval &precondition }
                 raise AccessDeniedException.new("Access denied")
               end
             end
-  
+
             use_transaction = (use_transaction == :unspecified) ? true : use_transaction
             db_opts = {}
 
@@ -276,7 +339,7 @@ module RESTHelpers
                                        Preference.defaults['show_suppressed']))
                 end
               end
-  
+
               self.instance_eval &block
             end
           end

--- a/backend/app/lib/rest.rb
+++ b/backend/app/lib/rest.rb
@@ -49,7 +49,6 @@ module RESTHelpers
 
 
   class Endpoint
-
     @@endpoints = []
 
 
@@ -139,6 +138,9 @@ module RESTHelpers
     #   appended to this when API docs are generated, otherwise this will
     #   replace the docs entirely.
     #
+    # Note: If you make prepend false, you should provide __Parameters__
+    #       and __Returns__ sections manually.
+    #
     # Recommended usage:
     #
     # endpoint.documentation do
@@ -156,9 +158,9 @@ module RESTHelpers
       if docs
         @documentation = docs
       end
-      
+
       @prepend_to_autodoc = prepend
-      
+
       self
     end
 

--- a/backend/spec/documentation_spec.rb
+++ b/backend/spec/documentation_spec.rb
@@ -2,33 +2,34 @@ require 'spec_helper'
 
 describe "Generate REST Documentation" do
 
+  it "gets all the endpoints and makes something can write documentation for" do
+    endpoints = ArchivesSpaceService::Endpoint.all.sort{|a,b| a[:uri] <=> b[:uri]}
+    output = {}
+    problems = []
 
- it "gets all the endpoints and makes something can write documentation for" do
- 
- 
-endpoints = ArchivesSpaceService::Endpoint.all.sort{|a,b| a[:uri] <=> b[:uri]}                                                                                                      
-output = {}
-problems = []
-
-models = {}
-    JSONModel.models.each_pair do |type, klass| 
+    models = {}
+    JSONModel.models.each_pair do |type, klass|
       begin
         models[type] = JSON.parse( build("json_#{type}".to_sym).to_json )
       rescue => err
-        # if you want a verbose output of the issues, you can set an ENV  
+        # if you want a verbose output of the issues, you can set an ENV
         $stderr.puts "Model problem with #{klass} : #{err.message}" if ENV["BUILD_DOCUMENTATION"]
       end
     end
 
-endpoints.each do |e|
-
+    endpoints.each do |e|
       output[e[:uri]] ||= {}
       output[e[:uri]][e[:method]] = {}
       e[:params].each do |p|
-        begin       
-          klass = p[1]
-          klass = klass.first if klass.is_a?(Array) 
-          
+        begin
+          if p.is_a? String
+            klass = p.to_sym
+          else
+            klass = p[1]
+          end
+
+          klass = klass.first if klass.is_a?(Array)
+
           if klass.is_a?(Symbol)
             record = klass.to_s
           elsif klass.respond_to?(:record_type)
@@ -41,24 +42,23 @@ endpoints.each do |e|
           else
             record = generate(klass.name.downcase.to_sym)
           end
-          output[e[:uri]][e[:method]][p[0]] = record
+          if p.is_a? String
+            output[e[:uri]][e[:method]][p] = record
+          else
+            output[e[:uri]][e[:method]][p[0]] = record
+          end
         rescue => err
-          # $stderr.puts "problem with #{e[:uri]} #{e[:method]}"
           problems << { :class => klass, :backtrace => err.backtrace,  :message => err.message }
-          next 
-          # raise err 
+          next
         end
       end
 
-end
-    
+    end
+
     file = File.join(File.dirname(__FILE__), '../../', "endpoint_examples.json")
     file_problems = File.join(File.dirname(__FILE__), '../../', "endpoint_examples_problems.json")
     File.open(file, "w") {  |f| f << output.to_json }
     File.open(file_problems, "w") {  |f| f << JSON.pretty_generate(problems) }
-    $stderr.puts "example file put at #{file}. Problems logged in #{file_problems}" 
-    
-
-
+    $stderr.puts "example file put at #{file}. Problems logged in #{file_problems}"
+  end
 end
-end 

--- a/backend/spec/rest_helper_spec.rb
+++ b/backend/spec/rest_helper_spec.rb
@@ -6,6 +6,20 @@ describe 'Rest Helpers' do
   before(:all) do
     RESTHelpers::Endpoint.get('/rest_helper_spec/get')
       .description("GET endpoint test")
+      .documentation do
+        <<~DOCS
+          __Some Extra Docs__
+
+          Documentation about what's goin' on with this endpoint
+        DOCS
+      end
+      .example('python') do
+        <<~PYTHON
+          from asnake.aspace import ASpace()
+
+          print(ASpace().repositories(2).name)
+        PYTHON
+      end
       .permissions([])
       .returns([200, "(json)"]) \
     do

--- a/backend/spec/rest_helper_spec.rb
+++ b/backend/spec/rest_helper_spec.rb
@@ -8,9 +8,11 @@ describe 'Rest Helpers' do
       .description("GET endpoint test")
       .documentation do
         <<~DOCS
-          __Some Extra Docs__
+        
+          __Heading for Some Extra Docs__
 
-          Documentation about what's goin' on with this endpoint
+          Documentation in markdown about what's goin' on with this endpoint
+            
         DOCS
       end
       .example('python') do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
These changes make it possible to add a documentation block (in markdown) and an example in any language supported by Rouge to an Endpoint.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The auto-generated API docs are a useful resource, but are in many cases unhelpful, misleading, or downright inaccurate.  Shell examples are wrong more often than right for endpoints that aren't resources or simple collections of same-type resources.  At the same time, they're the best we have, and replacing them with something better will take time and effort.

This code allows for manual docs to be inserted, while falling back to the existing generated docs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added calls to `Endpoint#documentation` and `Endpoint#example` in the spec for the REST helper.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
