### PR TITLE
switch to correct badge icon according to digital_object_digital_obje…

### DIFF
--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -8,7 +8,12 @@
         <div class="objectimage">
           <div class="panel panel-default">
             <a class="btn btn-default record-type-badge digital_object" style="width: 100%" href="<%= d_file['out'] %>" target="new" title="<%= t('digital_object._public.link')%>">
-              <i class="fa fa-file-image-o fa-4x"></i><br/>
+              <i class="fa <%= { '(moving_image)' => 'fa-file-video-o' ,
+                          '(sound_recording)' => 'fa-file-audio-o',
+                          '(sound_recording_musical)' => 'fa-file-audio-o',
+                          '(sound_recording_nonmusical)' => 'fa-file-audio-o' ,
+                          '(still_image)' => 'fa-file-image-o' ,
+                          '(text)' =>  'fa-file-text'}.fetch( d_file['material'], 'fa-file-o' ) %> fa-4x"></i><br/>
               <div class="panel-heading">
                 <%= d_file['caption'].blank? ? "#{t('enumerations.instance_instance_type.digital_object')} #{d_file['material']}" : d_file['caption'].html_safe %>
               </div>


### PR DESCRIPTION
…ct_type

<!--- Provide a general summary of your changes in the Title above -->
Currently, PUI displays the same icon badge for all digital objects, which happens to be the one to represent a still image. This is incorrect and misleading if it's a link to a video or audio file or service. 

## Description
<!--- Describe your changes in detail -->
Change chooses font-awesome badge icon according to the value of digital_object_digital_object_type, which is passed to the view as d_file['material'] after being wrapped in parentheses. Fallback for undefined value or value without a specific icon  is generic file icon fa_file_o .

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Digital object links are tagged with misleading icons. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested as a local plugin over several different types of digital_object_type, including None (unassigned value). 

Changes to the view are local to digital_object and resources with digital_objects views. 
No changes to data models or code outside of those views. 

Changes are based on current font-awesome-sass 4.7.0 gems. 
I saw in history there was an attempt to upgrade font-awesome gem and then a reversion back to 4.7.0.  
If font-awesome gem is updated, this may have to be redone, as there are some compatibility issues between FA 4 and 5 .  ( I'm guessing that's why there was a reversion. Let me know if it would be preferable to upgrade FA first. ) 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
