### PR TITLE
ANW-684

### DIFF
--- a/frontend/app/views/dates/_template.html.erb
+++ b/frontend/app/views/dates/_template.html.erb
@@ -88,7 +88,7 @@
     <div class="date-container">
       <%= form.label_and_select "label", form.possible_options_for("label") %>
       <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => "Describe the date or date range"}, :required => :conditionally} %>
-			<%= form.label_and_select "date_type", form.possible_options_for("date_type", true), :required => true %>
+			<%= form.label_and_select "date_type", form.possible_options_for("date_type", true, :exclude => (exclude ||= [])), :required => true %>
       <%form.emit_template("date_fields") %>
     </div>
   </div>

--- a/frontend/app/views/deaccessions/_template.html.erb
+++ b/frontend/app/views/deaccessions/_template.html.erb
@@ -14,7 +14,7 @@
         </h3>
         <div class="subrecord-form-container">
           <%= form.fields_for(form.obj["date"] || {"label" => "deaccession"}, "date") do | date | %>
-            <% render_aspace_partial :partial => "dates/template", :locals => {:form => form, :exclude => "range"} %>
+            <% render_aspace_partial :partial => "dates/template", :locals => {:form => form, :exclude => ["range"]} %>
             <% form.emit_template("date") %>
           <% end %>
         </div>

--- a/frontend/app/views/deaccessions/_template.html.erb
+++ b/frontend/app/views/deaccessions/_template.html.erb
@@ -14,7 +14,7 @@
         </h3>
         <div class="subrecord-form-container">
           <%= form.fields_for(form.obj["date"] || {"label" => "deaccession"}, "date") do | date | %>
-            <% render_aspace_partial :partial => "dates/template", :locals => {:form => form} %>
+            <% render_aspace_partial :partial => "dates/template", :locals => {:form => form, :exclude => "range"} %>
             <% form.emit_template("date") %>
           <% end %>
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Remove date type 'Range' from options for deaccession dates

## Description
<!--- Describe your changes in detail -->
Added a way to specify date types to exclude from dropdown when rendering date template. For deaccession dates, specified that 'range' should be excluded.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-684](https://archivesspace.atlassian.net/browse/ANW-684)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Option for 'Range' date type was appearing in dropdown for deaccession date type though it did not apply to deaccession dates.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested that deaccesion date type dropdown no longer includes 'Range' and other date type dropdowns remain unchanged.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
