### PR TITLE
Show an error message when the RDE hits a Sequel validation error

### DIFF
--- a/backend/app/model/mixins/components_add_children.rb
+++ b/backend/app/model/mixins/components_add_children.rb
@@ -30,8 +30,20 @@ module ComponentsAddChildren
           'ref' => self.uri
         }
       end
-
-      node_model.create_from_json(obj)
+      
+      begin
+        node_model.create_from_json(obj)
+      rescue Sequel::ValidationFailed => e
+        # We've run into something that the DB doesnt like.
+        # since we are dealing with a batch, we can add the
+        # offending value to the error message in an attempt 
+        # to enlighten our  user
+        e.errors.keys.each do |key|
+          next unless obj[key]
+          e.errors[key].map! { |msg| msg << " ( #{key}: #{obj[key]} )"}
+        end
+        raise e
+      end
     end
   end
 

--- a/frontend/app/controllers/archival_objects_controller.rb
+++ b/frontend/app/controllers/archival_objects_controller.rb
@@ -241,8 +241,13 @@ class ArchivalObjectsController < ApplicationController
         return render :text => I18n.t("rde.messages.success")
       rescue JSONModel::ValidationException => e
         @exceptions = @children.children.collect{|c| JSONModel(:archival_object).from_hash(c, false)._exceptions}
+        
+        if @exceptions.all?(&:blank?)
+          e.errors.each { |key, vals| flash.now[:error] = "#{key} : #{vals.join('<br/>')}" }
+        else
+          flash.now[:error] = I18n.t("rde.messages.rows_with_errors", :count => @exceptions.select{|e| !e.empty?}.length)
+        end
 
-        flash.now[:error] = I18n.t("rde.messages.rows_with_errors", :count => @exceptions.select{|e| !e.empty?}.length)
       end
 
     end

--- a/frontend/app/controllers/digital_object_components_controller.rb
+++ b/frontend/app/controllers/digital_object_components_controller.rb
@@ -208,8 +208,13 @@ class DigitalObjectComponentsController < ApplicationController
         return render :text => I18n.t("rde.messages.success")
       rescue JSONModel::ValidationException => e
         @exceptions = @children.children.collect{|c| JSONModel(:digital_object_component).from_hash(c, false)._exceptions}
+        
+        if @exceptions.all?(&:blank?)
+          e.errors.each { |key, vals| flash.now[:error] = "#{key} : #{vals.join('<br/>')}" }
+        else
+          flash.now[:error] = I18n.t("rde.messages.rows_with_errors", :count => @exceptions.select{|e| !e.empty?}.length)
+        end
 
-        flash.now[:error] = I18n.t("rde.messages.rows_with_errors", :count => @exceptions.select{|e| !e.empty?}.length)
       end
 
     end

--- a/frontend/app/controllers/digital_objects_controller.rb
+++ b/frontend/app/controllers/digital_objects_controller.rb
@@ -264,9 +264,16 @@ class DigitalObjectsController < ApplicationController
 
         return render :text => I18n.t("rde.messages.success")
       rescue JSONModel::ValidationException => e
-        @exceptions = @children.children.collect{|c| JSONModel(:digital_object_component).from_hash(c, false)._exceptions}
+        @exceptions = @children
+                      .children
+                      .collect{|c| JSONModel(:digital_object_component).from_hash(c, false)._exceptions}
 
-        flash.now[:error] = I18n.t("rde.messages.rows_with_errors", :count => @exceptions.select{|e| !e.empty?}.length)
+
+        if @exceptions.all?(&:blank?)
+          e.errors.each { |key, vals| flash.now[:error] = "#{key} : #{vals.join('<br/>')}" }
+        else
+          flash.now[:error] = I18n.t("rde.messages.rows_with_errors", :count => @exceptions.select{|e| !e.empty?}.length)
+        end
       end
 
     end

--- a/frontend/app/controllers/resources_controller.rb
+++ b/frontend/app/controllers/resources_controller.rb
@@ -278,7 +278,11 @@ class ResourcesController < ApplicationController
       rescue JSONModel::ValidationException => e
         @exceptions = @children.children.collect{|c| JSONModel(:archival_object).from_hash(c, false)._exceptions}
 
-        flash.now[:error] = I18n.t("rde.messages.rows_with_errors", :count => @exceptions.select{|e| !e.empty?}.length)
+        if @exceptions.all?(&:blank?)
+          e.errors.each { |key, vals| flash.now[:error] = "#{key} : #{vals.join('<br/>')}" }
+        else
+          flash.now[:error] = I18n.t("rde.messages.rows_with_errors", :count => @exceptions.select{|e| !e.empty?}.length)
+        end
       end
 
     end


### PR DESCRIPTION
A pass at fixing #1633 

The RDE will show errors related to JSONModel, but it also needs to show
things that pop up when the records are put into the DB. For example,
DO components require unique identifiers. If the RDE hits an issue when
trying to save, this will slightly modify the error message and just
display the message in the RDE error flash.


## How Has This Been Tested?

I tried it out locally. Make a DO, then go into the RDE. Make 2 records with the same identifier. 
You should see the error message and not the "Error with 0 rows..."

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
