### PR TITLE
Anw 892

### DIFF
--- a/backend/app/exporters/models/ead.rb
+++ b/backend/app/exporters/models/ead.rb
@@ -212,9 +212,7 @@ class EADModel < ASpaceExport::ExportModel
       data << contact["address_#{i}"]
     end
 
-    line = ""
-    line += %w(city region).map{|k| contact[k] }.compact.join(', ')
-    line += " #{contact['post_code']}"
+    line = %w(city region post_code).map{|k| contact[k] }.compact.join(' ')
     line.strip!
 
     data <<  line unless line.empty?
@@ -240,9 +238,7 @@ class EADModel < ASpaceExport::ExportModel
       data["address_#{i}"] = contact["address_#{i}"]
     end
 
-    line = ""
-    line += %w(city region).map{|k| contact[k] }.compact.join(', ')
-    line += " #{contact['post_code']}"
+    line = %w(city region post_code).map{|k| contact[k] }.compact.join(' ')
     line.strip!
     data['city_region_post_code'] = line unless line.empty?
 

--- a/public/app/views/pdf/_publication_statement.html.erb
+++ b/public/app/views/pdf/_publication_statement.html.erb
@@ -5,7 +5,6 @@
         <% Array(repository_information['address']).each do |line| %>
             <div class="repository-address-line"><%= line %></div>
         <% end %>
-
         <% address_properties = ['city', 'region', 'post_code'] %>
         <% if address_properties.any? {|attr| repository_information[attr]} %>
             <div class="repository-address-line">

--- a/public/app/views/pdf/_publication_statement.html.erb
+++ b/public/app/views/pdf/_publication_statement.html.erb
@@ -8,7 +8,9 @@
 
         <% address_properties = ['city', 'region', 'post_code'] %>
         <% if address_properties.any? {|attr| repository_information[attr]} %>
-            <div class="repository-address-line"><%= address_properties.map {|attr| repository_information[attr]}.join(', ') %></div>
+            <div class="repository-address-line">
+              <%= repository_information['city'] %>, <%= repository_information['region'] %> <%= repository_information['post_code'] %>
+            </div>
         <% end %>
     </div>
 

--- a/public/app/views/pdf/_publication_statement.html.erb
+++ b/public/app/views/pdf/_publication_statement.html.erb
@@ -7,9 +7,7 @@
         <% end %>
         <% address_properties = ['city', 'region', 'post_code'] %>
         <% if address_properties.any? {|attr| repository_information[attr]} %>
-            <div class="repository-address-line">
-              <%= repository_information['city'] %>, <%= repository_information['region'] %> <%= repository_information['post_code'] %>
-            </div>
+          <div class="repository-address-line"><%= address_properties.map {|attr| repository_information[attr]}.join(' ') %></div>
         <% end %>
     </div>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is a small fix for the address info in the PUI PDF. The old way had a comma between City, State, Zip. Proper address formatting just has a comma between City, State Zip

## Description
<!--- Describe your changes in detail -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
