### PR TITLE
ANW-697: Fix scriptcode migration

### DIFF
--- a/common/db/migrations/123_create_lang_materials_schema.rb
+++ b/common/db/migrations/123_create_lang_materials_schema.rb
@@ -70,7 +70,7 @@ def migrate_langmaterial_notes
                       :system_mtime => Time.now,
                       :user_mtime => Time.now
                     )
-                  self[:language_and_script].insert(
+                  language_and_script = self[:language_and_script].insert(
                       :json_schema_version => 1,
                       :language_id => langcode,
                       :lang_material_id => parsed_language_record,
@@ -86,20 +86,8 @@ def migrate_langmaterial_notes
                   scriptcode = self[:enumeration_value].filter(:value => script, :enumeration_id => enum ).get(:id)
 
                   puts "Updating script code for #{obj} #{record_id}: #{script} (#{scriptcode})"
-                  parsed_script_record = self[:lang_material].insert(
-                      :json_schema_version => 1,
-                      "#{obj}" => record_id,
-                      :create_time => Time.now,
-                      :system_mtime => Time.now,
-                      :user_mtime => Time.now
-                    )
-                  self[:language_and_script].insert(
-                      :json_schema_version => 1,
-                      :language_id => scriptcode,
-                      :lang_material_id => parsed_script_record,
-                      :create_time => Time.now,
-                      :system_mtime => Time.now,
-                      :user_mtime => Time.now
+                  self[:language_and_script].filter(:id => language_and_script).update(
+                      :script_id => scriptcode,
                     )
                 end
               end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The 123 migration was improperly migrating encoded scriptcodes in language of material notes into their own language_and_script records, resulting in indexer errors.

## Description
<!--- Describe your changes in detail -->
Migrates scriptcodes (which cannot live on their own in resource records) into the same language_and_script records as encoded languages.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-697

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug encountered when migrating a database with existing scriptcodes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested against previously failing database.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
