### PR TITLE
append to log instead of overwrite

### DIFF
--- a/launcher/archivesspace.sh
+++ b/launcher/archivesspace.sh
@@ -148,7 +148,7 @@ case "$1" in
         $shellcmd -c "cd '$ASPACE_LAUNCHER_BASE';
           (
              exec 0<&-; exec 1>&-; exec 2>&-;
-             $startup_cmd &> \"$ARCHIVESSPACE_LOGS\" &
+             $startup_cmd &>> \"$ARCHIVESSPACE_LOGS\" &
              echo \$! > \"$ASPACE_PIDFILE\"
           ) &
           disown $!"


### PR DESCRIPTION
changed logging from overwriting the log file on each startup to appending to the log if it exists. this preserves logging between service restarts and allows logrotate to copytruncate the log file without the program continuing to write from the previous offset, inadvertently creating large sparse files.
