### PR TITLE
ANW 669 - Add xlink attributes for EAD export

### DIFF
--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1156,6 +1156,7 @@ describe "EAD export mappings" do
   describe "Testing EAD Serializer mixed content behavior" do
 
     let(:note_with_p) { "<p>A NOTE!</p>" }
+    let(:note_with_extref) { "<extref href='http://duckduckgo.com'>A Good Search Engine</p>" }
     let(:note_with_linebreaks) { "Something, something,\n\nsomething." }
     let(:note_with_linebreaks_and_good_mixed_content) { "Something, something,\n\n<bioghist>something.</bioghist>\n\n" }
     let(:note_with_linebreaks_and_evil_mixed_content) { "Something, something,\n\n<bioghist>something.\n\n</bioghist>\n\n" }
@@ -1167,6 +1168,14 @@ describe "EAD export mappings" do
 
     it "can strip <p> tags from content when disallowed" do
       expect(serializer.strip_p(note_with_p)).to eq("A NOTE!")
+    end
+
+    it "adds xlink prefix to attributes in mixed content" do
+      expect(serializer.add_xlink_prefix(note_with_extref)).to eq("<extref xlink:href='http://duckduckgo.com'>A Good Search Engine</p>")
+    end
+
+    it "does not add xlink prefix when mixed content has no attributes" do
+      expect(serializer.add_xlink_prefix(note_with_p)).to eq(note_with_p)
     end
 
     it "can leave <p> tags in content" do

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1156,7 +1156,19 @@ describe "EAD export mappings" do
   describe "Testing EAD Serializer mixed content behavior" do
 
     let(:note_with_p) { "<p>A NOTE!</p>" }
-    let(:note_with_extref) { "<extref href='http://duckduckgo.com'>A Good Search Engine</p>" }
+    let(:note_with_archref) {"<archref audience='external'/>"}
+    let(:note_with_bibref) {"<bibref audience='internal'/>"}
+    let(:note_with_extptr) {"<extptr linktype='simple' entityref='entref' title='title' show='embed'/>"}
+    let(:note_with_extptrloc) {"<extptrloc href='http://www.example.com'/>"}
+    let(:note_with_extrefloc) {"<extrefloc href='http://www.example.com'/>"}
+    let(:note_with_linkgrp) {"<linkgrp linktype='extended'><extrefloc href='http://www.someserver.edu/findaids/3270.xml'><archref>archref</archref></extrefloc><extrefloc href='http://www.someserver.edu/findaids/9248.xml'><archref>archref</archref></extrefloc></linkgrp>"}
+    let(:note_with_ptr) {"<ptr linktype='simple' actuate='onrequest' show='replace' target='mss1982-062_add2'/>"}
+    let(:note_with_ptrloc) {"<ptrloc audience='external'/>"}
+    let(:note_with_ref) {"<ref linktype='simple' target='NonC:21-2' show='replace' actuate='onrequest'>"}
+    let(:note_with_refloc) {"<refloc target='a9'></refloc>"}
+    let(:note_with_resource) {"<resource linktype='resource' label='start'/>"}
+    let(:note_with_title) {"<title render='italic'/>"}
+    let(:note_with_extref) { "<extref linktype='simple' entityref='site' title='title' actuate='onrequest' show='new' href='http://duckduckgo.com'>A Good Search Engine</p>" }
     let(:note_with_linebreaks) { "Something, something,\n\nsomething." }
     let(:note_with_linebreaks_and_good_mixed_content) { "Something, something,\n\n<bioghist>something.</bioghist>\n\n" }
     let(:note_with_linebreaks_and_evil_mixed_content) { "Something, something,\n\n<bioghist>something.\n\n</bioghist>\n\n" }
@@ -1171,7 +1183,19 @@ describe "EAD export mappings" do
     end
 
     it "adds xlink prefix to attributes in mixed content" do
-      expect(serializer.add_xlink_prefix(note_with_extref)).to eq("<extref xlink:href='http://duckduckgo.com'>A Good Search Engine</p>")
+      expect(serializer.add_xlink_prefix(note_with_extref)).to eq("<extref xlink:linktype='simple' xlink:entityref='site' xlink:title='title' xlink:actuate='onrequest' xlink:show='new' xlink:href='http://duckduckgo.com'>A Good Search Engine</p>")
+      expect(serializer.add_xlink_prefix(note_with_archref)).to eq("<archref audience='external'/>")
+      expect(serializer.add_xlink_prefix(note_with_bibref)).to eq("<bibref audience='internal'/>")
+      expect(serializer.add_xlink_prefix(note_with_extptr)).to eq("<extptr xlink:linktype='simple' xlink:entityref='entref' xlink:title='title' xlink:show='embed'/>")
+      expect(serializer.add_xlink_prefix(note_with_extptrloc)).to eq("<extptrloc xlink:href='http://www.example.com'/>")
+      expect(serializer.add_xlink_prefix(note_with_extrefloc)).to eq("<extrefloc xlink:href='http://www.example.com'/>")
+      expect(serializer.add_xlink_prefix(note_with_linkgrp)).to eq("<linkgrp xlink:linktype='extended'><extrefloc xlink:href='http://www.someserver.edu/findaids/3270.xml'><archref>archref</archref></extrefloc><extrefloc xlink:href='http://www.someserver.edu/findaids/9248.xml'><archref>archref</archref></extrefloc></linkgrp>")
+      expect(serializer.add_xlink_prefix(note_with_ptr)).to eq("<ptr xlink:linktype='simple' xlink:actuate='onrequest' xlink:show='replace' xlink:target='mss1982-062_add2'/>")
+      expect(serializer.add_xlink_prefix(note_with_ptrloc)).to eq("<ptrloc audience='external'/>")
+      expect(serializer.add_xlink_prefix(note_with_ref)).to eq("<ref xlink:linktype='simple' xlink:target='NonC:21-2' xlink:show='replace' xlink:actuate='onrequest'>")
+      expect(serializer.add_xlink_prefix(note_with_refloc)).to eq("<refloc xlink:target='a9'></refloc>")
+      expect(serializer.add_xlink_prefix(note_with_resource)).to eq("<resource xlink:linktype='resource' label='start'/>")
+      expect(serializer.add_xlink_prefix(note_with_title)).to eq("<title render='italic'/>")
     end
 
     it "does not add xlink prefix when mixed content has no attributes" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make sure only specified attributes for specified tags have xlink added on export. The tags specified are: arc, archref, bibref, extptr, extptrloc, extref, extrefloc, linkgrp, ptr, ptrloc, ref, refloc, resource, and title. The specified attributes are: actuate, arcrole, entityref, from, href, id, linktype, parent, role, show, target, title, to, and xpointer.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-669

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
xlink is required to generate valid EAD exports.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
