### PR TITLE
Don't attempt to translate URI

### DIFF
--- a/backend/app/lib/crud_helpers.rb
+++ b/backend/app/lib/crud_helpers.rb
@@ -79,7 +79,6 @@ module CrudHelpers
 
         if existing_record
           e.errors[:conflicting_record] = [existing_record.uri]
-          e.errors[:@translated]
         end
       end
 

--- a/common/jsonmodel_i18n_mixin.rb
+++ b/common/jsonmodel_i18n_mixin.rb
@@ -16,7 +16,11 @@ module JSONModelI18nMixin
       [:errors, :warnings].each do |level|
         next unless exceptions[level]
         exceptions[level].clone.each do |path, msgs|
-          exceptions[level][path] = msgs.map{|m| translate_exception_message(m)}
+          if path == 'conflicting_record'
+            exceptions[level][path] = msgs
+          else
+            exceptions[level][path] = msgs.map{|m| translate_exception_message(m)}
+          end
         end
       end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Additional fix to finish off #1592 .

## Description
<!--- Describe your changes in detail -->
Explicitly skips attempts to translate error message when that error message has the key `conflicting_record`.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove translation missing error from error message received when attempting to create a duplicate agent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually, existing tests pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
