### PR TITLE
ANW-344: show separate headings for multiple notes of same type

### DIFF
--- a/public/app/models/record.rb
+++ b/public/app/models/record.rb
@@ -65,7 +65,15 @@ class Record
   end
 
   def note(type)
-    notes[type] || {}
+    if notes[type]
+      note = notes[type][0].clone
+      for i in 1...notes[type].length
+        note = merge_notes(note, notes[type][i])
+      end
+      note
+    else
+      {}
+    end
   end
 
   def request_item
@@ -148,16 +156,12 @@ class Record
   end
 
   def parse_notes
-    notes = {}
 
     if json.has_key?('notes')
       notes_html =  process_json_notes(json['notes'], (!full ? ABSTRACT : nil))
-      notes_html.each do |type, html|
-        notes[type] = html
-      end
+    else
+      {}
     end
-
-    notes
   end
 
   def parse_dates

--- a/public/app/views/shared/_multi_notes.html.erb
+++ b/public/app/views/shared/_multi_notes.html.erb
@@ -1,8 +1,5 @@
-<%#= debug @result.json['notes'] %>
-<% #types.each do  |type|
-types.each do |type|
+<% types.each do |type|
 	(@result.notes[type] || []).each do |note_struct|
-   # note_struct = @result.note(type)
 	   if !note_struct['note_text'].blank? %>
 	    <div class="note">
 	      <%= render  partial: 'shared/single_note',

--- a/public/app/views/shared/_multi_notes.html.erb
+++ b/public/app/views/shared/_multi_notes.html.erb
@@ -1,9 +1,13 @@
-<% types.each do  |type|
-   note_struct = @result.note(type)
-   if !note_struct['note_text'].blank? %>
-    <div class="note">
-      <%= render  partial: 'shared/single_note',
-          locals: {:type => type, :note_struct => @result.note(type)}  %>
-    </div>
-   <% end %>
+<%#= debug @result.json['notes'] %>
+<% #types.each do  |type|
+types.each do |type|
+	(@result.notes[type] || []).each do |note_struct|
+   # note_struct = @result.note(type)
+	   if !note_struct['note_text'].blank? %>
+	    <div class="note">
+	      <%= render  partial: 'shared/single_note',
+	          locals: {:type => type, :note_struct => note_struct}  %>
+	    </div>
+	   <% end %>
+	<% end %>
 <% end %>

--- a/public/app/views/shared/_record_innards.html.erb
+++ b/public/app/views/shared/_record_innards.html.erb
@@ -25,10 +25,11 @@
     <% end %>
 
     <% non_folder.each do |type| %>
-       <% note_struct =  @result.note(type) %>
+      <% (@result.notes[type] || []).each do |note_struct| %>
        <% unless note_struct['note_text'].blank? %>
         <%= render partial: 'shared/single_note', locals: {:type => type, :note_struct => note_struct}   %>
        <% end %>
+      <% end %>
     <% end %>
 
     <% unless @result.extents.blank? %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In stead of merging notes of the same type together (with the second heading deemphasized) show notes separately with labels emphasized equally.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-344](https://archivesspace.atlassian.net/browse/ANW-344)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When multiples of the same note are included in a resource record, the heading for the second iteration of the note appears with less emphasis, so that it looks like a sub note.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked in public interface that notes of same type are now equally emphasized.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22351973/55488078-5a34b000-55fd-11e9-832a-3f83bc174790.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
