### PR TITLE
ANW-749 get rid of duplicate record type sort option

### DIFF
--- a/frontend/app/views/shared/_pagination_summary.html.erb
+++ b/frontend/app/views/shared/_pagination_summary.html.erb
@@ -25,14 +25,6 @@
             </ul>
           </li>
         <% end %>
-        <% if show_record_type? %>
-          <li class="dropdown-submenu"><%= link_to I18n.t("search_sorting.primary_type"), build_search_params("sort2" => @search_data.sort_filter_for("primary_type", "desc")) %>
-            <ul class="dropdown-menu">
-              <li><%= link_to I18n.t("search_sorting.asc"), build_search_params("sort" => "primary_type asc") %></li>
-              <li><%= link_to I18n.t("search_sorting.desc"), build_search_params("sort" => "primary_type desc") %></li>
-            </ul>
-          </li>
-        <% end %>
         <% @search_data.sort_fields.each do |field| %>
           <li class="dropdown-submenu">
             <%= link_to I18n.t("search_sorting.#{field}"), build_search_params("sort" => @search_data.sort_filter_for(field, "desc")) %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Gets rid of duplicated record type sort option in the sort dropdown filter for search results

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-749](https://archivesspace.atlassian.net/browse/ANW-749)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The "Record Type" filter was appearing twice in the sort dropdown filter for search results.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested that record type now only appears once in the sort dropdown when appropriate.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22351973/53433987-97d16800-39c3-11e9-9526-81da96f60f52.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
