### PR TITLE
ANW-151: Don't allow transfer of DO's linked to repo-scoped records

### DIFF
--- a/backend/app/model/mixins/relationships.rb
+++ b/backend/app/model/mixins/relationships.rb
@@ -419,6 +419,9 @@ module Relationships
 
 
   def transfer_to_repository(repository, transfer_group = [])
+    if transfer_group.first.class == DigitalObject && !do_transferable?(transfer_group)
+      do_has_link_error(instances)
+    end
     # When a record is being transferred to another repository, any
     # relationships it has to records within the current repository must be
     # cleared.
@@ -441,6 +444,48 @@ module Relationships
     end
 
     super
+  end
+
+
+  def do_transferable?(transfer_group = [])
+    # ANW-151: Digital objects should not be transferable if they have instance links to other repository-scoped record types. If not transferrable, we throw an error and abort the transfer.
+    transferee = transfer_group.first[:id]
+
+    do_relationship = DigitalObject.find_relationship(:instance_do_link)
+
+    instances = do_relationship
+    .select(:instance_id).filter(:digital_object_id => transferee)
+    .map {|row| row[:instance_id]}
+
+    if !instances.empty?
+      do_has_link_error(instances)
+      false
+    else
+      true
+    end
+  end
+
+
+  def do_has_link_error(instances)
+    # Abort the transfer and provide the list of top-level records that are preventing it from completing.
+    exception = TransferConstraintError.new
+
+    ASModel.all_models.each do |model|
+      next unless model.associations.include?(:instance)
+
+      model
+        .eager_graph(:instance)
+        .filter(:instance__id => instances)
+        .select(Sequel.qualify(model.table_name, :id))
+        .each do |row|
+        exception.add_conflict(model.my_jsonmodel.uri_for(row[:id], :repo_id => self.class.active_repository),
+                        {:json_property => 'instances',
+                         :message => "DIGITAL_OBJECT_HAS_LINK"})
+        end
+    end
+
+    raise exception
+    return
   end
 
 

--- a/backend/app/model/mixins/relationships.rb
+++ b/backend/app/model/mixins/relationships.rb
@@ -457,11 +457,11 @@ module Relationships
     .select(:instance_id).filter(:digital_object_id => transferee)
     .map {|row| row[:instance_id]}
 
-    if !instances.empty?
+    if instances.empty?
+      true
+    else
       do_has_link_error(instances)
       false
-    else
-      true
     end
   end
 

--- a/backend/spec/model_repo_transfers_spec.rb
+++ b/backend/spec/model_repo_transfers_spec.rb
@@ -269,6 +269,29 @@ describe 'Record transfers' do
     end
   end
 
