### PR TITLE
ANW-257: Add hint to adding Assessment Attributes

### DIFF
--- a/frontend/app/views/assessments/_form.html.erb
+++ b/frontend/app/views/assessments/_form.html.erb
@@ -358,23 +358,23 @@
                   <% ratings_index += 1 %>
                 <% end %>
 
+                <tr>
+                  <th colspan="7">
+                    <strong><%= I18n.t('assessment._frontend.section.rating_attributes_additional') %></strong>
+                    <div>
+                      <small class="text-muted">
+                        <% if user_can?('manage_assessment_attributes') %>
+                          <%= link_to I18n.t('assessment._frontend.messages.manage_attributes_hint', :attribute_type => I18n.t('assessment._frontend.ratings')), {:controller => :assessment_attributes,
+                          :anchor => 'ratings', :action => :edit} %>
+                        <% else %>
+                          <%= I18n.t('assessment._frontend.messages.attributes_hint', :attribute_type => I18n.t('assessment._frontend.ratings')) %>
+                        <% end %>
+                      </small>
+                    </div>
+                  </th>
+                </tr>
 
                 <% if @assessment_attribute_definitions.repo_ratings.length > 0 %>
-                  <tr>
-                    <th colspan="7">
-                      <strong><%= I18n.t('assessment._frontend.section.rating_attributes_additional') %></strong>
-                      <div>
-                        <small class="text-muted">
-                          <% if user_can?('manage_assessment_attributes') %>
-                            <%= link_to I18n.t('assessment._frontend.messages.manage_attributes_hint', :attribute_type => I18n.t('assessment._frontend.ratings')), :controller => :assessment_attributes, :action => :edit %>
-                          <% else %>
-                            <%= I18n.t('assessment._frontend.messages.attributes_hint', :attribute_type => I18n.t('assessment._frontend.ratings')) %>
-                          <% end %>
-                        </small>
-                      </div>
-                    </th>
-                  </tr>
-
                   <% @assessment_attribute_definitions.repo_ratings.each do |rating| %>
                     <% form.push(form.set_index("ratings[]", ratings_index), ASUtils.wrap(form.obj['ratings']).find{|r| r['definition_id'] == rating['id']} || {}) do %>
                       <tr>
@@ -530,24 +530,25 @@
               </div>
             <% end %>
 
-            <% if @assessment_attribute_definitions.repo_formats.length > 0 %>
-              <div class="row">
-                <div class="col-md-12">
-                  <h4>
-                    <strong><%= I18n.t('assessment._frontend.section.format_attributes_additional') %></strong>
-                    <div>
-                      <small class="text-muted">
-                        <% if user_can?('manage_assessment_attributes') %>
-                          <%= link_to I18n.t('assessment._frontend.messages.manage_attributes_hint', :attribute_type => I18n.t('assessment._frontend.formats')), :controller => :assessment_attributes, :action => :edit %>
-                        <% else %>
-                          <%= I18n.t('assessment._frontend.messages.attributes_hint', :attribute_type => I18n.t('assessment._frontend.formats')) %>
-                        <% end %>
-                      </small>
-                    </div>
-                  </h4>
-                </div>
+            <div class="row">
+              <div class="col-md-12">
+                <h4>
+                  <strong><%= I18n.t('assessment._frontend.section.format_attributes_additional') %></strong>
+                  <div>
+                    <small class="text-muted">
+                      <% if user_can?('manage_assessment_attributes') %>
+                        <%= link_to I18n.t('assessment._frontend.messages.manage_attributes_hint', :attribute_type => I18n.t('assessment._frontend.formats')), {:controller => :assessment_attributes, :anchor => 'formats', :action => :edit} %>
+                      <% else %>
+                        <%= I18n.t('assessment._frontend.messages.attributes_hint', :attribute_type => I18n.t('assessment._frontend.formats')) %>
+                      <% end %>
+                    </small>
+                  </div>
+                </h4>
               </div>
