### PR TITLE
fix for json ld when dates of existence lacked a begin or end value i…

### DIFF
--- a/public/app/models/agent_corporate_entity.rb
+++ b/public/app/models/agent_corporate_entity.rb
@@ -8,10 +8,10 @@ class AgentCorporateEntity < Record
       'name' => json['display_name']['sort_name'],
       'sameAs' => raw['authority_id'],
       'alternateName' => json['names'].select{|n| !n['is_display_name']}.map{|n| n['sort_name']}
-    }.compact
+    }
 
     if (dates = json['dates_of_existence'].first)
-      md['foundingDate'] = dates['begin']
+      md['foundingDate'] = dates['begin'] if dates['begin']
       md['dissolutionDate'] = dates['end'] if dates['end']
     end
 
@@ -20,7 +20,7 @@ class AgentCorporateEntity < Record
                         }
     md['description'] = md['description'][0] if md['description'].length == 1
 
-    md.delete_if { |key,value| value.empty? }
+    md.compact.delete_if { |key,value| value.empty? }
   end
 
 

--- a/public/app/models/agent_family.rb
+++ b/public/app/models/agent_family.rb
@@ -8,10 +8,10 @@ class AgentFamily < Record
       'name' => json['display_name']['sort_name'],
       'sameAs' => raw['authority_id'],
       'alternateName' => json['names'].select{|n| !n['is_display_name']}.map{|n| n['sort_name']}
-    }.compact
+    }
 
     if (dates = json['dates_of_existence'].first)
-      md['foundingDate'] = dates['begin']
+      md['foundingDate'] = dates['begin'] if dates['begin']
       md['dissolutionDate'] = dates['end'] if dates['end']
     end
 
@@ -20,7 +20,7 @@ class AgentFamily < Record
                         }
     md['description'] = md['description'][0] if md['description'].length == 1
 
-    md.delete_if { |key,value| value.empty? }
+    md.compact.delete_if { |key,value| value.empty? }
   end
 
 

--- a/public/app/models/agent_person.rb
+++ b/public/app/models/agent_person.rb
@@ -8,10 +8,10 @@ class AgentPerson < Record
       'name' => json['display_name']['sort_name'],
       'sameAs' => raw['authority_id'],
       'alternateName' => json['names'].select{|n| !n['is_display_name']}.map{|n| n['sort_name']}
-    }.compact
+    }
 
     if (dates = json['dates_of_existence'].first)
-      md['birthDate'] = dates['begin']
+      md['birthDate'] = dates['begin'] if dates['begin']
       md['deathDate'] = dates['end'] if dates['end']
     end
 
@@ -75,7 +75,7 @@ class AgentPerson < Record
       out
     end
 
-    md.delete_if { |key,value| value.empty? }
+    md.compact.delete_if { |key,value| value.empty? }
   end
 
 


### PR DESCRIPTION
…n agent records

<!--- Provide a general summary of your changes in the Title above -->
See email thread an https://archivesspace.atlassian.net/browse/ANW-981. 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This bug causes agent records not to load at all in the PUI if a dates of existence sub record is created that lacks a "begin" or "end" value.  

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-981

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not sure how to add tests to the codebase, but I have tested this update and created new agent records to verify that they load.  E.g. a corporate agent record that has a "dates of existence", yet lacks a machine-readable begin or end date, now returns the following JSON in the PUI with no errors:

```
    {
  "@context": "http://schema.org/",
  "@type": "Organization",
  "@id": "http://localhost:3001//agents/corporate_entities/3",
  "name": "primary company name with no begin end values in doe"
}
```

There are other changes that I'd like to make in the JSON-LD mappings (e.g. adding a new mapping for https://schema.org/conditionsOfAccess, which is a newly-available property that's applicable to archival description), but this pull request is only intended to fix the bug reported on the ArchivesSpace listserv.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
