### PR TITLE
Ensure alert popups retain "X" to close, but with screen reader labels

### DIFF
--- a/frontend/app/assets/javascripts/utils.js
+++ b/frontend/app/assets/javascripts/utils.js
@@ -806,7 +806,7 @@ $(function() {
 
       // add a close icon to the alert
       var $close = $("<a>").attr("href", "javascript:void(0);").addClass("hide-alert");
-      $close.text("Close Alert").addClass("sr-only");
+      $close.attr("aria-label", "Close Alert");
       $close.append($("<span>").addClass("glyphicon glyphicon-remove"));
       $close.click(handleCloseAlert);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#1762 accidentally removed the "X" that allows users to close a number of ArchivesSpace alerts by placing the <a> inside of a screen reader only class.  This removes that addition and uses javascript to add an aria-label to the link for accessibility purposes.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Confirmed visually that the X returned, utilized ChromeVox and Wave plugin to confirm that the aria-label is being presented to screen reader users.  Broken Selenium tests that alerted me to this regression are now passing.

## Screenshots (if appropriate):
X's missing in 2.7.1:
![image](https://user-images.githubusercontent.com/15144646/75559753-00598780-5a12-11ea-8957-2b4dec2dda0c.png)

X to close back on alerts:
![image](https://user-images.githubusercontent.com/15144646/75559620-c5efea80-5a11-11ea-8ba2-1f4e3336319f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
