### PR TITLE
ANW-313: add background job to trim title whitespace

### DIFF
--- a/backend/app/lib/job_runners/trim_whitespace_runner.rb
+++ b/backend/app/lib/job_runners/trim_whitespace_runner.rb
@@ -1,0 +1,44 @@
+class TrimWhitespaceRunner < JobRunner
+  register_for_job_type('trim_whitespace_job')
+
+  def run
+    begin
+
+      modified_records = []
+
+      RequestContext.open(:repo_id => @job.repo_id) do
+
+        [Resource, ArchivalObject, Accession, DigitalObject, DigitalObjectComponent].each do |record_class|
+          @job.write_output("Trimming whitespace from #{record_class} titles")
+
+
+          count = 0
+          record_class.this_repo.each do |r|
+            if r[:title] && (trimmed = r[:title].strip) != r[:title]
+              count += 1
+              r.update(:title => trimmed)
+              modified_records << r.uri
+            end
+          end
+          @job.write_output("#{count} records modified.")
+          @job.write_output("================================")
+        end
+      end
+
+      if modified_records.empty?
+        @job.write_output("All done, no records modified.")
+      else
+        @job.write_output("All done, logging modified records.")
+      end
+
+      self.success!
+
+      # just reuse JobCreated api for now...
+      @job.record_created_uris(modified_records)
+    rescue Exception => e
+      @job.write_output(e.message)
+      @job.write_output(e.backtrace)
+      raise e
+    end
+  end
+end

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -1982,6 +1982,7 @@ en:
       report_job: Create Report
       container_conversion_job: Create Report
       generate_slugs_job: Generate Slugs for Entities
+      trim_whitespace_job: Trim Whitespace
       unknown_job_type: Unknown job type
     status: Status
     status_completed: Completed
@@ -2025,6 +2026,9 @@ en:
   print_to_pdf_job:
     include_unpublished: Include Unpublished
     source: Source
+
+  trim_whitespace_job:
+    description: Removes leading and trailing whitespace from titles for resources, accessions, digital objects, archival objects, and digital object components.
 
   advanced_search:
     type:

--- a/common/locales/es.yml
+++ b/common/locales/es.yml
@@ -1961,6 +1961,7 @@ es:
       report_job: Crear informe
       container_conversion_job: Crear informe
       generate_slugs_job: Generar Slugs para Entidades
+      trim_whitespace_job: Recortar espacios en blanco
       unknown_job_type: Tipo de trabajo desconocido
     status: Estado
     status_completed: Completado
@@ -2005,8 +2006,9 @@ es:
     include_unpublished: Incluir sin publicar
     source: Fuente
 
-  print_to_pdf_job:
-    include_unpublished: Incluir no publicado
+  trim_whitespace_job:
+    description: Elimina los espacios en blanco iniciales y finales de los títulos para fondos, actas de ingreso, objetos digitales, objetos de archivo y componentes de objetos digitales.
+
   advanced_search:
     type:
       text: Texto

--- a/common/locales/fr.yml
+++ b/common/locales/fr.yml
@@ -1981,6 +1981,7 @@ fr:
       report_job: Creer un rapport
       container_conversion_job: Creer un rapport
       generate_slugs_job: Générer des URL sémantiques pour les entitées
+      trim_whitespace_job: Couper les espaces
       unknown_job_type: Type de tâche inconnu
     status: Statut
     status_completed: Effectuée
@@ -2024,6 +2025,9 @@ fr:
   print_to_pdf_job:
     include_unpublished: Inclure ce qui n'est pas publié
     source: Source
+
+  trim_whitespace_job:
+    description: Supprime les espaces blancs de début et de fin des titres des ressources, entrées, objets numériques, objets d'archivage et composants d'objet numérique.
 
   advanced_search:
     type:

--- a/common/locales/ja.yml
+++ b/common/locales/ja.yml
@@ -1504,6 +1504,7 @@ ja:
       report_job: レポートを作成
       container_conversion_job: レポートを作成
       generate_slugs_job: エンティティのスラッグを生成する
+      trim_whitespace_job: 空白をトリム
       unknown_job_type: 不明なジョブタイプ
     status: 状態
     status_completed: 完了しました
@@ -1547,6 +1548,9 @@ ja:
   print_to_pdf_job:
     include_unpublished: 未公開を含める
     source: ソース
+
+  trim_whitespace_job:
+    description: リソース、アクセッション、デジタルオブジェクト、アーカイブオブジェクト、デジタルオブジェクトコンポーネントのタイトルから先頭と末尾の空白を削除します。
 
   advanced_search:
     type:

--- a/common/schemas/trim_whitespace_job.rb
+++ b/common/schemas/trim_whitespace_job.rb
@@ -1,0 +1,9 @@
+{
+  :schema => {
+    "$schema" => "http://www.archivesspace.org/archivesspace.json",
+    "version" => 1,
+    "type" => "object",
+
+    "properties" => {}
+  }
+}

--- a/frontend/app/views/jobs/_form.html.erb
+++ b/frontend/app/views/jobs/_form.html.erb
@@ -111,7 +111,7 @@
 
 
 <% define_template("report_job", jsonmodel_definition(:report_job)) do |form| %>
-  
+
   <%= form.hidden_input :report_type %>
 
   <div class="report-list">
@@ -122,7 +122,7 @@
           <button class="report-title btn btn-link" for="<%= code %>" type="button">
             <%= I18n.t("reports.#{code}.title") %>
           </button>
-          
+
           <button class="pull-right btn btn-primary select-report" for="<%= code %>" type="button">
             Select
           </button>
@@ -135,9 +135,9 @@
         <div class="report-description" for="<%= code %>">
           <%= I18n.t("reports.#{report["code"]}.description", :default => code) %>
         </div>
-        
+
       </div>
-      
+
     <% end %>
   </div>
 
@@ -168,6 +168,7 @@
       <%= render_aspace_partial :partial => "#{type}/form", :locals => {:object => @job, :form => form} %>
     <% rescue ActionView::MissingTemplate %>
       <%# don't require plugins to provide a form %>
+      <p><%= I18n.t("#{type}.description", :default => '') %></p>
     <% end %>
 
   <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Create a background job that cleans up leading and trailing white space in title fields.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-313](https://archivesspace.atlassian.net/browse/ANW-313)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Whether by human error in data entry or by copying and pasting existing inventories, titles may have leading or trailing white space it would be good to have an automated way to clean up the data. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked that background job finds and corrects all titles with leading or trailing white space for resources, archival objects, accessions, digital objects, and digital object components.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22351973/55903292-5247b380-5b9b-11e9-9bc6-8b00eaa5208a.png)
![image](https://user-images.githubusercontent.com/22351973/55903333-6be8fb00-5b9b-11e9-90de-3e0cb01363a0.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
