### PR TITLE
recognise more utf8 encodings

### DIFF
--- a/backend/app/model/db.rb
+++ b/backend/app/model/db.rb
@@ -370,7 +370,7 @@ eof
       non_utf8_tables = db[:information_schema__tables].
                         join(:information_schema__collation_character_set_applicability, :collation_name => :table_collation).
                         filter(:table_schema => Sequel.function(:database)).
-                        filter(Sequel.~(:character_set_name => 'utf8')).all
+                        filter(~Sequel.like(:character_set_name, 'utf8%')).all
 
       unless (non_utf8_tables.empty?)
         msg = <<EOF


### PR DESCRIPTION
## Description
This modifies the database table UTF-8 check to accept anyt character set starting with 'utf8', so that eg. 'utf8mb4' is accepted.

## Related JIRA Ticket or GitHub Issue
Fixes #1697 

## Motivation and Context
'utf8' is currently a 3-byte UTF-8 encoding, not capable of storing the Unicode supplementary range.
'utf8mb3' and 'utf8mb4' are also valid names, the former is an alias to 'utf8', the latter is the one people should be using for full Unicode compatibility.

## How Has This Been Tested?
Ran backend:devserver against MariaDB 10.3 and MySQL 5.7, the change made them accept both 'utf8' and 'utf8mb4'.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
