### PR TITLE
Rename/relocate container profile facets

### DIFF
--- a/frontend/app/views/container_profiles/_linker.html.erb
+++ b/frontend/app/views/container_profiles/_linker.html.erb
@@ -24,7 +24,7 @@
              data-name="ref"
              data-path="<%= form.path %>"
              data-url="<%= url_for :controller => :container_profiles, :action => :typeahead, :format => :json %>"
-             data-browse-url="<%= url_for :controller => :search, :action => :do_search, :format => :js, :facets => ContainerProfilesController.FACETS, :sort => "title_sort asc" %>"
+             data-browse-url="<%= url_for :controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.CONTAINER_PROFILE_FACETS, :sort => "title_sort asc" %>"
              data-selected="<%= selected_json %>"
              data-multiplicity="one"
              data-types='<%= linkable_types.to_json %>'

--- a/frontend/app/views/location_profiles/_linker.html.erb
+++ b/frontend/app/views/location_profiles/_linker.html.erb
@@ -24,7 +24,7 @@
              data-name="ref"
              data-path="<%= form.path %>"
              data-url="<%= url_for :controller => :location_profiles, :action => :typeahead, :format => :json %>"
-             data-browse-url="<%= url_for :controller => :search, :action => :do_search, :format => :js, :facets => ContainerProfilesController.FACETS, :sort => "title_sort asc" %>"
+             data-browse-url="<%= url_for :controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.CONTAINER_PROFILE_FACETS, :sort => "title_sort asc" %>"
              data-selected="<%= selected_json %>"
              data-multiplicity="one"
              data-types='<%= linkable_types.to_json %>'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix to the linker bug introduced in ANW-443 when container_profile facets were relocated to SearchResultData.

## Description
<!--- Describe your changes in detail -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
