### PR TITLE
Removed DEPRECATED OAI Settings

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -104,16 +104,6 @@ AppConfig[:job_thread_count] = 2
 
 AppConfig[:oai_proxy_url] = 'http://your-public-oai-url.example.com'
 
-# DEPRECATED OAI Settings: Moved to database in ANW-674
-# NOTE: As of release 2.5.2, these settings should be set in the Staff User interface
-# To change these settings, select Manage OAI-PMH Settings from the System menu in the staff interface
-# These three settings are at the top of the page in the General Settings section
-# These settings will be removed from the config file completely when version 2.6.0 is released
-AppConfig[:oai_admin_email] = 'admin@example.com'
-AppConfig[:oai_record_prefix] = 'oai:archivesspace'
-AppConfig[:oai_repository_name] = 'ArchivesSpace OAI Provider'
-
-
 # In addition to the sets based on level of description, you can define OAI Sets
 # based on repository codes and/or sponsors as follows
 #

--- a/common/config/config-deprecated.rb
+++ b/common/config/config-deprecated.rb
@@ -1,0 +1,8 @@
+AppConfig.set_deprecated_values(:option => :oai_repository_name,
+                    :value => nil)
+
+AppConfig.set_deprecated_values(:option => :oai_admin_email,
+                    :value => nil)
+
+AppConfig.set_deprecated_values(:option => :oai_record_prefix,
+                    :value => nil)

--- a/common/config/config-distribution.rb
+++ b/common/config/config-distribution.rb
@@ -48,7 +48,6 @@ class AppConfig
     @@aliases ||= {}
   end
 
-
   def self.deprecated_parameters
     @@deprecated_parameters ||= {}
   end
@@ -110,7 +109,7 @@ class AppConfig
       # Explicit Java property
       java.lang.System.getProperty("aspace.config")
     elsif ENV['ASPACE_CONFIG'] && File.exist?(ENV['ASPACE_CONFIG'])
-      # Setting a system config 
+      # Setting a system config
       ENV['ASPACE_CONFIG']
     elsif ENV['ASPACE_LAUNCHER_BASE'] && File.exist?(File.join(ENV['ASPACE_LAUNCHER_BASE'], "config", "config.rb"))
       File.join(ENV['ASPACE_LAUNCHER_BASE'], "config", "config.rb")
@@ -180,6 +179,7 @@ class AppConfig
     @@changed_from_default = {}
 
     require_relative 'config-aliases'
+    require_relative 'config-deprecated'
 
     AppConfig.load_defaults
 
@@ -197,6 +197,10 @@ class AppConfig
 
     aliases[alias_parameter] = target_parameter
     deprecated_parameters[alias_parameter] = options.fetch(:deprecated, false)
+  end
+
+  def self.set_deprecated_values(options)
+    @@parameters[options.fetch(:option)] = options.fetch(:value)
   end
 
   def self.parse_environment_value(value)


### PR DESCRIPTION
As of release 2.5.2, these settings should be set in the Staff User interface. To change these settings, select Manage OAI-PMH Settings from the System menu in the staff interface. These three settings are at the top of the page in the General Settings section
