### PR TITLE
ANW-937: Fixes to METS export

### DIFF
--- a/backend/app/exporters/serializers/mets.rb
+++ b/backend/app/exporters/serializers/mets.rb
@@ -1,43 +1,43 @@
-class METSSerializer < ASpaceExport::Serializer 
+class METSSerializer < ASpaceExport::Serializer
   serializer_for :mets
 
   def build(data, opts = {})
     builder = Nokogiri::XML::Builder.new(:encoding => "UTF-8") do |xml|
       if opts[:dmd]
-        mets(data, xml, opts[:dmd])     
+        mets(data, xml, opts[:dmd])
       else
-        mets(data, xml)     
+        mets(data, xml)
       end
-    end   
-    
+    end
+
     builder
   end
 
-  
+
   def serialize(data, opts = {})
 
     builder = build(data, opts)
-    
-    builder.to_xml   
+
+    builder.to_xml
   end
-  
+
 
   private
 
   def mets(data, xml, dmd = "mods")
-    xml.mets('xmlns' => 'http://www.loc.gov/METS/', 
-             'xmlns:mods' => 'http://www.loc.gov/mods/v3', 
-             'xmlns:dc' => 'http://purl.org/dc/elements/1.1/', 
+    xml.mets('xmlns' => 'http://www.loc.gov/METS/',
+             'xmlns:mods' => 'http://www.loc.gov/mods/v3',
+             'xmlns:dc' => 'http://purl.org/dc/elements/1.1/',
              'xmlns:xlink' => 'http://www.w3.org/1999/xlink',
              'xmlns:xsi' => "http://www.w3.org/2001/XMLSchema-instance",
              'xsi:schemaLocation' => "http://www.loc.gov/standards/mets/mets.xsd"){
-      xml.metsHdr(:CREATEDATE => Time.now) {
+      xml.metsHdr(:CREATEDATE => Time.now.iso8601) {
         xml.agent(:ROLE => data.header_agent_role, :TYPE => data.header_agent_type) {
           xml.name data.header_agent_name
           data.header_agent_notes.each do |note|
             xml.note note
           end
-        }        
+        }
       }
 
       xml.dmdSec(:ID => data.dmd_id) {
@@ -49,7 +49,7 @@ class METSSerializer < ASpaceExport::Serializer
                 mods_serializer.serialize_mods(data.mods_model, xml)
               end
             }
-          }          
+          }
         elsif dmd == 'dc'
           xml.mdWrap(:MDTYPE => 'DC') {
             xml.xmlData {
@@ -67,10 +67,10 @@ class METSSerializer < ASpaceExport::Serializer
       end
 
       xml.amdSec {
-        
+
       }
 
-      xml.fileSec { 
+      xml.fileSec {
         data.with_file_groups do |file_group|
           xml.fileGrp(:USE => file_group.use) {
             file_group.with_files do |file|
@@ -91,8 +91,8 @@ class METSSerializer < ASpaceExport::Serializer
       }
     }
   end
-  
-  def child_files(children, xml)    
+
+  def child_files(children, xml)
     children.each do |child|
       if child.file_versions.length
         serialize_files(child.file_versions, xml)
@@ -139,7 +139,7 @@ class METSSerializer < ASpaceExport::Serializer
     end
   end
 
-  
+
   def serialize_files(files, xml)
     @file_id ||= 0
     xml.fileGrp {
@@ -147,7 +147,7 @@ class METSSerializer < ASpaceExport::Serializer
         @file_id += 1
         atts = {'ID' => "f#{@file_id.to_s}"}
         atts.merge({'USE' => file['use_statement']}) if file['use_statement']
-        
+
         xml.file(atts) {
           xml.FLocat('xlink:href' => file['file_uri'], 'LOCTYPE' => 'URL') {}
         }

--- a/backend/app/exporters/serializers/mets.rb
+++ b/backend/app/exporters/serializers/mets.rb
@@ -30,7 +30,7 @@ class METSSerializer < ASpaceExport::Serializer
              'xmlns:dc' => 'http://purl.org/dc/elements/1.1/',
              'xmlns:xlink' => 'http://www.w3.org/1999/xlink',
              'xmlns:xsi' => "http://www.w3.org/2001/XMLSchema-instance",
-             'xsi:schemaLocation' => "http://www.loc.gov/standards/mets/mets.xsd"){
+             'xsi:schemaLocation' => "http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd"){
       xml.metsHdr(:CREATEDATE => Time.now.iso8601) {
         xml.agent(:ROLE => data.header_agent_role, :TYPE => data.header_agent_type) {
           xml.name data.header_agent_name

--- a/backend/spec/export_mets_spec.rb
+++ b/backend/spec/export_mets_spec.rb
@@ -76,7 +76,7 @@ describe "Exported METS document" do
 
 
   it "has the correct schema location" do
-    expect(@mets).to have_schema_location "http://www.loc.gov/standards/mets/mets.xsd"
+    expect(@mets).to have_schema_location "http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd"
   end
 
 

--- a/backend/spec/export_mets_spec.rb
+++ b/backend/spec/export_mets_spec.rb
@@ -86,6 +86,10 @@ describe "Exported METS document" do
       expect(@mets).to have_tag "metsHdr[@CREATEDATE]"
     end
 
+    it "outputs CREATEDATE attribute in ISO 8601" do
+      createdate = @mets.css('metsHdr').first.attribute('CREATEDATE').value
+      expect(createdate).to eq Time.strptime(createdate, "%FT%T%:z").iso8601
+    end
 
     it "has an agent statement" do
       expect(@mets).to have_tag "metsHdr/agent[@ROLE='CREATOR'][@TYPE='ORGANIZATION']/name" => @repo.name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR addresses two issues in the METS export:
1. Incomplete schema reference to schema location (currently "http://www.loc.gov/standards/mets/mets.xsd"; should be "http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd")
2. Date formatting for CREATEDATE attribute in metsHdr should be ISO 8601 extended, e.g.: 2019-12-17T13:26:34-05:00

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-937

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test for ISO 8601 compliance to the export_mets_spec and updated the schema location test. Ran backend test suite successfully. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
