### PR TITLE
Remove unnecessary configuration help_topic_prefix due to help pages refactor

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -302,9 +302,7 @@ AppConfig[:allow_user_registration] = true
 # Help Configuration
 AppConfig[:help_enabled] = true
 AppConfig[:help_url] = "https://archivesspace.atlassian.net/wiki/spaces/ArchivesSpaceUserManual/overview"
-AppConfig[:help_topic_prefix] = "/Default_CSH.htm#"
 AppConfig[:help_topic_base_url] = "https://archivesspace.atlassian.net/wiki/spaces/ArchivesSpaceUserManual/pages/"
-
 
 AppConfig[:shared_storage] = proc { File.join(AppConfig[:data_directory], "shared") }
 

--- a/frontend/config/initializers/help.rb
+++ b/frontend/config/initializers/help.rb
@@ -21,17 +21,9 @@ module ArchivesSpaceHelp
     AppConfig[:help_url]
   end
 
-  def self.topic_prefix
-    AppConfig[:help_topic_prefix] || ""
-  end
-
   def self.url_for_topic(topic)
     if self[topic]
-      if self[topic].is_a? Fixnum
-        return "#{base_url}#{topic_prefix}#{self[topic]}"
-      else
-        return "#{AppConfig[:help_topic_base_url]}#{self[topic]}"
-      end
+      return "#{AppConfig[:help_topic_base_url]}#{self[topic]}"
     end
   end
 

--- a/frontend/spec/selenium/common.rb
+++ b/frontend/spec/selenium/common.rb
@@ -55,7 +55,6 @@ def selenium_init(backend_fn, frontend_fn)
 
     AppConfig[:help_enabled] = true
     AppConfig[:help_url] = "http://localhost:9999/help_stub"
-    AppConfig[:help_topic_prefix] = "?topic="
 
     standalone = false
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The help pages have been moved to a new application so the AppConfig[:help_topic_prefix] was replaced with AppConfig[:help_topic_base_url] so need to remove AppConfig[:help_topic_prefix].

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
