### PR TITLE
ANW-777 Capitalize instances of origination/@label for agent role 'creator' in EAD export

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -341,7 +341,7 @@ class EADSerializer < ASpaceExport::Serializer
 
         next if !published && !@include_unpublished
 
-        role = link['role']
+        link['role'] == 'creator' ? role = link['role'].capitalize : role = link['role']
         relator = link['relator']
         sort_name = agent['display_name']['sort_name']
         rules = agent['display_name']['rules']

--- a/backend/app/exporters/serializers/ead3.rb
+++ b/backend/app/exporters/serializers/ead3.rb
@@ -1023,7 +1023,7 @@ class EAD3Serializer < EADSerializer
     unless data.creators_and_sources.nil?
       data.creators_and_sources.each do |link|
         agent = link['_resolved']
-        role = link['role']
+        link['role'] == 'creator' ? role = link['role'].capitalize : role = link['role']
         relator = link['relator']
         sort_name = agent['display_name']['sort_name']
         rules = agent['display_name']['rules']

--- a/backend/spec/export_ead3_spec.rb
+++ b/backend/spec/export_ead3_spec.rb
@@ -1087,6 +1087,17 @@ describe "EAD3 export mappings" do
         mt(sort_name, path_2)
       end
     end
+
+    # ANW-777
+    it "capitalizes instances of agent role 'creator' that are mapped to origination/@label" do
+      origination_labels = doc.xpath("//origination/@label")
+
+      origination_labels.each do |origination_label|
+        next unless origination_label.content == 'creator'
+        expected_label = origination_label.content.capitalize
+        expect(origination_label.content).to eq(expected_label)
+      end
+    end
   end
 
 

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -977,6 +977,17 @@ describe "EAD export mappings" do
         mt(sort_name, path_2)
       end
     end
+
+    # ANW-777
+    it "capitalizes instances of agent role 'creator' that are mapped to origination/@label" do
+      origination_labels = doc.xpath("//origination/@label")
+
+      origination_labels.each do |origination_label|
+        next unless origination_label.content == 'creator'
+        expected_label = origination_label.content.capitalize
+        expect(origination_label.content).to eq(expected_label)
+      end
+    end
   end
 
 
@@ -1268,7 +1279,7 @@ describe "EAD export mappings" do
       creators = @xml_including_unpublished.xpath('//origination')
       expect(creators.length).to eq(1)
       creator = creators.first
-      expect(creator).to have_attribute('label', 'creator')
+      expect(creator).to have_attribute('label', 'Creator')
       expect(creator).to have_attribute('audience', 'internal')
     end
 

--- a/backend/spec/fixtures/oai/responses/getrecord_oai_ead.xml
+++ b/backend/spec/fixtures/oai/responses/getrecord_oai_ead.xml
@@ -75,7 +75,7 @@
 
             <unittitle>Test resource 0</unittitle>
 
-            <origination label="creator">
+            <origination label="Creator">
               <persname authfilenumber="creator" role="cre" rules="local" source="local">Agent, Creator</persname>
 
     </origination>
@@ -294,7 +294,7 @@
             <did>
               <unittitle>Archival_Object 1</unittitle>
               <unitid>ArchivalObject OAI test 0</unitid>
-              <origination label="creator">
+              <origination label="Creator">
                 <persname authfilenumber="creator" role="cre" rules="local" source="local">Agent, Creator</persname>
               </origination>
               <physdesc altrender="whole">


### PR DESCRIPTION
## Description
The agent role 'creator' is now capitalized in the serialize_origination method for EADSerializer and EAD3Serializer.

## Related JIRA Ticket or GitHub Issue
[ANW-777](https://archivesspace.atlassian.net/browse/ANW-777) Capitalize "Creator" as the default <origination> LABEL value.

## Motivation and Context
In EAD and EAD3 export, the 'creator' agent role maps to the origination/@label attribute in lowercase, which requires users to capitalize this attribute manually in the exported EAD.

## How Has This Been Tested?
I added examples to the EAD and EAD3 spec files to test for capitalization of origination/@label. This also required capitalizing the attribute in one other example ("include the unpublished agent with audience internal when include_unpublished is true") and in the OAI response fixture for EAD. The backend test suite passed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
