### PR TITLE
Respect audience att on EAD import, add tests

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -972,7 +972,8 @@ class EADConverter < Converter
   def make_corp_template(opts)
     return nil if inner_xml.strip.empty?
     make :agent_corporate_entity, {
-      :agent_type => 'agent_corporate_entity'
+      :agent_type => 'agent_corporate_entity',
+      :publish => att('audience') == 'external' ?  true : false
     } do |corp|
       set ancestor(:resource, :archival_object), :linked_agents, {'ref' => corp.uri, 'role' => opts[:role]}
     end
@@ -992,6 +993,7 @@ class EADConverter < Converter
     return nil if inner_xml.strip.empty?
     make :agent_family, {
       :agent_type => 'agent_family',
+      :publish => att('audience') == 'external' ?  true : false
     } do |family|
       set ancestor(:resource, :archival_object), :linked_agents, {'ref' => family.uri, 'role' => opts[:role]}
     end
@@ -1011,6 +1013,7 @@ class EADConverter < Converter
     return nil if inner_xml.strip.empty?
     make :agent_person, {
       :agent_type => 'agent_person',
+      :publish => att('audience') == 'external' ?  true : false
     } do |person|
       set ancestor(:resource, :archival_object), :linked_agents, {'ref' => person.uri, 'role' => opts[:role]}
     end

--- a/backend/app/exporters/examples/ead/at-tracer.xml
+++ b/backend/app/exporters/examples/ead/at-tracer.xml
@@ -87,7 +87,7 @@
                 <physfacet>Resource-PhysicalFacet-AT</physfacet>
             </physdesc>
             <origination label="creator">
-                <corpname rules="dacs" source="naf" role="Creator (cre)">CNames-PrimaryName-AT. CNames-Subordinate1-AT. CNames-Subordiate2-AT. (CNames-Number-AT) (CNames-Qualifier-AT)</corpname>
+                <corpname rules="dacs" source="naf" role="Creator (cre)" audience="internal">CNames-PrimaryName-AT. CNames-Subordinate1-AT. CNames-Subordiate2-AT. (CNames-Number-AT) (CNames-Qualifier-AT)</corpname>
             </origination>
             <origination label="creator">
                 <famname rules="aacr" source="naf" role="Creator (cre)">FNames-FamilyName-AT, FNames-Prefix-AT, FNames-Qualifier-AT</famname>
@@ -312,7 +312,7 @@
         </separatedmaterial>
         <controlaccess>
             <corpname rules="dacs" source="naf" role="Donor (dnr)">CNames-PrimaryName-AT. CNames-Subordinate1-AT. CNames-Subordiate2-AT. (CNames-Number-AT) (CNames-Qualifier-AT)</corpname>
-            <corpname rules="dacs" source="naf">CNames-PrimaryName-AT. CNames-Subordinate1-AT. CNames-Subordiate2-AT. (CNames-Number-AT) (CNames-Qualifier-AT) -- Archives</corpname>
+            <corpname rules="dacs" source="naf" audience="external">CNames-PrimaryName-AT. CNames-Subordinate1-AT. CNames-Subordiate2-AT. (CNames-Number-AT) (CNames-Qualifier-AT) -- Archives</corpname>
             <famname rules="aacr" source="naf" role="Donor (dnr)">FNames-FamilyName-AT, FNames-Prefix-AT, FNames-Qualifier-AT</famname>
             <famname rules="aacr" source="naf">FNames-FamilyName-AT, FNames-Prefix-AT, FNames-Qualifier-AT -- Archives</famname>
             <persname rules="local" source="local" role="Donor (dnr)">PNames-Primary-AT, PNames-RestOfName-AT, PNames-Prefix-AT, PName-Number-AT, PNames-Suffix-AT, PNames-Title-AT,  (PNames-FullerForm-AT), PNames-Dates-AT, PNames-Qualifier-AT</persname>
@@ -492,7 +492,7 @@
                                             <corpname rules="dacs" source="naf" role="Creator (cre)">CNames-PrimaryName-AT. CNames-Subordinate1-AT. CNames-Subordiate2-AT. (CNames-Number-AT) (CNames-Qualifier-AT)</corpname>
                                         </origination>
                                         <origination label="creator">
