### PR TITLE
More release updates

### DIFF
--- a/backend/app/lib/slugs/slug_helpers_generate.rb
+++ b/backend/app/lib/slugs/slug_helpers_generate.rb
@@ -5,9 +5,9 @@ module SlugHelpers
   def self.clean_slug(slug)
 
     if slug
-      # if the slug contains two slashes next to each other, completely zero it out.
-      # this is intended to revert an entity to use the URI if the ID or name the slug was generated from is a URL.
-      slug = "" if slug =~ /\/\//
+      # if the slug contains two slashes (forward or backward) next to each other, completely zero it out.
+      # this is intended to revert an entity to use the URI if the ID or name the slug was generated from is a URI.
+      slug = "" if slug =~ /\/\// || slug =~ /\\/
 
       # remove markup tags
       slug = slug.gsub(/<\/?[^>]*>/, "")

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -617,14 +617,15 @@ AppConfig[:pui_page_custom_actions] = []
 #   'erb_partial' => 'shared/my_special_action',
 # }
 
-# Human-Readable URLs options                            
+# For Accessions browse set if accession date year filter values should be sorted ascending rather than descending (default)
+AppConfig[:sort_accession_date_filter_asc] = false
+
+# Human-Readable URLs options
 # use_human_readable_urls: determines whether fields and options related to human-readable URLs appear in the staff interface
 # Changing this option will not remove or clear any slugs that exist currently.
 # This setting only affects links that are displayed. URLs that point to valid slugs will still work.
 # WARNING: Changing this setting may require an index rebuild for changes to take effect.
 
-# TODO: for release, uncomment below and remove line that follows that so that HRU's are off by default.
-#AppConfig[:use_human_readable_urls] = false
 AppConfig[:use_human_readable_urls] = false
 
 # Use the repository in human-readable URLs
@@ -636,9 +637,6 @@ AppConfig[:auto_generate_slugs_with_id] = false
 
 # For Resources: if this option and auto_generate_slugs_with_id are both enabled, then slugs for Resources will be generated with EADID instead of the identifier.
 AppConfig[:generate_resource_slugs_with_eadid] = false
-                            
-# For archival objects: if this option and auto_generate_slugs_with_id are both enabled, then slugs for archival resources will be generated with Component Unique Identifier instead of the identifier.                            
-AppConfig[:generate_archival_object_slugs_with_cuid] = false
 
-# For Accessions browse set if accession date year filter values should be sorted ascending rather than descending (default)
-AppConfig[:sort_accession_date_filter_asc] = false
+# For archival objects: if this option and auto_generate_slugs_with_id are both enabled, then slugs for archival resources will be generated with Component Unique Identifier instead of the identifier.
+AppConfig[:generate_archival_object_slugs_with_cuid] = false

--- a/frontend/app/views/jobs/_show_templates.html.erb
+++ b/frontend/app/views/jobs/_show_templates.html.erb
@@ -35,10 +35,12 @@
 
     <%= form.label_with_field "import_type", job['import_type'] %>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= I18n.t("repository._singular") %></label>
-      <div class="col-sm-9 controls label-only"><%= resolve_readonly_link_to job.repository['_resolved']['repo_code'], job.repository['ref'] %></div>
-    </div>
+    <% if job["job_type"] != 'generate_slugs_job' %>
+      <div class="form-group">
+        <label class="col-sm-3 control-label"><%= I18n.t("repository._singular") %></label>
+        <div class="col-sm-9 controls label-only"><%= resolve_readonly_link_to job.repository['_resolved']['repo_code'], job.repository['ref'] %></div>
+      </div>
+    <% end %>
 
     <div class="form-group">
       <label class="col-sm-3 control-label"><%= I18n.t("job.owner") %></label>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Do not create human readable URL if there are two backslashes in the data
In the config.rb file, ensure use_human_readable_urls parameter is defaulted to false and move setting of new parameter above the human readable url parameters to make sure it doesn't look like it is part of that
Since generation of slugs is not a repository scoped background job, there is no need to include the current repository in the background job page

