### PR TITLE
Deduplicate check permissions for prefs & rde

### DIFF
--- a/backend/app/controllers/preferences.rb
+++ b/backend/app/controllers/preferences.rb
@@ -8,7 +8,7 @@ class ArchivesSpaceService < Sinatra::Base
     .returns([200, :created],
              [400, :error]) \
   do
-    check_permissions(params)
+    check_prefs_permissions(params)
     handle_create(Preference, params[:preference])
   end
 
@@ -70,7 +70,7 @@ class ArchivesSpaceService < Sinatra::Base
     .returns([200, :updated],
              [400, :error]) \
   do
-    check_permissions(params)
+    check_prefs_permissions(params)
     handle_update(Preference, params[:id], params[:preference])
   end
 
@@ -93,12 +93,12 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:delete_archival_record])
     .returns([200, :deleted]) \
   do
-    check_permissions(params)
+    check_prefs_permissions(params)
     handle_delete(Preference, params[:id])
   end
 
 
-  def check_permissions(params)
+  def check_prefs_permissions(params)
     if (params.has_key?(:preference))
       user_id = params[:preference]['user_id']
       repo_id = params[:preference]['repo_id']
@@ -111,18 +111,18 @@ class ArchivesSpaceService < Sinatra::Base
     if user_id.nil? &&
         repo_id == Repository.global_repo_id &&
         !current_user.can?(:administer_system)
-      raise AccessDeniedException.new
+      raise AccessDeniedException.new('Error editing Global preferences')
     end
 
     # trying to edit repo prefs
     if user_id.nil? &&
         !current_user.can?(:manage_repository)
-      raise AccessDeniedException.new
+      raise AccessDeniedException.new('Error editing Repository preferences')
     end
 
     # trying to edit user prefs
     if user_id && user_id != current_user.id
-      raise AccessDeniedException.new
+      raise AccessDeniedException.new('Error editing User preferences')
     end
   end
 

--- a/backend/app/controllers/rde_templates.rb
+++ b/backend/app/controllers/rde_templates.rb
@@ -8,7 +8,7 @@ class ArchivesSpaceService < Sinatra::Base
     .returns([200, :created],
              [400, :error]) \
   do
-    check_permissions(params)
+    check_rde_permissions(params)
     handle_create(RdeTemplate, params[:rde_template])
   end
 
@@ -42,12 +42,12 @@ class ArchivesSpaceService < Sinatra::Base
             ["repo_id", :repo_id])
     .permissions([:manage_rde_templates])
     .returns([200, :deleted]) \
-  do 
+  do
     handle_delete(RdeTemplate, params[:id])
   end
 
 
-  def check_permissions(params)
+  def check_rde_permissions(params)
     if !current_user.can?(:manage_rde_templates)
       raise AccessDeniedException.new
     end


### PR DESCRIPTION
The `check_permissions` method was defined in `preferences.rb` and `rde_templates.rb` both within the `ArchivesSpaceService` context, which results in the former being overridden.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
