### PR TITLE
Allow ampersands and mixed content with linebreaks

### DIFF
--- a/public/app/controllers/concerns/manipulate_node.rb
+++ b/public/app/controllers/concerns/manipulate_node.rb
@@ -30,7 +30,7 @@ module ManipulateNode
               .gsub(/\r\n\r\n/,"<br /><br />")
     end
 
-    txt = txt.gsub(/ & /, ' &amp; ')
+    txt = txt.gsub(/&(?![A-Za-z]+;|#[0-9]+;)/, '&amp;')
 
     txt = txt.gsub("xlink\:type=\"simple\"", "")
 

--- a/public/app/views/pdf/_archival_object.html.erb
+++ b/public/app/views/pdf/_archival_object.html.erb
@@ -14,7 +14,7 @@ end
 
 <div class="avoid-break">
     <div class="print-record-border print-record level-<%= level %>">
-        <p><a class="record-title" id="<%= record.uri %>"><%= process_mixed_content(record.display_string).gsub(/&amp;/,'&') %></a></p>
+        <p><a class="record-title" id="<%= record.uri %>"><%== process_mixed_content(record.display_string) %></a></p>
 
         <% Array(record.instances).each do |instance| %>
             <% if instance['sub_container'] %>
@@ -48,12 +48,12 @@ end
                     <% if !n['is_inherited'] %>
                       <h3>
                         <% if n['label'] %>
-                            <%= process_mixed_content(n['label']).gsub(/&amp;/,'&') %>
+                            <%== process_mixed_content(n['label']) %>
                         <% else %>
                             <%= I18n.t("enumerations._note_types.#{note_type}") %>
                         <% end %>
                       </h3>
-                      <p><%= process_mixed_content(n['note_text']).gsub(/&amp;/,'&') %></p>
+                      <p><%== process_mixed_content(n['note_text']) %></p>
                     <% end %>
                   <% end %>
                 <% end %>
@@ -80,7 +80,7 @@ end
                   <% if note_type == 'physdesc' %>
                     <% note.each do |n| %>
                       <% if !n['is_inherited'] %>
-                        <dt><%= I18n.t('resource._public.physdesc') %></dt><dd><%= process_mixed_content(n['note_text']).gsub(/&amp;/,'&') %></dd>
+                        <dt><%= I18n.t('resource._public.physdesc') %></dt><dd><%== process_mixed_content(n['note_text']) %></dd>
                       <% end %>
                     <% end %>
                   <% end %>

--- a/public/app/views/pdf/_resource.html.erb
+++ b/public/app/views/pdf/_resource.html.erb
@@ -14,7 +14,7 @@
         <% end %>
     <% end %>
 
-    <dt><%= I18n.t('resource._public.finding_aid.title') %></dt><dd><%= process_mixed_content(record.display_string).gsub(/&amp;/,'&') %></dd>
+    <dt><%= I18n.t('resource._public.finding_aid.title') %></dt><dd><%== process_mixed_content(record.display_string) %></dd>
 
     <dt><%= I18n.t('resource._public.identifier') %></dt><dd><%= record.identifier %></dd>
 
@@ -30,7 +30,7 @@
         <% if note_type == 'physdesc' %>
             <a id="note-<%= note_type %>"></a>
             <% note.each do |n| %>
-              <dt><%= I18n.t("enumerations._note_types.#{note_type}") %></dt><dd><%= process_mixed_content(n['note_text']).gsub(/&amp;/,'&') %></dd>
+              <dt><%= I18n.t("enumerations._note_types.#{note_type}") %></dt><dd><%== process_mixed_content(n['note_text']) %></dd>
             <% end %>
         <% end %>
     <% end %>
@@ -50,12 +50,12 @@
     <% note.each do |n| %>
       <h3>
         <% if n['label'] %>
-            <%= process_mixed_content(n['label']).gsub(/&amp;/,'&') %>
+            <%== process_mixed_content(n['label']) %>
         <% else %>
             <%= I18n.t("enumerations._note_types.#{note_type}") %>
         <% end %>
       </h3>
-      <p><%= process_mixed_content(n['note_text']).gsub(/&amp;/,'&') %></p>
+      <p><%== process_mixed_content(n['note_text']) %></p>
     <% end %>
 <% end %>
 

--- a/public/app/views/pdf/_titlepage.html.erb
+++ b/public/app/views/pdf/_titlepage.html.erb
@@ -2,10 +2,10 @@
     <div class="logo"><%= image_tag( record.resolved_repository['image_url'] || asset_path("archivesspace.small.png") ) %></div>
     <div class="title-block">
     <% if record.finding_aid['title'] %>
-        <h3 class="title"><%= process_mixed_content(record.finding_aid['title']).gsub(/&amp;/,'&') %></h3>
-        <h4 class="subtitle"><%= if record.finding_aid['subtitle'] then process_mixed_content(record.finding_aid['subtitle']).gsub(/&amp;/,'&') end %></h4>
+        <h3 class="title"><%== process_mixed_content(record.finding_aid['title'], :preserve_newlines => true) %></h3>
+        <h4 class="subtitle"><%== if record.finding_aid['subtitle'] then process_mixed_content(record.finding_aid['subtitle'], :preserve_newlines => true) end %></h4>
     <% else %>
-        <h3 class="title"><%= record.display_string %></h3>
+        <h3 class="title"><%== process_mixed_content(record.display_string, :preserve_newlines => true) %></h3>
     <% end %>
     </div>
 

--- a/public/app/views/pdf/_toc.html.erb
+++ b/public/app/views/pdf/_toc.html.erb
@@ -15,7 +15,7 @@
                 <a href="#note-<%= note_type %>">
                   <% note.each do |n| %>
                     <% if n['label'] %>
-                        <%= process_mixed_content(n['label']).gsub(/&amp;/,'&') %>
+                        <%== process_mixed_content(n['label']) %>
                     <% else %>
                         <%= I18n.t("enumerations._note_types.#{note_type}") %>
                     <% end %>
@@ -31,7 +31,7 @@
         <% end %>
 
         <% ordered_aos.each do |entry| %>
-            <li class="level-<%= entry.depth + 1 %>"><a href="#<%= entry.uri %>"><%== process_mixed_content(entry.display_string).gsub(/&amp;/,'&') %></a></li>
+            <li class="level-<%= entry.depth + 1 %>"><a href="#<%= entry.uri %>"><%== process_mixed_content(entry.display_string) %></a></li>
         <% end %>
     </ul>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix unintentional issue with handling linebreaks in PUI pdf generation.  Also moves all handling of PUI pdf ampersands to an updated process_mixed_content method.

## Description
<!--- Describe your changes in detail -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix bug introduced in #902 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Updated regex used for ampersands in process_mixed_content.
2. Removed ampersand related gsub's from pui pdf views.
3. Outputs raw content from pui pdf views.

Note: Public tests not run because they are currently failing in master for an unrelated reason.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
