### PR TITLE
ANW-975: Add select all option to all search listings

### DIFF
--- a/frontend/app/assets/javascripts/search.js
+++ b/frontend/app/assets/javascripts/search.js
@@ -26,6 +26,15 @@ $(function() {
       });
     });
 
+    $table.on("click", "#select_all", function(event) {
+      var $checkbox = $(this);
+      if ($checkbox.is(":checked")) {
+        $("tbody :checkbox:not(:checked)", self.$table).trigger("click");
+      } else {
+        $("tbody :checkbox:checked", self.$table).trigger("click");
+      }
+    });
+
     $(".multiselect-enabled").each(function() {
       var $multiselectEffectedWidget = $(this);
       if ($table.is($multiselectEffectedWidget.data("multiselect"))) {

--- a/frontend/app/views/search/_listing.html.erb
+++ b/frontend/app/views/search/_listing.html.erb
@@ -6,7 +6,7 @@
     <thead>
     <tr>
       <% if allow_multi_select? %>
-        <th><span class="sr-only"><%= I18n.t("search_results.selected") %></span></th>
+        <th><label for="select_all" class="sr-only"><%= I18n.t("search_results.selected") %></label><%= check_box_tag "select_all" %></th>
       <% end %>
       <% if params[:linker]==='true' %>
         <th></th>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds a "select all" checkbox to all search listing results similar to that used in Manage Top Containers.  The select all option is only visible to those with permissions that allow multiselect on search pages. 

## Description
<!--- Describe your changes in detail -->
While ANW-975 only specifically asks for this behavior on the locations search results page, that is managed by the shared search listing partial so this change impacts all search results lists that 1. have a multiselect option, and 2. for users with the permission to multiselect items.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-975

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Reduce clicking when wishing to select all items on a page of search results.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All existing tests (including frontend tests) pass.  Visually confirmed as working.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15144646/70077615-29af7680-15cf-11ea-9da6-007eaa90f638.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
