### PR TITLE
ANW-697: Update DO RDE for new languages

### DIFF
--- a/frontend/app/views/digital_object_components/_form_container.html.erb
+++ b/frontend/app/views/digital_object_components/_form_container.html.erb
@@ -22,10 +22,10 @@
 
   <% define_template("digital_object_component", jsonmodel_definition(:digital_object_component)) do |form| %>
     <section id="basic_information">
-      <h2>
+      <h3>
         <%= I18n.t("digital_object_component._frontend.section.basic_information") %>
         <%= link_to_help :topic => "digital_object_component_basic_information" %>
-      </h2>
+      </h3>
       <%= form.label_and_textfield "label", :required => :conditionally %>
       <%= form.label_and_textarea "title", :required => :conditionally %>
       <%= form.label_and_textfield "component_id" %>

--- a/frontend/app/views/digital_object_components/_rde_templates.html.erb
+++ b/frontend/app/views/digital_object_components/_rde_templates.html.erb
@@ -1,5 +1,6 @@
 <% define_template "rde_digital_object_component_sections" do |form| %>
-  <th data-id="basic" class="section-basic" colspan="5"><%= I18n.t("rde.sections.basic_information") %></th>
+  <th data-id="basic" class="section-basic" colspan="4"><%= I18n.t("rde.sections.basic_information") %></th>
+  <th data-id="language" class="section-language" colspan="2"><%= I18n.t("rde.sections.language") %></th>
   <th data-id="date" class="section-date" colspan="5" class="conditionally-required"><%= I18n.t("rde.sections.date") %></th>
   <th data-id="extent" class="section-extent" colspan="6" class="conditionally-required"><%= I18n.t("rde.sections.extent") %></th>
   <th data-id="file" class="section-file" colspan="10"><%= I18n.t("rde.sections.file_version") %></th>
@@ -11,7 +12,9 @@
   <th id="colTitle" class="fieldset-label conditionally-required sticky" data-section="basic"><%= I18n.t("digital_object_component.title") %></th>
   <th id="colCompId" class="fieldset-label sticky" data-section="basic"><%= I18n.t("digital_object_component.component_id") %></th>
   <th id="colPublish" class="fieldset-label sticky" data-section="basic"><%= I18n.t("digital_object_component.publish") %></th>
-  <th id="colLang" class="fieldset-label sticky" data-section="basic"><%= I18n.t("digital_object_component.language") %></th>
+
+  <th id="colLanguage" class="fieldset-label sticky" data-section="language"><%= I18n.t("language_and_script.language") %></th>
+  <th id="colScript" class="fieldset-label sticky" data-section="language"><%= I18n.t("language_and_script.script") %></th>
 
   <th id="colDLabel" class="fieldset-label sticky" data-section="date"><%= I18n.t("date.label") %></th>
   <th id="colExpr" class="fieldset-label sticky" data-section="date"><%= I18n.t("date.expression") %></th>
@@ -84,6 +87,7 @@
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
+  <col class="fieldset-col" data-default-width='150' />
 <% end %>
 
 <% define_template "rde_digital_object_component_row", jsonmodel_definition(:digital_object_component) do |form, digital_object_component| %>
@@ -108,8 +112,21 @@
     <td data-col="colTitle" class="form-group"><%= form.textfield "title" %></td>
     <td data-col="colCompId" class="form-group"><%= form.textfield "component_id" %></td>
     <td data-col="colPublish" class="form-group"><%= form.checkbox "publish", {}, user_prefs["publish"] %></td>
