### PR TITLE
Fix or skip regularly failing EAD export tests

### DIFF
--- a/backend/spec/export_ead3_spec.rb
+++ b/backend/spec/export_ead3_spec.rb
@@ -632,8 +632,9 @@ describe "EAD3 export mappings" do
         end
       end
 
-
-       it "maps notes of type 'dimensions' to did/physdesc" do
+      # This is not appropriate EAD3 via http://eadiva.com/physdesc/ which states:
+      # More importantly, much of [physdec's] functionality was moved to <physdescstructured> and it was left with only generic elements. It may not longer contain <dimensions>, <extent>, or <physfacet>.
+       xit "maps notes of type 'dimensions' to did/physdesc" do
          notes.select {|n| n['type'] == 'dimensions'}.each_with_index do |note, i|
            content = note_content(note)
            path = "#{desc_path}/did/physdesc[text()='#{content}']"
@@ -663,8 +664,9 @@ describe "EAD3 export mappings" do
         end
       end
 
-
-      it "maps notes of type 'physfacet' to did/physdesc" do
+      # This is not appropriate EAD3 via http://eadiva.com/physdesc/ which states:
+      # More importantly, much of [physdec's] functionality was moved to <physdescstructured> and it was left with only generic elements. It may not longer contain <dimensions>, <extent>, or <physfacet>.
+      xit "maps notes of type 'physfacet' to did/physdesc" do
         notes.select {|n| n['type'] == 'physfacet'}.each_with_index do |note, i|
           content = note_content(note)
           path = "#{desc_path}/did/physdesc[text()='#{content}']"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes EAD export tests that regularly fail by: 

- For EAD 2002 - specifying by id the specific dimension or physfacet content that should be mapped
- For EAD3 skipping the dimensions and physfacet tests with xit (explained below).

## Description
<!--- Describe your changes in detail -->
According to http://eadiva.com/physdesc/ :

> More importantly, much of [physdesc's] functionality was moved to <physdescstructured> and it was left with only generic elements. It **may not longer contain** `<dimensions>`, `<extent>`, or `<physfacet>`.

Therefore, tests that were mapping dimensions and physfacet to inside of <physdesc> have been skipped since this is not valid EAD3.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To get these tests to stop arbitrarily failing ;-)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
