### PR TITLE
Corrected Maintainer Label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:18.04 as build_release
-LABEL maintainer="ArchivesSpaceHome@lyrasis.org"
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && \
@@ -27,6 +26,8 @@ ADD docker-startup.sh /archivesspace/startup.sh
 RUN chmod u+x /archivesspace/startup.sh
 
 FROM ubuntu:18.04
+
+LABEL maintainer="ArchivesSpaceHome@lyrasis.org"
 
 ENV ARCHIVESSPACE_LOGS=/dev/null \
     LANG=C.UTF-8


### PR DESCRIPTION
The "maintainer" label is being applied during the creation of the `build_release` stage of the container build, instead of the final build stage. This means that the maintainer label has not been distributed with the `archivespace/archivespace` image.

```
austin@debian:archivesspace$ docker image pull archivesspace/archivesspace:2.6.0
2.6.0: Pulling from archivesspace/archivesspace
Digest: sha256:a3c0f3fea4159b5410eff52df5669c86a20f179e7a98c8b2ad252f9bf742fad8
Status: Image is up to date for archivesspace/archivesspace:2.6.0
austin@debian:archivesspace$ docker image inspect archivesspace/archivesspace:2.6.0 -f "{{json .Config.Labels}} {{json .ContainerConfig.Labels}}"
null {}
```

Using Nginx as an example:

```
austin@debian:archivesspace$ docker image pull nginx && docker image inspect nginx -f "{{json .Config.Labels}} {{json .ContainerConfig.Labels}}"
Using default tag: latest
latest: Pulling from library/nginx
f5d23c7fed46: Pull complete 
918b255d86e5: Pull complete 
8c0120a6f561: Pull complete 
Digest: sha256:eb3320e2f9ca409b7c0aa71aea3cf7ce7d018f03a372564dbdb023646958770b
Status: Downloaded newer image for nginx:latest
{"maintainer":"NGINX Docker Maintainers <docker-maint@nginx.com>"} {"maintainer":"NGINX Docker Maintainers <docker-maint@nginx.com>"}
```