### PR TITLE
Add new configuration option for mode the staff link on the PUI opens records in the staff interface

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -515,7 +515,12 @@ AppConfig[:pui_page_actions_cite] = true
 AppConfig[:pui_page_actions_bookmark] = true
 AppConfig[:pui_page_actions_request] = true
 AppConfig[:pui_page_actions_print] = true
-AppConfig[:pui_enable_staff_link] = true # when a user is authenticated, add a link back to the staff interface from the specified record
+
+# when a user is authenticated, add a link back to the staff interface from the specified record
+AppConfig[:pui_enable_staff_link] = true
+# by default, staff link will open record in staff interface in edit mode,
+# change this to 'readonly' for it to open in readonly mode
+AppConfig[:pui_staff_link_mode] = 'edit'
 
 # PUI Request Function (used when AppConfig[:pui_page_actions_request] = true)
 # the following determine on what kinds of records the request button is displayed

--- a/public/app/assets/javascripts/smart_staff_links.js
+++ b/public/app/assets/javascripts/smart_staff_links.js
@@ -20,7 +20,7 @@ $(function() {
   }).done(function( data ) {
     if (data === true) {
       var staff = $('#staff-link');
-      link = FRONTEND_URL + "/resolve/edit?uri=" + RECORD_URI + "&autoselect_repo=true";
+      link = FRONTEND_URL + "/resolve/" + STAFF_LINK_MODE + "?uri=" + RECORD_URI + "&autoselect_repo=true";
       staff.attr("href", link);
       staff.removeClass("hide");
     }

--- a/public/app/views/layouts/application.html.erb
+++ b/public/app/views/layouts/application.html.erb
@@ -64,6 +64,7 @@
 			<script>
 				FRONTEND_URL = "<%= j(AppConfig[:frontend_proxy_url]) %>";
 				RECORD_URI = "<%= j(@result.uri) %>";
+				STAFF_LINK_MODE = "<%= j(AppConfig[:pui_staff_link_mode]) %>";
 			</script>
 		<% end %>
 	<% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The new configuration option is AppConfig[:pui_staff_link_mode] which is defaulted to 'edit' which is what currently happens in the core code base. If it gets changed to 'readonly', it opens the record in the staff interface in readonly/view mode.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-874
If the person pressing on the staff link in the PUI doesn't have permission to edit the record in the staff interface, the link fails.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually checked that the mode changes when change value for new configuration option AppConfig[:pui_staff_link_mode] 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
