### PR TITLE
ANW-1020. uniq_ao_pos index constraint violation fix

### DIFF
--- a/backend/app/model/mixins/tree_nodes.rb
+++ b/backend/app/model/mixins/tree_nodes.rb
@@ -65,7 +65,7 @@ module TreeNodes
       current_physical_position = self.position
       current_logical_position = ordered_siblings.where { position < current_physical_position }.count
 
-      # If we are already are the correct logical position, do nothing
+      # If we are already at the correct logical position, do nothing
       return if (target_logical_position == current_logical_position)
 
       # We'll determine which node will fall to the left of our moved node, and
@@ -170,22 +170,11 @@ module TreeNodes
       # change the root record on the fly.  I guess we'll allow this...
       extra_values = extra_values.merge(self.class.determine_tree_position_for_new_node(json))
     else
-      if !json.position
-        # The incoming JSON had no position set.  Just keep what we already had.
-        extra_values['position'] = self.position
-      end
+      # ensure we retain the current (physical) position when updating the record
+      extra_values['position'] = self.position
     end
 
-    # Save the logical position to use in setting the position further on.
-    logical_position = json.position
-
-    # Reset json.position to physical position before saving to the database
-    json.position = self.position
-
     obj = super(json, extra_values, apply_nested_records)
-
-    # Set json.position back to logical position for any further processing
-    json.position = logical_position
 
     if json.position
       # Our incoming JSON wants to set the position.  That's fine

--- a/backend/app/model/mixins/tree_nodes.rb
+++ b/backend/app/model/mixins/tree_nodes.rb
@@ -65,6 +65,9 @@ module TreeNodes
       current_physical_position = self.position
       current_logical_position = ordered_siblings.where { position < current_physical_position }.count
 
+      # If we are already are the correct logical position, do nothing
+      return if (target_logical_position == current_logical_position)
+
       # We'll determine which node will fall to the left of our moved node, and
       # which will fall to the right.  We're going to set our physical position to
       # the halfway point of those two nodes.  For example, if left node is
@@ -173,7 +176,16 @@ module TreeNodes
       end
     end
 
+    # Save the logical position to use in setting the position further on.
+    logical_position = json.position
+
+    # Reset json.position to physical position before saving to the database
+    json.position = self.position
+
     obj = super(json, extra_values, apply_nested_records)
+
+    # Set json.position back to logical position for any further processing
+    json.position = logical_position
 
     if json.position
       # Our incoming JSON wants to set the position.  That's fine


### PR DESCRIPTION
## Description

When editing an archival object, a database constraint violation of the "uniq_ao_pos" index in the "archival_object" table may occur when saving the object, giving an error message similar to the following in the GUI:

```
translation missing: - translation missing: validation_errors.database_integrity_constraint_conflict_javacommysqljdbcexceptionsjdbc4mysqlintegrityconstraintviolationexceptionduplicate_entryroot@/repositories/2/resources/1608-500for_keyuniq_ao_pos
```

While the error message is superficially similar to that described in  AR-1326: DB Constraint Violation for transferred Archival Object positionsAccepted (https://archivesspace.atlassian.net/browse/AR-1326), the fundamental cause is different, as it occurs in ArchivesSpace v2.7.0.

As indicated in James Bullen's April 5, 2017 comment:

> In 2.0 we have refactored how positions are handled and resequencing is no longer required, so that config option has been disabled.

Due to the v2.0 refactoring, neither of the fixes mentioned in AR-1326 (i.e., resequencing on startup, or using the "https://github.com/archivesspace/resync" plugin) are relevant.

Upon investigation, the problem appears to be the following:

In the "backend/app/model/mixins/tree_nodes.rb" file, there is a distinction between "logical position" and "physical position" of an archival object. The "physical position" is the actual value in the "position" field in the "archival_object" table in the database. This value contains "gaps" to enable insertion of elements without having to change all the other elements to preserve the order of the object in the list. The "logical position" is the "gapless" position of the object in the list, used by the API.

When generating the JSON object from the database in the "sequel_to_jsonmodel" method, the "physical position" retrieved from the database is stored in the "json.position" field. This is replaced in the method by the "logical position", and the logical position is what is returned by the API. When the object is updated, the "json.position" field returned from the form still has the logical position. In the "update_from_json" method in "tree_nodes.rb", the object is saved to the database, where the JSON contains the logical position, not the physical position.

An example of this that we've seen occur is the following. In our database, the "physical position" of Archival Object #538301 is "501500", which has a "logical position" of "500". When attempting to save Archival Object #538301, the "json.position" field sent to update the database contains "500" (the logical positon), which conflicts with Archival Object #537801, which has a physical position of "500".

This problem only affects specific records because of the gaps in the physical position. As more records get added to the system, a logical/physical position conflict becomes more likely.

## Related JIRA Ticket or GitHub Issue

https://archivesspace.atlassian.net/browse/ANW-1020

## How Has This Been Tested?

Added test cases to the "backend/spec/tree_position_spec.rb" file that will
fail the logical position is used in writing the object to the database, and
which will fail if the physical position of an archival object changes after being
updated without having changed its logical position.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
