### PR TITLE
Add "nofollow" rel attribute to links in facets/filters in PUI

### DIFF
--- a/public/app/views/shared/_only_facets.html.erb
+++ b/public/app/views/shared/_only_facets.html.erb
@@ -31,6 +31,7 @@
       <% facet_count += 1 %>
       <dd>
         <a href="<%= app_prefix("#{@page_search}&filter_fields[]=#{type}&filter_values[]=#{CGI.escape(v)}") %>"
+           rel="nofollow"
            title="<%= t('search_results.filter_by')%> '<%= get_pretty_facet_value(type,v) %>'">
           <%= get_pretty_facet_value(type,v) %>
         </a>


### PR DESCRIPTION
This change asks search engine crawlers not to follow the links in facets. Such filtered search pages are not information sources themselves, and do not have distinct titles, so I don't think it is desirable for them to appear in search results.

## Description
Soon after we launched, we noticed [Amazonbot](https://developer.amazon.com/support/amazonbot) was the first crawler to hit our public user interface. It honours robots.txt instructions but does not support sitemaps, so it just spiders through all the links in the HTML. Unfortunately, that means it spent most of its time trying every combination of facets in the collections list, until it reached some kind of preset limit and shut down. Instead of throwing wave after wave of search results pages at it, this change allows it to crawl to every collection (and subject, agent, etc) by following the pagination links, but not waste time following the links in the filters.

Googlebot does not support the rel attribute for internal links, only links out to other web sites, but seems to be smart enough not to follow facet links anyway (or maybe it is because we submit sitemaps via the Google Search Console.) Bingbot does support it. So this is not a definitive solution. But stopping just a few crawlers will reduce some load.

Note that if pull requests #1778 and #1792 are approved, they will increase the number of potential permutations of facets that can be applied.

## Related JIRA Ticket or GitHub Issue
N/A

## How Has This Been Tested?
This change has been on our production system as part of a local plug-in for six months, with no issues.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
