### PR TITLE
ANW-669: bugfix for attributes in mixed content causing validation errors

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -94,9 +94,25 @@ class EADSerializer < ASpaceExport::Serializer
     content = content.gsub(/\xE2\x80\x9C/, '"').gsub(/\xE2\x80\x9D/, '"').gsub(/\xE2\x80\x98/, "\'").gsub(/\xE2\x80\x99/, "\'")
   end
 
-  def sanitize_mixed_content(content, context, fragments, allow_p = false  )
-#    return "" if content.nil?
 
+  # ANW-669: Fix for attributes in mixed content causing errors when validating against the EAD schema.
+
+  # If content looks like it contains a valid XML element with an attribute,
+  # Then replace anything that looks like an attribute like " foo=" with " xlink:foo=".
+
+  # References used for valid element and attribute names:
+  # https://www.xml.com/pub/a/2001/07/25/namingparts.html
+  # https://razzed.com/2009/01/30/valid-characters-in-attribute-names-in-htmlxml/
+
+  def add_xlink_prefix(content)
+    if content =~ /<[A-Za-z_:]{1}[A-Za-z0-9_:.]* [a-zA-Z_:]{1}[-a-zA-Z0-9_:.]*=/
+      content.gsub(/ [a-zA-Z_:]{1}[-a-zA-Z0-9_:.]*=/) {|match| " xlink:#{match.strip}"}
+    else
+      content
+    end
+  end
+
+  def sanitize_mixed_content(content, context, fragments, allow_p = false  )
     # remove smart quotes from text
     content = remove_smart_quotes(content)
 
@@ -109,6 +125,8 @@ class EADSerializer < ASpaceExport::Serializer
     else
       content = strip_p(content)
     end
+
+    content = add_xlink_prefix(content)
 
     begin
       if ASpaceExport::Utils.has_html?(content)

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1146,6 +1146,7 @@ describe "EAD export mappings" do
   describe "Testing EAD Serializer mixed content behavior" do
 
     let(:note_with_p) { "<p>A NOTE!</p>" }
+    let(:note_with_extref) { "<extref href='http://duckduckgo.com'>A Good Search Engine</p>" }
     let(:note_with_linebreaks) { "Something, something,\n\nsomething." }
     let(:note_with_linebreaks_and_good_mixed_content) { "Something, something,\n\n<bioghist>something.</bioghist>\n\n" }
     let(:note_with_linebreaks_and_evil_mixed_content) { "Something, something,\n\n<bioghist>something.\n\n</bioghist>\n\n" }
@@ -1157,6 +1158,14 @@ describe "EAD export mappings" do
 
     it "can strip <p> tags from content when disallowed" do
       expect(serializer.strip_p(note_with_p)).to eq("A NOTE!")
+    end
+
+    it "adds xlink prefix to attributes in mixed content" do
+      expect(serializer.add_xlink_prefix(note_with_extref)).to eq("<extref xlink:href='http://duckduckgo.com'>A Good Search Engine</p>")
+    end
+
+    it "does not add xlink prefix when mixed content has no attributes" do
+      expect(serializer.add_xlink_prefix(note_with_p)).to eq(note_with_p)
     end
 
     it "can leave <p> tags in content" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a step in EAD serializer that prepends "xlink:" to any attribute inside an element in mixed content. 

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-669
https://github.com/archivesspace/archivesspace/issues/1087

## Motivation and Context
Bugfix for validation errors.

## How Has This Been Tested?
Confirmed validation was failing when generating EAD for a resource with a note with contents like: ```"<extref href='http://foobar.com'>Test</p>"```

Added fix, and confirmed that post-fix XML was validating correctly. Used xmllint as validation tool.

Added unit tests for changes.

Also checked EAD3 schema -- but EAD3 exports of the test resource were correctly validating against the EAD3 RNG without any changes needed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
