### PR TITLE
ANW-697: Use same langmaterial logic for AOs in PUI PDF

### DIFF
--- a/public/app/views/pdf/_archival_object.html.erb
+++ b/public/app/views/pdf/_archival_object.html.erb
@@ -76,6 +76,14 @@ end
                     <dt><%= I18n.t('resource._public.physdesc') %></dt><dd><%= extent['display'] %></dd>
                 <% end %>
 
+                <% unless record.notes.include?('langmaterial') || record.lang_materials.blank? %>
+                  <% record.lang_materials.each do |lang_material| %>
+                    <% next if lang_material['_inherited'] %>
+                    <dt><%= I18n.t('resource._public.lang') %></dt>
+                        <dd><%= t('enumerations.language_iso639_2.' + lang_material['language'])%></dd>
+                  <% end %>
+                <% end %>
+
                 <% record.notes.each do |note_type, note| %>
                   <% if note_type == 'physdesc' %>
                     <% note.each do |n| %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update in response to testing:

- Include control value language of material in PUI PDF if language of material note is not present.

## Description
<!--- Describe your changes in detail -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
