### PR TITLE
ANW-874

### DIFF
--- a/public/app/assets/javascripts/smart_staff_links.js
+++ b/public/app/assets/javascripts/smart_staff_links.js
@@ -20,7 +20,7 @@ $(function() {
   }).done(function( data ) {
     if (data === true) {
       var staff = $('#staff-link');
-      link = FRONTEND_URL + "/resolve/edit?uri=" + RECORD_URI + "&autoselect_repo=true";
+      link = FRONTEND_URL + "/resolve/readonly?uri=" + RECORD_URI + "&autoselect_repo=true";
       staff.attr("href", link);
       staff.removeClass("hide");
     }


### PR DESCRIPTION
PUI staff_links link to /resolve/readonly instead of /resolve/edit 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
trivial one line change to public/app/assets/javascripts/smart_staff_links.js
change target link from /resolve/edit to /resolve/readonly 

Documentation and config comments say only: "attempt to add a link back to the staff interface"  : 
doesn't require update as it's not explicit about what link back. 

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-874](https://archivesspace.atlassian.net/browse/ANW-874)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
/resolve/edit requires edit permission, and fails for users without that repository permission.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
manually tested links after rebuild. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Should not affect anything else.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.