### PR TITLE
Removed Repository from slug BASE_RECORD_TYPES

### DIFF
--- a/backend/app/lib/slugs/slug_helpers_eligibility.rb
+++ b/backend/app/lib/slugs/slug_helpers_eligibility.rb
@@ -8,7 +8,6 @@ module SlugHelpers
   ].freeze
 
   BASE_RECORD_TYPES = [
-    Repository,
     Resource,
     Subject,
     DigitalObject,

--- a/backend/app/lib/slugs/slug_helpers_generate.rb
+++ b/backend/app/lib/slugs/slug_helpers_generate.rb
@@ -87,6 +87,7 @@ module SlugHelpers
 
   # runs dedupe if necessary
   def self.run_dedupe_slug(slug)
+
     # search for dupes
     if !slug.empty? && slug_in_use?(slug)
       slug = dedupe_slug(slug, 1)
@@ -94,6 +95,7 @@ module SlugHelpers
       slug
     end
     cache << slug if job_running?
+
     slug
   end
 
@@ -140,20 +142,23 @@ module SlugHelpers
   # given a slug, return true if slug is used by another entity.
   # return false otherwise.
   def self.slug_in_use?(slug)
+
     if job_running?
       cache.include? slug
     else
-      slug_record_types.inject(0) {|count, klass| count + klass.where(:slug => slug).count } > 0
+      (slug_record_types + [Repository]).inject(0) {|count, klass| count + klass.where(:slug => slug).count } > 0
     end
   end
 
   # dupe_slug is already in use.
   def self.dedupe_slug(dupe_slug, count)
+
     new_slug = "#{dupe_slug}_#{count}"
     loop do
       break unless slug_in_use?(new_slug)
       new_slug = "#{dupe_slug}_#{count += 1}"
     end
+
     new_slug
   end
 end

--- a/backend/app/model/ASModel_sequel.rb
+++ b/backend/app/model/ASModel_sequel.rb
@@ -85,12 +85,17 @@ module ASModel
             self[:is_slug_auto] = 0
         end
       elsif self.class == Repository
-        if (!self.exists? && (self[:slug].nil? || self[:slug].empty?)) ||
-            self.column_changed?(:repo_code)
+        if (!self.exists? && (self[:slug].nil? || self[:slug].empty?))
           cleaned_slug = SlugHelpers.clean_slug(self[:repo_code])
           self[:slug] = SlugHelpers.run_dedupe_slug(cleaned_slug)
+          self[:is_slug_auto] = 1
+        elsif !SlugHelpers::is_slug_auto_enabled?(self) &&
+              !self[:slug].nil? && !self[:slug].empty? &&
+              self.column_changed?(:slug)
+          cleaned_slug = SlugHelpers.clean_slug(self[:slug])
+          self[:slug] = SlugHelpers.run_dedupe_slug(cleaned_slug)
         end
-        self[:is_slug_auto] = 1
+
       end
     end
 

--- a/backend/spec/model_repository_spec.rb
+++ b/backend/spec/model_repository_spec.rb
@@ -188,7 +188,10 @@ describe 'Repository model' do
 
   end
 
-  describe "slug tests" do
+  describe "slug tests with human_readable_urls enabled" do
+    before(:all) do
+      AppConfig[:use_human_readable_urls] = true
+    end
     describe "slug autogen enabled" do
       describe "by name" do
         before(:all) do
@@ -264,4 +267,85 @@ describe 'Repository model' do
       end
     end
   end
+
+  describe "slug tests with human_readable_urls disabled" do
+    before(:all) do
+      AppConfig[:use_human_readable_urls] = false
+    end
+    describe "slug autogen enabled" do
+      describe "by name" do
+        before(:all) do
+          AppConfig[:auto_generate_slugs_with_id] = false
+        end
+        it "autogenerates a slug via repo_code" do
+          repository = Repository.create_from_json(build(:json_repo, :is_slug_auto => true))
+          expected_slug = clean_slug(repository[:repo_code])
+          expect(repository[:slug]).to eq(expected_slug)
+        end
+      end
+      describe "by id" do
+        before(:all) do
+          AppConfig[:auto_generate_slugs_with_id] = true
+        end
+        it "autogenerates a slug via repo_code" do
+          repository = Repository.create_from_json(build(:json_repo, :is_slug_auto => true))
+          expected_slug = clean_slug(repository[:repo_code])
+          expect(repository[:slug]).to eq(expected_slug)
+        end
+        it "cleans slug" do
+          repository = Repository.create_from_json(build(:json_repo, :is_slug_auto => true, :repo_code => "Foo Bar Baz&&&&"))
+          expect(repository[:slug]).to eq("foo_bar_baz")
+        end
+
+        it "dedupes slug" do
+          repository1 = Repository.create_from_json(build(:json_repo, :is_slug_auto => true, :repo_code => "foo"))
+          repository2 = Repository.create_from_json(build(:json_repo, :is_slug_auto => true, :repo_code => "foo#"))
+          expect(repository1[:slug]).to eq("foo")
+          expect(repository2[:slug]).to eq("foo_1")
+        end
+      end
+    end
+
+    describe "slug autogen disabled" do
+      before(:all) do
+        AppConfig[:auto_generate_slugs_with_id] = false
+      end
+      it "slug does not change when config set to autogen by title and title updated" do
+        repository = Repository.create_from_json(build(:json_repo, :is_slug_auto => false, :slug => "foo"))
+        repository.update(:name => rand(100000000))
+        expect(repository[:slug]).to eq("foo")
+      end
+
+      it "slug does not change when config set to autogen by id and id updated" do
+        repository = Repository.create_from_json(build(:json_repo, :is_slug_auto => false, :slug => "foo"))
+        repository.update(:repo_code => rand(100000000))
+        expect(repository[:slug]).to eq("foo")
+      end
+
+      it "automatically sets the slug equal to the repo code if autogen is off and slug is empty" do
+        repository = Repository.create_from_json(build(:json_repo, :is_slug_auto => false, :slug => nil, :repo_code => "Foo Bar Baz"))
+        expected_slug = clean_slug(repository[:repo_code])
+        expect(repository[:slug]).to eq(expected_slug)
+      end
+    end
+
+    describe "manual slugs" do
+      it "cleans manual slugs" do
+        repository = Repository.create_from_json(build(:json_repo, :is_slug_auto => false))
+        repository.update(:slug => "Foo Bar Baz ###")
+        expect(repository[:slug]).to eq("foo_bar_baz")
+      end
+
+      it "dedupes manual slugs" do
+        repository1 = Repository.create_from_json(build(:json_repo, :is_slug_auto => false, :slug => "foo"))
+        repository2 = Repository.create_from_json(build(:json_repo, :is_slug_auto => false))
+
+        repository2.update(:slug => "foo")
+
+        expect(repository1[:slug]).to eq("foo")
+        expect(repository2[:slug]).to eq("foo_1")
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Repositories handled as a special case and adding repositories to the BASE_RECORD_TYPES messes up the handling of slug deduplication