### PR TITLE
Render marked up display strings in accession show/edit h2s

### DIFF
--- a/frontend/app/views/accessions/edit.html.erb
+++ b/frontend/app/views/accessions/edit.html.erb
@@ -11,7 +11,7 @@
         <%= render_aspace_partial :partial => "accessions/toolbar" %>
         <div class="record-pane">
           <%= link_to_help :topic => "accession" %>
-          <h2><%= @accession.display_string %> <span class="label label-info"><%= I18n.t("accession._singular") %></span></h2>
+          <h2><%= clean_mixed_content(@accession.display_string) %> <span class="label label-info"><%= I18n.t("accession._singular") %></span></h2>
           <input type="hidden" name="_method" value="put" />
           <%= render_aspace_partial :partial => "accessions/form", :locals => {:form => form} %>
         </div>

--- a/frontend/app/views/accessions/show.html.erb
+++ b/frontend/app/views/accessions/show.html.erb
@@ -10,7 +10,7 @@
     <%= render_aspace_partial :partial => "accessions/toolbar" %>
     <div class="record-pane">
       <%= readonly_context :accession, @accession do |readonly| %>
-          <h2><%= @accession.display_string %> <span class="label label-info label-default"><%= I18n.t("accession._singular") %></span></h2>
+          <h2><%= clean_mixed_content(@accession.display_string) %> <span class="label label-info label-default"><%= I18n.t("accession._singular") %></span></h2>
 
           <%= render_aspace_partial :partial => "shared/flash_messages" %>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Accession display strings containing markup (e.g. <title render="italic">) weren't being properly rendered in the form/show views.  This brings accession records into line with the other major record types and ensures that marked up display strings are italicized/styled inside the <h2>.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Call `clean_mixed_content` on <h2> content as is already done elsewhere (aos, resources, digital objects, etc.).

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually inspected, automated tests pass.

## Screenshots (if appropriate):
Prior to fix: 
<img width="728" alt="italics" src="https://user-images.githubusercontent.com/15144646/70828604-aefa0e80-1db9-11ea-8697-4af00e8174f9.png">

After fix:
![image](https://user-images.githubusercontent.com/15144646/70828624-bae5d080-1db9-11ea-99f8-39f619a69c10.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
