### PR TITLE
Respect published status of non-creator agents for EAD

### DIFF
--- a/backend/app/exporters/lib/export_helpers.rb
+++ b/backend/app/exporters/lib/export_helpers.rb
@@ -43,7 +43,7 @@ module ASpaceExport
         results = []
         linked = self.linked_agents || []
         linked.each_with_index do |link, i|
-          next if link['role'] == 'creator'
+          next if link['role'] == 'creator' || (link['_resolved']['publish'] == false && !@include_unpublished)
           role = link['relator'] ? link['relator'] : (link['role'] == 'source' ? 'fmo' : nil)
 
           agent = link['_resolved'].dup
@@ -69,6 +69,7 @@ module ASpaceExport
           atts[:source] = source if source
           atts[:rules] = rules if rules
           atts[:authfilenumber] = authfilenumber if authfilenumber
+          atts[:audience] = 'internal' if link['_resolved']['publish'] == false
 
           results << {:node_name => node_name, :atts => atts, :content => content}
         end

--- a/backend/spec/export_ead3_spec.rb
+++ b/backend/spec/export_ead3_spec.rb
@@ -11,7 +11,7 @@ describe "EAD3 export mappings" do
   def load_export_fixtures
     @agents = {}
     5.times {
-      a = create([:json_agent_person, :json_agent_corporate_entity, :json_agent_family].sample)
+      a = create([:json_agent_person, :json_agent_corporate_entity, :json_agent_family].sample, :publish => true)
       @agents[a.uri] = a
     }
 

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -15,7 +15,7 @@ describe "EAD export mappings" do
   def load_export_fixtures
     @agents = {}
     5.times {
-      a = create([:json_agent_person, :json_agent_corporate_entity, :json_agent_family].sample)
+      a = create([:json_agent_person, :json_agent_corporate_entity, :json_agent_family].sample, :publish => true)
       @agents[a.uri] = a
     }
 

--- a/backend/spec/fixtures/oai/agents.json
+++ b/backend/spec/fixtures/oai/agents.json
@@ -115,5 +115,40 @@
         "publish": false,
         "title": "UNPUBLISHED Agent, Creator",
         "uri": "/agents/people/import_4"
+    },
+    {
+        "agent_type": "agent_corporate_entity",
+        "display_name": {
+            "authority_id": "UNPUBLISHED corporate source",
+            "authorized": true,
+            "is_display_name": true,
+            "jsonmodel_type": "name_corporate_entity",
+            "primary_name": "UNPUBLISHED Corporate Agent",
+            "rules": "local",
+            "sort_name": "UNPUBLISHED Corporate Agent",
+            "sort_name_auto_generate": true,
+            "source": "local"
+        },
+        "is_linked_to_published_record": true,
+        "jsonmodel_type": "agent_corporate_entity",
+        "linked_agent_roles": [
+            "source"
+        ],
+        "names": [
+            {
+                "authority_id": "UNPUBLISHED corporate source",
+                "authorized": true,
+                "is_display_name": true,
+                "jsonmodel_type": "name_corporate_entity",
+                "primary_name": "UNPUBLISHED Corporate Agent",
+                "rules": "local",
+                "sort_name": "UNPUBLISHED Corporate Agent",
+                "sort_name_auto_generate": true,
+                "source": "local"
+            }
+        ],
+        "publish": false,
+        "title": "UNPUBLISHED Corporate Agent",
+        "uri": "/agents/people/import_5"
     }
 ]

--- a/backend/spec/fixtures/oai/resource.json
+++ b/backend/spec/fixtures/oai/resource.json
@@ -58,6 +58,12 @@
             "relator": "cre",
             "role": "creator",
             "title": "UNPUBLISHED Creator Agent"
+        },
+        {
+            "ref": "/agents/people/import_5",
+            "relator": "fmo",
+            "role": "source",
+            "title": "UNPUBLISHED Corporate Agent"
         }
     ],
     "notes": [

--- a/backend/spec/model_oai_spec.rb
+++ b/backend/spec/model_oai_spec.rb
@@ -392,6 +392,18 @@ describe 'OAI handler' do
       expect(response.body).not_to match(/note with unpublished parent node/)
     end
 
+    it "should respect publish flags on creator agents for ead exports" do
+      uri = "/oai?verb=GetRecord&identifier=oai:archivesspace/#{@test_resource_record}&metadataPrefix=oai_ead"
+      response = get uri
+      expect(response.body).not_to match(/UNPUBLISHED Creator Agent/)
+    end
+
+    it "should respect publish flags on source agents for ead exports" do
+      uri = "/oai?verb=GetRecord&identifier=oai:archivesspace/#{@test_resource_record}&metadataPrefix=oai_ead"
+      response = get uri
+      expect(response.body).not_to match(/UNPUBLISHED Corporate Agent/)
+    end
+
     it "should respect publish flags for marc exports" do
       uri = "/oai?verb=GetRecord&identifier=oai:archivesspace/#{@test_resource_record}&metadataPrefix=oai_marc"
       response = get uri


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Ensure that the published status of a non-creator agent is respected on EAD export and via oai_ead.

## Description
<!--- Describe your changes in detail -->
Added a check for published status to `export_helpers.rb`.  Updated existing tests and added 2 new tests to confirm publication status is respected via OAI.  

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-906

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix to address lack of published status check for controlaccess agents.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually (EAD export and OAI GetRecord).  New and existing tests pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
