### PR TITLE
Also escape ampersands on subnotes

### DIFF
--- a/public/app/views/pdf/_archival_object.html.erb
+++ b/public/app/views/pdf/_archival_object.html.erb
@@ -48,7 +48,7 @@ end
                     <% if !n['is_inherited'] %>
                       <h3>
                         <% if n['label'] %>
-                            <%= process_mixed_content(n['label']) %>
+                            <%= process_mixed_content(n['label']).gsub(/&amp;/,'&') %>
                         <% else %>
                             <%= I18n.t("enumerations._note_types.#{note_type}") %>
                         <% end %>

--- a/public/app/views/pdf/_archival_object.html.erb
+++ b/public/app/views/pdf/_archival_object.html.erb
@@ -53,7 +53,7 @@ end
                             <%= I18n.t("enumerations._note_types.#{note_type}") %>
                         <% end %>
                       </h3>
-                      <p><%= process_mixed_content(n['note_text']) %></p>
+                      <p><%= process_mixed_content(n['note_text']).gsub(/&amp;/,'&') %></p>
                     <% end %>
                   <% end %>
                 <% end %>
@@ -80,7 +80,7 @@ end
                   <% if note_type == 'physdesc' %>
                     <% note.each do |n| %>
                       <% if !n['is_inherited'] %>
-                        <dt><%= I18n.t('resource._public.physdesc') %></dt><dd><%= process_mixed_content(n['note_text']) %></dd>
+                        <dt><%= I18n.t('resource._public.physdesc') %></dt><dd><%= process_mixed_content(n['note_text']).gsub(/&amp;/,'&') %></dd>
                       <% end %>
                     <% end %>
                   <% end %>

--- a/public/app/views/pdf/_resource.html.erb
+++ b/public/app/views/pdf/_resource.html.erb
@@ -14,7 +14,7 @@
         <% end %>
     <% end %>
 
-    <dt><%= I18n.t('resource._public.finding_aid.title') %></dt><dd><%= process_mixed_content('record.display_string').gsub(/&amp;/,'&') %></dd>
+    <dt><%= I18n.t('resource._public.finding_aid.title') %></dt><dd><%= process_mixed_content(record.display_string).gsub(/&amp;/,'&') %></dd>
 
     <dt><%= I18n.t('resource._public.identifier') %></dt><dd><%= record.identifier %></dd>
 

--- a/public/app/views/pdf/_resource.html.erb
+++ b/public/app/views/pdf/_resource.html.erb
@@ -14,7 +14,7 @@
         <% end %>
     <% end %>
 
-    <dt><%= I18n.t('resource._public.finding_aid.title') %></dt><dd><%= process_mixed_content('record.display_string') %></dd>
+    <dt><%= I18n.t('resource._public.finding_aid.title') %></dt><dd><%= process_mixed_content('record.display_string').gsub(/&amp;/,'&') %></dd>
 
     <dt><%= I18n.t('resource._public.identifier') %></dt><dd><%= record.identifier %></dd>
 
@@ -30,7 +30,7 @@
         <% if note_type == 'physdesc' %>
             <a id="note-<%= note_type %>"></a>
             <% note.each do |n| %>
-              <dt><%= I18n.t("enumerations._note_types.#{note_type}") %></dt><dd><%= process_mixed_content(n['note_text']) %></dd>
+              <dt><%= I18n.t("enumerations._note_types.#{note_type}") %></dt><dd><%= process_mixed_content(n['note_text']).gsub(/&amp;/,'&') %></dd>
             <% end %>
         <% end %>
     <% end %>
@@ -50,12 +50,12 @@
     <% note.each do |n| %>
       <h3>
         <% if n['label'] %>
-            <%= process_mixed_content(n['label']) %>
+            <%= process_mixed_content(n['label']).gsub(/&amp;/,'&') %>
         <% else %>
             <%= I18n.t("enumerations._note_types.#{note_type}") %>
         <% end %>
       </h3>
-      <p><%= process_mixed_content(n['note_text']) %></p>
+      <p><%= process_mixed_content(n['note_text']).gsub(/&amp;/,'&') %></p>
     <% end %>
 <% end %>
 

--- a/public/app/views/pdf/_titlepage.html.erb
+++ b/public/app/views/pdf/_titlepage.html.erb
@@ -2,8 +2,8 @@
     <div class="logo"><%= image_tag( record.resolved_repository['image_url'] || asset_path("archivesspace.small.png") ) %></div>
     <div class="title-block">
     <% if record.finding_aid['title'] %>
-        <h3 class="title"><%= process_mixed_content(record.finding_aid['title']) %></h3>
-        <h4 class="subtitle"><%= process_mixed_content(record.finding_aid['subtitle']) %></h4>
+        <h3 class="title"><%= process_mixed_content(record.finding_aid['title']).gsub(/&amp;/,'&') %></h3>
+        <h4 class="subtitle"><%= process_mixed_content(record.finding_aid['subtitle']).gsub(/&amp;/,'&') %></h4>
     <% else %>
         <h3 class="title"><%= record.display_string %></h3>
     <% end %>

--- a/public/app/views/pdf/_titlepage.html.erb
+++ b/public/app/views/pdf/_titlepage.html.erb
@@ -3,7 +3,7 @@
     <div class="title-block">
     <% if record.finding_aid['title'] %>
         <h3 class="title"><%= process_mixed_content(record.finding_aid['title']).gsub(/&amp;/,'&') %></h3>
-        <h4 class="subtitle"><%= process_mixed_content(record.finding_aid['subtitle']).gsub(/&amp;/,'&') %></h4>
+        <h4 class="subtitle"><%= if record.finding_aid['subtitle'] then process_mixed_content(record.finding_aid['subtitle']).gsub(/&amp;/,'&') end %></h4>
     <% else %>
         <h3 class="title"><%= record.display_string %></h3>
     <% end %>

--- a/public/app/views/pdf/_toc.html.erb
+++ b/public/app/views/pdf/_toc.html.erb
@@ -15,7 +15,7 @@
                 <a href="#note-<%= note_type %>">
                   <% note.each do |n| %>
                     <% if n['label'] %>
-                        <%= process_mixed_content(n['label']) %>
+                        <%= process_mixed_content(n['label']).gsub(/&amp;/,'&') %>
                     <% else %>
                         <%= I18n.t("enumerations._note_types.#{note_type}") %>
                     <% end %>
@@ -31,7 +31,7 @@
         <% end %>
 
         <% ordered_aos.each do |entry| %>
-            <li class="level-<%= entry.depth + 1 %>"><a href="#<%= entry.uri %>"><%== process_mixed_content(entry.display_string) %></a></li>
+            <li class="level-<%= entry.depth + 1 %>"><a href="#<%= entry.uri %>"><%== process_mixed_content(entry.display_string).gsub(/&amp;/,'&') %></a></li>
         <% end %>
     </ul>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Small fix for subnotes that have ampersands. This escapes the &amps and turns them into plain old & when printing to a PDF.

## Description
<!--- Describe your changes in detail -->

Just a good ol' `.gsub(/&amp;/,'&')`

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

https://archivesspace.atlassian.net/browse/ANW-822

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Printing PDFs with an & in the note or subnote ends up looking bad.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
