### PR TITLE
ANW-872: add link for revision statements

### DIFF
--- a/frontend/app/views/resources/_sidebar.html.erb
+++ b/frontend/app/views/resources/_sidebar.html.erb
@@ -6,6 +6,7 @@
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'date', :property => 'dates') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'extent', :property => 'extents') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'finding_aid', :property => :none) %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'revision_statement', :property => 'revision_statements') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'related_accession', :property => 'related_accessions') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'linked_agent', :property => 'linked_agents') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'subject', :property => 'subjects') %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a link to the side navigation bar to the revision statements section for resource records.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-872](https://archivesspace.atlassian.net/browse/ANW-872)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Revision statements are the only section for resources that does not have a sidebar link. This makes navigation more difficult.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked that a link now appears for revision statements both on view and edit and it works appropriately.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22351973/55487071-6586dc00-55fb-11e9-92c0-47dd435a6adb.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
