### PR TITLE
Remove code which adds a match-all clause to negated subqueries

### DIFF
--- a/backend/app/model/solr.rb
+++ b/backend/app/model/solr.rb
@@ -45,11 +45,12 @@ class Solr
           construct_advanced_query_string(subq, use_literal)
         }
 
-        # Solr doesn't allow purely negative expression groups, so we add a
-        # match all query to compensate when we hit one of these.
-        if advanced_query['subqueries'].all? {|subquery| subquery['negated']}
-          clauses << '*:*'
-        end
+# This causes incorrect results for X NOT Y queries via the PUI, see https://github.com/archivesspace/archivesspace/issues/1699
+#        # Solr doesn't allow purely negative expression groups, so we add a
+#        # match all query to compensate when we hit one of these.
+#        if advanced_query['subqueries'].all? {|subquery| subquery['negated']}
+#          clauses << '*:*'
+#        end
 
         subqueries = clauses.join(" #{advanced_query['op']} ")
 

--- a/backend/spec/model_solr_spec.rb
+++ b/backend/spec/model_solr_spec.rb
@@ -117,7 +117,7 @@ describe 'Solr model' do
        "subqueries"=>[{"jsonmodel_type"=>"boolean_query",
                        "op"=>"AND",
                        "subqueries"=>[{"field"=>"title",
-                                       "value"=>"Hornstein",
+                                       "value"=>"tennis",
                                        "negated"=>true,
                                        "jsonmodel_type"=>"field_query",
                                        "literal"=>false}]},
@@ -126,16 +126,16 @@ describe 'Solr model' do
                        "subqueries"=>[{"jsonmodel_type"=>"boolean_query",
                                        "op"=>"AND",
                                        "subqueries"=>[{"field"=>"keyword",
-                                                       "value"=>"*",
+                                                       "value"=>"golf",
                                                        "negated"=>false,
                                                        "jsonmodel_type"=>"field_query",
                                                        "literal"=>false}]}]}]}
     }
 
-    it "compensates for purely negative expressions by adding a match-all clause" do
+    it "constructs advanced query containing Boolean NOT without adding a match-all clause" do
       query_string = Solr::Query.construct_advanced_query_string(canned_query)
 
-      expect(query_string).to eq("((-title:(Hornstein) AND *:*) AND ((fullrecord:(*))))")
+      expect(query_string).to eq("((-title:(tennis)) AND ((fullrecord:(golf))))")
     end
 
   end


### PR DESCRIPTION
This fixes issue #1699, so that advanced searches including Boolean NOT performed via the public user interface will return the correct number of hits.

## Description
This essentially reverts https://github.com/archivesspace/archivesspace/commit/d4473b71a4ebe8c0f7030ea3869e435584965cb5 which seems to be the cause for Boolean NOT queries returning too few results, see issue #1699 for an analysis. I haven't heard from the original committer, nor been able to work out why that change was made, although one possibility is that it was needed at the time but the subsequent https://github.com/archivesspace/archivesspace/commit/9b2724fc76af9f2f7de2f5d41df1b22b8c9f5383 commit changed the behaviour of Solr.

## Related JIRA Ticket or GitHub Issue
#1699 
Possibly also https://archivesspace.atlassian.net/browse/ANW-753

## How Has This Been Tested?
This change has been made on our production system (2.5.1 using external Solr 7.7) by overriding the _Solr::construct_advanced_query_string_ method using a local plug-in.
I have tested the same change made in solr.rb in a development system (on master using internal Solr 4.10).
The only automated test that it breaks is the one created in the original commit. Instead of deleting that test I have modified it.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have <strike>added</strike> modified tests to cover my changes.
- [x] All new and existing tests passed.
