### PR TITLE
ANW-373: add siblings in tree directly under selected node in stead of at end

### DIFF
--- a/frontend/app/assets/javascripts/ajaxtree.js.erb
+++ b/frontend/app/assets/javascripts/ajaxtree.js.erb
@@ -281,6 +281,7 @@ AjaxTree.prototype.add_new_after = function(node, level) {
 
     var target_position = 0;
     var parent_id = null;
+    var position = null;
 
     var root_node = $('#'+this.tree.large_tree.root_tree_id);
     var root_uri_parts = TreeIds.uri_to_parts(root_node.data('uri'));
@@ -311,12 +312,13 @@ AjaxTree.prototype.add_new_after = function(node, level) {
             }
         }
     } else {
-        /* We're adding a new sibling to the end of the current level */
-        var endmarker = node.nextAll('.end-marker.indent-level-'+level+':last');
-        endmarker.after($new_tr);
+        /* We're adding a new sibling after selected node */
+        tree.large_tree.collapseNode(node);
+        node.after($new_tr);
         $new_tr.find('.record-title')[0].focus();
 
         parent_id = node.data('parent_id');
+        position = node.data('position') + 1;
     }
 
     var params = {
@@ -327,6 +329,10 @@ AjaxTree.prototype.add_new_after = function(node, level) {
 
     if (parent_id) {
         params[node_uri_parts.type + '_id'] = parent_id;
+    }
+
+    if (position) {
+        params['position'] = position;
     }
 
     var url = AS.app_prefix(self._new_node_form_url_for(node.data('jsonmodel_type')));
@@ -410,7 +416,7 @@ AjaxTree.prototype.confirmChanges = function(target_tree_id) {
 
     $("#dismissChangesButton", "#saveYourChangesModal").on("click", function() {
         $form.data("form_changed", false);
-        
+
         $("#saveYourChangesModal").modal("hide");
         var tree_id = self.tree_id_from_hash();
         var uri = $('#' + tree_id).data('uri');
@@ -455,7 +461,7 @@ AjaxTree.prototype.blockout_form = function() {
     }
     var $blockout = $('<div>').addClass('blockout');
     $blockout.height(self.$pane.height());
-    // add 30 to take into account for outer margin :/ 
+    // add 30 to take into account for outer margin :/
     $blockout.width(self.$pane.width() + 30);
     $blockout.css('left', '-15px');
     self.$pane.prepend($blockout);

--- a/frontend/app/controllers/archival_objects_controller.rb
+++ b/frontend/app/controllers/archival_objects_controller.rb
@@ -12,6 +12,7 @@ class ArchivalObjectsController < ApplicationController
     @archival_object = JSONModel(:archival_object).new._always_valid!
     @archival_object.parent = {'ref' => JSONModel(:archival_object).uri_for(params[:archival_object_id])} if params.has_key?(:archival_object_id)
     @archival_object.resource = {'ref' => JSONModel(:resource).uri_for(params[:resource_id])} if params.has_key?(:resource_id)
+    @archival_object.position = params[:position]
 
     if user_prefs['default_values']
       defaults = DefaultValues.get 'archival_object'

--- a/frontend/app/controllers/classification_terms_controller.rb
+++ b/frontend/app/controllers/classification_terms_controller.rb
@@ -10,6 +10,7 @@ class ClassificationTermsController < ApplicationController
     @classification_term = JSONModel(:classification_term).new._always_valid!
     @classification_term.parent = {'ref' => JSONModel(:classification_term).uri_for(params[:classification_term_id])} if params.has_key?(:classification_term_id)
     @classification_term.classification = {'ref' => JSONModel(:classification).uri_for(params[:classification_id])} if params.has_key?(:classification_id)
+    @classification_term.position = params[:position]
 
     if user_prefs['default_values']
       defaults = DefaultValues.get 'classification_term'

--- a/frontend/app/controllers/digital_object_components_controller.rb
+++ b/frontend/app/controllers/digital_object_components_controller.rb
@@ -12,6 +12,7 @@ class DigitalObjectComponentsController < ApplicationController
     @digital_object_component.title = I18n.t("digital_object_component.title_default", :default => "")
     @digital_object_component.parent = {'ref' => JSONModel(:digital_object_component).uri_for(params[:digital_object_component_id])} if params.has_key?(:digital_object_component_id)
     @digital_object_component.digital_object = {'ref' => JSONModel(:digital_object).uri_for(params[:digital_object_id])} if params.has_key?(:digital_object_id)
+    @digital_object_component.position = params[:position]
 
     if user_prefs['default_values']
       defaults = DefaultValues.get 'digital_object_component'

--- a/frontend/app/views/archival_objects/_form_container.html.erb
+++ b/frontend/app/views/archival_objects/_form_container.html.erb
@@ -14,6 +14,7 @@
 
   <%= form.hidden_input "parent", nil, {"data-base-name" => "archival_object[parent]", "class" => "hidden-parent-uri"} %>
   <%= form.hidden_input "resource" %>
+  <%= form.hidden_input "position" %>
 
   <%= hidden_field_tag "id", @archival_object.id %>
   <%= hidden_field_tag "uri", @archival_object.uri %>

--- a/frontend/app/views/classification_terms/_form_container.html.erb
+++ b/frontend/app/views/classification_terms/_form_container.html.erb
@@ -11,6 +11,7 @@
 
   <%= form.hidden_input "parent", nil, {"data-base-name" => "classification_term[parent]", "class" => "hidden-parent-uri"} %>
   <%= form.hidden_input "classification" %>
+  <%= form.hidden_input "position" %>
 
   <%= hidden_field_tag "id", @classification_term.id %>
   <%= hidden_field_tag "uri", @classification_term.uri %>

--- a/frontend/app/views/digital_object_components/_form_container.html.erb
+++ b/frontend/app/views/digital_object_components/_form_container.html.erb
@@ -15,6 +15,7 @@
 
   <%= form.hidden_input "parent", nil, {"data-base-name" => "digital_object_component[parent]", "class" => "hidden-parent-uri"} %>
   <%= form.hidden_input "digital_object" %>
+  <%= form.hidden_input "position" %>
 
   <%= hidden_field_tag "id", @digital_object_component.id %>
   <%= hidden_field_tag "uri", @digital_object_component.uri %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When adding an archival object, digital object component, or classification term using the 'add sibling' button, the new component will be added directly after the component that was selected when 'add sibling' was initiated rather than at the end of that level.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-373](https://archivesspace.atlassian.net/browse/ANW-373)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently, new siblings are always placed at the bottom of the list of siblings, which can be extremely annoying when trying to insert a new object in a long list.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked that new siblings now appear after selected node in view and that they are saved here when the record is saved.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
