### PR TITLE
ANW-670: handle deleting assessment attribute notes when deleting assessment

### DIFF
--- a/backend/app/model/assessment.rb
+++ b/backend/app/model/assessment.rb
@@ -334,6 +334,7 @@ class Assessment < Sequel::Model(:assessment)
 
   def self.handle_delete(ids_to_delete)
     DB.open do |db|
+      db[:assessment_attribute_note].filter(:assessment_id => ids_to_delete).delete
       db[:assessment_attribute].filter(:assessment_id => ids_to_delete).delete
     end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Handle deleting of assessment attribute notes linked to an assessment when deleting the assessment so it does not fail.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-670](https://archivesspace.atlassian.net/browse/ANW-670)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If there is a note in the ratings section of an assessment record, you get an error when attempting to delete.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked that you can now delete an assessment with assessment attribute notes and that it deletes the appropriate attribute notes records from the database.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
