### PR TITLE
Remove solr and demo db deletion from frontend:clean ant task

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -413,15 +413,19 @@
     </java>
   </target>
 
-   <target name="frontend:clean" depends="solr:nuke, db:delete" description="Delete the Rails tmp directory, solr index and test database">
+   <target name="frontend:clean" description="Delete the Rails tmp directory">
     <delete failonerror="false" dir="../frontend/tmp" />
     <delete failonerror="false" dir="../frontend/public/assets" />
     <mkdir dir="../frontend/public/assets" />
     <mkdir dir="../frontend/public/assets/00-do-not-put-things-here" />
   </target>
 
-  <target name="db:delete" depends="set-classpath" description="Delete test database">
-    <delete dir="build/archivesspace_demo_db" />
+  <target name="solr-db-delete" description="Delete the solr index, test database, and log files">
+    <delete failonerror="false" file="${aspace.data_directory}/frontend_test_log.out" />
+    <delete failonerror="false" file="${aspace.data_directory}/backend_test_log.out" />
+    <delete failonerror="false" file="${aspace.data_directory}/derby.log" />
+    <delete failonerror="false" dir="${aspace.data_directory}/archivesspace_demo_db" />
+    <antcall target="solr:nuke" />
   </target>
 
   <target name="frontend:devserver" depends="set-classpath, frontend:clean" description="Start an instance of the ArchivesSpace frontend development server">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Solr index and demo database was being deleted every time the frontend devserver was starting up.
That has been moved to its own task solr-db-delete and taken out of the frontend:clean task.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1005

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
