### PR TITLE
Anw 697 resource browse

### DIFF
--- a/common/db/migrations/126_cleanup_preferences.rb
+++ b/common/db/migrations/126_cleanup_preferences.rb
@@ -1,0 +1,34 @@
+require_relative 'utils'
+require 'json'
+
+Sequel.migration do
+  up do
+
+    self[:preference].each do |pref|
+
+      parsed = JSON.parse(pref[:defaults])
+
+      # Remove all existing langmaterials from the note_order array following ANW-697
+      if parsed['note_order'].include?('langmaterial')
+        parsed['note_order'].delete('langmaterial')
+        self[:preference].filter(:id => pref[:id]).update(
+          :defaults => JSON.dump(parsed).to_sequel_blob,
+          :system_mtime => Time.now
+        )
+      end
+
+      # Remove any resource browse columns set to language following ANW-697
+      (1..5).to_a.each do |n|
+        if parsed.key?("resource_browse_column_#{n}") && parsed["resource_browse_column_#{n}"].include?('language')
+          parsed.delete("resource_browse_column_#{n}")
+          self[:preference].filter(:id => pref[:id]).update(
+            :defaults => JSON.dump(parsed).to_sequel_blob,
+            :system_mtime => Time.now
+          )
+        end
+      end
+
+    end
+
+  end
+end

--- a/common/schemas/defaults.rb
+++ b/common/schemas/defaults.rb
@@ -4,7 +4,7 @@ accession_browse_column_enum = [
                       "publish", 'no_value'
                      ]
 resource_browse_column_enum = [
-                      "identifier", "resource_type", "level", "language", "restrictions",
+                      "identifier", "resource_type", "level", "restrictions",
                       "ead_id", "finding_aid_status", "publish", 'no_value'
                      ]
 digital_object_browse_column_enum = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Further cleanup following #1666  This PR removes "language" as a configurable user-defined browse option for resource records.  Also removes the old languages of material note from the note_order preference section.

## Description
<!--- Describe your changes in detail -->


## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Prior to fix: 
<img width="935" alt="before_anw697browse" src="https://user-images.githubusercontent.com/15144646/65428674-c6d97c00-dde2-11e9-9ecb-0de07415136c.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
