### PR TITLE
Show scope note inheritance on record page and search results

### DIFF
--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -17,6 +17,9 @@
           end
 	  if !note_struct['note_text'].blank? %>
           <div class="abstract single_note"><span class='inline-label'><%= note_struct['label'] %></span>
+            <% unless note_struct['is_inherited'].blank? %>
+              <%= inheritance(note_struct['is_inherited']).html_safe %>
+            <% end %>
            <% if note_struct['note_text'].length > AppConfig[:abstract_note_length] %>
              <% truncated_note = note_struct['note_text'][0..AppConfig[:abstract_note_length]-1] %>
              <% end_index = truncated_note.rindex(' ') || AppConfig[:abstract_note_length]-1 %>

--- a/public/app/views/shared/_single_note.html.erb
+++ b/public/app/views/shared/_single_note.html.erb
@@ -14,12 +14,18 @@
              <span class='inline-label'><%= subnote['_inline_label'] %></span>
            <% end %>
            <span class="note-content">
+             <% unless note_struct['is_inherited'].blank? %>
+               <%= inheritance(note_struct['is_inherited']).html_safe %>
+             <% end %>
              <%= subnote['_text'].html_safe %>
            </span>
          </div>
        <% end %>
      <% else %>
        <div class="note-content">
+         <% unless note_struct['is_inherited'].blank? %>
+           <%= inheritance(note_struct['is_inherited']).html_safe %>
+         <% end %>
          <%= note_struct['note_text'].html_safe %>
        </div>
      <% end %>

--- a/public/spec/controllers/resources_controller_spec.rb
+++ b/public/spec/controllers/resources_controller_spec.rb
@@ -40,7 +40,7 @@ describe ResourcesController, type: :controller do
   it 'should show the published resources' do
     expect(get(:index)).to have_http_status(200)
     results = assigns(:results)
-    expect(results['total_hits']).to eq(4)
+    expect(results['total_hits']).to eq(5)
     expect(results.records.first['title']).to eq("Published Resource")
   end
 

--- a/public/spec/factories.rb
+++ b/public/spec/factories.rb
@@ -176,6 +176,16 @@ module AspaceFactories
         language { "eng" }
       end
 
+      factory :resource_with_scope, class: JSONModel(:resource) do
+        title { generate :resource_title }
+        id_0 { generate :id_0 }
+        extents { [build(:extent)] }
+        dates { [build(:date)] }
+        level { "collection" }
+        language { "eng" }
+        notes { [build(:json_note_multipart)] }
+      end
+
       factory :archival_object, class: JSONModel(:archival_object) do
         title { generate(:archival_object_title) }
         ref_id { generate(:ref_id) }
@@ -238,6 +248,16 @@ module AspaceFactories
           "colTitle" => "DEFAULT TITLE",
           "colLevel" => "item"
         } }
+      end
+
+      factory :json_note_multipart, class: JSONModel(:note_multipart) do
+        type { 'scopecontent' }
+        subnotes { [ build(:json_note_text, :publish => true) ] }
+        publish { true } 
+      end
+
+      factory :json_note_text, class: JSONModel(:note_text) do
+        content { generate(:alphanumstr) }
       end
 
       factory :name_person, class: JSONModel(:name_person) do

--- a/public/spec/features/record_innards_spec.rb
+++ b/public/spec/features/record_innards_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Record innards', js: true do
+  it 'should display when a scope note is inherited' do
+    visit('/')
+    click_link 'Collections'
+    expect(current_path).to eq ('/repositories/resources')
+    resource = first("a[class='record-title']", text: 'Resource with scope note')
+    visit(resource['href'])
+    click_link 'Collection Organization'
+    finished_all_ajax_requests?
+    res = first("div[id='record-number-0']")
+    res_href = res.first("a")['href']
+    first_ao = first("div[id='record-number-1']")
+    first_ao_href = first_ao.first("a")['href']
+    # Resource with scope note should not be prepended with "From the"
+    visit(res_href)
+    within '.upper-record-details' do
+      expect(page).not_to have_css(".note-content", text: "From the")
+    end
+    # Archival object child of a resource with a scope note should be prepended with "From the"
+    visit(first_ao_href)
+    within '.upper-record-details' do
+      expect(page).to have_css(".note-content", text: "From the")
+    end
+
+  end
+
+end

--- a/public/spec/features/resources_spec.rb
+++ b/public/spec/features/resources_spec.rb
@@ -7,7 +7,7 @@ describe 'Resources', js: true do
     click_link 'Collections'
     expect(current_path).to eq ('/repositories/resources')
     within all('.col-sm-12')[0] do
-      expect(page).to have_content("Showing Collections: 1 - 3 of 3")
+      expect(page).to have_content("Showing Collections: 1 - 4 of 4")
     end
     within all('.col-sm-12')[1] do
       expect(page.all("a[class='record-title']", text: 'Published Resource').length).to eq 1

--- a/public/spec/spec_helper.rb
+++ b/public/spec/spec_helper.rb
@@ -85,6 +85,12 @@ def setup_test_data
   end
   create(:resource, title: "Resource for Phrase Search", publish: true)
   create(:resource, title: "Search as Phrase Resource", publish: true)
+
+  resource_with_scope = create(:resource_with_scope, title: "Resource with scope note", publish: true)
+  aos = (0..5).map do
+    create(:archival_object,
+           resource: { 'ref' => resource_with_scope.uri }, publish: true)
+  end
   run_all_indexers
 end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes ANW-900.  Respects inheritance settings from AppConfig when displaying scope and contents notes on record pages and search results page.

## Description
<!--- Describe your changes in detail -->
Added checks for 'is_inherited' to the shared `single_note` and `result` partials.

Also, added new `record_innards` spec with a test to confirm inheritance is/is not conveyed on a resource and archival object page.

Updated 2 existing tests to reflect addition of new resource created in `spec_helper`.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-900

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixed bug in ANW-900.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually and added new public test.

## Screenshots (if appropriate):

Context conveyed on search results page:
![image](https://user-images.githubusercontent.com/15144646/58183178-df8f2500-7c7c-11e9-9cc9-447ca4670d24.png)


Context conveyed on record page:
![image](https://user-images.githubusercontent.com/15144646/58184090-6f819e80-7c7e-11e9-8d18-7a1bbd88efd6.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
