### PR TITLE
A note is an array of hashes so need to iterate over each hash to get to the data for the PDF

### DIFF
--- a/public/app/views/pdf/_archival_object.html.erb
+++ b/public/app/views/pdf/_archival_object.html.erb
@@ -43,15 +43,19 @@ end
 
         <div class="indented">
             <% record.notes.each do |note_type, note| %>
-                <% if note_type != 'physdesc' && !note['is_inherited'] %>
-                    <h3>
-                        <% if note['label'] %>
-                            <%= note['label'] %>
+                <% if note_type != 'physdesc' %>
+                  <% note.each do |n| %>
+                    <% if !n['is_inherited'] %>
+                      <h3>
+                        <% if n['label'] %>
+                            <%= n['label'] %>
                         <% else %>
                             <%= I18n.t("enumerations._note_types.#{note_type}") %>
                         <% end %>
-                    </h3>
-                    <p><%== note['note_text'].gsub(/&(?!amp;)/,'&amp;') %></p>
+                      </h3>
+                      <p><%== n['note_text'].gsub(/&(?!amp;)/,'&amp;') %></p>
+                    <% end %>
+                  <% end %>
                 <% end %>
             <% end %>
 
@@ -73,9 +77,13 @@ end
                 <% end %>
 
                 <% record.notes.each do |note_type, note| %>
-                    <% if note_type == 'physdesc' && !note['is_inherited'] %>
-                        <dt><%= I18n.t('resource._public.physdesc') %></dt><dd><%== note['note_text'].gsub(/&(?!amp;)/,'&amp;') %></dd>
+                  <% if note_type == 'physdesc' %>
+                    <% note.each do |n| %>
+                      <% if !n['is_inherited'] %>
+                        <dt><%= I18n.t('resource._public.physdesc') %></dt><dd><%== n['note_text'].gsub(/&(?!amp;)/,'&amp;') %></dd>
+                      <% end %>
                     <% end %>
+                  <% end %>
                 <% end %>
 
                 <%= render(:partial => 'digital_object_links', :locals => {

--- a/public/app/views/pdf/_resource.html.erb
+++ b/public/app/views/pdf/_resource.html.erb
@@ -29,7 +29,9 @@
     <% record.notes.each do |note_type, note| %>
         <% if note_type == 'physdesc' %>
             <a id="note-<%= note_type %>"></a>
-            <dt><%= I18n.t("enumerations._note_types.#{note_type}") %></dt><dd><%== note['note_text'].gsub(/&(?!amp;)/,'&amp;') %></dd>
+            <% note.each do |n| %>
+              <dt><%= I18n.t("enumerations._note_types.#{note_type}") %></dt><dd><%== n['note_text'].gsub(/&(?!amp;)/,'&amp;') %></dd>
+            <% end %>
         <% end %>
     <% end %>
 
@@ -45,14 +47,16 @@
 <% record.notes.each do |note_type, note| %>
     <% next if ['physdesc'].include?(note_type) %>
     <a id="note-<%= note_type %>"></a>
-    <h3>
-        <% if note['label'] %>
-            <%= note['label'] %>
+    <% note.each do |n| %>
+      <h3>
+        <% if n['label'] %>
+            <%= n['label'] %>
         <% else %>
             <%= I18n.t("enumerations._note_types.#{note_type}") %>
         <% end %>
-    </h3>
-    <p><%== note['note_text'].gsub(/&(?!amp;)/,'&amp;') %></p>
+      </h3>
+      <p><%== n['note_text'].gsub(/&(?!amp;)/,'&amp;') %></p>
+    <% end %>
 <% end %>
 
 <a id="administrative-information"></a>

--- a/public/app/views/pdf/_toc.html.erb
+++ b/public/app/views/pdf/_toc.html.erb
@@ -13,11 +13,13 @@
             <% next if ['physdesc'].include?(note_type) %>
             <li class="level-1">
                 <a href="#note-<%= note_type %>">
-                    <% if note['label'] %>
-                        <%= note['label'] %>
+                  <% note.each do |n| %>
+                    <% if n['label'] %>
+                        <%= n['label'] %>
                     <% else %>
                         <%= I18n.t("enumerations._note_types.#{note_type}") %>
                     <% end %>
+                  <% end %>
                 </a>
             </li>
         <% end %>


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
PUI PDFs would not generate because the views did not take into consideration that the notes were arrays of hashes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Now I am able to generate a PDF from the PUI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
