### PR TITLE
ANW-391: Do not close RDE modal with click outside window

### DIFF
--- a/frontend/app/assets/javascripts/rde.js
+++ b/frontend/app/assets/javascripts/rde.js
@@ -1295,7 +1295,7 @@ $(function() {
   });
 
   $(document).bind("rdeshow.aspace", function(event, $node, $button) {
-    var $modal = AS.openCustomModal("rapidDataEntryModal", $button.text(), AS.renderTemplate("modal_content_loading_template"), 'full', {keyboard: false}, $button);
+    var $modal = AS.openCustomModal("rapidDataEntryModal", $button.text(), AS.renderTemplate("modal_content_loading_template"), 'full', {backdrop: 'static', keyboard: false}, $button);
 
     $(document).triggerHandler("rdeload.aspace", [$node.data('uri'), $modal]);
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Clicking outside of the rapid data entry modal window will not close the window.  The only way to close the window is by clicking the "X" at the top of the screen.  Change only applies to the RDE modal, not other modals in the application (e.g. search/browse top container from within a resource/accession/ao record).

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-391

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make it harder for users to accidentally close the RDE window with wayward clicks that lead to substantial data loss.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Confirmed visually, existing tests pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
