### PR TITLE
ANW-657 Background Jobs Terminology

### DIFF
--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -1975,11 +1975,11 @@ en:
     _plural: Background Jobs
     job_type: Job Type
     types:
-      print_to_pdf_job: Print To PDF
+      print_to_pdf_job: Generate PDF
       import_job: Import Data
       find_and_replace_job: Batch Find and Replace (Beta)
-      report_job: Reports
-      container_conversion_job: Reports
+      report_job: Create Report
+      container_conversion_job: Create Report
       generate_slugs_job: Generate Slugs for Entities
       unknown_job_type: Unknown job type
     status: Status

--- a/common/locales/es.yml
+++ b/common/locales/es.yml
@@ -1952,11 +1952,11 @@
     _plural: Tareas en el background
     job_type: Tipo de tarea
     types:
-      print_to_pdf_job: Imprimir en PDF
+      print_to_pdf_job: Generar PDF
       import_job: Importar Datos
       find_and_replace_job: Busca y reemplaza en bloque (Beta)
-      report_job: Informes
-      container_conversion_job: Informes
+      report_job: Crear informe
+      container_conversion_job: Crear informe
       unknown_job_type: Tipo de trabajo desconocido
     status: Estado
     status_completed: Completado

--- a/common/locales/fr.yml
+++ b/common/locales/fr.yml
@@ -1975,11 +1975,11 @@ fr:
     _plural: Tâches d'arrière-plan
     job_type: Type de tâche
     types:
-      print_to_pdf_job: Imprimer en PDF
+      print_to_pdf_job: Générer un PDF
       import_job: Importer des données
       find_and_replace_job: Rechercher et remplacer en masse (Bêta)
-      report_job: Rapports
-      container_conversion_job: Rapports
+      report_job: Creer un rapport
+      container_conversion_job: Creer un rapport
       generate_slugs_job: Générer des URL sémantiques pour les entitées
       unknown_job_type: Type de tâche inconnu
     status: Statut

--- a/common/locales/ja.yml
+++ b/common/locales/ja.yml
@@ -1495,11 +1495,11 @@ ja:
     _plural: バックグラウンドジョブ
     job_type: ジョブの種類
     types:
-      print_to_pdf_job: PDFへの印刷
+      print_to_pdf_job: PDFを生成
       import_job: データのインポート
       find_and_replace_job: バッチの検索と置換（ベータ版）
-      report_job: レポート
-      container_conversion_job: レポート
+      report_job: レポートを作成
+      container_conversion_job: レポートを作成
       unknown_job_type: 不明なジョブタイプ
     status: 状態
     status_completed: 完了しました

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -98,7 +98,7 @@ en:
     publish_confirm_message: "<p>Performing this action will publish this record, any sub-records (External Documents, Notes, etc) and all components in the hierarchy.</p>"
     view_search_results: Go to Search Results
     view_published: View Published
-    print_to_pdf: Print Resource To PDF
+    print_to_pdf: Generate PDF
     resource_to_pdf: Resource to Print
     download_pdf: Download PDF
     download_report: Download Report
@@ -1049,7 +1049,7 @@ en:
       audit_data: Audit Data
       actions:
         create: Create Job
-        save: Queue Job
+        save: Start Job
         new: New Background Job
         cancel: Cancel Job
         add_file: Add file

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -98,7 +98,7 @@
     publish_confirm_message: "<p>Realizar esta acción va a publicar este documento, los registros secundarios (documentos externos, notas, etc.) y todos los componentes de la jerarquía.</p>"
     view_search_results: Ir a los resultados de búsqueda
     view_published: Ver publicados
-    print_to_pdf: Imprimir Fondos en PDF
+    print_to_pdf: Generar PDF
     resource_to_pdf: Fondo a imprimir
     download_pdf: Descargar PDF
     download_report: Descargar Informe
@@ -1030,7 +1030,7 @@
       audit_data: Datos de auditoría
       actions:
         create: Crear tarea
