### PR TITLE
ANW-217 and ANW-260: Note content box

### DIFF
--- a/frontend/app/assets/javascripts/mixed_content.js
+++ b/frontend/app/assets/javascripts/mixed_content.js
@@ -47,15 +47,23 @@ $(function() {
           "Ctrl-Space": function(cm) { CodeMirror.xmlHint(cm, ''); }
         },
         lineWrapping: true,
+        onChange: function(cm) {
+          resize($editor.cursorCoords(true, 'local').y);
+        },
         onCursorActivity: function(cm) {
           if (cm.somethingSelected()) {
             var coords_start = $editor.cursorCoords(true, "local");
             var coords_end = $editor.cursorCoords(false, "local");
 
+            resize(coords_end.y);
+
             var top_offset = $wrapWithAction.height() - 20 + coords_end.y;
-            var left_offset = Math.min(
-                                coords_start.y == coords_end.y ? coords_start.x : coords_end.x,
-                                $($editor.getWrapperElement()).width() - $wrapWithAction.width()
+            var left_offset = Math.max(
+                                Math.min(
+                                  (coords_start.y == coords_end.y ? coords_start.x : coords_end.x) - 83.5,
+                                  $($editor.getWrapperElement()).width() - $wrapWithAction.width()
+                                ),
+                                0
                               );
 
             $wrapWithAction
@@ -73,6 +81,18 @@ $(function() {
 
       $this.data("CodeMirror", $editor);
       $this.addClass("initialised");
+
+
+      var resize = function(height) {
+        var $wrapper = $($editor.getWrapperElement());
+        height += 34 + $wrapWithAction.height();
+        if (height >= $wrapper.height()) {
+          $editor.setSize('auto', height);
+        }
+      };
+
+      resize($editor.getScrollInfo().height);
+
 
       var onWrapActionChange = function(event) {
         if ($editor.somethingSelected() && $wrapWithActionSelect.val() != "") {

--- a/frontend/app/assets/javascripts/mixed_content.js
+++ b/frontend/app/assets/javascripts/mixed_content.js
@@ -47,15 +47,10 @@ $(function() {
           "Ctrl-Space": function(cm) { CodeMirror.xmlHint(cm, ''); }
         },
         lineWrapping: true,
-        onChange: function(cm) {
-          resize($editor.cursorCoords(true, 'local').y);
-        },
         onCursorActivity: function(cm) {
           if (cm.somethingSelected()) {
             var coords_start = $editor.cursorCoords(true, "local");
             var coords_end = $editor.cursorCoords(false, "local");
-
-            resize(coords_end.y);
 
             var top_offset = $wrapWithAction.height() - 20 + coords_end.y;
             var left_offset = Math.max(
@@ -81,18 +76,7 @@ $(function() {
 
       $this.data("CodeMirror", $editor);
       $this.addClass("initialised");
-
-
-      var resize = function(height) {
-        var $wrapper = $($editor.getWrapperElement());
-        height += 34 + $wrapWithAction.height();
-        if (height >= $wrapper.height()) {
-          $editor.setSize('auto', height);
-        }
-      };
-
-      resize($editor.getScrollInfo().height);
-
+      $editor.setSize('auto', 'auto');
 
       var onWrapActionChange = function(event) {
         if ($editor.somethingSelected() && $wrapWithActionSelect.val() != "") {

--- a/frontend/app/views/notes/_template.html.erb
+++ b/frontend/app/views/notes/_template.html.erb
@@ -106,7 +106,7 @@
     <div class="tabbable tabs-below">
       <div class="tab-content">
         <div class="tab-pane active" id="<%= form.id_for("item") %>_raw">
-          <%= form.textarea(nil, item, { :escape => false, :class => "mixed-content"}) %>
+          <%= form.textarea(nil, item, { :escape => false, :class => "mixed-content" }) %>
         </div>
         <div class="tab-pane" id="<%= form.id_for("item") %>_parsed">
           <%= clean_note(item).html_safe %>

--- a/frontend/vendor/assets/stylesheets/codemirror/codemirror.less
+++ b/frontend/vendor/assets/stylesheets/codemirror/codemirror.less
@@ -62,7 +62,7 @@
   cursor: default;
 }
 .CodeMirror-lines {
-  padding: .4em;
+  padding: .4em .4em 3.2em;
   white-space: pre;
   cursor: text;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The note content box now automatically expands to fit the text inside it. Additionally, it expands with enough padding to ensure that the highlight wrap in tag feature always has enough space and shows up.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-217](https://archivesspace.atlassian.net/browse/ANW-217)
[ANW-260](https://archivesspace.atlassian.net/browse/ANW-260)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It would be more convenient when writing notes to have the text box dynamically expand to fit the content.

The wrap in tag highlighting feature is only usable when highlighting text that appears towards the beginning of a note field. When trying to invoke the feature towards the bottom of a note field with several paragraphs of text, the "wrap with" popup is not visible when highlighting text.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked that the note content box resizes appropriately when adding a new note, modifying an existing note, or resizing the browser window. Additionally checked that the highlight and wrap in tag feature always displays correctly. no matter how long the note is.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22351973/55495485-fca76000-560a-11e9-9f77-5b33ec941155.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
