### PR TITLE
Missing translation

### DIFF
--- a/backend/app/lib/crud_helpers.rb
+++ b/backend/app/lib/crud_helpers.rb
@@ -79,6 +79,7 @@ module CrudHelpers
 
         if existing_record
           e.errors[:conflicting_record] = [existing_record.uri]
+          e.errors[:@translated]
         end
       end
 

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -1942,6 +1942,7 @@ en:
   validation_errors:
     agent_must_be_unique: Agent records cannot be identical
     subject_must_be_unique: Subject records cannot be identical
+    conflicting_record: Conflicting record
     missing_required_property: Property is required but was missing
     missing_property: Property was missing
     not_a_valid_date: Not a valid date

--- a/common/locales/es.yml
+++ b/common/locales/es.yml
@@ -1922,6 +1922,7 @@ es:
   validation_errors:
     agent_must_be_unique: Registros de autoridad no pueden ser idénticos
     subject_must_be_unique: Los registros de sujetos no pueden ser idénticos
+    conflicting_record: Registro conflictivo
     missing_required_property: Propiedad es necesaria pero falta
     missing_property: Faltaba propiedad
     not_a_valid_date: No es una fecha válida

--- a/common/locales/fr.yml
+++ b/common/locales/fr.yml
@@ -1942,6 +1942,7 @@ fr:
   validation_errors:
     agent_must_be_unique: Il ne peut y avoir deux notices d'agents identiques
     subject_must_be_unique: Il ne peut y avoir deux notices sujets identiques
+    conflicting_record: Enregistrement contradictoire
     missing_required_property: Propriété requise qui manquait
     missing_property: Propriété manquante
     not_a_valid_date: N'est pas une date valide

--- a/common/locales/ja.yml
+++ b/common/locales/ja.yml
@@ -1466,6 +1466,7 @@ ja:
   validation_errors:
     agent_must_be_unique: エージェントレコードは同一ではありません
     subject_must_be_unique: 件名のレコードは同一ではありません
+    conflicting_record: 競合するレコード
     missing_required_property: プロパティは必須ですが行方不明です
     missing_property: プロパティが見つかりませんでした
     not_a_valid_date: 有効な日付ではありません

--- a/frontend/app/views/shared/_form_messages.html.erb
+++ b/frontend/app/views/shared/_form_messages.html.erb
@@ -92,7 +92,11 @@
                      data-target="<%= form.id_for_javascript(attr) %>"
                      data-message="<%= h(msg) %>">
                   <% unless attr === 'coded_errors' %>
-                  	<%= I18n.t(form.path_to_i18n_key(attr)) %> - 
+                    <% if attr === 'conflicting_record' %>
+                      <%= I18n.t("validation_errors.conflicting_record") %> -
+                    <% else %>
+                    	<%= I18n.t(form.path_to_i18n_key(attr)) %> -
+                    <% end %>
                   <% end %>
                   <%= msg %>
                 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Error messaging when attempting to save duplicate agents included several "translation missings."

## Description
<!--- Describe your changes in detail -->
* Added `translated` key to errors of the type `conflicting_record` so that the application would not attempt to translate the conflicting record URI.
* Provided a translations for the `conflicting_record` error.
* Pointed to that new translation when the error key was `conflicting_record`.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove translation missing messages.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing manually, automated tests pass.

## Screenshots (if appropriate):
Before
<img width="558" alt="translation_before" src="https://user-images.githubusercontent.com/15144646/58480157-b90f3500-8127-11e9-86a9-3b731ad73982.png">

After
<img width="397" alt="translation_after" src="https://user-images.githubusercontent.com/15144646/58480149-b6144480-8127-11e9-8b34-06714f473eab.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
