### PR TITLE
solr_backup_schedule cron schedule fix

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -73,7 +73,7 @@ AppConfig[:mysql_binlog] = false
 
 # By default, Solr backups will run at midnight.  See https://crontab.guru/ for
 # information about the schedule syntax.
-AppConfig[:solr_backup_schedule] = "0 * * * *"
+AppConfig[:solr_backup_schedule] = "0 0 * * *"
 AppConfig[:solr_backup_number_to_keep] = 1
 AppConfig[:solr_backup_directory] = proc { File.join(AppConfig[:data_directory], "solr_backups") }
 # add default solr params, i.e. use AND for search: AppConfig[:solr_params] = { "q.op" => "AND" }

--- a/docs/doc/file.configuration.html
+++ b/docs/doc/file.configuration.html
@@ -207,7 +207,7 @@ Note that this will have a performance impact!</p>
 <p>Set Solr back up schedule. By default, Solr backups will run at midnight.  See https://crontab.guru/ for
  information about the schedule syntax.</p>
 
-<p><code>AppConfig[:solr_backup_schedule] = "0 * * * *"</code></p>
+<p><code>AppConfig[:solr_backup_schedule] = "0 0 * * *"</code></p>
 
 <h4 id="appconfigsolrbackupnumbertokeep"><code>AppConfig[:solr_backup_number_to_keep]</code></h4>
 

--- a/docs/user/configuring-archivesspace.md
+++ b/docs/user/configuring-archivesspace.md
@@ -168,7 +168,7 @@ Set to true if you have enabled MySQL binary logging.
 Set Solr back up schedule. By default, Solr backups will run at midnight.  See https://crontab.guru/ for
  information about the schedule syntax.
 
-`AppConfig[:solr_backup_schedule] = "0 * * * *"`
+`AppConfig[:solr_backup_schedule] = "0 0 * * *"`
 
 
 #### `AppConfig[:solr_backup_number_to_keep]`


### PR DESCRIPTION
## Description
Issue #1618 describes how a comment in `config-defaults.rb` doesn't align with the actual configuration - while the comment says that Solr backups run at midnight, they run hourly instead.  This error was also present at some points in documentation, which have also been updated.

## Related JIRA Ticket or GitHub Issue
#1618 

## Motivation and Context
Documentation shouldn't disagree with features, esp. regarding backup scheduling.

## How Has This Been Tested?
Untested (sorry!)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
