### PR TITLE
Make displaying search-in-collection form configurable option in other contexts

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -525,6 +525,10 @@ AppConfig[:pui_page_actions_bookmark] = true
 AppConfig[:pui_page_actions_request] = true
 AppConfig[:pui_page_actions_print] = true
 
+# Enable / disable search-in-collection form in sidebar when viewing records
+AppConfig[:pui_search_collection_from_archival_objects] = false
+AppConfig[:pui_search_collection_from_collection_organization] = false
+
 # when a user is authenticated, add a link back to the staff interface from the specified record
 AppConfig[:pui_enable_staff_link] = true
 # by default, staff link will open record in staff interface in edit mode,

--- a/public/app/views/objects/show.html.erb
+++ b/public/app/views/objects/show.html.erb
@@ -30,6 +30,9 @@
           heading_text = t('cont_arr')
         end
       %>
+      <% if AppConfig[:pui_search_collection_from_archival_objects] %>
+        <%= render partial: 'shared/search_collection_form', :locals => {:resource_uri => @result.resource_uri, :action_text => "#{t('actions.search_in', :type => t('resource._singular'))}"} %>
+      <% end %>
       <%= render partial: 'shared/children_tree', :locals => {:heading_text => heading_text, :root_node_uri => @result.root_node_uri, :current_node_uri => @result.uri} %>
     </div>
    <% end %>

--- a/public/app/views/resources/infinite.html.erb
+++ b/public/app/views/resources/infinite.html.erb
@@ -33,7 +33,10 @@
   </div>
 
   <div id="sidebar" class="sidebar sidebar-container col-sm-3 resizable-sidebar infinite-tree-sidebar">
-    <div class="infinite-tree-view largetree-container" id='tree-container'></div>
+  <% if AppConfig[:pui_search_collection_from_collection_organization] %>
+    <%= render partial: 'shared/search_collection_form', :locals => {:resource_uri => @result['uri'], :action_text => t('actions.search_in', :type => t('resource._singular'))} %>
+  <% end %>
+  <div class="infinite-tree-view largetree-container" id='tree-container'></div>
   </div>
 </div>
 

--- a/public/app/views/resources/show.html.erb
+++ b/public/app/views/resources/show.html.erb
@@ -27,41 +27,9 @@
     <% if defined?(@filters) && defined?(@search) %>
     <%= render partial: 'shared/facets' %>
    <% end %>
-
-   <a name="search" title="<%= t('internal_links.search_collection') %>"></a>
-    <div class="search">
-
-	<%= form_tag(app_prefix("#{@result['uri']}/search"), method: 'get', :class=> "form-horizontal") do %>
-	<div class="form-group">
-	  <%= label_tag(:filter_q0,  "#{t('actions.search_in', :type=> t('resource._singular'))}", :class => 'sr-only') %>
-
-          <%= text_field_tag('filter_q[]', nil,:id => 'filter_q0', :placeholder =>  "#{t('actions.search_in', :type => t('resource._singular'))}", :class=> "form-control") %>
-	</div>
-
-	<div class="form-group">
-	  <%= hidden_field_tag('op[]','') %>
-	  <%= hidden_field_tag('field[]','') %>
-	  <%= hidden_field_tag('limit','') %>
-	  <%= hidden_field_tag('q[]','*') %>
-
-    <div class="col-md-6 year_from">
-  	   <%= label_tag(:from_year0, "#{t('search_results.filter.from_year')}", :class => 'sr-only') %>
-  	   <%= text_field_tag('from_year[]', nil, :id=>'from_year0', :size => 4,:maxlength => 4, :placeholder => t('search_results.filter.from_year'),
-              :class=>"form-control") %>
-    </div>
-
-    <div class="col-md-6 year_to">
-        <%= label_tag(:to_year0, "#{t('search_results.filter.to_year')}", :class=> 'sr-only') %>
-        <%= text_field_tag('to_year[]', nil, :size => 4, :maxlength => 4, :class=> "form-control", :id => 'to_year0',
-             :placeholder => t('search_results.filter.to_year')) %>
-    </div>
-	</div>
-        <%= submit_tag(t('search-button.label'), :class=>'btn btn-primary btn-sm') %>
-	<% end %>
-    </div>
-
-    <%= render partial: 'shared/children_tree', :locals => {:heading_text => t('cont_arr'), :root_node_uri => @result.uri, :current_node_uri => @result.uri} %>
-  </div>
+   <%= render partial: 'shared/search_collection_form', :locals => {:resource_uri => @result['uri'], :action_text => "#{t('actions.search_in', :type => t('resource._singular'))}"} %>
+   <%= render partial: 'shared/children_tree', :locals => {:heading_text => t('cont_arr'), :root_node_uri => @result.uri, :current_node_uri => @result.uri} %>
+ </div>
 </div>
 
 <%= render partial: 'shared/modal_actions' %>

