### PR TITLE
ANW-550 Add confirm modal to merge container profiles workflow

### DIFF
--- a/frontend/app/assets/javascripts/browse_merge.js
+++ b/frontend/app/assets/javascripts/browse_merge.js
@@ -22,8 +22,8 @@ function activateBtn(event) {
 };
 
 $(document).on("click", "#batchMerge", function() {
-  let modal_title = $(this).text() + " " + $("h2").text()
-  let dialog_content = AS.renderTemplate("batch_merge_modal_template", {
+  let modal_title = "Merge Container Profiles";
+  let dialog_content = AS.renderTemplate("merge_container_profiles_modal", {
     selection: get_selection()
   });
   AS.openCustomModal("batchMergeModal", modal_title, dialog_content,

--- a/frontend/app/assets/javascripts/browse_merge.js
+++ b/frontend/app/assets/javascripts/browse_merge.js
@@ -28,4 +28,43 @@ $(document).on("click", "#batchMerge", function() {
   });
   AS.openCustomModal("batchMergeModal", modal_title, dialog_content,
     'full');
+  
+  // Access modal1 DOM
+  const $selectTargetBtn = $("[data-js='selectTarget']");
+
+  $selectTargetBtn.on("click", function(e) {
+    e.preventDefault();
+
+    console.log('CLICK FROM $SELECTTARGETBTN!')
+
+    // Set up data for form submission
+    const mergeList = get_selection()
+                      .map(function(profile) {
+                        return {
+                          uri: profile.uri,
+                          display_string: profile.display_string
+                        }
+                      });
+
+    const targetEl = document.querySelector('input[name="target[]"]:checked');
+
+    const target = {
+      display_string: targetEl.getAttribute('aria-label'),
+      uri: targetEl.getAttribute('value')
+    };
+
+    const victims = mergeList.reduce(function(acc, profile) {
+      if (profile.display_string !== target.display_string) {
+        acc.push(profile.display_string);
+      }
+      return acc;
+    }, [])
+
+    // Init modal2
+    AS.openCustomModal("bulkMergeConfirmModal", "Confirm Merge Container Profiles", AS.renderTemplate("confirm_merge_container_profiles_modal", {
+      mergeList,
+      target,
+      victims
+    }), false);
+  });
 });

--- a/frontend/app/views/shared/_templates.html.erb
+++ b/frontend/app/views/shared/_templates.html.erb
@@ -51,6 +51,29 @@
 <% end %>
 --></div>
 
+<div id="merge_container_profiles_modal"><!--
+  <%= form_tag({:controller => :container_profiles}, {:class => "form-horizontal", :id => "batch_merge_form" }) do |f| %>
+    <div class="modal-body">
+      <p class="alert alert-info" id="alertBucket"><%= I18n.t("container_profile._frontend.bulk_operations.merge_instructions") %></p>
+      <div class="selected-record-list well" id="mergeList">
+        <div role="radiogroup" aria-labelledby="mergeList">
+          {for item in selection}
+            <% item_uri = "${item.uri}" %>
+            <div id="chkPref" role="radio" tabindex="0">
+              <%= radio_button_tag "target[]", "${item.uri}", false, :"data-object" => item_uri, :"aria-label" => "${item.display_string}", :"id" => "${item.uri}", :onclick => "activateBtn()", :onKeyPress => "activateBtn()" %>
+              <span>${item.display_string}</span>
+            </div>
+          {/for}
+        </div>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-primary merge-button" data-js="selectTarget" disabled="disabled"><%= I18n.t("container_profile._frontend.bulk_operations.merge_select_target") %></button>
+      <button class="btn btn-cancel btn-default" data-dismiss="modal"><%= I18n.t("actions.cancel") %></button>
+    </div>
+  <% end %>
+--></div>
+
 <div id="save_changes_modal_template"><!--
    <div class="modal-body">
       <%= I18n.t "save_changes_modal.body" %>

--- a/frontend/app/views/shared/_templates.html.erb
+++ b/frontend/app/views/shared/_templates.html.erb
@@ -52,6 +52,7 @@
 --></div>
 
 <div id="merge_container_profiles_modal"><!--
+<% if ["container_profiles"].include?(controller_name) %>
   <%= form_tag({:controller => :container_profiles}, {:class => "form-horizontal", :id => "batch_merge_form" }) do |f| %>
     <div class="modal-body">
       <p class="alert alert-info" id="alertBucket"><%= I18n.t("container_profile._frontend.bulk_operations.merge_instructions") %></p>
@@ -72,9 +73,11 @@
       <button class="btn btn-cancel btn-default" data-dismiss="modal"><%= I18n.t("actions.cancel") %></button>
     </div>
   <% end %>
---></div>
+<% end %>
+  --></div>
 
 <div id="confirm_merge_container_profiles_modal"><!--
+<% if ["container_profiles"].include?(controller_name) %>
   <%= form_tag({:controller => :batch_merge, :action => controller_name}, {:class => "form-horizontal", :id => "batch_merge_form" }) do |f| %>
     <div class="modal-body">
       <p class="alert alert-danger" id="alertBucket"><%= I18n.t("container_profile._frontend.bulk_operations.confirm_merge_question") %></p>
@@ -102,6 +105,7 @@
       <button class="btn btn-cancel btn-default" data-dismiss="modal"><%= I18n.t("actions.cancel") %></button>
     </div>
   <% end %>
+<% end %>
 --></div>
 
 <div id="save_changes_modal_template"><!--

--- a/frontend/app/views/shared/_templates.html.erb
+++ b/frontend/app/views/shared/_templates.html.erb
@@ -23,34 +23,6 @@
   </div>
 --></div>
 
-<div id="batch_merge_modal_template"><!--
-<% if ["container_profiles"].include?(controller_name) %>
-  <%= form_tag({:controller => :batch_merge, :action => controller_name}, {:class => "form-horizontal", :id => "batch_merge_form" }) do |f| %>
-  <div class="modal-body">
-    <div class="alert alert-info" id="alertBucket"><%= I18n.t("actions.batch_merge") %></div>
-    <div class="selected-record-list well" id="mergeList">
-      <div role="radiogroup" aria-labelledby="mergeList">
-        {for item in selection}
-          <% item_uri = "${item.uri}" %>
-          <div id="chkPref" role="radio" tabindex="0">
-            <%= radio_button_tag "target[]", "${item.uri}", false, :"data-object" => item_uri, :"aria-label" => "${item.display_string}", :"id" => "${item.uri}", :onclick => "activateBtn()", :onKeyPress => "activateBtn()" %>
-            <span>${item.display_string}</span>
-          </div>
-        {/for}
-      </div>
-      {for item in selection}
-        <input type="hidden" name="victims[]" value="${item.uri}">
-      {/for}
-    </div>
-  </div>
-  <div class="modal-footer">
-      <button type="submit" class="btn btn-danger merge-button" disabled="disabled"><%= I18n.t("actions.merge_n_records", {:n => "${selection.length}"}) %></button>
-      <button class="btn btn-cancel btn-default" data-dismiss="modal"><%= I18n.t("actions.cancel") %></button>
-  </div>
-  <% end %>
-<% end %>
---></div>
-
 <div id="merge_container_profiles_modal"><!--
 <% if ["container_profiles"].include?(controller_name) %>
   <%= form_tag({:controller => :container_profiles}, {:class => "form-horizontal", :id => "batch_merge_form" }) do |f| %>

--- a/frontend/app/views/shared/_templates.html.erb
+++ b/frontend/app/views/shared/_templates.html.erb
@@ -74,6 +74,36 @@
   <% end %>
 --></div>
 
+<div id="confirm_merge_container_profiles_modal"><!--
+  <%= form_tag({:controller => :batch_merge, :action => controller_name}, {:class => "form-horizontal", :id => "batch_merge_form" }) do |f| %>
+    <div class="modal-body">
+      <p class="alert alert-danger" id="alertBucket"><%= I18n.t("container_profile._frontend.bulk_operations.confirm_merge_question") %></p>
+      <h4><%= I18n.t("container_profile._frontend.bulk_operations.confirm_merge_victims") %></h4>
+      <ul>
+        {for victim in victims}
+          <li>${victim}</li>
+        {/for}
+      </ul>
+      <h4><%= I18n.t("container_profile._frontend.bulk_operations.confirm_merge_target") %></h4>
+      <ul>
+        <li>${target.display_string}</li>
+      </ul>
+      <div class="selected-record-list" id="mergeList">
+      
+        {for profile in mergeList}
+          <input type="hidden" name="victims[]" value="${profile.uri}">
+        {/for}
+        
+        <input type="hidden" name="target[]" value="${target.uri}">
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button type="submit" class="btn btn-danger merge-button"><%= I18n.t("actions.merge_n_records", {:n => "${mergeList.length}"}) %></button>
+      <button class="btn btn-cancel btn-default" data-dismiss="modal"><%= I18n.t("actions.cancel") %></button>
+    </div>
+  <% end %>
+--></div>
+
 <div id="save_changes_modal_template"><!--
    <div class="modal-body">
       <%= I18n.t "save_changes_modal.body" %>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1244,6 +1244,14 @@ en:
         merged: Container Profiles(s) Merged
       section:
         basic_information: Basic Information
+      bulk_operations:
+        merge: Merge Container Profiles
+        merge_instructions: Select the container profile into which all of the other listed container profile(s) will merge. Any linked records will be re-linked to this profile and all information for the other container profile(s) will be deleted.
+        merge_select_target: Select merge target
+        confirm_merge: Confirm Merge Container Profiles
+        confirm_merge_question: Are you sure you want to merge the container profiles as listed below? This action is irreversible.
+        confirm_merge_victims: "Merge the following container profile(s):" 
+        confirm_merge_target: "Into this container profile:"
     name: Name
     name_tooltip: |
         <p>REQUIRED FIELD. The name of the container profile. May be generic or specific.</p>

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -1240,6 +1240,14 @@ es:
         updated: Perfil de contenedor actualizado
       section:
         basic_information: Información básica
+      bulk_operations:
+        merge: Fusionar perfiles de contenedores
+        merge_instructions: Seleccione el perfil de contenedor en el que se fusionarán todos los demás perfiles de contenedor enumerados. Todos los registros vinculados se volverán a vincular a este perfil y se eliminará toda la información para los otros perfiles de contenedor.
+        merge_select_target: Seleccionar objetivo de fusión
+        confirm_merge: Confirmar perfiles de contenedor de fusión
+        confirm_merge_question: ¿Está seguro de que desea fusionar los perfiles del contenedor como se enumeran a continuación? Esta acción es irreversible.
+        confirm_merge_victims: "Combinar los siguientes perfiles de contenedor:" 
+        confirm_merge_target: "En este perfil de contenedor:"
     name: Nombre
     name_tooltip: |
         <p>CAMPO REQUERIDO. El nombre del perfil de contenedores. Pueden ser genéricos o específicos.</p>

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -1238,6 +1238,14 @@ fr:
         updated: Profil de conditionnement actualisé
       section:
         basic_information: Information de base
+      bulk_operations:
+        merge: Fusionner les profils de conteneur
+        merge_instructions: Sélectionnez le profil de conteneur dans lequel tous les autres profils de conteneur répertoriés fusionneront. Tous les enregistrements liés seront à nouveau liés à ce profil et toutes les informations des autres profils de conteneur seront supprimées.
+        merge_select_target: Sélectionner la cible de fusion
+        confirm_merge: Confirmer les profils de conteneur de fusion
+        confirm_merge_question: Voulez-vous vraiment fusionner les profils de conteneur comme indiqué ci-dessous? Cette action est irréversible.
+        confirm_merge_victims: "Fusionner les profils de conteneur suivants:" 
+        confirm_merge_target: "Dans ce profil de conteneur:"
     name: Nom
     name_tooltip: |
         <p>CHAMP OBLIGATOIRE. Le nom d'un profil de conditionnements. Peut être générique ou spécifique.</p>

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -1236,6 +1236,14 @@ ja:
         updated: 更新されたコンテナプロファイル
       section:
         basic_information: 基本情報
+      bulk_operations:
+        merge: コンテナプロファイルのマージ
+        merge_instructions: リストされている他のすべてのコンテナプロファイルがマージされるコンテナプロファイルを選択します。 リンクされたレコードはすべてこのプロファイルに再リンクされ、他のコンテナプロファイルのすべての情報が削除されます。
+        merge_select_target: マージターゲットを選択
+        confirm_merge: マージコンテナプロファイルの確認
+        confirm_merge_question: 以下にリストされているように、コンテナープロファイルをマージしてもよろしいですか？ このアクションは元に戻せません。
+        confirm_merge_victims: "次のコンテナプロファイルをマージします:" 
+        confirm_merge_target: "このコンテナプロファイルに:"
     name: 名
     name_tooltip: "<p>必要なフィールド。コンテナプロファイルの名前。ジェネリックまたは特定のものがあります。 </p><p>例： </p><ul><li>ドキュメントボックス</li><li>ページ15
       </li><li>小さなカードのファイルボックス</li></ul>"


### PR DESCRIPTION
## Description

This PR adds a confirmation modal to the merge Container Profiles workflow.

![merge container profiles with confirmation](https://raw.githubusercontent.com/brianzelip/archivesspace/ANW-550-zelip/zelip/ANW-550-after.gif)

This PR builds off the confirm merge Top Containers work from #1756.

### File Changes

1. frontend/app/views/shared/_templates.html.erb

- add `#merge_container_profiles_modal` template
- add `#confirm_merge_container_profiles_modal` template

2. frontend/app/assets/javascripts/browse_merge.js

- add two modal workflow, passing data through the DOM via event listeners

3. frontend/config/locales/{en|es|fr|ja}.yml

- add i18n copy

## Related JIRA Ticket or GitHub Issue

[ANW-550](https://archivesspace.atlassian.net/browse/ANW-550)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

See above

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
