### PR TITLE
Allow running of individual public specs

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -902,6 +902,9 @@
 
   <target name="public:test" depends="set-classpath, public:copy-shared-resources" description="Run the unit test suite">
     <property name="spec" value=""/>
+    <condition property="spec-arg" value="${spec}" else="">
+      <isset property="spec"/>
+    </condition>
     <property name="example" value=""/>
     <condition property="example-arg" value="-e &quot;${example}&quot;" else="">
       <isset property="example"/>
@@ -914,7 +917,7 @@
       <env key="GEM_HOME" value="${gem_home}" />
       <env key="GEM_PATH" value="" />
       <env key="BUNDLE_PATH" value="${gem_home}" />
-      <arg line="--debug ../build/gems/bin/rspec -b --format d --order rand:1 ${example-arg}" />
+      <arg line="--debug ../build/gems/bin/rspec -b --format d --order rand:1 ${example-arg} spec/${spec-arg}" />
     </java>
   </target>
 

--- a/public/spec/spec_helper.rb
+++ b/public/spec/spec_helper.rb
@@ -126,7 +126,7 @@ RSpec.configure do |config|
     end
     # For some reason we have to manually shutdown mizuno for the test suite to
     # quit.
-    Rack::Handler.get('mizuno').instance_variable_get(:@server).stop
+    Rack::Handler.get('mizuno').instance_variable_get(:@server) ? Rack::Handler.get('mizuno').instance_variable_get(:@server).stop : next
   end
 
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Provides the ability to run select public tests, in a similar way as implemented in the backend.

## Description
<!--- Describe your changes in detail -->
Allows users to provide a filepath to a public spec and have only that one spec run.  So, for example:

`build/run public:test -Dspec="features/accessibility_spec.rb"`

will run only the tests in `accessibility_spec.rb`.

Also, since individual specs may now be run in isolation, it is possible to reach the end of testing and not have mizuno fire up.  Added a ternary to confirm that mizuno is actually running before attempting to stop it.  

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
No longer requires the entire public test suite to be run to test one area of the code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually.  Can still run all tests with build/run public:test, while also being able to specify single spec files (similar to specifying a single test via the example argument).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
