### PR TITLE
ANW-253: Show subject source in record's subjects listing

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -617,13 +617,14 @@ AppConfig[:pui_page_custom_actions] = []
 #   'erb_partial' => 'shared/my_special_action',
 # }
 
+# For Accessions browse set if accession date year filter values should be sorted ascending rather than descending (default)
+AppConfig[:sort_accession_date_filter_asc] = false
+
 # use_human_readable_URLs:
 # Changing this option will not remove or clear any slugs that exist currently.
 # This setting only affects links that are displayed. URLs that point to valid slugs will still work.
 # WARNING: Changing this setting may require an index rebuild for changes to take effect.
 
-# TODO: for release, uncomment below and remove line that follows that so that HRU's are off by default.
-#AppConfig[:use_human_readable_URLs] = false
 AppConfig[:use_human_readable_URLs] = false
 
 # Use the repository in slug based URLs
@@ -635,10 +636,9 @@ AppConfig[:auto_generate_slugs_with_id] = false
 
 # For Resources: if this option and auto_generate_slugs_with_id are both enabled, then slugs for Resources will be generated with EADID instead of the identifier.
 AppConfig[:generate_resource_slugs_with_eadid] = false
+                            
+# For archival objects: if this option and auto_generate_slugs_with_id are both enabled, then slugs for archival resources will be generated with Component Unique Identifier instead of the identifier.
 AppConfig[:generate_archival_object_slugs_with_cuid] = false
-
-# For Accessions browse set if accession date year filter values should be sorted ascending rather than descending (default)
-AppConfig[:sort_accession_date_filter_asc] = false
 
 # Determines if the subject source is shown along with the subject heading in records' subject listings
 # This can help differentiate between subjects with the same heading

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -620,12 +620,14 @@ AppConfig[:pui_page_custom_actions] = []
 # For Accessions browse set if accession date year filter values should be sorted ascending rather than descending (default)
 AppConfig[:sort_accession_date_filter_asc] = false
 
-# use_human_readable_URLs:
+# Human-Readable URLs options
+# use_human_readable_urls: determines whether fields and options related to human-readable URLs appear in the staff interface
+
 # Changing this option will not remove or clear any slugs that exist currently.
 # This setting only affects links that are displayed. URLs that point to valid slugs will still work.
 # WARNING: Changing this setting may require an index rebuild for changes to take effect.
 
-AppConfig[:use_human_readable_URLs] = false
+AppConfig[:use_human_readable_urls] = false
 
 # Use the repository in slug based URLs
 # Warning: setting repo_name_in_slugs to true when it has previously been set to false will break links, unless all slugs are regenerated.

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -639,3 +639,7 @@ AppConfig[:generate_archival_object_slugs_with_cuid] = false
 
 # For Accessions browse set if accession date year filter values should be sorted ascending rather than descending (default)
 AppConfig[:sort_accession_date_filter_asc] = false
+
+# Determines if the subject source is shown along with the subject heading in records' subject listings
+# This can help differentiate between subjects with the same heading
+AppConfig[:show_source_in_subject_listing] = false

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -1670,6 +1670,7 @@ en:
     authority_id_tooltip: |
         <p>The unique identifier for the record within the source from which it was acquired, (i.e. an LCSH number). The identifier may be represented as a URI.</p>
     source: Source
+    subject_source: Subject Source
     source_tooltip: |
         <p>The vocabulary from which an established term is taken.</p>
         <p>Values in this Controlled Value List may be modified.</p>

--- a/common/locales/es.yml
+++ b/common/locales/es.yml
@@ -1651,6 +1651,7 @@ es:
     authority_id_tooltip: |
         <p>El identificador único para el registro de la fuente de la cual fue adquirida, (es decir, un número LCSH). El identificador puede ser representado como un URI.</p>
     source: Fuente
+    subject_source: Fuente de la materia
     source_tooltip: |
         <p>El vocabulario desde donde se toma un plazo establecido.</p>
         <p>Los valores en esta lista de valores controlados pueden ser modificados.</p>

--- a/common/locales/fr.yml
+++ b/common/locales/fr.yml
@@ -1670,6 +1670,7 @@ fr:
     authority_id_tooltip: |
         <p>L'identifiant unique pour la notice dans la source d'où provient l'acquisition, (par ex. un numéro LCSH). L'identifiant peut être représenté sous forme d'URI.</p>
     source: Source
+    subject_source: Sujet Source
     source_tooltip: |
         <p>Le glossaire d'où provient un terme standard.</p>
         <p>Les valeurs dans cette liste de valeurs contrôlées peuvent être modifiées.</p>

--- a/common/locales/ja.yml
+++ b/common/locales/ja.yml
@@ -1247,6 +1247,7 @@ ja:
     authority_id: オーソリティID
     authority_id_tooltip: "<p>取得元のレコードの一意の識別子（つまり、LCSH番号）。識別子はURIとして表すことができる。 </p>"
     source: ソース
+    subject_source: 件名ソース
     source_tooltip: "<p>確立された用語が使われている語彙。 </p><p>この管理された値リストの値は変更することができます。 </p><p>例：
       </p><ul><li>医療対象見出し（メッシュ） </li><li>議会図書館の見出し見出し（lcsh） </li></ul>"
     scope_note: スコープノート

--- a/public/app/views/shared/_present_list.html.erb
+++ b/public/app/views/shared/_present_list.html.erb
@@ -35,9 +35,12 @@
         <% unless item['uri'].blank? %>
          <a href="<%= app_prefix(item['uri']) %>">
         <% end %>
-        <%= item['title'] + (list_clss == 'subjects_list' ? " - #{t("enumerations.subject_source.#{item['source']}")}" : '') %>
+        <%= item['title'] %>
         <% unless item['uri'].blank? %>
          </a>
+         <% if list_clss == 'subjects_list' && AppConfig[:show_source_in_subject_listing] %>
+          <strong><%= t("subject.subject_source") %>: </strong><%= t("enumerations.subject_source.#{item['source']}") %>
+         <% end %>
         <% end %>
        <% else %>
          <%= item %>

--- a/public/app/views/shared/_present_list.html.erb
+++ b/public/app/views/shared/_present_list.html.erb
@@ -35,7 +35,7 @@
         <% unless item['uri'].blank? %>
          <a href="<%= app_prefix(item['uri']) %>">
         <% end %>
-        <%= item['title'] %>
+        <%= item['title'] + (list_clss == 'subjects_list' ? " - #{t("enumerations.subject_source.#{item['source']}")}" : '') %>
         <% unless item['uri'].blank? %>
          </a>
         <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add the ability to show subject sources along with the subject heading in the PUI if a config option is turned on.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-253](https://archivesspace.atlassian.net/browse/ANW-253)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There may be subjects with headings that are identical or nearly identical, so in these cases it is necessary to show the subject source in order to distinguish between them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked that the subject sources show up if and only if the config option is turned on.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22351973/57086109-89f1d900-6ccb-11e9-9d63-4c853e15b8f9.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
