### PR TITLE
ANW-604 Provide translation for description rules in PUI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,11 @@ script:
 notifications:
   email: false
 bundler_args: --retry 5
+dist: trusty
 addons:
+  apt:
+    packages:
+    - libgconf-2-4
   chrome: stable
   artifacts:
     debug: true

--- a/public/app/views/resources/_finding_aid.html.erb
+++ b/public/app/views/resources/_finding_aid.html.erb
@@ -13,6 +13,8 @@
               <%= t("enumerations.language_iso639_2.#{@result.finding_aid[item]}") %>
             <% elsif item == "script" %>
               <%= t("enumerations.script_iso15924.#{@result.finding_aid[item]}") %>
+            <% elsif item == "description_rules" %>
+              <%= t("enumerations.resource_finding_aid_description_rules.#{@result.finding_aid[item]}") %>
             <% else %>
               <%= @result.finding_aid[item] %>
             <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Display the translation value (e.g. Describing Archives: A Content Standard) for Finding Aid Description Rules instead of the code (dacs) in the "Finding Aid & Administrative Information" of a PUI Resource record. 

## Description
<!--- Describe your changes in detail -->
Updated the `resources/finding_aid` template to provide the translation.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-604

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Enhanced PUI user experience.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
