### PR TITLE
ANW-145: Exclude current record from digital object merge

### DIFF
--- a/frontend/app/views/digital_objects/_linker.html.erb
+++ b/frontend/app/views/digital_objects/_linker.html.erb
@@ -4,6 +4,8 @@
    else
      selected_json = "{}"
    end
+
+   exclude_ids = [] if exclude_ids.blank?
 %>
 <div class="form-group required">
   <label class="control-label col-sm-2"><%= I18n.t("digital_object._singular") %></label>
@@ -21,6 +23,7 @@
              data-format_property="title"
              data-multiplicity="one"
              data-types='["digital_object"]'
+             data-exclude='<%= exclude_ids.to_json %>'
       />
       
       <% if form.obj.has_key?('_resolved') %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When opting to merge digital objects, the linker form provided allows you to select the currently active digital object to merge into (e.g. you can attempt to merge a digital object into itself).  This fix ensures that the currently active record is excluded from the linker form in the same manner that it is done with other major record types (resources, accessions, subjects, etc.).

## Description
<!--- Describe your changes in detail -->
Added `exclude_ids` to the digital objects linker in the same fashion is used in other major record linkers.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-145 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Do not allow users to attempt to merge digital objects into themselves.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tests; existing tests passing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
