### PR TITLE
ANW-975: Update to handle back button

### DIFF
--- a/frontend/app/assets/javascripts/agents.browse_merge.js
+++ b/frontend/app/assets/javascripts/agents.browse_merge.js
@@ -26,6 +26,15 @@ $(function() {
       });
     });
 
+    $table.on("click", "#select_all", function(event) {
+      var $checkbox = $(this);
+      if ($checkbox.is(":checked")) {
+        $("tbody :checkbox:not(:checked)", self.$table).trigger("click");
+      } else {
+        $("tbody :checkbox:checked", self.$table).trigger("click");
+      }
+    });
+
     $(".multiselect-enabled").each(function() {
       var $multiselectEffectedWidget = $(this);
       var target = "";

--- a/frontend/app/views/search/_listing.html.erb
+++ b/frontend/app/views/search/_listing.html.erb
@@ -6,7 +6,7 @@
     <thead>
     <tr>
       <% if allow_multi_select? %>
-        <th><label for="select_all" class="sr-only"><%= I18n.t("search_results.selected") %></label><%= check_box_tag "select_all" %></th>
+        <th><label for="select_all" class="sr-only"><%= I18n.t("search_results.selected") %></label><%= check_box_tag "select_all", 1, false, "autocomplete" => "off" %></th>
       <% end %>
       <% if params[:linker]==='true' %>
         <th></th>
@@ -57,7 +57,7 @@
           <td class="multiselect-column">
             <label>
               <span class="sr-only"><%= I18n.t("search_results.selected") %></span>
-              <%= check_box_tag "multiselect-item", result["id"], false %>
+              <%= check_box_tag "multiselect-item", result["id"], false, "autocomplete" => "off" %>
             </label>
           </td>
         <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The additional of the select_all checkbox in #1726 can potentially have the unintended consequence of reloading a search listing page with individual checkboxes selected but the select_all box unselected.  This forces autocomplete to off for the multiselect column inputs for search listing results to avoid this behavior if the user uses the browser's back button.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR sets autocomplete to off for the multiselect inputs.  It also ensures that multiselection will work on agents by including the multiselect js in agents.browse_merge.js (since agents does not natively inclue search.js).

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/projects/ANW/issues/ANW-975

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually.

## Screenshots (if appropriate):
Improper behavior prior to this PR.
![out](https://user-images.githubusercontent.com/15144646/71749434-6f1bc980-2e43-11ea-9f88-42ce00655bd4.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
