### PR TITLE
ANW-232: make classifications show up as linked records for agents

### DIFF
--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -465,6 +465,11 @@ class IndexerCommon
       if ['classification', 'classification_term'].include?(doc['primary_type'])
         doc['classification_path'] = ASUtils.to_json(record['record']['path_from_root'])
         doc['agent_uris'] = ASUtils.wrap(record['record']['creator']).collect{|agent| agent['ref']}
+        doc['published_agent_uris'] = []
+        if record['record']['creator']['_resolved']['publish']
+          doc['published_agent_uris'] << record['record']['creator']['ref']
+        end
+        doc['agents'] = ASUtils.wrap(record['record']['creator']).collect{|link| link['_resolved']['display_name']['sort_name']}
         doc['identifier_sort'] = IndexerCommon.generate_sort_string_for_identifier(record['record']['identifier'])
         doc['repo_sort'] = record['record']['repository']['_resolved']['display_string']
         doc['has_classification_terms'] = record['record']['has_classification_terms']

--- a/indexer/app/lib/indexer_common_config.rb
+++ b/indexer/app/lib/indexer_common_config.rb
@@ -65,6 +65,8 @@ class IndexerCommonConfig
       'collections',
       'surveyed_by',
       'reviewer',
+
+      'creator'
     ]
   end
 

--- a/public/app/controllers/agents_controller.rb
+++ b/public/app/controllers/agents_controller.rb
@@ -7,7 +7,7 @@ class AgentsController <  ApplicationController
     process_slug_or_id(params)
   }
 
-  DEFAULT_AG_TYPES = %w{repository resource accession archival_object digital_object}
+  DEFAULT_AG_TYPES = %w{repository resource accession archival_object digital_object classification}
   DEFAULT_AG_FACET_TYPES = %w{primary_type subjects}
   DEFAULT_AG_SEARCH_OPTS = {
     'sort' => 'title_sort asc',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added some fields to the index record for classifications for the creator agent so that the classification will show up in the linked records for that agent both in the staff interface and the PUI. **This will require re-index to take effect.**

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-232](https://archivesspace.atlassian.net/browse/ANW-232)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There's no classification record in the search result page, even when an agent is linked as the creator of this classification. This information should show up somewhere.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Looked to see that classifications now show up in linked records for agents in both the staff and public interface.

## Screenshots (if appropriate):
Classification with creator:
![image](https://user-images.githubusercontent.com/22351973/55493600-3ecea280-5607-11e9-99fb-36473f9894ff.png)

That creator in SUI:
![image](https://user-images.githubusercontent.com/22351973/55493894-bdc3db00-5607-11e9-9fe1-59228281b8f4.png)

That creator in PUI:
![image](https://user-images.githubusercontent.com/22351973/55493997-f5328780-5607-11e9-8c22-9664177f0bc9.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
