### PR TITLE
Update path to drivers and fix depreciations

### DIFF
--- a/public/spec/controllers/application_controller_spec.rb
+++ b/public/spec/controllers/application_controller_spec.rb
@@ -15,7 +15,7 @@ class SlugQueryResponseMock
   end
 
   def body
-    return {:id => @id, :table => @table, :repo_id => @repo_id}.to_json 
+    return {:id => @id, :table => @table, :repo_id => @repo_id}.to_json
   end
 end
 
@@ -40,7 +40,7 @@ describe RepositoriesController, type: :controller do
   end
 
   it "should set id params based on response from backend" do
-    HTTP.stub(:get_response) { SlugQueryResponseMock.new(3, "repository") }
+    allow(HTTP).to receive(:get_response) { SlugQueryResponseMock.new(3, "repository") }
 
     response = get :show, params: {:slug_or_id => "foobar"}
     expect(controller.params[:id]).to eq(3)
@@ -66,7 +66,7 @@ describe SubjectsController, type: :controller do
   end
 
   it "should set id params based on response from backend" do
-    HTTP.stub(:get_response) { SlugQueryResponseMock.new(3, "repository") }
+    allow(HTTP).to receive(:get_response) { SlugQueryResponseMock.new(3, "repository") }
 
     response = get :show, params: {:slug_or_id => "foobar"}
     expect(controller.params[:id]).to eq(3)
@@ -96,7 +96,7 @@ describe AgentsController, type: :controller do
   end
 
   it "set param['eid'] = 'people' if the response from the backend indicates the agent is an agent_person" do
-    HTTP.stub(:get_response) { SlugQueryResponseMock.new(2, "agent_person") }
+    allow(HTTP).to receive(:get_response) { SlugQueryResponseMock.new(2, "agent_person") }
 
     response = get :show, params: {:slug_or_id => "who"}
     expect(controller.params[:id]).to eq(2)
@@ -104,7 +104,7 @@ describe AgentsController, type: :controller do
   end
 
   it "set param['eid'] = 'families' if the response from the backend indicates the agent is an agent_family" do
-    HTTP.stub(:get_response) { SlugQueryResponseMock.new(1, "agent_family") }
+    allow(HTTP).to receive(:get_response) { SlugQueryResponseMock.new(1, "agent_family") }
 
     response = get :show, params: {:slug_or_id => "fam"}
     expect(controller.params[:id]).to eq(1)
@@ -112,15 +112,15 @@ describe AgentsController, type: :controller do
   end
 
   it "set param['eid'] = 'corporate_entities' if the response from the backend indicates the agent is an agent_corporate_entity" do
-    HTTP.stub(:get_response) { SlugQueryResponseMock.new(4, "agent_corporate_entity") }
+    allow(HTTP).to receive(:get_response) { SlugQueryResponseMock.new(4, "agent_corporate_entity") }
 
     response = get :show, params: {:slug_or_id => "corp"}
     expect(controller.params[:id]).to eq(4)
     expect(controller.params[:eid]).to eq("corporate_entities")
-  end  
+  end
 
    it "set param['eid'] = 'software' if the response from the backend indicates the agent is agent_software" do
-    HTTP.stub(:get_response) { SlugQueryResponseMock.new(8, "agent_software") }
+    allow(HTTP).to receive(:get_response) { SlugQueryResponseMock.new(8, "agent_software") }
 
     response = get :show, params: {:slug_or_id => "prog"}
     expect(controller.params[:id]).to eq(8)
@@ -164,7 +164,7 @@ describe AccessionsController, type: :controller do
   end
 
   it "should set id params based on response from backend" do
-    HTTP.stub(:get_response) { SlugQueryResponseMock.new(6, "accession", 5) }
+    allow(HTTP).to receive(:get_response) { SlugQueryResponseMock.new(6, "accession", 5) }
 
     response = get :show, params: {:slug_or_id => "foobar"}
     expect(controller.params[:id]).to eq(6)
@@ -204,7 +204,7 @@ describe ResourcesController, type: :controller do
   end
 
   it "should set id params based on response from backend" do
-    HTTP.stub(:get_response) { SlugQueryResponseMock.new(6, "resource", 5) }
+    allow(HTTP).to receive(:get_response) { SlugQueryResponseMock.new(6, "resource", 5) }
 
     response = get :show, params: {:slug_or_id => "foobar"}
     expect(controller.params[:id]).to eq(6)
