### PR TITLE
Old way CSVs Option: config option not to limit the csv fields

### DIFF
--- a/backend/app/model/search.rb
+++ b/backend/app/model/search.rb
@@ -31,7 +31,7 @@ class Search
       set_writer_type( params[:dt] || "json" )
 
     query.remove_csv_header if ( params[:dt] == "csv" and params[:no_csv_header] )
-    query.limit_fields_to(params[:fields]) if params[:fields]
+    query.limit_fields_to(params[:fields]) if params[:fields] && AppConfig[:limit_csv_fields]
 
     results = Solr.search(query)
 

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -646,7 +646,7 @@ AppConfig[:show_source_in_subject_listing] = false
 # ARKs configuration options
 # determines whether fields and options related to ARKs appear in the staff interface
 AppConfig[:arks_enabled] = false
-                            
+
 # NAAN value to use in ARK URLs.
 # Should be set to institutional NAAN, or any other value valid in URLs.
 AppConfig[:ark_naan] = "f00001"
@@ -654,3 +654,6 @@ AppConfig[:ark_naan] = "f00001"
 # URL prefix to use in ARK URLs.
 # In most cases this will be the same as the PUI URL.
 AppConfig[:ark_url_prefix] = proc { AppConfig[:public_proxy_url] }
+
+# Specifies if the fields that show up in csv should be limited to those in search results
+AppConfig[:limit_csv_fields] = true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a config option to determine whether to limit the columns in the csv (i.e. option to do it the old way)

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-250](https://archivesspace.atlassian.net/projects/ANW/issues/ANW-250)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
