### PR TITLE
Docker: Added Database wait, MYSQL vars, and volume mounts for config and data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,12 @@ RUN DEBIAN_FRONTEND=noninteractive \
       ca-certificates \
       openjdk-8-jre-headless \
       wget \
-      unzip && \
+      unzip
+      mysql-client && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g 1000 archivesspace && \
     useradd -l -M -u 1000 -g archivesspace archivesspace && \
+    mkdir -p /archivesspace/config /archivesspace/data && \
     chown -R archivesspace:archivesspace /archivesspace
 
 USER archivesspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
       ca-certificates \
       openjdk-8-jre-headless \
       wget \
-      unzip
+      unzip \
       mysql-client && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g 1000 archivesspace && \

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -54,11 +54,11 @@ if [[ -z $APPCONFIG_DB_URL ]] && [[ "$url_check" -eq "3" ]]; then
     if [[ ! -z $MYSQL_PASSWORD ]]; then
         export APPCONFIG_DB_URL="jdbc:mysql://${DB_ADDR}:${MYSQL_PORT}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=${MYSQL_USER}&password=${MYSQL_PASSWORD}"
     else
-        echo "Need to set MYSQL_PASSWORD while using the other MYSQL_XXXX variables."
+        echo "Error you need to set MYSQL_PASSWORD while using the other MYSQL_XXXX variables."
         exit 1
     fi
 else
-    echo "You have set MYSQL_XXX variables and APPCONFIG_DB_URL, you only can one."
+    echo "Error you have set MYSQL_XXX variables and APPCONFIG_DB_URL, you only can use one or the other."
     exit 1
 fi
 
@@ -76,7 +76,7 @@ echo "Waiting up to $MYSQL_DELAY seconds for MySQL. Checking every $MYSQL_CHECK_
 
 while ! mysql -h "$DB_ADDR" --port="$MYSQL_PORT" --user="$MYSQL_USER" --password="$MYSQL_PASSWORD" -e "show databases;" > /dev/null 2>&1; do
     if [ $counter -gt $MYSQL_DELAY ]; then
-        >&2 echo "We have been waiting for MySQL too long already; failing."
+        >&2 echo "Error we have been waiting for MySQL too long already; failing."
         exit 1
     fi;
 

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -28,6 +28,63 @@ fi
 # clear out tmp pre-startup as it can build up if persisted
 rm -rf $DATA_TMP_DIR/*
 
+# If they pass in $APPCONFIG_DB_URL, we need to check if the other vars that make it up were passed in too
+# Otherwise it could lead to defaults and passed in variables causing bad results
+url_check=0
+
+if [[ -z $DB_ADDR ]]; then
+  DB_ADDR="database"
+else
+    url_check=$[url_check+1]
+fi
+
+if [[ -z $MYSQL_PORT ]]; then
+  MYSQL_PORT=3306
+else
+    url_check=$[url_check+1]
+fi
+
+if [[ -z $MYSQL_USER ]]; then
+  MYSQL_USER="root"
+else
+    url_check=$[url_check+1]
+fi
+
+if [[ -z $APPCONFIG_DB_URL ]] && [[ "$url_check" -eq "3" ]]; then
+    if [[ ! -z $MYSQL_PASSWORD ]]; then
+        export APPCONFIG_DB_URL="jdbc:mysql://${DB_ADDR}:${MYSQL_PORT}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=${MYSQL_USER}&password=${MYSQL_PASSWORD}"
+    else
+        echo "Need to set MYSQL_PASSWORD while using the other MYSQL_XXXX variables."
+        exit 1
+    fi
+else
+    echo "You have set MYSQL_XXX variables and APPCONFIG_DB_URL, you only can one."
+    exit 1
+fi
+
+if [[ -z $MYSQL_DELAY ]]; then
+  MYSQL_DELAY=60
+fi
+
+if [[ -z $MYSQL_CHECK_INTERVAL ]]; then
+  MYSQL_CHECK_INTERVAL=5
+fi
+
+counter=0
+
+echo "Waiting up to $MYSQL_DELAY seconds for MySQL. Checking every $MYSQL_CHECK_INTERVAL seconds."
+
+while ! mysql -h "$DB_ADDR" --port="$MYSQL_PORT" --user="$MYSQL_USER" --password="$MYSQL_PASSWORD" -e "show databases;" > /dev/null 2>&1; do
+    if [ $counter -gt $MYSQL_DELAY ]; then
+        >&2 echo "We have been waiting for MySQL too long already; failing."
+        exit 1
+    fi;
+
+    >&1 echo "Connection failed, retrying in $MYSQL_CHECK_INTERVAL seconds."
+    counter=`expr $counter + $MYSQL_CHECK_INTERVAL`
+    sleep $MYSQL_CHECK_INTERVAL
+done
+
 /archivesspace/scripts/setup-database.sh
 if [[ "$?" != 0 ]]; then
   echo "Error running the database setup script."


### PR DESCRIPTION
## Description
Added support for a database wait function. This stops docker containers from entering a restart loop. 

Added MYSQL vars to allow for a more docker experience.

Added support for volume mounts of data and config folders 

Most of the code came from @AustinTSchaffer, he was a big help in all of this!

## Related JIRA Ticket or GitHub Issue
Fixes #1456 
Kind of Fixes #1495

## Motivation and Context
Most of the context to these issues stem from #1456 

## How Has This Been Tested?
Here is my docker-compose file:
```
version: '3'
services:
  database:
    image: mysql:5.7
    restart: always
    ports:
      - "3306:3306"
    volumes:
      - /volume1/docker/Archivesspace/mysql-archivesspace:/var/lib/mysql
    command: --character-set-server=utf8 --collation-server=utf8_unicode_ci --innodb_buffer_pool_size=2G --innodb_buffer_pool_instances=2
    env_file:
      - database.env
  archivesspace:
    image: archivesspace/archivesspace:latest
    restart: always
    ports:
      - "8080:8080"
      - "8081:8081"
      - "8082:8082"
      - "8089:8089"
      - "8090:8090"
    volumes:
      - /volume1/docker/Archivesspace/data-archivesspace:/archivesspace/data
      - /volume1/docker/Archivesspace/config-archivesspace:/archivesspace/config
      - /volume1/docker/Archivesspace/plugins-archivesspace:/archivesspace/plugins
    environment:
      DB_ADDR: database
      MYSQL_PORT: 3306
    env_file:
      - database.env
    depends_on:
      - database

```

This test the volume mounts and database wait. You can see the database wait in the logs.
To do a little more testing add a `APPCONFIG_DB_URL` to the above config. It should exit the startup script with an error, saying you can't have both `APPCONFIG_DB_URL` set and MYSQL vars. 

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
