### PR TITLE
ANW-149: Import @label attribute if present for physdesc note types

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -290,6 +290,7 @@ class EADConverter < Converter
       make :note_singlepart, {
         :type => note_name,
         :persistent_id => att('id'),
+        :label => att('label'),
 		    :publish => att('audience') != 'internal',
         :content => format_content( content.sub(/<head>.?<\/head>/, '').strip)
       } do |note|
@@ -303,6 +304,7 @@ class EADConverter < Converter
       make :note_multipart, {
         :type => note_name,
         :persistent_id => att('id'),
+        :label => att('label'),
 		    :publish => att('audience') != 'internal',
         :subnotes => {
           'jsonmodel_type' => 'note_text',

--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -291,7 +291,7 @@ class EADConverter < Converter
         :type => note_name,
         :persistent_id => att('id'),
         :label => att('label'),
-		    :publish => att('audience') != 'internal',
+        :publish => att('audience') != 'internal',
         :content => format_content( content.sub(/<head>.?<\/head>/, '').strip)
       } do |note|
         set ancestor(:resource, :archival_object), :notes, note
@@ -305,7 +305,7 @@ class EADConverter < Converter
         :type => note_name,
         :persistent_id => att('id'),
         :label => att('label'),
-		    :publish => att('audience') != 'internal',
+        :publish => att('audience') != 'internal',
         :subnotes => {
           'jsonmodel_type' => 'note_text',
           'content' => format_content( content )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The EAD importer does not currently retain content in the option `@label` attribute.  This PR remedies that.

## Description
<!--- Describe your changes in detail -->
Updated the `make_single_note` and `make_nested_note` methods to utilize the `@label` attribute if present.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-149 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested; confirmed all existing tests passed.

## Screenshots (if appropriate):
EAD with labels:
![image](https://user-images.githubusercontent.com/15144646/70565626-7f03fe80-1b60-11ea-9fd7-46e2483193e6.png)

Notes with labels:
![image](https://user-images.githubusercontent.com/15144646/70565579-6c89c500-1b60-11ea-9bf9-4dafdb18319f.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
