### PR TITLE
Handle suppression in found_in column

### DIFF
--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -194,10 +194,12 @@ module SearchHelper
   end
 
   def get_ancestor_title(field)
-    if field.include?('resources') || field.include?('digital_objects')
-      clean_mixed_content(JSONModel::HTTP.get_json(field)['title'])
-    else
-      clean_mixed_content(JSONModel::HTTP.get_json(field)['display_string'])
+    if !JSONModel::HTTP.get_json(field).nil?
+      if field.include?('resources') || field.include?('digital_objects')
+        clean_mixed_content(JSONModel::HTTP.get_json(field)['title'])
+      else
+        clean_mixed_content(JSONModel::HTTP.get_json(field)['display_string'])
+      end
     end
   end
 

--- a/frontend/app/views/search/_context.html.erb
+++ b/frontend/app/views/search/_context.html.erb
@@ -1,9 +1,11 @@
 <% ancestors = context_ancestor(result) %>
 <% if ancestors != nil && ancestors != [''] %>
   <% ancestors.reverse.each_with_index do |ancestor, i| %>
-    <%= resolve_readonly_link_to((get_ancestor_title(ancestor).html_safe), ancestor) %>
-    <% if i < ancestors.length - 1 %>
-      <%= context_separator(result) %>
+    <% unless get_ancestor_title(ancestor) == nil %>
+      <%= resolve_readonly_link_to((get_ancestor_title(ancestor).html_safe), ancestor) %>
+      <% if i < ancestors.length - 1 %>
+        <%= context_separator(result) %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/frontend/spec/selenium/spec/search_spec.rb
+++ b/frontend/spec/selenium/spec/search_spec.rb
@@ -1,0 +1,322 @@
+require_relative 'spec_helper'
+
+describe "Search Listing" do
+
+  before(:all) do
+    @repo = create(:repo, :repo_code => "search_listing_test_#{Time.now.to_i}")
+
+    set_repo @repo
+
+    @accession = create(:accession,
+                        :title => "A test accession #{Time.now.to_i}_#{$$}")
+
+    @accession2 = create(:accession,
+                        :title => "Another test accession #{Time.now.to_i}_#{$$}",
+                        :content_description => "old moldy newspapers found in a dumpster")
+
+    @resource = create(:resource,
+                       :title => 'Resource')
+
+    @archival_object_1 = create(:archival_object,
+                                {:title => 'Resource is my mama',
+                                :resource => {:ref => @resource.uri}})
+    @archival_object_2 = create(:archival_object,
+                                {:resource => {:ref => @resource.uri}})
+    @archival_object_3 = create(:archival_object,
+                                {:resource => {:ref => @resource.uri}})
+
+    @digital_object_1 = create(:digital_object,
+                               :title => "Independent DO")
+
+    @suppressed_resource = create(:resource,
+                               :title => 'Suppressed resource',
+                               :instances => [build(:instance_digital,
+                                                    :digital_object => {'ref' => @digital_object_1.uri})])
+    @suppressed_resource.set_suppressed(true)
+
+    @viewer_user = create_user(@repo => ['repository-viewers'])
+
+    run_all_indexers
+
+    @driver = Driver.get
+    @driver.login_to_repo($admin, @repo)
+  end
+
+  before(:each) do
+
+    @driver.wait_for_ajax
+  end
+
+  after(:all) do
+    @driver.quit
+  end
+
+
+  describe "search results" do
+    it "supports global searches" do
+      @driver.find_element(:id, 'global-search-button').click
+      assert(5) { @driver.find_element_with_text("//h3", /Search Results/) }
+    end
+
+    it "supports filtering global searches by type" do
+      @driver.find_element(:id, 'global-search-button').click
+      @driver.find_element(:link, "Accession").click
+      assert(5) { @driver.find_element_with_text("//h3", /Filtered By/) }
+      assert(5) { @driver.find_element_with_text("//a", /Record Type: Accession/) }
+      assert(5) { @driver.find_element_with_text('//div', /Showing .*2.* of.*Results/) }
+      assert(5) { @driver.find_element_with_text("//td", /#{@accession.title}/) }
+      assert(5) { @driver.find_element_with_text("//td", /#{@accession2.title}/) }
+    end
+
+    it "supports some basic fulltext search globally" do
+      @driver.clear_and_send_keys([:id => "global-search-box"], 'newspapers')
+      @driver.find_element(:id, 'global-search-button').click
+      assert(5) { @driver.find_element_with_text('//div', /Showing 1.* of.*Results/) }
+      assert(5) { @driver.find_element_with_text("//td", /#{@accession2.title}/) }
+    end
+
+    it "displays search results with context" do
+      @driver.clear_and_send_keys([:id => "global-search-box"], 'mama')
+      @driver.find_element(:id, 'global-search-button').click
+      assert(5) { @driver.find_element_with_text('//th', /Found in/) }
+      assert(5) { @driver.find_element_with_text('//td', /#{@resource.title}/) }
+    end
+
+    it "does not display suppressed records to viewers" do
+      @driver.login_to_repo(@viewer_user, @repo)
+      @driver.clear_and_send_keys([:id => "global-search-box"], 'Suppressed')
+      @driver.find_element(:id, 'global-search-button').click
+      assert(5) { @driver.find_element_with_text('//div/div/div/div/p', /No records found/) }
+    end
+
+    it "does display suppressed records to admins" do
+      @driver.login_to_repo($admin, @repo)
+      @driver.clear_and_send_keys([:id => "global-search-box"], 'Suppressed')
+      @driver.find_element(:id, 'global-search-button').click
+      assert(5) { @driver.find_element_with_text('//tr/td', /#{@suppressed_resource.title}/) }
+    end
+
+    it "does display DOs linked to suppressed records to viewers" do
+      @driver.login_to_repo(@viewer_user, @repo)
+      @driver.clear_and_send_keys([:id => "global-search-box"], 'Independent')
+      @driver.find_element(:id, 'global-search-button').click
+      assert(5) { @driver.find_element_with_text('//tr/td', /#{@digital_object_1.title}/) }
+      assert(5) { @driver.find_element_with_text('//th', /Found in/) }
+      expect {
+        @driver.find_element_with_text('//tr/td[3]', / /, false, true).text()
+      }.to raise_error(Selenium::WebDriver::Error::NoSuchElementError)
+    end
+  end
+end
+
+describe "Advanced Search" do
+
+  before(:all) do
+    @repo = create(:repo,
+                   :repo_code => "adv_search_test_#{Time.now.to_i}",
+                   :publish => true)
+    set_repo @repo
+
+    @keywords = (0..9).to_a.map { SecureRandom.hex }
+
+    @accession_1 = create(:accession,
+                          :title => "#{@keywords[0]} #{@keywords[4]}",
+                          :publish => true)
+    @accession_2 = create(:accession,
+                          :title => "#{@keywords[1]} #{@keywords[5]}",
+                          :publish => false)
+
+    @resource_1 = create(:resource,
+                         :title => "#{@keywords[0]} #{@keywords[6]}",
+                         :publish => false)
+
+    @resource_2 = create(:resource,
+                         :title => "#{@keywords[2]} #{@keywords[7]}",
+                         :publish => true)
+
+    @digital_object_1 = create(:digital_object,
+                               :title => "#{@keywords[0]} #{@keywords[8]}")
+    @digital_object_2 = create(:digital_object,
+                               :title => "#{@keywords[3]} #{@keywords[9]}")
+
+    run_index_round
+
+    @driver = Driver.get.login_to_repo($admin, @repo)
+  end
+
+
+  after(:all) do
+    @driver.quit
+  end
+
+
+  it "is available via the navbar and renders when toggled" do
+    @driver.find_element(:css => ".navbar .search-switcher").click
+    @driver.find_element(:css => ".search-switcher-hide")
+  end
+
+  it "finds matches with one keyword field query" do
+    @driver.clear_and_send_keys([:id => "v0"], @keywords[0])
+
+    @driver.click_and_wait_until_gone(:css => ".advanced-search .btn-primary")
+
+    # result list should contain those items with the @keywords[0] in the title
+    @driver.find_element_with_text("//td", /#{@accession_1.title}/)
+    @driver.find_element_with_text("//td", /#{@resource_1.title}/)
+    @driver.find_element_with_text("//td", /#{@digital_object_1.title}/)
+
+    # these records should not appear in the results
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@accession_2.title}')]")
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@resource_2.title}')]")
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@digital_object_2.title}')]")
+  end
+
+  it "finds single match with two keyword ANDed field queries" do
+    # add a 2nd query row
+    @driver.find_element(:css => ".advanced-search-add-row-dropdown").click
+    @driver.find_element(:css => ".advanced-search-add-text-row").click
+
+    @driver.clear_and_send_keys([:id => "v0"], @keywords[0])
+    @driver.clear_and_send_keys([:id => "v1"], @keywords[4])
+    @driver.find_element(:id => "f1").select_option("title")
+
+    @driver.click_and_wait_until_gone(:css => ".advanced-search .btn-primary")
+
+    # result list should contain those items with a keyword @keywords[0]
+    # and with the title containing @keywords[4]
+    @driver.find_element_with_text("//td", /#{@accession_1.title}/)
+
+    # and these results should no longer be there
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@resource_1.title}')]")
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@digital_object_1.title}')]")
+
+    # these records should not appear in the results
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@accession_2.title}')]")
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@resource_2.title}')]")
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@digital_object_2.title}')]")
+  end
+
+  it "finds matches with two keyword ORed field queries" do
+    @driver.find_element(:id => "op1").select_option("OR")
+
+    @driver.click_and_wait_until_gone(:css => ".advanced-search .btn-primary")
+
+    # result list should contain those items with both @keywords[0] and @keywords[4]
+    @driver.find_element_with_text("//td", /#{@accession_1.title}/)
+    @driver.find_element_with_text("//td", /#{@resource_1.title}/)
+    @driver.find_element_with_text("//td", /#{@digital_object_1.title}/)
+
+    # these records should not appear in the results
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@accession_2.title}')]")
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@resource_2.title}')]")
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@digital_object_2.title}')]")
+  end
+
+  it "finds matches with two keyword joined AND NOTed field queries" do
+    @driver.find_element(:id => "op1").select_option("NOT")
+
+    @driver.click_and_wait_until_gone(:css => ".advanced-search .btn-primary")
+
+    # result list should contain those items with both @keywords[0] and NOT @keywords[4]
+    @driver.find_element_with_text("//td", /#{@resource_1.title}/)
+    @driver.find_element_with_text("//td", /#{@digital_object_1.title}/)
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@accession_1.title}')]")
+
+    # these records should not appear in the results
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@accession_2.title}')]")
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@resource_2.title}')]")
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@digital_object_2.title}')]")
+  end
+
+  it "clear resets the fields" do
+    @driver.click_and_wait_until_gone(:css => ".advanced-search .reset-advanced-search")
+
+    expect(@driver.find_element(:id => "v0").attribute("value")).to eq("")
+  end
+
+  it "allow adding of mulitple rows of the same type" do
+    # in response to a bug
+    @driver.find_element(:css => ".advanced-search-add-row-dropdown").click
+    @driver.find_element(:css => ".advanced-search-add-bool-row").click
+    @driver.find_element(:css => ".advanced-search-add-row-dropdown").click
+    @driver.find_element(:css => ".advanced-search-add-bool-row").click
+
+    @driver.find_element(:id => "v1")
+    @driver.find_element(:id => "v2")
+
+    @driver.click_and_wait_until_gone(:css => ".advanced-search .reset-advanced-search")
+  end
+
+  it "filters records based on a boolean search" do
+    # Let's find all records with keyword 1
+    @driver.clear_and_send_keys([:id => "v0"], @keywords[0])
+    @driver.find_element(:id => "f0").select_option("title")
+
+    @driver.click_and_wait_until_gone(:css => ".advanced-search .btn-primary")
+
+    @driver.find_element_with_text("//td", /#{@accession_1.title}/)
+    @driver.find_element_with_text("//td", /#{@resource_1.title}/)
+
+    # add a boolean field row
+    @driver.find_element(:css => ".advanced-search-add-row-dropdown").click
+    @driver.find_element(:css => ".advanced-search-add-bool-row").click
+
+    # let's only find those that are unpublished
+    @driver.find_element(:id => "f1").select_option("published")
+    @driver.find_element(:id => "v1").select_option("false")
+
+    @driver.click_and_wait_until_gone(:css => ".advanced-search .btn-primary")
+
+    @driver.find_element_with_text("//td", /#{@resource_1.title}/)
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@accession_1.title}')]")
+
+    # now let's flip it to find those that are published
+    @driver.find_element(:id => "v1").select_option("true")
+
+    @driver.click_and_wait_until_gone(:css => ".advanced-search .btn-primary")
+
+    @driver.find_element_with_text("//td", /#{@accession_1.title}/)
+    @driver.ensure_no_such_element(:xpath, "//td[contains(text(), '#{@resource_1.title}')]")
+  end
+
+  it "filters records based on a date field search" do
+    @driver.find_element(:css => ".advanced-search-add-row-dropdown").click
+    @driver.find_element(:css => ".advanced-search-add-date-row").click
+
+    # let's find all records created after 2014
+    @driver.clear_and_send_keys([:id => "v2"], "2012-01-01")
+    @driver.find_element(:id => "op2").select_option("AND")
+    @driver.find_element(:id => "f2").select_option("create_time")
+    @driver.find_element(:id => "dop2").select_option("greater_than")
+
+    @driver.click_and_wait_until_gone(:css => ".advanced-search .btn-primary")
+
+    @driver.find_element_with_text("//td", /#{@accession_1.title}/)
+
+    # change to lesser than.. there should be no results!
+    @driver.find_element(:id => "dop2").select_option("lesser_than")
+
+    @driver.click_and_wait_until_gone(:css => ".advanced-search .btn-primary")
+
+    @driver.find_element_with_text('//p[contains(@class, "alert-info")]', /No records found/)
+  end
+
+  it "hides when toggled" do
+    advanced_search_form = @driver.find_element(:css => "form.advanced-search")
+
+    @driver.find_element(:link => "Hide Advanced Search").click
+
+    expect {
+      assert(100) {
+        raise "Advanced Search still visible" if advanced_search_form.displayed?
+      }
+    }.not_to raise_error
+  end
+
+  it "doesn't display when a normal search is performed" do
+    @driver.clear_and_send_keys([:id => "global-search-box"], @keywords[0])
+    @driver.find_element(:id => "global-search-button").click
+
+    @driver.ensure_no_such_element(:css => "form.advanced-search")
+  end
+end

--- a/selenium/spec/factories.rb
+++ b/selenium/spec/factories.rb
@@ -191,7 +191,7 @@ module SeleniumFactories
         sort_name { generate(:sort_name) }
         name_order { %w(direct inverted).sample }
         number { generate(:alphanumstr) }
-        sort_name_auto_generate true
+        sort_name_auto_generate { true }
         dates { generate(:alphanumstr) }
         qualifier { generate(:alphanumstr) }
       end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Under specific circumstances searches can fail when the search results returned contain a suppressed record in the "Found in" column and the user conducting the search does not have permission to view suppressed records.

## Description
<!--- Describe your changes in detail -->
Added two checks in `search_helper.rb` and the context column partial to avoid nilMethod errors.

Also, copied existing tests from `selenium/search_spec.rb` to newer `frontend/spec/selenium/spec` directory, and added 3 new tests to check context column behavior.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Reported to users group email list by Kevin Clair 4/25/19.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To remedy bug in context column. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added three new tests.  All existing and new tests passed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
