### PR TITLE
Fix to solr params from config.rb file for PUI

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -85,6 +85,8 @@ AppConfig[:solr_backup_directory] = proc { File.join(AppConfig[:data_directory],
 #      "pf" => 'title^10',
 #      "ps" => 0,
 #    }
+# For more information about solr parameters, please consult the solr documentation
+# here: https://lucene.apache.org/solr/
 # Configuring search operator to be AND by default - ANW-427
 AppConfig[:solr_params] = { "q.op" => "AND" }
 

--- a/public/app/controllers/concerns/searchable.rb
+++ b/public/app/controllers/concerns/searchable.rb
@@ -331,6 +331,15 @@ module Searchable
     default.each do |k,v|
       opts[k] = v
     end
+    if AppConfig[:solr_params].any?
+      AppConfig[:solr_params].each do |param, value|
+        if value.respond_to? :call
+          opts[param.to_sym] = self.instance_eval(&value)
+        else
+          opts[param.to_sym] = value
+        end
+      end
+    end
     opts
   end
 

--- a/public/app/services/archives_space_client.rb
+++ b/public/app/services/archives_space_client.rb
@@ -48,7 +48,7 @@ class ArchivesSpaceClient
   end
 
   def search(query, page = 1, search_opts = {})
-    search_opts = set_search_opts(search_opts)
+    search_opts = DEFAULT_SEARCH_OPTS.merge(search_opts)
     url = build_url('/search', search_opts.merge(:q => query, :page => page))
     results = do_search(url)
 
@@ -57,7 +57,7 @@ class ArchivesSpaceClient
 
   # handles multi-line searching
   def advanced_search(base, page = 1, search_opts = {})
-    search_opts = set_search_opts(search_opts)
+    search_opts = DEFAULT_SEARCH_OPTS.merge(search_opts)
     url = build_url(base,  search_opts.merge(:page => page))
     results = do_search(url)
 
@@ -65,7 +65,7 @@ class ArchivesSpaceClient
   end
   # calls the '/search/records' endpoint
   def search_records(record_list, search_opts = {}, full_notes = false)
-    search_opts = set_search_opts(search_opts)
+    search_opts = DEFAULT_SEARCH_OPTS.merge(search_opts)
 
     url = build_url('/search/records', search_opts.merge("uri[]" => record_list))
     results = do_search(url)
@@ -77,7 +77,7 @@ class ArchivesSpaceClient
   end
 
   def get_raw_record(uri, search_opts = {})
-    search_opts = set_search_opts(search_opts)
+    search_opts = DEFAULT_SEARCH_OPTS.merge(search_opts)
     url = build_url('/search/records', search_opts.merge("uri[]" => ASUtils.wrap(uri)))
     results = do_search(url)
 
@@ -95,7 +95,7 @@ class ArchivesSpaceClient
   end
 
   def search_repository( base, repo_id, page = 1, search_opts = {})
-    search_opts = set_search_opts(search_opts)
+    search_opts = DEFAULT_SEARCH_OPTS.merge(search_opts)
 
     url = build_url(base,search_opts.merge(:page => page))
     results = do_search(url)
@@ -123,7 +123,7 @@ class ArchivesSpaceClient
   end
 
   def get_repos_sublist(uri, type, search_opts = {})
-    search_opts = set_search_opts(search_opts)
+    search_opts = DEFAULT_SEARCH_OPTS.merge(search_opts)
     search_opts = search_opts.merge({"q" => "(used_within_published_repository:\"#{uri}\" AND publish:true AND types:pui_#{type})"})
     url = build_url("/search", search_opts)
     results = do_search(url)
@@ -267,20 +267,4 @@ class ArchivesSpaceClient
     end
     filter_str
   end
-
-  # Include configurable solr parameters from AppConfig in the search options hash
-  def set_search_opts(search_opts = {})
-    search_opts = DEFAULT_SEARCH_OPTS.merge(search_opts)
-    if AppConfig[:solr_params].any?
-      AppConfig[:solr_params].each do |param, value|
-        if value.respond_to? :call
-          search_opts[param.to_sym] = self.instance_eval(&value)
-        else
-          search_opts[param.to_sym] = value
-        end
-      end
-    end
-    search_opts
-  end
-
 end

--- a/public/spec/controllers/concerns_controller_spec.rb
+++ b/public/spec/controllers/concerns_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+class ConcernsController < ApplicationController
+  include Searchable
+end
+
+describe ConcernsController do
+
+  it 'includes AppConfig[:solr_params] in the search options' do
+    AppConfig[:solr_params] = { "mm" => "3<90%", "q.op" => "AND" }
+    AppConfig[:solr_params].each do | k, v |
+      expect(subject.default_search_opts[k.to_sym]).to eq(v)
+    end
+  end
+
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The solr_params AppConfig values were not being passed into the PUI for searches. This fixes that issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
