### PR TITLE
select correct badge according to digital_object_type

### DIFF
--- a/public/app/controllers/concerns/result_info.rb
+++ b/public/app/controllers/concerns/result_info.rb
@@ -150,6 +150,7 @@ module ResultInfo
              dig_f = process_file_versions(it)
              dig_f['caption'] = CGI::escapeHTML(title) if dig_f['caption'].blank? && !title.blank?
            end
+          dig_f['material'] = it['digital_object_type'].blank? ? '' : '(' << it['digital_object_type'] << ')'
         end
         dig_objs.push(dig_f) unless dig_f.blank?
       end

--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -8,7 +8,12 @@
         <div class="objectimage">
           <div class="panel panel-default">
             <a class="btn btn-default record-type-badge digital_object" style="width: 100%" href="<%= d_file['out'] %>" target="new" title="<%= t('digital_object._public.link')%>">
-              <i class="fa fa-file-image-o fa-4x"></i><br/>
+              <i class="fa <%= { '(moving_image)' => 'fa-file-video-o' ,
+                          '(sound_recording)' => 'fa-file-audio-o',
+                          '(sound_recording_musical)' => 'fa-file-audio-o',
+                          '(sound_recording_nonmusical)' => 'fa-file-audio-o' ,
+                          '(still_image)' => 'fa-file-image-o' ,
+                          '(text)' =>  'fa-file-text'}.fetch( d_file['material'], 'fa-file-o' ) %> fa-4x"></i><br/>
               <div class="panel-heading">
                 <%= d_file['caption'].blank? ? "#{t('enumerations.instance_instance_type.digital_object')} #{d_file['material']}" : d_file['caption'].html_safe %>
               </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Selects the correct Font-Awesome badge icon according to digital_object_type

## Description
<!--- Describe your changes in detail -->
digital_object_type is already passed to the view encoded as `dig_obj['material']` for digital_objects, where it is used as part of the caption.  Patch also passes it for digital_instances so that it can work consistently in both views. 

Change to the view selects the appropriate icon according to digital_object_type. 

<!--- Why is this change required? What problem does it solve? -->
The view itself  is easy to fix in a local plugin, however the fact that the controller helper functions only work for digital_objects and not digital_object_instances ( which both display the same digital object links ), I would consider a bug which makes it difficult to fix this locally in a plugin. 

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested locally on a wide variety of digital objects and digital object types. 

<!--- Include details of your testing environment, and the tests you ran to -->
These patches were originally prepared some time ago, but were withdrawn when I noticed changes to which version of Font-Awesome gem was being used.  I have generated diff patches and reapplied them to latest master and redid tests. 
<!--- see how your change affects other areas of the code, etc. -->
Should not affect anything but digital object and instance views. 

I have run rubocop over the changed files. 
The view passes with no issues.
public/app/controllers/concerns/result_info.rb shows 155 offenses. 
I did not attempt to correct them as they would make the diffs and changes for this commit too confusing. I think it better to apply non-functional, format only changes as a separate patch. 

## Screenshots (if appropriate):
Examples:

<img width="1423" alt="Screen Shot 2020-01-09 at 6 31 34 PM" src="https://user-images.githubusercontent.com/3428955/72115045-9b3bbc80-3313-11ea-8522-cbae63d54019.png">

<img width="1423" alt="Screen Shot 2020-01-09 at 6 31 15 PM" src="https://user-images.githubusercontent.com/3428955/72115050-a2fb6100-3313-11ea-964e-6d751ee2c54f.png">



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
