### PR TITLE
Fixes #1488 by switching on WheelEvent.deltaMode

### DIFF
--- a/public/app/assets/javascripts/infinite_scroll.js
+++ b/public/app/assets/javascripts/infinite_scroll.js
@@ -27,7 +27,7 @@
 
     var scrollTimer = undefined;
 
-    InfiniteScroll.prototype.function getLineHeight(element){
+    InfiniteScroll.prototype.getLineHeight = function(element){
         var temp, height;
         temp = document.createElement(element.nodeName);
         temp.setAttribute("style","margin:0px;padding:0px;font-family:"+element.style.fontFamily+";font-size:"+element.style.fontSize);

--- a/public/app/assets/javascripts/infinite_scroll.js
+++ b/public/app/assets/javascripts/infinite_scroll.js
@@ -27,6 +27,17 @@
 
     var scrollTimer = undefined;
 
+    InfiniteScroll.prototype.function getLineHeight(element){
+        var temp, height;
+        temp = document.createElement(element.nodeName);
+        temp.setAttribute("style","margin:0px;padding:0px;font-family:"+element.style.fontFamily+";font-size:"+element.style.fontSize);
+        temp.innerHTML = "test";
+        temp = element.parentNode.appendChild(temp);
+        height = temp.clientHeight;
+        temp.parentNode.removeChild(temp);
+        return height;
+    }
+
     InfiniteScroll.prototype.scrollBy = function (px) {
         var self = this;
 
@@ -100,7 +111,7 @@
             /* In pixel mode deltaY can be used directly, but in line and page mode,
                multiply to get pixel values. */
             if (e.originalEvent.deltaMode == WheelEvent.DOM_DELTA_LINE) {
-                scrollAmount = (scrollAmount < 0 ? -1 : 1) * 55;
+              scrollAmount = (scrollAmount * self.getLineHeight(self.wrapper.get(0)));
             } else if (e.originalEvent.deltaMode == WheelEvent.DOM_DELTA_PAGE) {
                 scrollAmount = (scrollAmount < 0 ? -1 : 1) * self.wrapper.height();
             }

--- a/public/app/assets/javascripts/infinite_scroll.js
+++ b/public/app/assets/javascripts/infinite_scroll.js
@@ -97,6 +97,14 @@
 
             var scrollAmount = e.originalEvent.deltaY;
 
+            /* In pixel mode deltaY can be used directly, but in line and page mode,
+               multiply to get pixel values. */
+            if (e.originalEvent.deltaMode == WheelEvent.DOM_DELTA_LINE) {
+                scrollAmount = (scrollAmount < 0 ? -1 : 1) * 55;
+            } else if (e.originalEvent.deltaMode == WheelEvent.DOM_DELTA_PAGE) {
+                scrollAmount = (scrollAmount < 0 ? -1 : 1) * self.wrapper.height();
+            }
+
             self.scrollBy(scrollAmount);
         });
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Takes into account WheelEvent.deltaMode, multiplying scrollAmount by wrapper height if it's page, or former default if it's line (finding actual line-height might be preferable, but this restores status quo and is much easier.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
#1488 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Scrolling is broken for sure on Firefox and maybe elsewhere.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
