### PR TITLE
Modify the view published button in the staff interface toolbar

### DIFF
--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -22,19 +22,9 @@
         <% end %>
         <div class="btn-toolbar pull-right">
           <div class="btn-group">
-            <% if @accession.publish %>
-              <div class="btn btn-inline-form">
-                <% if AppConfig[:use_human_readable_urls] && !@accession['slug'].nil? && !@accession['slug'].empty? %>
-                  <% if AppConfig[:repo_name_in_slugs] %>
-                    <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], 'repositories', session[:repo_slug], 'accessions', @accession['slug']).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
-                  <% else %>
-                    <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], 'accessions', @accession['slug']).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
-                  <% end %>
-                <% else %>
-                  <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], @accession.uri).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
-                <% end %>
-              </div>
-            <% end %>
+
+            <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => @accession} %>
+
             <% if user_can?('update_event_record') && !@accession.suppressed %>
               <%= render_aspace_partial :partial => "shared/event_dropdown", :locals => {:record => @accession } %>
             <% end %>

--- a/frontend/app/views/agents/_toolbar.html.erb
+++ b/frontend/app/views/agents/_toolbar.html.erb
@@ -26,15 +26,9 @@
         <div class="btn btn-inline-form">
           <%= link_to I18n.t("actions.export_eac"), {:controller => :exports, :action => :download_eac, :id => @agent.id, :type => @agent.agent_type}, :class => "btn btn-sm btn-default" %>
         </div>
-        <% if @agent.publish %>
-          <div class="btn btn-inline-form">
-            <% if AppConfig[:use_human_readable_urls] && !@agent['slug'].nil? && !@agent['slug'].empty? %>
-              <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], 'agents', @agent['slug']).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
-            <% else %>
-              <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], @agent.uri).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
-            <% end %>
-          </div>
-        <% end %>
+
+        <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => @agent} %>
+
         <% if user_can?('merge_agent_record') %>
           <%=
           render_aspace_partial :partial => "agents/merge_dropdown",

--- a/frontend/app/views/shared/_component_toolbar.html.erb
+++ b/frontend/app/views/shared/_component_toolbar.html.erb
@@ -30,6 +30,12 @@
             <%= render_aspace_partial :partial => "shared/event_dropdown", :locals => {:record => record} %>
           <% end %>
 
+          <% if ['archival_object', 'digital_object_component'].include?(record.jsonmodel_type) %>
+            <% unless record.has_unpublished_ancestor %>
+              <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => record} %>
+            <% end %>
+          <% end %>
+
           <div class="btn-group dropdown" id="other-dropdown" style="display: none">
             <a class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
               <%= I18n.t('actions.more') %>

--- a/frontend/app/views/shared/_resource_toolbar.html.erb
+++ b/frontend/app/views/shared/_resource_toolbar.html.erb
@@ -33,19 +33,9 @@
                           :"data-confirm-btn-class" => "btn-primary",
                         }) %>
           </div>
-          <% if record.publish %>
-          	<div class="btn-group">
-              <% if AppConfig[:use_human_readable_urls] && !record['slug'].nil? && !record['slug'].empty? %>
-                <% if AppConfig[:repo_name_in_slugs] %>
-                  <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], 'repositories', session[:repo_slug], "#{record_type}" + 's', record['slug']).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
-                <% else %>
-                  <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], "#{record_type}" + 's', record['slug']).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
-                <% end %>
-              <% else %>
-                <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], record.uri).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
-              <% end %>
-            </div>
-          <% end %>
+
+          <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => record} %>
+
           <div class="btn-group">
             <a class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);">
               <%= I18n.t("actions.export") %>

--- a/frontend/app/views/shared/_view_published_button.html.erb
+++ b/frontend/app/views/shared/_view_published_button.html.erb
@@ -1,0 +1,23 @@
+<% if record.publish %>
+
+  <% record_type = record.jsonmodel_type %>
+
+  <div class="btn-group">
+
+    <% if AppConfig[:use_human_readable_urls] && !record['slug'].nil? && !record['slug'].empty? %>
+      <% if ['agent_person', 'agent_family', 'agent_corporate_entity', 'agent_software'].include?(record_type) %>
+        <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], 'agents', @agent['slug']).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
+      <% elsif AppConfig[:repo_name_in_slugs] %>
+        <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], 'repositories', session[:repo_slug], "#{record_type}" + 's', record['slug']).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
+      <% else %>
+        <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], "#{record_type}" + 's', record['slug']).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
+      <% end %>
+    <% else %>
+      <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], record.uri).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
+    <% end %>
+
+  </div>
+
+<% end %>
+
+


### PR DESCRIPTION
## Description
This pull request has two aims:

 - Move the code to render the 'View Published' toolbar button to its own shared template. This has the benefits of reducing repetition in the code (replacing multiple lines in the templates for resources, accessions, and agents with a single render call in each) and make it easier for plug-ins to override the behaviour of this button.
 - Add the 'View Published' toolbar button to archival objects and digital objects components. Because those can be nested, within other records, an additional check is ensures the button is not displayed if they have an unpublished ancestor.

Each is in a separate commit, so if it was a design choice not to have view published buttons on archival objects then that can be reverted. But it seems like an obvious improvement, and it is a feature which has been requested by archivists here.

## Related JIRA Ticket or GitHub Issue
None

## How Has This Been Tested?
Manually tested with all affected record types on a development system. Passes all frontend tests.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
