### PR TITLE
ANW-873: Subnotes created from RDE should be published

### DIFF
--- a/frontend/app/models/mixins/record_children.rb
+++ b/frontend/app/models/mixins/record_children.rb
@@ -46,7 +46,8 @@ module RecordChildren
             # Multipart and biog/hist notes use a 'text' subnote type for their content.
             if ['note_multipart', 'note_bioghist'].include?(child["notes"][i]["jsonmodel_type"])
               child["notes"][i]["subnotes"] = [{"jsonmodel_type" => "note_text",
-                                                "content" => child["notes"][i]["content"].join(" ")}]
+                                                "content" => child["notes"][i]["content"].join(" "),
+                                                "publish" => true}]
             end
 
           elsif child["notes"][i]["type"].blank? and child["notes"][i]["content"][0].blank?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When creating multipart notes using RDE the main note section is set to published, but the subnote (containing the provided content) is not.  This PR fixes this incongruity by ensuring both values are set to "true" on create (this is the existing behavior for singlepart notes).

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Updated the `record_children` mixin to ensure text subnotes are also defaulting to published on create.  Publication defaults set in preference are still respected on record creation outside of RDE, so if the preference checkbox for publish is unchecked, notes (and other subrecords) creating manually/not created inside the RDE will remain unpublished.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-873

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually inspected and automated tests passing.

## Screenshots (if appropriate):
Prior to this PR multipart notes created from RDE had both published and unpublished checkboxes checked.  This fix creates multipart notes with both checkboxes set to true/published.
![image](https://user-images.githubusercontent.com/15144646/71033623-ad945300-20e5-11ea-8a56-9d204c80b86f.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
