### PR TITLE
Only allow administer_system users to run background job for slug gen

### DIFF
--- a/backend/app/lib/job_runners/generate_slugs_runner.rb
+++ b/backend/app/lib/job_runners/generate_slugs_runner.rb
@@ -1,8 +1,8 @@
 class GenerateSlugsRunner < JobRunner
 
   register_for_job_type('generate_slugs_job',
-                        {:create_permissions => :manage_repository,
-                         :cancel_permissions => :manage_repository,
+                        {:create_permissions => :administer_system,
+                         :cancel_permissions => :administer_system,
                          :allow_reregister => true})
 
    def generate_slug_for(thing)


### PR DESCRIPTION
Change up the permissions required for running the slugs generation background job, only allow users with administer_system permissions to run job.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