-              <div class="row">
+            </div>
+            <div class="row">
+
+              <% if @assessment_attribute_definitions.repo_formats.length > 0 %>
                 <% @assessment_attribute_definitions.repo_formats.each do |format| %>
                   <% form.push(form.set_index("formats[]", formats_index), ASUtils.wrap(form.obj['formats']).find{|r| r['definition_id'] == format['id']} || {}) do %>
                     <div class="col-md-6">
@@ -629,23 +630,23 @@
               <% end %>
             </div>
 
-            <% if @assessment_attribute_definitions.repo_conservation_issues.length > 0 %>
-              <div class="row">
-                <div class="col-md-12">
-                  <h4>
-                    <strong><%= I18n.t('assessment._frontend.section.conservation_issue_attributes_additional') %></strong>
-                    <div>
-                      <small class="text-muted">
-                        <% if user_can?('manage_assessment_attributes') %>
-                          <%= link_to I18n.t('assessment._frontend.messages.manage_attributes_hint', :attribute_type => I18n.t('assessment._frontend.conservation_issues')), :controller => :assessment_attributes, :action => :edit %>
-                        <% else %>
-                          <%= I18n.t('assessment._frontend.messages.attributes_hint', :attribute_type => I18n.t('assessment._frontend.conservation_issues')) %>
-                        <% end %>
-                      </small>
-                    </div>
-                  </h4>
-                </div>
+            <div class="row">
+              <div class="col-md-12">
+                <h4>
+                  <strong><%= I18n.t('assessment._frontend.section.conservation_issue_attributes_additional') %></strong>
+                  <div>
+                    <small class="text-muted">
+                      <% if user_can?('manage_assessment_attributes') %>
+                        <%= link_to I18n.t('assessment._frontend.messages.manage_attributes_hint', :attribute_type => I18n.t('assessment._frontend.conservation_issues')), {:controller => :assessment_attributes, :anchor => 'conservation_issues', :action => :edit} %>
+                      <% else %>
+                        <%= I18n.t('assessment._frontend.messages.attributes_hint', :attribute_type => I18n.t('assessment._frontend.conservation_issues')) %>
+                      <% end %>
+                    </small>
+                  </div>
+                </h4>
               </div>
+            </div>
+            <% if @assessment_attribute_definitions.repo_conservation_issues.length > 0 %>
               <div class="row">
                 <% @assessment_attribute_definitions.repo_conservation_issues.each do |conservation_issue| %>
                   <% form.push(form.set_index("conservation_issues[]", conservation_issues_index), ASUtils.wrap(form.obj['conservation_issues']).find{|r| r['definition_id'] == conservation_issue['id']} || {}) do %>

--- a/frontend/vendor/assets/stylesheets/bootstrap/variables.less
+++ b/frontend/vendor/assets/stylesheets/bootstrap/variables.less
@@ -838,7 +838,7 @@
 //** Horizontal offset for forms and lists.
 @component-offset-horizontal: 180px;
 //** Text muted color
-@text-muted:                  @gray-light;
+@text-muted:                  @gray;
 //** Abbreviations and acronyms border color
 @abbr-border-color:           @gray-light;
 //** Headings small color


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Rearranged existing code to ensure link/hint text about adding additional assessment attributes is visible to users with appropriate permissions even when no additional attributes have been added yet.  On the **edit** page for assessments one of the two should be provided:

- For users with permission to create/update assessment attributes, a link to manage the additional attributes for this repository;
- For users with permission to view the edit form for assessment records, but lacking permission to add/update assessment attributes, hint text should be provided.

Also updated the font color of `text-muted` (used for the above hint text) from light gray to gray to pass color contrast checks.   

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-257

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Visually inspected, existing tests passed.

## Screenshots (if appropriate):

For users that may add/update assessment attributes:
<img width="992" alt="anw-257" src="https://user-images.githubusercontent.com/15144646/74667517-6a9c3d80-5171-11ea-89e5-23dd92378a54.png">

For users that may edit assessment records, but not add assessment attributes:
<img width="997" alt="anw-257-2" src="https://user-images.githubusercontent.com/15144646/74667508-65d78980-5171-11ea-95d9-91714363c57a.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
