### PR TITLE
Pass resource record to PUI PDF footer template

### DIFF
--- a/public/app/models/finding_aid_pdf.rb
+++ b/public/app/models/finding_aid_pdf.rb
@@ -82,7 +82,7 @@ class FindingAidPDF
       end
     end
 
-    out_html.write(renderer.render_to_string partial: 'footer', layout: false)
+    out_html.write(renderer.render_to_string partial: 'footer', layout: false, :locals => {:record => @resource})
     out_html.close
 
     out_html


### PR DESCRIPTION
## Description
This is a very small change to pass the resource record data structure to the template which renders the footer of PDFs generated by the public user interface (completely unrelated to PDFs generated via XSL-FO by the backend.)

This has no effect in stock ArchivesSpace, but makes it easier for plug-in writers to customize the end of the PDFs (e.g. to add indexes or revision statements to end of PDFs.)

## Related JIRA Ticket or GitHub Issue
None

## How Has This Been Tested?
Makes no functional difference itself so nothing to test.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
