### PR TITLE
Fix problem of unescaped ampersands in single-part fields

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -107,6 +107,7 @@ class EADSerializer < ASpaceExport::Serializer
     if allow_p
       content = handle_linebreaks(content)
     else
+      escape_content(content)
       content = strip_p(content)
     end
 


### PR DESCRIPTION
## Description
Currently data is only run through escape_content if <p>s are allowed.  This runs non-p data through escape_content as well.  The EAD3 serializer already does this.

## Related JIRA Ticket or GitHub Issue
ANW-751

## Motivation and Context
Bug fix

## How Has This Been Tested?
Tested with examples given in ticket
ran backend:test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
