### PR TITLE
Background job for container labels

### DIFF
--- a/backend/app/exporters/models/labels.rb
+++ b/backend/app/exporters/models/labels.rb
@@ -1,8 +1,8 @@
 class LabelModel < ASpaceExport::ExportModel
   model_for :labels
-  
+
   @ao = Class.new do
-    
+
     def initialize(tree)
       obj = URIResolver.resolve_references( ArchivalObject.to_jsonmodel(tree['id']),
                                            ['top_container', 'top_container::container_profile',
@@ -10,7 +10,7 @@ class LabelModel < ASpaceExport::ExportModel
       @json = JSONModel::JSONModel(:archival_object).new(obj)
       @tree = tree
     end
-    
+
     def method_missing(meth)
       if @json.respond_to?(meth)
         @json.send(meth)
@@ -18,53 +18,65 @@ class LabelModel < ASpaceExport::ExportModel
         nil
       end
     end
-    
+
     def children
       return nil unless @tree['children']
       @tree['children'].map { |subtree| self.class.new(subtree) }
     end
- 
+
   end
-    
+
+  attr_reader :file
 
   def initialize(obj, tree)
     @json = obj
     @tree = tree
 
-    @rows = generate_label_rows(self.children) 
+    @file = ASUtils.tempfile('labels_')
+    append(headers)
+
+    generate_label_rows(self.children)
   end
-  
-  
+
+
+  def append(row)
+    CSV.open(@file, 'a', col_sep: "\t") { |csv| csv << row }
+  end
+
+
+  def full_row(row)
+    [self.repo_name, self.title, self.identifier] + row
+  end
+
+
   def headers
     %w(
       Repository\ Name Resource\ Title  Resource\ Identifier Series\ Archival\ Object\ Title
       Archival\ Object\ Title Container\ Profile Top\ Container Top\ Container\ Barcode
-      SubContainer\ 1 SubContainer\ 2 Current\ Location 
+      SubContainer\ 1 SubContainer\ 2 Current\ Location
     )
   end
-  
- 
-  # The first 3 cells are pulled from the tip-top AO, with the rest being 
-  # added once we pull child AOs, Instance, TC, C.Profile, etc
-  def rows
-    @rows.map {|r| [self.repo_name, self.title, self.identifier] + r }
+
+
+  def stream
+    File.open(@file).each # enumerator for stream response
   end
-  
+
 
   def self.from_aspace_object(obj, tree)
     labler = self.new(obj, tree)
-    
+
     labler
   end
-    
-  
+
+
   def self.from_resource(obj, tree)
     labler = self.from_aspace_object(obj, tree)
-    
+
     labler
   end
-  
-  
+
+
   def method_missing(meth)
     if @json.respond_to?(meth)
       @json.send(meth)
@@ -72,14 +84,14 @@ class LabelModel < ASpaceExport::ExportModel
       nil
     end
   end
-  
+
   def identifier
     @identifier ||= [:id_0, :id_1, :id_2, :id_3].map {|i| self.send(i) }.reject {|i| i.nil? }.join("-")
-    
+
     @identifier
   end
-  
-  
+
+
   def repo_name
     if self.repository && self.repository.has_key?('_resolved')
       self.repository['_resolved']['name']
@@ -87,8 +99,8 @@ class LabelModel < ASpaceExport::ExportModel
       "Unknown"
     end
   end
-  
-  
+
+
   def children
     return nil unless @tree.children
 
@@ -96,9 +108,10 @@ class LabelModel < ASpaceExport::ExportModel
 
     @tree.children.map { |subtree| ao_class.new(subtree) }
   end
- 
+
+
   # this is a convenience method to either return either the value from a hash
-  # from an array of keys or a blank string ( if it does not exist ) 
+  # from an array of keys or a blank string ( if it does not exist )
   def value_or_blank(hash, keys = [] )
     keys.reduce(hash) do |memo, k|
       if memo.is_a?(Hash) && memo[k]
@@ -112,47 +125,46 @@ class LabelModel < ASpaceExport::ExportModel
   def generate_label_rows(objects)
     @top_containers ||= []
     @series ||= ""
-    rows = []
-    
+
     objects.each do |obj|
-      @series = obj.display_string if obj.level == 'series' 
+      @series = obj.display_string if obj.level == 'series'
       obj.instances.each do |instance|
         next unless (sub = instance['sub_container'])
-        next if @top_containers.include?(sub['top_container']['ref'])
-        @top_containers << sub['top_container']['ref']
-       
+        # output each unique container per series (a container may be used in multiple series)
+        digest = Digest::SHA1.hexdigest(@series + sub['top_container']['ref'])
+        next if @top_containers.include?(digest)
+        @top_containers << digest
+
         # We get the Series ( the ancestor AO with the level == 'series' ) and
         # the name of the AO we're processing
-        container_row = [@series, obj.display_string] 
+        container_row = [@series, obj.display_string]
 
         # Top Container time
         top = sub['top_container']['_resolved']
 
-        # this will give us: 
+        # this will give us:
         #  "#{name} [#{depth}d, #{height}h, #{width}w #{dimension_units}] extent measured by #{extent_dimension}"
         container_row << value_or_blank( top, %w( container_profile _resolved display_string ))
 
         container_row << "#{value_or_blank( top, %w( type ))}: #{value_or_blank( top, %w( indicator ))}"
-       
+
         container_row << value_or_blank(top, %w( barcode ))
 
         # these get the grandchild SubContainers of the Top Container
         # e.g. Carton: 1 and Folder: 71
         container_row << [ value_or_blank( sub, %w( type_2 )), value_or_blank( sub, %w( indicator_2 ) ) ]
-          .reject { |v| v.empty? }.join(":") 
+          .reject { |v| v.empty? }.join(":")
         container_row << [ value_or_blank( sub, %w( type_3 )), value_or_blank( sub, %w( indicator_3 ) ) ]
-          .reject { |v| v.empty? }.join(":") 
+          .reject { |v| v.empty? }.join(":")
 
-        
+
         current_location = top["container_locations"].find { |loc| loc["status"] === 'current'  } || {}
-        container_row << value_or_blank( current_location, %w( _resolved title  ) ) 
+        container_row << value_or_blank( current_location, %w( _resolved title  ) )
 
-        rows << container_row
+        append(full_row(container_row))
       end
-      rows.push(*generate_label_rows(obj.children))
+      generate_label_rows(obj.children)
 
     end
-    
-    rows
-  end    
+  end
 end

--- a/backend/app/lib/export.rb
+++ b/backend/app/lib/export.rb
@@ -27,7 +27,7 @@ module ExportHelpers
 
 
   def tsv_response(tsv)
-    [status, {"Content-Type" => "text/tab-separated-values"}, [tsv + "\n"]]
+    [status, {"Content-Type" => "text/tab-separated-values"}, tsv.stream]
   end
 
 
@@ -36,7 +36,7 @@ module ExportHelpers
     obj = resolve_references(Resource.to_jsonmodel(resource), ['repository'])
     labels = ASpaceExport.model(:labels).from_resource(JSONModel(:resource).new(obj),
                                                        resource.tree(:all, mode = :sparse))
-    ASpaceExport::serialize(labels, :serializer => :tsv)
+    labels
   end
 
 

--- a/backend/app/lib/job_runners/container_labels_runner.rb
+++ b/backend/app/lib/job_runners/container_labels_runner.rb
@@ -1,0 +1,32 @@
+require_relative "../../exporters/lib/exporter"
+
+class ContainerLabelsRunner < JobRunner
+  include JSONModel
+  register_for_job_type('container_labels_job')
+
+  def run
+    begin
+      RequestContext.open(:repo_id => @job.repo_id) do
+        parsed = JSONModel.parse_reference(@json.job["source"])
+        resource = Resource.get_or_die(parsed[:id])
+        obj = URIResolver.resolve_references(Resource.to_jsonmodel(resource), ['repository'])
+
+        @job.write_output("Generating Container Labels #{obj["title"]}  ")
+
+        labels = ASpaceExport.model(:labels).from_resource(
+          JSONModel(:resource).new(obj),
+          resource.tree(:all, mode = :sparse)
+        )
+
+        job_file = @job.add_file(labels.file)
+        @job.write_output("File generated at #{job_file.full_file_path.inspect} ")
+        self.success!
+        job_file
+      end
+    rescue Exception => e
+      @job.write_output(e.message)
+      @job.write_output(e.backtrace)
+      raise e
+    end
+  end
+end

--- a/backend/spec/export_label_spec.rb
+++ b/backend/spec/export_label_spec.rb
@@ -71,8 +71,8 @@ describe 'Export Labels Mappings' do
     end
 
     it "should have the proper values" do
-      # header, parent, 16 arch objs
-      expect(@labels.split("\r").length).to eq(18)
+      # header, 16 arch objs
+      expect(@labels.split("\n").length).to eq(17)
     end
   end
 
@@ -93,7 +93,7 @@ describe 'Export Labels Mappings' do
 
     it "only lists a top container once" do
       # header and single row
-      expect(@labels.chomp.split("\r").length).to eq(2)
+      expect(@labels.chomp.split("\n").length).to eq(2)
     end
 
   end

--- a/backend/spec/factories.rb
+++ b/backend/spec/factories.rb
@@ -708,6 +708,10 @@ FactoryBot.define do
     filenames { (0..3).map { generate(:alphanumstr) } }
   end
 
+  factory :json_container_labels_job, class: JSONModel(:container_labels_job) do
+    source  { create(:json_resource).uri }
+  end
+
   factory :json_print_to_pdf_job, class: JSONModel(:print_to_pdf_job) do
     source  { create(:json_resource).uri }
   end

--- a/backend/spec/model_container_labels_job_spec.rb
+++ b/backend/spec/model_container_labels_job_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+def container_labels_job(resource_uri)
+  build(
+    :json_job,
+    :job => build(:json_container_labels_job, source: resource_uri)
+  )
+end
+
+def create_resource_with_tree(opts = {})
+  resource = create_resource
+
+  parent = create(
+    :json_archival_object,
+    {
+      :resource => {"ref" => resource.uri},
+      :level => "series",
+      :component_id => SecureRandom.hex
+    }.merge(opts.fetch(:parent_properties, {}))
+  )
+
+  child = create(
+    :json_archival_object,
+    "resource" => {"ref" => resource.uri},
+    "parent" => {"ref" => parent.uri},
+    "instances" => [build(:json_instance)]
+  )
+
+  resource
+end
+
+describe "Container labels job model" do
+
+  let(:user) { create_nobody_user }
+
+  it "can create a container labels job" do
+    opts = {:title => generate(:generic_title)}
+    resource = create_resource_with_tree(opts)
+
+    json = container_labels_job(resource.uri)
+    job = Job.create_from_json(
+      json,
+      :repo_id => $repo_id,
+      :user => user
+    )
+
+    jr = JobRunner.for(job)
+    jr.run
+    job.refresh
+
+    expect(job).not_to be_nil
+    expect(job.job_type).to eq("container_labels_job")
+    expect(job.owner.username).to eq('nobody')
+    expect(job.job_files.length).to eq(1)
+  end
+
+end

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -1979,6 +1979,7 @@ en:
     _plural: Background Jobs
     job_type: Job Type
     types:
+      container_labels_job: Container Labels
       print_to_pdf_job: Generate PDF
       import_job: Import Data
       find_and_replace_job: Batch Find and Replace (Beta)

--- a/common/locales/es.yml
+++ b/common/locales/es.yml
@@ -1958,6 +1958,7 @@ es:
     _plural: Tareas en el background
     job_type: Tipo de tarea
     types:
+      container_labels_job: Container Labels
       print_to_pdf_job: Generar PDF
       import_job: Importar Datos
       find_and_replace_job: Busca y reemplaza en bloque (Beta)

--- a/common/locales/fr.yml
+++ b/common/locales/fr.yml
@@ -1978,6 +1978,7 @@ fr:
     _plural: Tâches d'arrière-plan
     job_type: Type de tâche
     types:
+      container_labels_job: Container Labels
       print_to_pdf_job: Générer un PDF
       import_job: Importer des données
       find_and_replace_job: Rechercher et remplacer en masse (Bêta)

--- a/common/locales/ja.yml
+++ b/common/locales/ja.yml
@@ -1500,6 +1500,7 @@ ja:
     _plural: バックグラウンドジョブ
     job_type: ジョブの種類
     types:
+      container_labels_job: Container Labels
       print_to_pdf_job: PDFを生成
       import_job: データのインポート
       find_and_replace_job: バッチの検索と置換（ベータ版）

--- a/common/schemas/container_labels_job.rb
+++ b/common/schemas/container_labels_job.rb
@@ -1,0 +1,17 @@
+{
+  :schema => {
+    "$schema" => "http://www.archivesspace.org/archivesspace.json",
+    "version" => 1,
+    "type" => "object",
+    "properties" => {
+      "format" => {
+        "type" => "string",
+        "default" => "tsv"
+      },
+      "source" => {
+        "type" => "string",
+        "ifmissing" => "error"
+      },
+    }
+  }
+}

--- a/frontend/app/assets/javascripts/jobs.crud.js
+++ b/frontend/app/assets/javascripts/jobs.crud.js
@@ -21,7 +21,7 @@ var init = function() {
                 location_end_linker.show();
             }
 
-            $('.report_type').hide();        
+            $('.report_type').hide();
             $('.report_type.' + selected_report_type).show();
         };
 
@@ -81,7 +81,7 @@ var init = function() {
 
     };
 
-    var initPrintToPdfJobForm = function() {
+    var initSourceJobForm = function() {
         $("#job_ref_").attr("name", "job[source]").attr("id", "job_source_");
     };
 
@@ -293,8 +293,8 @@ var init = function() {
                 input.files = dt.files;
                 $form.append(input);
             });
-            
-            
+
+
             return true;
         });
 