--- a/public/app/views/shared/_search_collection_form.html.erb
+++ b/public/app/views/shared/_search_collection_form.html.erb
@@ -1,0 +1,35 @@
+<a name="search" title="<%= t('internal_links.search_collection') %>"></a>
+<div class="search">
+
+  <%= form_tag(app_prefix("#{resource_uri}/search"), method: 'get', :class=> "form-horizontal") do %>
+
+    <div class="form-group">
+      <%= label_tag(:filter_q0,  "#{t('actions.search_in', :type=> t('resource._singular'))}", :class => 'sr-only') %>
+      <%= text_field_tag('filter_q[]', nil,:id => 'filter_q0', :placeholder =>  "#{action_text}", :class=> "form-control") %>
+    </div>
+
+    <div class="form-group">
+      <%= hidden_field_tag('op[]','') %>
+      <%= hidden_field_tag('field[]','') %>
+      <%= hidden_field_tag('limit','') %>
+      <%= hidden_field_tag('q[]','*') %>
+
+      <div class="col-md-6 year_from">
+        <%= label_tag(:from_year0, "#{t('search_results.filter.from_year')}", :class => 'sr-only') %>
+        <%= text_field_tag('from_year[]', nil, :id=>'from_year0', :size => 4,:maxlength => 4, :placeholder => t('search_results.filter.from_year'),
+                           :class=>"form-control") %>
+      </div>
+
+      <div class="col-md-6 year_to">
+        <%= label_tag(:to_year0, "#{t('search_results.filter.to_year')}", :class=> 'sr-only') %>
+        <%= text_field_tag('to_year[]', nil, :size => 4, :maxlength => 4, :class=> "form-control", :id => 'to_year0',
+                           :placeholder => t('search_results.filter.to_year')) %>
+      </div>
+
+    </div>
+
+    <%= submit_tag(t('search-button.label'), :class=>'btn btn-primary btn-sm') %>
+
+  <% end %>
+
+</div>


### PR DESCRIPTION
## Description
It is a common customization to add the search-in-collection form to the sidebar on archival object pages. At the Bodleian we have [done it](https://archives.bodleian.ox.ac.uk/repositories/2/archival_objects/113), Yale [do it](https://archives.yale.edu/repositories/6/archival_objects/2621367), and Harvard [do it](https://hollisarchives.lib.harvard.edu/repositories/24/archival_objects/387951). But we've each had to implement it by overriding templates, which is a maintenance issue when it comes time to upgrade to a new ArchivesSpace release. This pull request makes it an option in the config file. And also to add the same form to the collection organization view (which we may be the only ones [to do](https://archives.bodleian.ox.ac.uk/repositories/2/resources/2157/collection_organization).)

The rationale was, for us, that people arriving at an archival object's page won't necessarily know that search-in-collection is available by going to the collection-level page. Especially if they've come from Google, which sometimes sends people to the wrong record (it indexes the tree so every archival object has the potential to match on keywords in the titles of all the others). And in collection organization it compensates for the web browser's search-in-page being broken in that view.

But the default is to only display the form on the collection-level page, as before, so if it was a design choice to not have it elsewhere then this merely makes it an option.

## Related JIRA Ticket or GitHub Issue
None

## How Has This Been Tested?
As described above, these changes have been made previous in a plug-in, and been in production for the last six months. I've applied the same code changes to a development system and tested manually. It passed automates tests with or without the options enabled.

## Screenshots (if appropriate):
![screenshot_search_form](https://user-images.githubusercontent.com/33721187/76321059-69c27b80-62d9-11ea-9d61-33df84256748.png)

![screenshot_search_form2](https://user-images.githubusercontent.com/33721187/76322639-8cee2a80-62db-11ea-86e4-71a7db27d190.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
