### PR TITLE
Process tree node deletes in batches

### DIFF
--- a/indexer/app/lib/pui_indexer.rb
+++ b/indexer/app/lib/pui_indexer.rb
@@ -182,7 +182,9 @@ class PUIIndexer < PeriodicIndexer
     end
 
     if tree_indexer.deletes.length > 0
-      delete_records(tree_indexer.deletes, :parent_id_field => 'pui_parent_id')
+      tree_indexer.deletes.each_slice(100) do |deletes|
+        delete_records(deletes, :parent_id_field => 'pui_parent_id')
+      end
     end
 
     handle_deletes(:parent_id_field => 'pui_parent_id')


### PR DESCRIPTION
Small optimization for pui indexer tree node deletion. In some cases process can generate large numbers of nodes to delete (400k seen in most extreme case) so batching creates much more reasonable Solr update queries and provides more visibility in the log (vs. appearing to be "hung").

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
