### PR TITLE
ANW-805: Change logic for when dao/daogrp/daolink get "internal" audience attributes

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -543,14 +543,14 @@ class EADSerializer < ASpaceExport::Serializer
     content = ""
     content << title if title
     content << ": " if date['expression'] || date['begin']
-      if date['expression']
-        content << date['expression']
-      elsif date['begin']
-      content << date['begin']
-      if date['end'] != date['begin']
-          content << "-#{date['end']}"
-        end
+    if date['expression']
+      content << date['expression']
+    elsif date['begin']
+    content << date['begin']
+    if date['end'] != date['begin']
+        content << "-#{date['end']}"
       end
+    end
     atts['xlink:title'] = digital_object['title'] if digital_object['title']
 
 

--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -518,13 +518,13 @@ class EADSerializer < ASpaceExport::Serializer
     end
   end
 
-  # set daoloc audience attr == 'internal' if this is an unpublished && include_unpublished is set
-  def get_audience_flag_for_file_version(file_version)
-    if file_version['file_uri'] &&
-       (file_version['publish'] == false && @include_unpublished)
-      return "internal"
+  def is_digital_object_published?(digital_object, file_version = nil)
+    if !digital_object['publish']
+      return false
+    elsif !file_version.nil? and !file_version['publish']
+      return false
     else
-      return "external"
+      return true
     end
   end
 
@@ -538,19 +538,19 @@ class EADSerializer < ASpaceExport::Serializer
     title = digital_object['title']
     date = digital_object['dates'][0] || {}
 
-    atts = digital_object["publish"] === false ? {:audience => 'internal'} : {}
+    atts = {}
 
     content = ""
     content << title if title
     content << ": " if date['expression'] || date['begin']
-    if date['expression']
-      content << date['expression']
-    elsif date['begin']
+      if date['expression']
+        content << date['expression']
+      elsif date['begin']
       content << date['begin']
       if date['end'] != date['begin']
-        content << "-#{date['end']}"
+          content << "-#{date['end']}"
+        end
       end
-    end
     atts['xlink:title'] = digital_object['title'] if digital_object['title']
 
 
@@ -559,6 +559,7 @@ class EADSerializer < ASpaceExport::Serializer
       atts['xlink:href'] = digital_object['digital_object_id']
       atts['xlink:actuate'] = 'onRequest'
       atts['xlink:show'] = 'new'
+      atts['audience'] = 'internal' unless is_digital_object_published?(digital_object)
       xml.dao(atts) {
         xml.daodesc{ sanitize_mixed_content(content, xml, fragments, true) } if content
       }
@@ -570,19 +571,22 @@ class EADSerializer < ASpaceExport::Serializer
       atts['xlink:show'] = file_version['xlink_show_attribute'] || 'new'
       atts['xlink:role'] = file_version['use_statement'] if file_version['use_statement']
       atts['xlink:href'] = file_version['file_uri']
-      atts['xlink:audience'] = get_audience_flag_for_file_version(file_version)
+      atts['audience'] = 'internal' unless is_digital_object_published?(digital_object, file_version)
       xml.dao(atts) {
         xml.daodesc{ sanitize_mixed_content(content, xml, fragments, true) } if content
       }
     else
-      xml.daogrp( atts.merge( { 'xlink:type' => 'extended'} ) ) {
+      atts['xlink:type'] = 'extended'
+      atts['audience'] = 'internal' unless is_digital_object_published?(digital_object)
+      xml.daogrp( atts ) {
         xml.daodesc{ sanitize_mixed_content(content, xml, fragments, true) } if content
         file_versions_to_display.each do |file_version|
+          atts = {}
           atts['xlink:type'] = 'locator'
           atts['xlink:href'] = file_version['file_uri']
           atts['xlink:role'] = file_version['use_statement'] if file_version['use_statement']
           atts['xlink:title'] = file_version['caption'] if file_version['caption']
-          atts['xlink:audience'] = get_audience_flag_for_file_version(file_version)
+          atts['audience'] = 'internal' unless is_digital_object_published?(digital_object, file_version)
           xml.daoloc(atts)
         end
       }

--- a/backend/app/exporters/serializers/ead3.rb
+++ b/backend/app/exporters/serializers/ead3.rb
@@ -522,13 +522,14 @@ class EAD3Serializer < EADSerializer
 
             EADSerializer.run_serialize_step(data, xml, @fragments, :did)
 
+            # Change from EAD 2002: dao must be children of did in EAD3, not archdesc
+            data.digital_objects.each do |dob|
+              serialize_digital_object(dob, xml, @fragments)
+            end
+
           }# </did>
 
           serialize_nondid_notes(data, xml, @fragments)