-    <td data-col="colLang" class="form-group">
-      <%= form.select "language", jsonmodel_definition(:digital_object_component).options_for(form, "language", true) %>
+    <td data-col="colLanguage" class="form-group">
+      <% form.push(form.set_index("lang_materials[]", 0), begin digital_object_component["lang_materials"][0] || {} rescue {} end) do %>
+        <% form.push(form.set_index("language_and_script", 0), form["language_and_script"] || {}) do %>
+          <%= form.select "language",
+          jsonmodel_definition(:language_and_script).options_for(form, "language", true) %>
+        <% end %>
+      <% end %>
+    </td>
+    <td data-col="colScript" class="form-group">
+      <% form.push(form.set_index("lang_materials[]", 0), begin archival_object["lang_materials"][0] || {} rescue {} end) do %>
+        <% form.push(form.set_index("language_and_script", 0), form["language_and_script"] || {}) do %>
+          <%= form.select "script",
+          jsonmodel_definition(:language_and_script).options_for(form, "script", true) %>
+        <% end %>
+      <% end %>
     </td>
     <td data-col="colDLabel" class="form-group">
       <% form.push(form.set_index("dates[]", 0), begin digital_object_component["dates"][0] || {} rescue {} end) do %>
@@ -140,35 +157,35 @@
       <% end %>
     </td>
     <td data-col="colEPortion" class="form-group">
-      <% form.push(form.set_index("extents[]", 0), begin archival_object["extents"][0] || {} rescue {} end) do %>
+      <% form.push(form.set_index("extents[]", 0), begin digital_object_component["extents"][0] || {} rescue {} end) do %>
         <%= form.select "portion", jsonmodel_definition(:extent).options_for(form, "portion", true) %>
       <% end %>
-      <% form.push("extents", begin archival_object["extents"] || [] rescue [] end) do %>
+      <% form.push("extents", begin digital_object_component["extents"] || [] rescue [] end) do %>
         <span id="<%= form.id_for(nil) %>"></span>
       <% end %>
     </td>
     <td data-col="colENumber" class="form-group">
-      <% form.push(form.set_index("extents[]", 0), begin archival_object["extents"][0] || {} rescue {} end) do %>
+      <% form.push(form.set_index("extents[]", 0), begin digital_object_component["extents"][0] || {} rescue {} end) do %>
         <%= form.textfield "number" %>
       <% end %>
     </td>
     <td data-col="colEType" class="form-group">
-      <% form.push(form.set_index("extents[]", 0), begin archival_object["extents"][0] || {} rescue {} end) do %>
+      <% form.push(form.set_index("extents[]", 0), begin digital_object_component["extents"][0] || {} rescue {} end) do %>
         <%= form.select "extent_type", jsonmodel_definition(:extent).options_for(form, "extent_type", true) %>
       <% end %>
     </td>
     <td data-col="colEContainer" class="form-group">
-      <% form.push(form.set_index("extents[]", 0), begin archival_object["extents"][0] || {} rescue {} end) do %>
+      <% form.push(form.set_index("extents[]", 0), begin digital_object_component["extents"][0] || {} rescue {} end) do %>
         <%= form.textfield "container_summary" %>
       <% end %>
     </td>
     <td data-col="colEPhysical" class="form-group">
-      <% form.push(form.set_index("extents[]", 0), begin archival_object["extents"][0] || {} rescue {} end) do %>
+      <% form.push(form.set_index("extents[]", 0), begin digital_object_component["extents"][0] || {} rescue {} end) do %>
         <%= form.textfield "physical_details" %>
       <% end %>
     </td>
     <td data-col="colEDimensions" class="form-group">
-      <% form.push(form.set_index("extents[]", 0), begin archival_object["extents"][0] || {} rescue {} end) do %>
+      <% form.push(form.set_index("extents[]", 0), begin digital_object_component["extents"][0] || {} rescue {} end) do %>
         <%= form.textfield "dimensions" %>
       <% end %>
     </td>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates the digital object component RDE template to account for changes to the language of materials model made in #1666 

## Description
<!--- Describe your changes in detail -->
Updated RDE template.

Also addressed two unrelated/preexisting issues with the DO RDE template:
- Changed extents section from templating using `archival_object["extents"]` to `digital_object_component["extents"]`
- Fixed styling of resulting digital object component edit form to make Basic Information an <h3> instead of <h2>

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Required for full implementation of #1666 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
