### PR TITLE
Update Capybara for public tests

### DIFF
--- a/public/Gemfile
+++ b/public/Gemfile
@@ -61,7 +61,7 @@ group :test do
   gem "factory_bot_rails"
   gem "fog-aws", "2.0.0", :require => false
   gem 'selenium-webdriver'
-  gem 'capybara', '3.12.0'
+  gem 'capybara', '3.15.1'
   gem 'launchy'
   gem 'axe-matchers'
 end

--- a/public/Gemfile.lock
+++ b/public/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     builder (3.2.3)
-    capybara (3.12.0)
+    capybara (3.15.1)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -197,7 +197,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    regexp_parser (1.4.0)
+    regexp_parser (1.5.0)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
       rspec-expectations (~> 3.6.0)
@@ -292,7 +292,7 @@ DEPENDENCIES
   atomic (= 1.0.1)
   axe-matchers
   bootstrap-sass (~> 3.3.6)
-  capybara (= 3.12.0)
+  capybara (= 3.15.1)
   clipboard-rails
   coffee-rails (= 4.2.1)
   factory_bot_rails


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Bump Capybara for public tests to 3.15.1 (latest that supports Ruby >= 2.3.0) to clear several deprecation warnings with public tests.

## Description
<!--- Describe your changes in detail -->
Bump Capybara.  Deprecations discovered while working on #1589 .

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Resolves numerous deprecation warnings in public tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests run without deprecation warnings.

## Screenshots (if appropriate):
Prior to change: 
![image](https://user-images.githubusercontent.com/15144646/58197806-03616380-7c9b-11e9-998a-1a92fe4bf22d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
