### PR TITLE
ANW-760: Don't drop content in title tags inside record linkers

### DIFF
--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -107,7 +107,7 @@ module ApplicationHelper
     else
       html += "<span class='icon-token'></span>"
     end
-    html += opts[:label]
+    html += clean_mixed_content(opts[:label])
     html += "</div>"
     html.html_safe
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Display strings/titles containing markup (e.g. `<title render="italic">`) weren't properly parsed by the `render_token` method, resulting in all content inside tags being dropped altogether.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Calling `clean_mixed_content` on the label attribute passed to `render_token`.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-760

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually inspected; automated tests pass.

## Screenshots (if appropriate):
Italicized content is no longer being dropped from the "Active restrictions" table on a top container record.
![image](https://user-images.githubusercontent.com/15144646/70826034-e82f8000-1db3-11ea-8e7a-21678e1bfae0.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
