### PR TITLE
Deterministic order by id unless order provided

### DIFF
--- a/backend/app/lib/crud_helpers.rb
+++ b/backend/app/lib/crud_helpers.rb
@@ -51,7 +51,7 @@ module CrudHelpers
 
     modified_since_time = Time.at(pagination_data[:modified_since])
     dataset = dataset.where { system_mtime >= modified_since_time }
-    dataset = dataset.order(*order) if order
+    dataset = order ? dataset.order(*order) : dataset.order(:id)
 
     if pagination_data[:page]
       # Classic pagination mode


### PR DESCRIPTION
For `handle_listing` api results apply conventional order (by id ASC) when no order is supplied.

## Motivation and Context
2 issues have been pointed out: a) currently retrieving a list of records can appear unordered (it isn't clear what the default sort method is) b) without an explicit order (required by pagination) the results are non-deterministic and therefore it's possible to get "duplicate' results (where the same record appears in different pages).

## How Has This Been Tested?
Applied via a plugin on a set of sites where problem was identified. Confirmed issue was resolved.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
