### PR TITLE
ANW-326: show resource identifier for archival objects in search results

### DIFF
--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -43,9 +43,9 @@
       <div class="result_context">
         <strong><%= t('context') %>: </strong>
         <span  class="repo_name">
-          <%= link_to result.resolved_repository.fetch('name'), 
+          <%= link_to result.resolved_repository.fetch('name'),
                      app_prefix(repository_base_url(
-                      "uri" => result.resolved_repository.fetch('uri'), 
+                      "uri" => result.resolved_repository.fetch('uri'),
                       "slug" => result.resolved_repository.fetch('slug') {|s| nil })) %>
         </span>
 
@@ -53,7 +53,9 @@
           <% result.ancestors.each do |ancestor| %>
             <%= t('context_delimiter') %>
             <span class="ancestor">
-            <%= link_to process_mixed_content(ancestor.fetch('title', "[#{ ancestor.fetch('level', 'untitled')}]" )).html_safe, app_prefix(ancestor.fetch('uri')) %>
+            <% identifier = ancestor.has_key?('id_0') ? (0..3).collect {|i| ancestor["id_#{i}"]}.compact.join('-') : nil %>
+            <% title = process_mixed_content(ancestor.fetch('title', "[#{ ancestor.fetch('level', 'untitled')}]" )).html_safe %>
+            <%= link_to (identifier.blank? ? title : "#{identifier}, #{title}"), app_prefix(ancestor.fetch('uri')) %>
             </span>
           <% end %>
         <% else %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In stead on only showing the resource title in the link in context, show the resource identifier and title separated by a comma.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-326](https://archivesspace.atlassian.net/browse/ANW-326)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The resource identifier is not currently shown for archival object search results. This can make it difficult to understand the context of a record.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested that the resource identifier now shows up along with the resource title.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22351973/56152437-a5e24480-5f81-11e9-8701-4601e17e50b5.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
