### PR TITLE
ANW-783: Fix linking issues in subject and agent records

### DIFF
--- a/common/db/migrations/130_reindex_linked_records.rb
+++ b/common/db/migrations/130_reindex_linked_records.rb
@@ -1,0 +1,20 @@
+require_relative 'utils'
+
+Sequel.migration do
+
+  up do
+    $stderr.puts("Triggering a reindex of all archival records linked to subjects")
+
+    ['accession', 'archival_object', 'resource', 'digital_object', 'digital_object_component'].each do |table|
+      subject_rlshp = self[:subject_rlshp].exclude("#{table}_id": nil).map{|rlshp| rlshp[:"#{table}_id"]}.uniq
+      subject_rlshp.each do |r|
+        self[:"#{table}"].where(id: r).update(:system_mtime => Time.now)
+      end
+    end
+  end
+
+
+  down do
+  end
+
+end

--- a/frontend/app/views/agents/show.html.erb
+++ b/frontend/app/views/agents/show.html.erb
@@ -108,7 +108,7 @@
         <%= show_plugins_for(@agent, readonly) %>
 
 
-        <%= render_aspace_partial :partial => "search/embedded", :locals => {:filter_term => {"agents" => @agent.title}.to_json, :heading_text => I18n.t("agent._frontend.section.search_embedded")} %>
+        <%= render_aspace_partial :partial => "search/embedded", :locals => {:filter_term => {"agent_uris" => @agent.uri}.to_json, :heading_text => I18n.t("agent._frontend.section.search_embedded")} %>
 
         <%= render_aspace_partial :partial => "search/embedded", :locals => {:filter_term => {"rights_statement_agent_uris" => @agent.uri}.to_json, :heading_text => I18n.t("agent._frontend.section.linked_via_rights_statement")} %>
 

--- a/frontend/app/views/subjects/show.html.erb
+++ b/frontend/app/views/subjects/show.html.erb
@@ -33,7 +33,7 @@
         <%= render_aspace_partial :partial => "external_documents/show", :locals => { :external_documents => @subject.external_documents, :section_id => "subject_external_documents_" } %>
       <% end %>
 
-      <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @subject, :filter_term => {"subjects" => @subject.title}.to_json, :heading_text => I18n.t("subject._frontend.section.search_embedded")} %>
+      <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @subject, :filter_term => {"subject_uris" => @subject.uri}.to_json, :heading_text => I18n.t("subject._frontend.section.search_embedded")} %>
 
       <% if @subject.external_ids.length > 0 && show_external_ids? %>
         <%= render_aspace_partial :partial => "external_ids/show", :locals => { :external_ids => @subject.external_ids, :section_id => "subject_external_ids_" } %>

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -200,6 +200,7 @@ class IndexerCommon
   def add_subjects(doc, record)
     if record['record']['subjects']
       doc['subjects'] = record['record']['subjects'].map {|s| s['_resolved']['title']}.compact
+      doc['subject_uris'] = record['record']['subjects'].collect{|link| link['ref']}
     end
   end
 

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -65,6 +65,7 @@
    <field name="system_generated" type="boolean" indexed="true" stored="true" multiValued="false" />
 
    <field name="subjects" type="string" indexed="true" stored="true" multiValued="true"/>
+   <field name="subject_uris" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="creators" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="agents" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="published_agents" type="string" indexed="true" stored="true" multiValued="true"/>


### PR DESCRIPTION
When viewing subjects in the staff interface, the "Linked Records" section lists all the resources, archival objects, etc which have been associated with the subject. But when there are duplicate subjects (e.g. same title/term but different sources) both subjects list the same records. The same can happen for agents.

## Description
The problems is the "Linked Records" section is rendered by a call to the _search/embedded_ template, which searches the "subjects" Solr index field for records matching the title of the subject. Searching for the subject's URI instead will return accurate results: only the records which have actually been linked to the subject. This requires creating a new Solr index field called "subject_uris" and modifying the indexer to populate it.

The fix for agents is the same except an "agent_uris" Solr index field already exists.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-783
https://archivesspace.atlassian.net/browse/ANW-841

## How Has This Been Tested?
This fix has been working in a plug-in on a production 2.5.1 system for six months.
I have made the same modifications to a development system and tested manually (creating duplicate subject/agent records, linking them to different resource records, then verifying that only the correct ones are listed for each). Running the test suites returns no failures.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