-
-          data.digital_objects.each do |dob|
-                serialize_digital_object(dob, xml, @fragments)
-          end
 
           serialize_bibliographies(data, xml, @fragments)
 

--- a/backend/app/exporters/serializers/ead3.rb
+++ b/backend/app/exporters/serializers/ead3.rb
@@ -1350,7 +1350,7 @@ class EAD3Serializer < EADSerializer
     title = digital_object['title']
     date = digital_object['dates'][0] || {}
 
-    atts = digital_object["publish"] === false ? {:audience => 'internal'} : {}
+    atts = {}
 
     content = ""
     content << title if title
@@ -1377,6 +1377,7 @@ class EAD3Serializer < EADSerializer
       atts['href'] = digital_object['digital_object_id']
       atts['actuate'] = 'onrequest'
       atts['show'] = 'new'
+      atts['audience'] = 'internal' unless is_digital_object_published?(digital_object)
       xml.dao(atts) {
         xml.descriptivenote { sanitize_mixed_content(content, xml, fragments, true) } if content
       }
@@ -1386,6 +1387,7 @@ class EAD3Serializer < EADSerializer
         atts['actuate'] = (file_version['xlink_actuate_attribute'].respond_to?(:downcase) && file_version['xlink_actuate_attribute'].downcase) || 'onrequest'
         atts['show'] = (file_version['xlink_show_attribute'].respond_to?(:downcase) && file_version['xlink_show_attribute'].downcase) || 'new'
         atts['localtype'] = file_version['use_statement'] if file_version['use_statement']
+        atts['audience'] = 'internal' unless is_digital_object_published?(digital_object, file_version)
         xml.dao(atts) {
           xml.descriptivenote { sanitize_mixed_content(content, xml, fragments, true) } if content
         }

--- a/backend/spec/export_ead3_spec.rb
+++ b/backend/spec/export_ead3_spec.rb
@@ -1172,12 +1172,12 @@ describe "EAD3 export mappings" do
       end
     end
 
-    it "maps each resource.instances[].instance.digital_object to archdesc/dao" do
+    it "maps each resource.instances[].instance.digital_object to archdesc/did/dao" do
       digital_objects.each do |obj|
         if obj['file_versions'].length > 0
           obj['file_versions'].each do |fv|
             href = fv["file_uri"] || obj.digital_object_id
-            path = "/ead/archdesc/dao[@href='#{href}']"
+            path = "/ead/archdesc/did/dao[@href='#{href}']"
 
             content = description_content(obj)
 

--- a/backend/spec/export_ead3_spec.rb
+++ b/backend/spec/export_ead3_spec.rb
@@ -1151,12 +1151,11 @@ describe "EAD3 export mappings" do
 
         file_versions = d['file_versions']
 
-        if file_versions.length == 0
+        if file_versions.length < 2
           basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:dao"
-        elsif file_versions.length == 1
+        else
+          # The EAD3 export probably should output a daoset but currently does not
           basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:dao"
-        elsif file_versions.length > 1
-          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:daoset/xmlns:dao"
         end
 
         # for each file version in the digital object

--- a/backend/spec/export_ead3_spec.rb
+++ b/backend/spec/export_ead3_spec.rb
@@ -1144,6 +1144,34 @@ describe "EAD3 export mappings" do
       content
     end
 
+    # ANW-805
+    it "sets audience attribute in dao tags according to publish status of both digital object and file version" do
+      # for each digital object generated
+      digital_objects.each do |d|
+
+        file_versions = d['file_versions']
+
+        if file_versions.length == 0
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:dao"
+        elsif file_versions.length == 1
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:dao"
+        elsif file_versions.length > 1
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:did/xmlns:daoset/xmlns:dao"
+        end
+
+        # for each file version in the digital object
+        file_versions.each do |fv|
+
+          publish = fv['publish'] && d['publish']
+
+          if publish
+            expect(@doc).to have_node(basepath + "[not(@audience='internal')]")
+          else
+            expect(@doc).to have_node(basepath + "[@audience='internal']")
+          end
+        end
+      end
+    end
 
     it "maps each resource.instances[].instance.digital_object to archdesc/dao" do
       digital_objects.each do |obj|

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1166,11 +1166,9 @@ describe "EAD export mappings" do
 
         file_versions = d['file_versions']
 
-        if file_versions.length == 0
+        if file_versions.length < 2
           basepath = "/xmlns:ead/xmlns:archdesc/xmlns:dao"
