### PR TITLE
ANW-1018: Add language facet

### DIFF
--- a/frontend/app/models/search_result_data.rb
+++ b/frontend/app/models/search_result_data.rb
@@ -105,6 +105,8 @@ class SearchResultData
     return I18n.t("enumerations.event_outcome.#{facet.to_s}", :default => facet) if facet_group === "outcome"
     return I18n.t("enumerations.subject_term_type.#{facet.to_s}", :default => facet) if facet_group === "first_term_type"
 
+    return I18n.t("enumerations.language_iso639_2.#{facet}", :default => facet) if facet_group === "langcode"
+
     if facet_group === "source"
       if single_type? and types[0] === "subject"
         return I18n.t("enumerations.subject_source.#{facet}", :default => facet)

--- a/frontend/app/models/search_result_data.rb
+++ b/frontend/app/models/search_result_data.rb
@@ -251,7 +251,7 @@ class SearchResultData
   end
 
   def self.BASE_FACETS
-    ["primary_type","creators","subjects"]
+    ["primary_type","creators","subjects","langcode"]
   end
 
   def self.AGENT_FACETS
@@ -263,11 +263,11 @@ class SearchResultData
   end
 
   def self.RESOURCE_FACETS
-    ["subjects", "publish", "level", "classification_path", "primary_type"]
+    ["subjects", "publish", "level", "classification_path", "primary_type", "langcode"]
   end
 
   def self.DIGITAL_OBJECT_FACETS
-    ["subjects", "publish", "digital_object_type", "level", "primary_type"]
+    ["subjects", "publish", "digital_object_type", "level", "primary_type", "langcode"]
   end
 
   def self.CONTAINER_PROFILE_FACETS

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -207,6 +207,7 @@ en:
       assessment_survey_year: Survey Year
       assessment_record_types: Record Type
       assessment_completed: Completed
+      langcode: Language of Materials
     help:
       row_selection: Click a row to select it for bulk operations. Hold alt while clicking a checkbox to select, or unselect, multiple previous rows.
 

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -736,6 +736,20 @@ class IndexerCommon
         doc['title_sort'] = doc['assessment_id'].to_s.rjust(10, '0')
       end
     }
+
+
+    add_document_prepare_hook {|doc, record|
+      doc['langcode'] ||= []
+      if record['record'].has_key?('lang_materials') and record['record']['lang_materials'].is_a?(Array)
+        record['record']['lang_materials'].each { |langmaterial|
+          if langmaterial.has_key?('language_and_script')
+            doc['langcode'].push(langmaterial['language_and_script']['language'])
+          end
+        }
+        doc['langcode'].uniq!
+      end
+    }
+
   end
 
 

--- a/public/app/controllers/concerns/handle_faceting.rb
+++ b/public/app/controllers/concerns/handle_faceting.rb
@@ -34,6 +34,9 @@ module HandleFaceting
     pv = strip_mixed_content(v)
     if k == 'primary_type'
       pv = I18n.t("#{v}._singular")
+    elsif k == 'langcode'
+      # Lookup three-letter language codes
+      pv = I18n.t("enumerations.language_iso639_2.#{v}", :default => v)
     elsif %w(repository used_within_published_repository).include?(k)
       repos = Repository.get_repos
       if repos[v].nil?

--- a/public/app/controllers/objects_controller.rb
+++ b/public/app/controllers/objects_controller.rb
@@ -12,7 +12,7 @@ class ObjectsController <  ApplicationController
     process_slug_or_id(params)
   }
 
-  DEFAULT_OBJ_FACET_TYPES = %w(repository primary_type subjects published_agents)
+  DEFAULT_OBJ_FACET_TYPES = %w(repository primary_type subjects published_agents langcode)
   DEFAULT_OBJ_SEARCH_OPTS = {
     'resolve[]' => ['repository:id', 'resource:id@compact_resource', 'ancestors:id@compact_resource', 'top_container_uri_u_sstr:id'],
     'facet.mincount' => 1,

--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -10,7 +10,7 @@ class ResourcesController < ApplicationController
     process_slug_or_id(params)
   }
 