-                                            <famname rules="aacr" source="naf" role="Creator (cre)">FNames-FamilyName-AT, FNames-Prefix-AT, FNames-Qualifier-AT</famname>
+                                            <famname rules="aacr" source="naf" role="Creator (cre)" audience="internal">FNames-FamilyName-AT, FNames-Prefix-AT, FNames-Qualifier-AT</famname>
                                         </origination>
                                         <origination label="creator">
                                             <persname rules="local" source="local" role="Creator (cre)">PNames-Primary-AT, PNames-RestOfName-AT, PNames-Prefix-AT, PName-Number-AT, PNames-Suffix-AT, PNames-Title-AT,  (PNames-FullerForm-AT), PNames-Dates-AT, PNames-Qualifier-AT</persname>
@@ -559,7 +559,7 @@
                                     </bioghist>
                                     <controlaccess>
                                         <corpname rules="dacs" source="naf">CNames-PrimaryName-AT. CNames-Subordinate1-AT. CNames-Subordiate2-AT. (CNames-Number-AT) (CNames-Qualifier-AT) -- Pictorial works</corpname>
-                                        <famname rules="aacr" source="naf">FNames-FamilyName-AT, FNames-Prefix-AT, FNames-Qualifier-AT -- Pictorial works</famname>
+                                        <famname rules="aacr" source="naf" audience="external">FNames-FamilyName-AT, FNames-Prefix-AT, FNames-Qualifier-AT -- Pictorial works</famname>
                                         <persname rules="local" source="local">PNames-Primary-AT, PNames-RestOfName-AT, PNames-Prefix-AT, PName-Number-AT, PNames-Suffix-AT, PNames-Title-AT,  (PNames-FullerForm-AT), PNames-Dates-AT, PNames-Qualifier-AT -- Pictorial works</persname>
                                         <function source="local">Subjects--Function-AT</function>
                                         <genreform source="local">Subjects--GenreForm--AT</genreform>

--- a/backend/spec/lib_ead_converter_spec.rb
+++ b/backend/spec/lib_ead_converter_spec.rb
@@ -272,6 +272,9 @@ ANEAD
       expect(linked['role']).to eq('subject')
 
       #   ELSE
+      #   Respect audience attribute as set in at-tracer.xml
+      expect(c1['publish']).to be_falsey
+      expect(c2['publish']).to be_truthy
       #   IF @rules != NULL ==> name_corporate_entity.rules
       expect([c1, c2].map {|c| c['names'][0]['rules']}.uniq).to eq(['dacs'])
       #   IF @source != NULL ==> name_corporate_entity.source
@@ -292,6 +295,9 @@ ANEAD
       n2 = fams.find{|f| f['uri'] == links.find{|l| l['role'] == 'subject' }['ref'] }['names'][0]['family_name']
       expect(n2).to eq("FNames-FamilyName-AT, FNames-Prefix-AT, FNames-Qualifier-AT -- Pictorial works")
       #   ELSE
+      #   Respect audience attribute as set in at-tracer.xml
+      expect(fams.find{|f| f['uri'] == links.find{|l| l['role'] == 'creator' }['ref'] }['publish']).to be_falsey
+      expect(fams.find{|f| f['uri'] == links.find{|l| l['role'] == 'subject' }['ref'] }['publish']).to be_truthy
       #   IF @rules != NULL
       expect(fams.map{|f| f['names'][0]['rules']}.uniq).to eq(['aacr'])
       #   IF @source != NULL
@@ -306,6 +312,8 @@ ANEAD
       #   IF nested in <controlaccess>
       expect(@archival_objects['06']['linked_agents'].reverse.find {|l| @people.map{|p| p['uri'] }.include?(l['ref'])}['role']).to eq('subject')
       #   ELSE
+      #   If audience attribute is not present in at-tracer.xml, default to unpublished
+      expect(@people.map {|p| p['publish']}.uniq).to eq([false])
       #   IF @rules != NULL
       expect(@people.map {|p| p['names'][0]['rules']}.uniq).to eq(['local'])
       #   IF @source != NULL


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If `<corpname>`, `<famname>`, or `<persname>`'s contain `audience` attributes, respect that attribute.  Default to internal/unpublished if no attribute present.  Also, updated the at-tracer.xml sample to include some attributes in order to add tests to `lib_ead_converter_spec.rb`.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests to `lib_ead_converter_spec.rb`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