-        save: Guardar tarea
+        save: Empezar tarea
         new: Nueva tarea en el background
         cancel: Cancelar tarea
         add_file: Agregar archivo

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -98,7 +98,7 @@ fr:
     publish_confirm_message: "<p>Effectuer cette opération publiera cette notice, toutes les éventuelles sous-notices (Documents externes, notes, etc.) et tous les composants de la hiérarchie.</p>"
     view_search_results: Aller aux résultats de la recherche
     view_published: Voir publiés
-    print_to_pdf: Imprimer ressource en PDF
+    print_to_pdf: Générer un PDF
     resource_to_pdf: Ressource à imprimer
     download_pdf: Télécharger PDF
     download_report: Télécharger rapport
@@ -1049,7 +1049,7 @@ fr:
       audit_data: Audit Data
       actions:
         create: Créer job
-        save: Mettre la tâche en file d'attente
+        save: Commencer tâche
         new: Nouvelle tâche d'arrière-plan
         cancel: Annuler tâche
         add_file: Ajouter fichier

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -104,7 +104,7 @@ ja:
       </p>"
     view_search_results: 検索結果に移動
     view_published: ビューの公開
-    print_to_pdf: PDFへのリソースの印刷
+    print_to_pdf: PDFを生成
     resource_to_pdf: 印刷するリソース
     download_pdf: PDFをダウンロード
     download_report: ダウンロードレポート
@@ -1039,7 +1039,7 @@ ja:
       audit_data: 監査データ
       actions:
         create: ジョブの作成
-        save: キュージョブ
+        save: 仕事を始める
         new: 新しいバックグラウンドジョブ
         cancel: ジョブをキャンセルする
         add_file: ファイルを追加する

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -1915,12 +1915,6 @@ en:
       novalue: No value defined
     user_defined_enum_4:
       novalue: No value defined
-    job_type:
-      print_to_pdf_job: Print To PDF
-      import_job: Import Data
-      find_and_replace_job: Batch Find and Replace (Beta)
-      report_job: Reports
-      container_conversion_job: Reports
     dimension_units:
       inches: Inches
       feet: Feet

--- a/public/config/locales/es.yml
+++ b/public/config/locales/es.yml
@@ -1915,12 +1915,6 @@ es:
       novalue: No value defined
     user_defined_enum_4:
       novalue: No value defined
-    job_type:
-      print_to_pdf_job: Print To PDF
-      import_job: Import Data
-      find_and_replace_job: Batch Find and Replace (Beta)
-      report_job: Reports
-      container_conversion_job: Reports
     dimension_units:
       inches: Inches
       feet: Feet

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -1915,12 +1915,6 @@ fr:
       novalue: Aucune valeur définie
     user_defined_enum_4:
       novalue: Aucune valeur définie
-    job_type:
-      print_to_pdf_job: Imprimer en PDF
-      import_job: Importer données
-      find_and_replace_job: Rechercher et remplacer en masse (Bêta)
-      report_job: Rapports
-      container_conversion_job: Rapports
     dimension_units:
       inches: Inches
       feet: Feet

--- a/public/config/locales/ja.yml
+++ b/public/config/locales/ja.yml
@@ -1833,12 +1833,6 @@ ja:
       novalue: 値が定義されていない
     user_defined_enum_4:
       novalue: 値が定義されていない
-    job_type:
-      print_to_pdf_job: PDFへの印刷
-      import_job: データのインポート
-      find_and_replace_job: バッチの検索と置換（ベータ版）
-      report_job: レポート
-      container_conversion_job: レポート
     dimension_units:
       inches: インチ
       feet: 足


### PR DESCRIPTION
Changed some terminology for background jobs.

## Description
<!--- Describe your changes in detail -->
- Changed 'Queue Job' to 'Start Job'
- Changed 'Print to PDF' and 'Print Resource to PDF' to 'Generate PDF'
- Changed 'Reports' to 'Create Report'
- Got rid of unused job type translations in public

## Related JIRA Ticket or GitHub Issue
[ANW-657](https://archivesspace.atlassian.net/browse/ANW-657)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Makes the functionality of background jobs actions clearer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked that new terminology shows up appropriately in staff interface.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
