### PR TITLE
Fix EAD export of language notes containing XML as CDATA

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -325,7 +325,7 @@ class EADSerializer < ASpaceExport::Serializer
         serialize_did_notes(data, xml, fragments)
 
         if (languages = data.lang_materials)
-          serialize_languages(languages, xml)
+          serialize_languages(languages, xml, fragments)
         end
 
         EADSerializer.run_serialize_step(data, xml, fragments, :did)

--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -205,7 +205,7 @@ class EADSerializer < ASpaceExport::Serializer
             serialize_did_notes(data, xml, @fragments)
 
             if (languages = data.lang_materials)
-              serialize_languages(languages, xml)
+              serialize_languages(languages, xml, @fragments)
             end
 
             data.instances_with_sub_containers.each do |instance|
@@ -659,7 +659,7 @@ class EADSerializer < ASpaceExport::Serializer
     end
   end
 
-  def serialize_languages(languages, xml)
+  def serialize_languages(languages, xml, fragments)
     lm = []
     language_notes = languages.map {|l| l['notes']}.compact.reject {|e|  e == [] }.flatten
     if !language_notes.empty?
@@ -672,7 +672,7 @@ class EADSerializer < ASpaceExport::Serializer
           att ||= {}
 
           xml.send(note['type'], att.merge(audatt)) {
-            sanitize_mixed_content(content, xml,ASpaceExport::Utils.include_p?(note['type']))
+            sanitize_mixed_content(content, xml, fragments, ASpaceExport::Utils.include_p?(note['type']))
           }
           lm << note
         end


### PR DESCRIPTION
Fix export of language notes containing XML as CDATA in langmaterial elements in EAD 2002.

## Description
Add fragments argument to serialize_languages method, as with other serialze_* methods, and the EAD3 version of the same method.

## Related JIRA Ticket or GitHub Issue
#1721 

## Motivation and Context
Bug fix, see issue.

## How Has This Been Tested?
Tested on development system with test data as per issue. Does not cause any existing backend unit tests to fail.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