-        elsif file_versions.length == 1
-          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:dao"
-        elsif file_versions.length > 1
+        else
           basepath = "/xmlns:ead/xmlns:archdesc/xmlns:daogrp/xmlns:daoloc"
         end
 

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1122,7 +1122,6 @@ describe "EAD export mappings" do
 
           if publish
             expect(@doc_unpub).to have_node(basepath + "[@xlink:href='#{file_uri}']")
-            expect(@doc).to have_node(basepath + "[@xlink:audience='external']")
           else
             expect(@doc_unpub).not_to have_node(basepath + "[@xlink:href='#{file_uri}']")
           end
@@ -1153,14 +1152,42 @@ describe "EAD export mappings" do
 
           if publish
             expect(@doc).to have_node(basepath + "[@xlink:href='#{file_uri}']")
-            expect(@doc).to have_node(basepath + "[@xlink:audience='external']")
           else
             expect(@doc).to have_node(basepath + "[@xlink:href='#{file_uri}']")
-            expect(@doc).to have_node(basepath + "[@xlink:audience='internal']")
           end
         end
       end
     end
+
+    # ANW-805: Moved audience attribute of dao/daoloc to its own test. Still quite rudimentary.
+    it "sets audience attribute in dao tags according to publish status of both digital object and file version" do
+      # for each digital object generated
+      digital_objects.each do |d|
+
+        file_versions = d['file_versions']
+
+        if file_versions.length == 0
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:dao"
+        elsif file_versions.length == 1
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:dao"
+        elsif file_versions.length > 1
+          basepath = "/xmlns:ead/xmlns:archdesc/xmlns:daogrp/xmlns:daoloc"
+        end
+
+        # for each file version in the digital object
+        file_versions.each do |fv|
+
+          publish = fv['publish'] && d['publish']
+
+          if publish
+            expect(@doc).to have_node(basepath + "[not(@audience='internal')]")
+          else
+            expect(@doc).to have_node(basepath + "[@audience='internal']")
+          end
+        end
+      end
+    end
+
   end
 
 


### PR DESCRIPTION
This pull request changes three things:

1. Fixes invalid EAD2002 caused by output of `xlink:audience` attributes when exporting something with digital objects.
2. Attempts to change the logic of when to output an `audience` attribute for digital objects discussed in ANW-805.
3. While adding tests for the above, I noticed the EAD3 exported was invalid when digital objects are linked to a resource, due to the exporter continuing to place `dao` in `archdesc` (which was fine in EAD2002 but wrong in EAD3.)

Regarding number 2 above, here is the new logic implemented described in detail:
 - If a digital object is _unpublished_, the exported `dao` or `daogrp`
element gets an `audience` attribute of "internal".
 - Any file versions within an _unpublished_ digital object get an
`audience` attribute of "internal", regardless of their own publish
status. This is the case whether they are exported as `dao` (because
they're the only file version in the digital object) or `daolink` (when
there are multiple file versions.)
- File versions within a _published_ digital object which are themselves
_unpublished_ get an `audience` attribute of "internal" (when they are
the only file version in the digital object that will override the
published status of the digital object as both are exported as a single
`dao` element.)
- `audience` attributes of "external" are _not_ created (which is how it
works for all other elements in the EAD exporter, but maybe there was a
reason why digital objects differ?)

## Description
- Replaces the `get_audience_flag_for_file_version` method with a new
`is_digital_object_published?` method, to make the logic hopefully a
bit clearer.
- Only creates `audience` attributes (in the EAD namespace) not
`xlink:audience` ones (in the XLink namespace) which was causing
exported EAD2002 to be invalid.
- Moves the testing of `audience` attributes for `dao` in EAD2002 export to its own test.
- Adds the same test of `audience` attributes for `dao` to EAD3 export
- Moves the output of `dao` at the resource level from being a child of `archdesc` to a child of the `did` itself in the `archdesc`. This produces valid EAD3.
- Modifies an existing EAD3 test to reflect moving `dao` to `archdesc/did`.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-805

## How Has This Been Tested?
We have not actually started adding digital objects to our production
system (but plan to do soon) so I tested this in a development system by
creating digital objects covering the various permutations of published
or unpublished statuses of digital objects and file versions. The
resulting EAD export files are attached:

[ead.zip](https://github.com/archivesspace/archivesspace/files/4213762/ead.zip)

Both validate successfully against their respective schemas. The EAD3
is a little unclear because `daogrp` has not been replaced with
`daoset`, so there is nowhere for the captions on individual file
versions to be exported. But that is a different issue. 

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Edit: Fixed italics.