### PR TITLE
require active_support/inflector in migrations

### DIFF
--- a/build/scripts/migrate_db.rb
+++ b/build/scripts/migrate_db.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'active_support/inflector'
 
 if $0 =~ /scripts[\/\\]rb[\/\\]migrate_db.rb$/
   # This script runs in two contexts: build/run as a part of development, and


### PR DESCRIPTION
## Description
Added requirement for activesupport/inflector into the migrate_db.rb.

This change was required due to the use of parameterize in [migration #120](https://github.com/archivesspace/archivesspace/blob/21ae42891ca69416742f9f55625590381cb95219/common/db/migrations/120_clean_slugs_for_repositories.rb#L23).

## Related JIRA Ticket or GitHub Issue
https://github.com/archivesspace/archivesspace/issues/1784

## How Has This Been Tested?
The migrations were run and completed successfully using the parameterize method.

## Screenshots (if appropriate):

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