@@ -369,7 +369,7 @@ var init = function() {
     };
 
     var type = $("#job_type").val();
-    
+
     $(".linker:not(.initialised)").linker();
 
     // these were added because it was neccesary to get translation
@@ -377,8 +377,10 @@ var init = function() {
 
     if (type == "report_job") {
         initReportJobForm();
+    } else if (type == "container_labels_job") {
+        initSourceJobForm();
     } else if (type == "print_to_pdf_job") {
-        initPrintToPdfJobForm();
+        initSourceJobForm();
     } else if (type == "find_and_replace_job") {
         initFindAndReplaceJobForm();
     } else if (type == "import_job") {

--- a/frontend/app/controllers/exports_controller.rb
+++ b/frontend/app/controllers/exports_controller.rb
@@ -8,14 +8,14 @@ class ExportsController < ApplicationController
 
 
   def container_labels
-     download_export(
-       "/repositories/#{JSONModel::repository}/resource_labels/#{params[:id]}.tsv")
+    @resource = JSONModel(:resource).find(params[:id], find_opts)
+    render :layout => false
    end
 
 
   def download_marc
     download_export(
-      "/repositories/#{JSONModel::repository}/resources/marc21/#{params[:id]}.xml", 
+      "/repositories/#{JSONModel::repository}/resources/marc21/#{params[:id]}.xml",
       :include_unpublished_marc => params[:include_unpublished_marc]
       )
   end

--- a/frontend/app/views/exports/container_labels.html.erb
+++ b/frontend/app/views/exports/container_labels.html.erb
@@ -1,0 +1,13 @@
+<script type="text/javascript">
+	var submitJob = function() {
+		console.log("Submiting job");
+		document.getElementById("job-form").submit();
+	}
+	window.onload = submitJob;
+</script>
+
+<%= form_for :job, :url => {:controller => :jobs, :action => :create}, :html => {:id => "job-form", :style => "display: none;"} do |f| %>
+  <%= f.hidden_field :source, :value => @resource.uri %>
+  <%= f.hidden_field :jsonmodel_type, :value => "container_labels_job" %>
+  <%= f.hidden_field :job_type, :value => 'container_labels_job' %>
+<% end %>

--- a/frontend/app/views/jobs/_form.html.erb
+++ b/frontend/app/views/jobs/_form.html.erb
@@ -1,3 +1,10 @@
+<% define_template("container_labels_job", jsonmodel_definition(:container_labels_job)) do |form| %>
+
+  <%= form.hidden_input :source, :class => 'translation-placeholder' %>
+  <%= render_aspace_partial :partial => "resources/linker", :locals => { :form => form, :field_label => I18n.t("actions.container_labels") }%>
+
+<% end %>
+
 <% define_template("find_and_replace_job", jsonmodel_definition(:find_and_replace_job)) do |form| %>
     <p><%= I18n.t("job._frontend.messages.find_and_replace_instructions") %></p>
 
@@ -111,7 +118,7 @@
 
 
 <% define_template("report_job", jsonmodel_definition(:report_job)) do |form| %>
-  
+
   <%= form.hidden_input :report_type %>
 
   <div class="report-list">
@@ -122,7 +129,7 @@
           <button class="report-title btn btn-link" for="<%= code %>" type="button">
             <%= I18n.t("reports.#{code}.title") %>
           </button>
-          
+
           <button class="pull-right btn btn-primary select-report" for="<%= code %>" type="button">
             Select
           </button>
@@ -135,9 +142,9 @@
         <div class="report-description" for="<%= code %>">
           <%= I18n.t("reports.#{report["code"]}.description", :default => code) %>
         </div>
-        
+
       </div>
-      
+
     <% end %>
   </div>
 
@@ -160,7 +167,7 @@
 
 <%# Now create a template for all job types not handled above - eg from plugins %>
 <% job_types.keys.each do |type| %>
-  <% next if ['find_and_replace_job', 'print_to_pdf_job', 'import_job', 'report_job', 'generate_slugs_job'].include?(type) %>
+  <% next if ['container_labels_job', 'find_and_replace_job', 'print_to_pdf_job', 'import_job', 'report_job', 'generate_slugs_job'].include?(type) %>
 
   <% define_template(type, jsonmodel_definition(type.intern)) do |form| %>
 

--- a/frontend/app/views/jobs/_show_templates.html.erb
+++ b/frontend/app/views/jobs/_show_templates.html.erb
@@ -52,6 +52,16 @@
 <% end %>
 
 
+<% define_template "container_labels_job", jsonmodel_definition(:container_labels_job) do |form, job| %>
+
+    <div class="form-group">
+      <label class="col-sm-3 control-label"><%= I18n.t("actions.container_labels")  %></label>
+      <div class="col-sm-9 controls label-only"><%= job['source'] %></div>
+    </div>
+
+<% end %>
+
+
 <% define_template "import_job", jsonmodel_definition(:import_job) do |form, job| %>
 
     <div class="form-group">
@@ -104,7 +114,7 @@
 
 <%# Now create a template for all job types not handled above - eg from plugins %>
 <% job_types.keys.each do |type| %>
-  <% next if ['find_and_replace_job', 'print_to_pdf_job', 'import_job', 'report_job'].include?(type) %>
+  <% next if ['container_labels_job', 'find_and_replace_job', 'print_to_pdf_job', 'import_job', 'report_job'].include?(type) %>
   <% define_template(type, jsonmodel_definition(type.intern)) do |form, job| %>
 
     <% begin %>

--- a/frontend/app/views/resources/_toolbar.html.erb
+++ b/frontend/app/views/resources/_toolbar.html.erb
@@ -47,7 +47,7 @@
       </li>
 
 
-      <li><%= link_to I18n.t("actions.container_labels"), {:controller => :exports, :action => :container_labels, :id => @resource.id} %></li>
+      <li><%= link_to I18n.t("actions.container_labels"), {:controller => :exports, :action => :container_labels, :id => @resource.id}, :id => 'container-labels-link', :target => "_blank" %></li>
 
       <% if user_can?('create_job') %>
         <% if job_types['print_to_pdf_job']['create_permissions'].reject{|perm| user_can?(perm)}.empty? %>


### PR DESCRIPTION
The download container labels functionality can timeout for resources with larger numbers of archival objects. To address this a) refactored the labels code to not hold onto a list of objects by incrementally writing processed rows to tsv, b) for the api, stream the response from the generated tempfile, c) for the ui, pushed the feature to a background job.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/projects/ANW/issues/ANW-880?filter=myopenissues

## How Has This Been Tested?
Tested with database containing resources that would timeout using existing download container labels functionality.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