-  DEFAULT_RES_FACET_TYPES = %w{primary_type subjects published_agents}
+  DEFAULT_RES_FACET_TYPES = %w{primary_type subjects published_agents langcode}
   DEFAULT_RES_INDEX_OPTS = {
     'resolve[]' => ['repository:id', 'resource:id@compact_resource', 'top_container_uri_u_sstr:id'],
     'sort' => 'title_sort asc',

--- a/public/app/controllers/search_controller.rb
+++ b/public/app/controllers/search_controller.rb
@@ -2,7 +2,7 @@ class SearchController < ApplicationController
 
   include PrefixHelper
 
-  DEFAULT_SEARCH_FACET_TYPES = ['repository','primary_type', 'subjects', 'published_agents']
+  DEFAULT_SEARCH_FACET_TYPES = ['repository','primary_type', 'subjects', 'published_agents','langcode']
   DEFAULT_SEARCH_OPTS = {
 #    'sort' => 'title_sort asc',
     'resolve[]' => ['repository:id', 'resource:id@compact_resource', 'ancestors:id@compact_resource', 'top_container_uri_u_sstr:id'],

--- a/public/app/views/shared/_only_facets.html.erb
+++ b/public/app/views/shared/_only_facets.html.erb
@@ -3,7 +3,7 @@
 <dl id="facets">
 
   <%
-    preferred_facet_order = %w(repository primary_type agents subjects)
+    preferred_facet_order = %w(repository primary_type agents subjects langcode)
     ordered_facet_types = @facets.keys.sort{|a,b|
       if preferred_facet_order.include?(a) && preferred_facet_order.include?(b)
         preferred_facet_order.index(a) <=> preferred_facet_order.index(b)

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -188,6 +188,7 @@ en:
       type_enum_s: Type
       published_series_title_u_sstr: Series
       instance_type_enum_s: Instance type
+      langcode: Language
 
   search_sorting:
     sort_by: "Sort by:"

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -84,6 +84,7 @@
 
    <!-- Archival Record properties required for facets -->
    <field name="level" type="string" indexed="true" stored="true" multiValued="false"/>
+   <field name="langcode" type="string" indexed="true" stored="true" multiValued="true"/>
 
    <!-- Accession properties required for facets -->
    <field name="accession_date_year" type="int" indexed="true" stored="true" multiValued="false" />


### PR DESCRIPTION
Enhancement to add a language of materials facet which allows users to filter resources and archival objects by their language of materials.

## Description
- New "langcode" Solr field
- New indexer hook to populate that field from the values of language of materials drop-downs. It does not index any additional languages which might be recorded inside language notes (as the language codes used, if any, would not be guaranteed to be ISO-639/2)
- Modifications to PUI to display facet in search and browsing resources and digital objects
- Similar modifications to staff interface

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1018

## How Has This Been Tested?
This is based on modifications made to our production system, which have been in use for six months. But that is running a pre-2.7.0 version of ArchivesSpace. This pull request is different, because of the changes introduced in 2.7.0 which stored languages differently. This version has only been lightly tested on a development system. When running tests, a couple of public ones fail, but I cannot see how those are related to this change:
```
[java] rspec ./spec/features/resources_spec.rb:17 # Resources should be able to properly navigate from Collection Organization back to Resource
[java] rspec ./spec/features/record_innards_spec.rb:5 # Record innards should display when a scope note is inherited
```
This may not be ready to include in the next release, and it may not align with the current direction of development, but I wanted to make this available for discussion.

## Screenshots (if appropriate):
![pui_language_facet](https://user-images.githubusercontent.com/33721187/73774183-6fc5b980-477b-11ea-95f3-14634b144184.png)
![staff_interface_language_facet](https://user-images.githubusercontent.com/33721187/73774184-6fc5b980-477b-11ea-8c3c-520464bcee85.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
