### PR TITLE
ANW-927: make process for creating language notes more efficient

### DIFF
--- a/frontend/app/assets/javascripts/notes.crud.js
+++ b/frontend/app/assets/javascripts/notes.crud.js
@@ -367,6 +367,7 @@ $(function() {
       };
 
       $(".subrecord-form-heading:first .btn.add-note", $this).click(createTopLevelNote);
+      $(".subrecord-form-heading:first .btn.add-note", $this.filter("#lang_material_notes")).triggerHandler('click');
 
       $(".subrecord-form-heading:first .btn.apply-note-order", $this).click(applyNoteOrder);
 

--- a/frontend/app/assets/javascripts/notes.crud.js
+++ b/frontend/app/assets/javascripts/notes.crud.js
@@ -367,7 +367,11 @@ $(function() {
       };
 
       $(".subrecord-form-heading:first .btn.add-note", $this).click(createTopLevelNote);
-      $(".subrecord-form-heading:first .btn.add-note", $this.filter("#lang_material_notes")).triggerHandler('click');
+      $this.filter("#lang_material_notes").each(function() {
+        if ($("li", $this).length == 0) {
+          $(".subrecord-form-heading:first .btn.add-note", $this).triggerHandler("click");
+        }
+      });
 
       $(".subrecord-form-heading:first .btn.apply-note-order", $this).click(applyNoteOrder);
 

--- a/frontend/app/assets/javascripts/notes.crud.js
+++ b/frontend/app/assets/javascripts/notes.crud.js
@@ -14,7 +14,7 @@ $(function() {
       if ($this.hasClass("initialised") || $this.hasClass("too-many") ) {
         return;
       }
-        
+
 
       var index = $(".subrecord-form-fields", $this).length;
 
@@ -361,6 +361,7 @@ $(function() {
 
         var $topLevelNoteTypeSelector = $("select.top-level-note-type", $subform);
         $topLevelNoteTypeSelector.change(changeNoteTemplate);
+        $topLevelNoteTypeSelector.triggerHandler('change');
 
         index++;
       };
@@ -374,14 +375,14 @@ $(function() {
       if ($target_subrecord_list.children("li").length > 1) {
         $(".subrecord-form-heading:first .btn.apply-note-order", $this).removeAttr("disabled");
       }
-     
+
       var initRemoveActions = function() {
         $(".subrecord-form-inline", $this).each(function() {
           initRemoveActionForSubRecord($(this));
         });
-      } 
+      }
 
-      var initNoteForms = function($noteForm ) { 
+      var initNoteForms = function($noteForm ) {
         // initialising forms
         var $list = $("ul.subrecord-form-list:first", $this)
         AS.initSubRecordSorting($list);

--- a/frontend/app/views/notes/_template.html.erb
+++ b/frontend/app/views/notes/_template.html.erb
@@ -52,7 +52,7 @@
           <label class="control-label col-sm-2"><%= I18n.t("note.note_type") %></label>
           <div class="col-sm-4">
             <select class="form-control top-level-note-type">
-              <option></option>
+              <% unless nested_in_jsonmodel == 'lang_material' %><option></option><% end %>
               <% model_note_types = all_note_types ? all_note_types : note_types_for(nested_in_jsonmodel || form['jsonmodel_type']) %>
               <% model_note_types.sort_by {|value, hash| hash[:i18n]}.each do |value, hash| %>
                 <option value="<%= hash[:target] %>"><%= hash[:i18n] %></option>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Creating a language note now only requires one click to load the template.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-927](https://archivesspace.atlassian.net/browse/ANW-927)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Creating a language note requires multiple clicks even though only one note is possible from this area.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Language note type is selected and template is loaded as soon as you click add note.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
