### PR TITLE
[ANW-864] launcher.rb - was looking for AppConfig[:frontend_cookie_secret_cookie_secret]

### DIFF
--- a/launcher/launcher.rb
+++ b/launcher/launcher.rb
@@ -94,7 +94,7 @@ end
 
 
 def generate_secret_for(secret)
-  file = File.join(AppConfig[:data_directory], "#{secret}_cookie_secret.dat")
+  file = File.join(AppConfig[:data_directory], "#{secret}.dat")
 
   if !File.exist?(file)
     File.write(file, SecureRandom.hex)
@@ -146,7 +146,7 @@ def main
   end
 
   cookie_secrets = [:frontend_cookie_secret, :public_cookie_secret].each do |secret|
-    if !AppConfig.has_key?("#{secret}_cookie_secret".intern)
+    if !AppConfig.has_key?("#{secret}".intern)
       java.lang.System.set_property("aspace.config.#{secret}",
                                     generate_secret_for(secret))
     end


### PR DESCRIPTION
## Description
launcher.rb was not correctly interpreting pre-configured AppConfig[:frontend_cookie_secret] and AppConfig[:public_cookie_secret] when they were set in config.rb.

 launcher.rb was looking for AppConfig[:frontend_cookie_secret_cookie_secret]/AppConfig[:public_cookie_secret_cookie_secret], creating new secrets in .dat files and using them instead.

## Related JIRA Ticket or GitHub Issue
[ANW-864](https://archivesspace.atlassian.net/projects/ANW/issues/ANW-864)

## Motivation and Context
I've been working on clustering and more specifically Kubernetes and releasing a Helm chart for ArchivesSpace.  Found that Staff/PUI cookies were not matching when scaling up the frontends.  

## How Has This Been Tested?

Cut a ZIP release with this launcher and started it in normal single-node mode. It created a data/frontend_cookie_secret.dat file and uses it.

Then I pre-set AppConfig[:frontend_cookie_secret] and ran a second copy of just the staff interface on a secondary port (simulating a clustered install).  This worked where it hadn't before.  Also, it did not create a cookie_secret .dat file at all (which is the expected behavior when a value is provided).

Also, I'm able to horizontally scale up the frontend and PUI in my local Kubernetes playground (version 0.1 of the Helm chart to be released very soon!)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (no real test existing in the launcher code)
- [ ] All new and existing tests passed.
