### PR TITLE
Accounts for potentially missing note_order array

### DIFF
--- a/common/db/migrations/126_cleanup_preferences.rb
+++ b/common/db/migrations/126_cleanup_preferences.rb
@@ -9,7 +9,7 @@ Sequel.migration do
       parsed = JSON.parse(pref[:defaults])
 
       # Remove all existing langmaterials from the note_order array following ANW-697
-      if parsed['note_order'].include?('langmaterial')
+      if parsed['note_order']&.include?('langmaterial')
         parsed['note_order'].delete('langmaterial')
         self[:preference].filter(:id => pref[:id]).update(
           :defaults => JSON.dump(parsed).to_sequel_blob,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Small tweak to the 126 migration introduced in #1680 that accounts for the possibility that the defaults JSON object may be lacking a note_order array.

## Description
<!--- Describe your changes in detail -->
Utilized safe navigation operator when checking for presence of langmaterial in the note_order array.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At least one user experienced issues upgrading their database with the following error:

```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!! !!
!! Database migration error. !!
!! Your upgrade has encountered a problem. !!
!! You must resolve these issues before the database migration can complete. !!
!! !!
!! !!
!! Error: !!
!! #<NoMethodError: undefined method 'include?' for nil:NilClass
Did you mean? include_class> !!
!! undefined method 'include?' for nil:NilClass
Did you mean? include_class !!
!! uri:classloader:/db/migrations/126_cleanup_preferences.rb:12:in 'block in (root)'
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