+  it "will not transfer digital objects linked to a repository-scoped parent" do
+    digital_object = create(:json_digital_object)
+    do_instance = build(:json_instance_digital,
+                        :digital_object => {:ref => digital_object.uri})
+
+    resource = create(:json_resource)
+
+    ao = create(:json_archival_object,
+                :title => "hello again",
+                :instances => [do_instance],
+                :resource => {'ref' => resource.uri})
+
+    begin
+      DigitalObject[digital_object.id].transfer_to_repository(@target_repo)
+    rescue TransferConstraintError
+      error = $!
+    end
+
+    expect(error).not_to be_nil
+    expect(error.conflicts[ao.uri][:message]).to eq('DIGITAL_OBJECT_HAS_LINK')
+
+  end
+
   it "detects when a digital object can't be moved as a part of a transfer" do
     digital_object = create(:json_digital_object)
     do_instance = build(:json_instance_digital,

--- a/frontend/app/views/transfer/_transfer_failures.html.erb
+++ b/frontend/app/views/transfer/_transfer_failures.html.erb
@@ -14,6 +14,15 @@
                     <% end %>
                 </ul>
             </p>
+        <% elsif @transfer_errors.values.all? {|e| e['message'] == 'DIGITAL_OBJECT_HAS_LINK'} %>
+            <p>
+                <%= I18n.t('actions.transfer_failed_digital_objects_linked_to_records') %>:
+                <ul>
+                    <% @transfer_errors.keys.each do |uri| %>
+                        <li><%= link_to uri, {:controller => :resolver, :action => :resolve_readonly, :uri => uri} %></li>
+                    <% end %>
+                </ul>
+            </p>
         <% else %>
             <%# Shouldn't happen, but give something to report... %>
             <%= @transfer_errors.inspect %>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -63,6 +63,7 @@ en:
     transfer_successful: Transfer Successful.  Records may take a moment to appear in the target repository while re-indexing takes place.
     transfer_failed: Transfer Failed
     transfer_failed_records_using_digital_objects: "The following records link to digital objects that would be transferred, but doing so would break their instance links"
+    transfer_failed_digital_objects_linked_to_records: "This digital object links to other records held in this repository. To proceed with this transfer, remove the links in the following records"
     unset_default: Unset Default
     unsuppress: Unsuppress
     unsuppress_confirm_title: Unsuppress this Record?

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -65,6 +65,7 @@ es:
     transfer_successful: Transferencia exitosa.  Los registros pueden tardar un momento en aparecer en el repositorio de destino mientras nueva indexación se lleva a cabo.
     transfer_failed: Transferencia fallida
     transfer_failed_records_using_digital_objects: "Los siguientes registros se vinculan a objetos digitales que se transferirían, pero hacerlo rompería sus enlaces de instancia"
+    transfer_failed_digital_objects_linked_to_records: "Este objeto digital se vincula a otros registros contenidos en este repositorio. Para continuar con esta transferencia, elimine los enlaces en los siguientes registros"
     unset_default: Desactivada por defecto
     unsuppress: Desactivar
     unsuppress_confirm_title: ¿Bloquear este registro?

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -63,6 +63,7 @@ fr:
     transfer_successful: Transfert réussi.  L'apparition des notices dans le service d'archives cible peut tarder, le temps qu'une réindexation ait lieu.
     transfer_failed: Echec du transfert
     transfer_failed_records_using_digital_objects: "Les notices suivantes pointent vers des objets numériques qui pourraient être transférés, mais le faire briserait leurs liens d'instances"
+    transfer_failed_digital_objects_linked_to_records: "Cet objet numérique est lié à d'autres enregistrements de ce référentiel. Pour procéder à ce transfert, supprimez les liens des enregistrements suivants"
     unset_default: Désactiver défaut
     unsuppress: Débloquer
     unsuppress_confirm_title: Débloquer cette notice?

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -65,6 +65,7 @@ ja:
     transfer_successful: 転送成功。インデックスの再作成中にレコードがターゲットリポジトリに表示されるまでに時間がかかることがあります。
     transfer_failed: 転送に失敗しました
     transfer_failed_records_using_digital_objects: 次のレコードは、転送されるデジタルオブジェクトにリンクしますが、そのようにすると、インスタンスリンクが破損します
+    transfer_failed_digital_objects_linked_to_records: 「このデジタルオブジェクトは、このリポジトリに保持されている他のレコードにリンクしています。この転送を続行するには、次のレコードのリンクを削除してください」
     unset_default: 既定の設定を解除する
     unsuppress: 抑止力
     unsuppress_confirm_title: この記録を抑止しますか？


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently, if a user attempts to transfer a digital object record that has an instance link to a repo-scoped record (e.g. resource or archival object) the DO will transfer, but leaves behind a broken instance relationship.  This results in a number of problems:
- The related record (resource or ao) returns a false Record Not Found error in the interface (even though the record is still in the db);
- The transferred DO is not properly indexed and not searchable in its new repo; and,
- If the user go directly to that DO using it's uri a "server error" is returned.

The only way to resolve this bug is to go back into the database and manually update the DO's repo back to it's original repo.

This PR makes it impossible to transfer a DO that has an instance relationship with another repo-scoped record.  Instead, a warning is thrown alerting the user to the existing relationship(s) and stating these instance links must first be deleted before the transfer can complete.

## Description
<!--- Describe your changes in detail -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-151 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Results in the several bugs described above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested and confirmed that:
- Digital objects with no instance links will transfer;
- Digital objects with instance links will present the no error and not transfer; and, 
- Resource records that are the only parent of a digital object transfer and will transfer both the resource record and the digital object to the new repository.

All existing automated tests passed, and new backend test added.

## Screenshots (if appropriate):
Transfer failure warning:
![image](https://user-images.githubusercontent.com/15144646/70184313-9604a580-16b5-11ea-98df-b1cbe702a582.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
