### PR TITLE
Staff UI tweaks

### DIFF
--- a/frontend/app/views/agents/_merge_dropdown.html.erb
+++ b/frontend/app/views/agents/_merge_dropdown.html.erb
@@ -15,7 +15,7 @@
 
         <fieldset>
           <div class="alert alert-danger missing-ref-message" style="display: none;"><%= I18n.t "#{singular}._frontend.messages.please_select_a_#{singular}_to_merge" %></div>
-          <%= render_aspace_partial :partial => "#{controller}/linker", :locals => { :form => form,  :exclude_ids => [record.uri], :hide_create => true, :multiplicity => multiplicity }%>
+          <%= render_aspace_partial :partial => "#{controller}/linker", :locals => { :form => form,  :exclude_ids => [record.uri], :hide_create => true, :multiplicity => multiplicity, :layout => 'stacked' }%>
         </fieldset>
         <div class="form-actions">
           <%=

--- a/frontend/app/views/shared/_event_dropdown.html.erb
+++ b/frontend/app/views/shared/_event_dropdown.html.erb
@@ -14,8 +14,8 @@
             <%= select_tag "add_event_event_type", options_for_select(event_types.map{|event_type| [I18n.t("enumerations.event_event_type.#{event_type}", :default => event_type), event_type]}), :'aria-labelledby' => "form_add_event" %>
           </fieldset>
           <div class="form-actions">
-            <button class="btn add-event-button"><%= I18n.t("actions.add_event") %></button>
-            <a class="btn btn-close pull-right" href="#"><%= I18n.t("actions.cancel") %></a>
+            <button class="btn add-event-button btn-default"><%= I18n.t("actions.add_event") %></button>
+            <a class="btn btn-close pull-right btn-default" href="#"><%= I18n.t("actions.cancel") %></a>
           </div>
         <% end %>
       </li>

--- a/frontend/app/views/shared/_merge_dropdown.html.erb
+++ b/frontend/app/views/shared/_merge_dropdown.html.erb
@@ -15,7 +15,7 @@
 
         <fieldset>
           <div class="alert alert-danger missing-ref-message" style="display: none;"><%= I18n.t "#{singular}._frontend.messages.please_select_a_#{singular}_to_merge" %></div>
-          <%= render_aspace_partial :partial => "#{controller}/linker", :locals => { :form => form,  :exclude_ids => [record.uri], :hide_create => true, :multiplicity => multiplicity }%>
+          <%= render_aspace_partial :partial => "#{controller}/linker", :locals => { :form => form,  :exclude_ids => [record.uri], :hide_create => true, :multiplicity => multiplicity, :layout => 'stacked' }%>
         </fieldset>
         <div class="form-actions">
           <%=

--- a/frontend/app/views/shared/_templates.html.erb
+++ b/frontend/app/views/shared/_templates.html.erb
@@ -41,7 +41,7 @@
       {/if}
    </div>
    <div class="modal-footer">
-      <button id="confirmButton" class="btn {if defined('confirm_class') && confirm_class} ${confirm_class}{/if}">{if defined('confirm_label') && confirm_label}${confirm_label}{else}<%= I18n.t "actions.confirm" %>{/if}</button>
+      <button id="confirmButton" class="btn btn-default {if defined('confirm_class') && confirm_class} ${confirm_class}{/if}">{if defined('confirm_label') && confirm_label}${confirm_label}{else}<%= I18n.t "actions.confirm" %>{/if}</button>
       <button class="btn btn-cancel btn-default" data-dismiss="modal"><%= I18n.t "actions.cancel" %></button>
    </div>
 --></div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a few staff UI styling issues.

## Description
<!--- Describe your changes in detail -->
Updated merge dropdown partials (shared and agent merge) to fix spacing issue in dropdown menu.  Also, added btn-default class to event dropdown and shared template buttons to add default button styling.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Tweak staff side UI styling inconsistencies.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All existing tests pass.

## Screenshots (if appropriate):

Merge dropdown before fix:
![image](https://user-images.githubusercontent.com/15144646/57804841-9fceb780-7729-11e9-8148-d89b2e223b72.png)

Merge dropdown after fix:
![image](https://user-images.githubusercontent.com/15144646/57804847-a6f5c580-7729-11e9-82ec-67d77e5b030d.png)

Event dropdown before fix:
![image](https://user-images.githubusercontent.com/15144646/57804913-cd1b6580-7729-11e9-8dd7-b74fc03a1864.png)

Event dropdown after fix:
![image](https://user-images.githubusercontent.com/15144646/57804862-b117c400-7729-11e9-927a-89610b6b7a99.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
