### PR TITLE
Use correct record_types in slug partial display

### DIFF
--- a/frontend/app/views/classification_terms/_show_inline.html.erb
+++ b/frontend/app/views/classification_terms/_show_inline.html.erb
@@ -13,7 +13,7 @@
           <h3><%= I18n.t("classification_term._frontend.section.basic_information") %></h3>
             <%= form.label_and_textarea "identifier" %>
 
-            <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @resource} if AppConfig[:use_human_readable_URLs] %>
+            <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @classification_term} if AppConfig[:use_human_readable_URLs] %>
 
             <%= form.label_and_textarea "title" %>
             <%= form.label_and_textarea "description" %>

--- a/frontend/app/views/classifications/_show_inline.html.erb
+++ b/frontend/app/views/classifications/_show_inline.html.erb
@@ -15,7 +15,7 @@
             <%= form.label_and_textarea "identifier" %>
             <%= form.label_and_textarea "title" %>
 
-            <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @resource} if AppConfig[:use_human_readable_URLs] %>
+            <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @classification} if AppConfig[:use_human_readable_URLs] %>
 
             <%= form.label_and_textarea "description" %>
 

--- a/frontend/app/views/subjects/show.html.erb
+++ b/frontend/app/views/subjects/show.html.erb
@@ -16,7 +16,7 @@
         <section id="basic_information">
           <h3><%= I18n.t("subject._frontend.section.basic_information") %></h3>
 
-          <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @resource} if AppConfig[:use_human_readable_URLs] %>
+          <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @subject} if AppConfig[:use_human_readable_URLs] %>
 
           <%= form.label_and_textfield "authority_id" %>
           <%= form.label_and_select "source", form.possible_options_for("source", true) %>


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
500 errors generated when selecting view mode from browse page for subjects:

I, [2019-03-04T09:15:47.309906 #3141]  INFO -- : Completed 500 Internal Server Error in 191ms
F, [2019-03-04T09:15:47.315912 #3141] FATAL -- :   
F, [2019-03-04T09:15:47.317235 #3141] FATAL -- : ActionView::Template::Error (undefined method `[]' for nil:NilClass):
F, [2019-03-04T09:15:47.317933 #3141] FATAL -- :      5:   <%= form.label_with_field "public_url", form.hidden_input("public_url") + "<span class='identifier-display'><span class='identifier-display-part'>#{form.slug_url_field("slug", session[:repo_slug], AppConfig[:repo_slug_in_URL])}</span></span>".html_safe %>
     6: <% end %>
     7: <% if record_type == @repository %>
     8:   <%= form.label_and_textfield "slug", :field_opts => {:readonly => @repository['repository']['is_slug_auto'] } %>
     9: <% else %>
    10:   <%= form.label_and_textfield "slug", :field_opts => {:readonly => record_type.is_slug_auto } %>
    11: <% end %>
F, [2019-03-04T09:15:47.320160 #3141] FATAL -- :   
F, [2019-03-04T09:15:47.320485 #3141] FATAL -- : app/views/shared/_slug.html.erb:8:in `_app_views_shared__slug_html_erb__197375159_2346'
app/helpers/application_helper.rb:295:in `render_aspace_partial'
app/views/subjects/show.html.erb:19:in `block in _app_views_subjects_show_html_erb__2124876959_2330'
app/helpers/aspace_form_helper.rb:489:in `emit_template'
app/views/subjects/show.html.erb:28:in `block in _app_views_subjects_show_html_erb__2124876959_2330'
app/helpers/aspace_form_helper.rb:1076:in `readonly_context'
app/views/subjects/show.html.erb:10:in `_app_views_subjects_show_html_erb__2124876959_2330'


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Had to set use_human_readable_urls to true in the config.rb file. Then manually tested by pulling up subject browse page and clicking on view button. Also found same issue with classifications and classification_terms.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
