### PR TITLE
Pui language

### DIFF
--- a/public/app/models/resource.rb
+++ b/public/app/models/resource.rb
@@ -93,7 +93,7 @@ class Resource < Record
       subj['authority_id'] ? subj['authority_id'] : subj['title']
     }
 
-    if !json['language'].blank?
+    if !raw['language'].blank?
          md['inLanguage'] = {
            '@type' => 'Language',
            'name' => I18n.t("enumerations.language_iso639_2.#{raw['language']}", :default => raw['language'])

--- a/public/app/models/resource.rb
+++ b/public/app/models/resource.rb
@@ -93,7 +93,7 @@ class Resource < Record
       subj['authority_id'] ? subj['authority_id'] : subj['title']
     }
 
-    if raw['language'].try(:any?)
+    if !json['language'].blank?
          md['inLanguage'] = {
            '@type' => 'Language',
            'name' => I18n.t("enumerations.language_iso639_2.#{raw['language']}", :default => raw['language'])

--- a/public/app/views/resources/_infinite_item.html.erb
+++ b/public/app/views/resources/_infinite_item.html.erb
@@ -50,9 +50,9 @@
         <% end %>
     <% end %>
 
-    <% if @result['language'] %>
+    <% if @result['json']['language'] %>
         <dt><%= t('resource._public.lang')%></dt>
-        <dd><%= t('enumerations.language_iso639_2.' + @result['language'].downcase) %></dd>
+        <dd><%= t('enumerations.language_iso639_2.' + @result['json']['language'].downcase) %></dd>
     <% else %>
       <% langmaterial_note = @result.note('langmaterial') %>
       <% if langmaterial_note && !langmaterial_note['note_text'].blank? %>

--- a/public/app/views/resources/_infinite_item.html.erb
+++ b/public/app/views/resources/_infinite_item.html.erb
@@ -50,9 +50,9 @@
         <% end %>
     <% end %>
 
-    <% if @result['json']['language'] %>
+    <% if @result['language'] %>
         <dt><%= t('resource._public.lang')%></dt>
-        <dd><%= t('enumerations.language_iso639_2.' + @result['json']['language'].downcase) %></dd>
+        <dd><%= t('enumerations.language_iso639_2.' + @result['language'].downcase) %></dd>
     <% else %>
       <% langmaterial_note = @result.note('langmaterial') %>
       <% if langmaterial_note && !langmaterial_note['note_text'].blank? %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, the PUI doesn't display language of materials information in the linked data in the html source.  This appears to be a simple oversight because the code that is present is looking for the language key in a place where it does not exist (at least not anymore?).  This corrects that.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently broken and discovered when preparing to make changes for [ANW-697] and [ANW-382].

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually inspected.  No existing tests fail.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
