### PR TITLE
ANW-824: add translation for note_bibliography

### DIFF
--- a/common/locales/enums/en.yml
+++ b/common/locales/enums/en.yml
@@ -1347,6 +1347,7 @@ en:
       appraisal: Appraisal
       arrangement: Arrangement
       bibliography: Bibliography
+      note_bibliography: Bibliography
       bioghist: Biographical / Historical
       custodhist: Custodial History
       fileplan: File Plan

--- a/common/locales/enums/es.yml
+++ b/common/locales/enums/es.yml
@@ -1347,6 +1347,7 @@
       appraisal: Nota de valoración
       arrangement: Nota de organización
       bibliography: Nota de bibliografía
+      note_bibliography: Nota de bibliografía
       bioghist: Nota biográfica/histórica
       custodhist: Nota de historia archivística
       fileplan: Nota de proyecto de expediente

--- a/common/locales/enums/fr.yml
+++ b/common/locales/enums/fr.yml
@@ -1347,6 +1347,7 @@
       appraisal: Evaluation
       arrangement: Classement
       bibliography: Bibliographie
+      note_bibliography: Bibliographie
       bioghist: Biographique / Historique
       custodhist: Historique de la conservation
       fileplan: Plan de classement

--- a/common/locales/enums/ja.yml
+++ b/common/locales/enums/ja.yml
@@ -1347,6 +1347,7 @@ ja:
       appraisal: 審査
       arrangement: 配置
       bibliography: 参考文献
+      note_bibliography: 参考文献
       bioghist: 伝記/歴史
       custodhist: 親権史
       fileplan: ファイルプラン


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a translation for note_bibliography which is the default label for bibliography notes in the PUI.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-824](https://archivesspace.atlassian.net/browse/ANW-824)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously, bibliography notes were given no header if a label was not specified.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked in public interface that bibliography notes now show up with  a label.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
