### PR TITLE
Make sure to handle transfer of digital objects without digital object components

### DIFF
--- a/backend/app/model/mixins/relationships.rb
+++ b/backend/app/model/mixins/relationships.rb
@@ -67,12 +67,12 @@ AbstractRelationship = Class.new(Sequel::Model) do
       # Suppress this new relationship if it points to a suppressed record
       values[:suppressed] = 1
     end
-   
-    # some objects ( like events? ) seem to leak their ids into the mix. 
+
+    # some objects ( like events? ) seem to leak their ids into the mix.
     values.reject! { |key| key == :id or key == "id"  }
     if ( obj1.is_a?(Location) or obj2.is_a?(Location) )
       values.reject! { |key| key == :jsonmodel_type or key == "jsonmodel_type"  }
-    end 
+    end
     self.create(values)
   end
 
@@ -419,9 +419,16 @@ module Relationships
 
 
   def transfer_to_repository(repository, transfer_group = [])
-    if transfer_group.first.class == DigitalObject && !do_transferable?(transfer_group)
-      do_has_link_error(instances)
+    if transfer_group.empty?
+      do_id = self.class == DigitalObject ? self[:id] : 0
+    else
+      do_id = transfer_group.first.class == DigitalObject ? transfer_group.first[:id] : 0
     end
+
+    unless do_id == 0
+      return unless do_transferable?(do_id)
+    end
+
     # When a record is being transferred to another repository, any
     # relationships it has to records within the current repository must be
     # cleared.
@@ -447,14 +454,12 @@ module Relationships
   end
 
 
-  def do_transferable?(transfer_group = [])
+  def do_transferable?(do_id)
     # ANW-151: Digital objects should not be transferable if they have instance links to other repository-scoped record types. If not transferrable, we throw an error and abort the transfer.
-    transferee = transfer_group.first[:id]
-
     do_relationship = DigitalObject.find_relationship(:instance_do_link)
 
     instances = do_relationship
-    .select(:instance_id).filter(:digital_object_id => transferee)
+    .select(:instance_id).filter(:digital_object_id => do_id)
     .map {|row| row[:instance_id]}
 
     if instances.empty?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
If there were no digital object components, the transfer of a digital object to another repository would go through even though it was attached to an archival object.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