@@ -243,7 +243,7 @@ describe ObjectsController, type: :controller do
   end
 
   it "should set id params based on response from backend for digital objects" do
-    HTTP.stub(:get_response) { SlugQueryResponseMock.new(6, "digital_object", 5) }
+    allow(HTTP).to receive(:get_response) { SlugQueryResponseMock.new(6, "digital_object", 5) }
 
     response = get :show, params: {:slug_or_id => "foobar", :obj_type => "digital_objects"}
     expect(controller.params[:id]).to eq(6)
@@ -252,7 +252,7 @@ describe ObjectsController, type: :controller do
   end
 
   it "should set id params based on response from backend for archival objects" do
-    HTTP.stub(:get_response) { SlugQueryResponseMock.new(6, "archival_object", 5) }
+    allow(HTTP).to receive(:get_response) { SlugQueryResponseMock.new(6, "archival_object", 5) }
 
     response = get :show, params: {:slug_or_id => "foobar", :obj_type => "archival_objects"}
     expect(controller.params[:id]).to eq(6)
@@ -261,7 +261,7 @@ describe ObjectsController, type: :controller do
   end
 
   it "should set id params based on response from backend for digital object components" do
-    HTTP.stub(:get_response) { SlugQueryResponseMock.new(6, "digital_object_components", 5) }
+    allow(HTTP).to receive(:get_response) { SlugQueryResponseMock.new(6, "digital_object_components", 5) }
 
     response = get :show, params: {:slug_or_id => "foobar", :obj_type => "digital_object_components"}
     expect(controller.params[:id]).to eq(6)
@@ -302,7 +302,7 @@ describe ClassificationsController, type: :controller do
     end
 
     it "should set id params based on response from backend" do
-      HTTP.stub(:get_response) { SlugQueryResponseMock.new(6, "classifications", 5) }
+      allow(HTTP).to receive(:get_response) { SlugQueryResponseMock.new(6, "classifications", 5) }
 
       response = get :show, params: {:slug_or_id => "foobar"}
       expect(controller.params[:id]).to eq(6)
@@ -313,7 +313,7 @@ describe ClassificationsController, type: :controller do
   describe "Classification terms" do
     it "should set id params == slug params if slug params are integers" do
       response = get :term, params: {:slug_or_id => "1", :repo_slug => "4"}
-  
+
       expect(controller.params[:id]).to eq("1")
       expect(controller.params[:rid]).to eq("4")
     end
@@ -337,7 +337,7 @@ describe ClassificationsController, type: :controller do
     end
 
     it "should set id params based on response from backend" do
-      HTTP.stub(:get_response) { SlugQueryResponseMock.new(6, "classification_terms", 5) }
+      allow(HTTP).to receive(:get_response) { SlugQueryResponseMock.new(6, "classification_terms", 5) }
 
       response = get :term, params: {:slug_or_id => "foobar"}
       expect(controller.params[:id]).to eq(6)

--- a/public/spec/rails_helper.rb
+++ b/public/spec/rails_helper.rb
@@ -25,9 +25,9 @@ if ENV['SELENIUM_CHROME']
 elsif ENV['SELENIUM_HEADY_CHROME']
   Capybara.javascript_driver = :chrome
 elsif java.lang.System.getProperty('os.name').downcase == 'linux'
-  ENV['PATH'] = "#{File.join(ASUtils.find_base_directory, 'selenium', 'bin', 'geckodriver', 'linux')}:#{ENV['PATH']}"
+  ENV['PATH'] = "#{File.join(ASUtils.find_base_directory, 'common', 'selenium', 'bin', 'geckodriver', 'linux')}:#{ENV['PATH']}"
 else #osx
-  ENV['PATH'] = "#{File.join(ASUtils.find_base_directory, 'selenium', 'bin', 'geckodriver', 'osx')}:#{ENV['PATH']}"
+  ENV['PATH'] = "#{File.join(ASUtils.find_base_directory, 'common', 'selenium', 'bin', 'geckodriver', 'osx')}:#{ENV['PATH']}"
 end
 
 # This should change once the app gets to a point where it's not just throwing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updating driver locations for public tests per changes in #1410 and updating depreciated public test syntax.

## Description
<!--- Describe your changes in detail -->
#1410 relocates geckodrivers to `common` which breaks current public tests.  This updates `public/spec/rails_helper.rb` so that is can find those relocated drivers.  Similarly, it updates the syntax of some tests in `application_controller_spec.rb` to remove depreciation warnings.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
