### PR TITLE
Improvements to Enumeration Model Migrate

### DIFF
--- a/backend/app/controllers/enumeration.rb
+++ b/backend/app/controllers/enumeration.rb
@@ -50,7 +50,8 @@ class ArchivesSpaceService < Sinatra::Base
     .params(["migration", JSONModel(:enumeration_migration), "The migration request", :body => true])
     .permissions([:update_enumeration_record])
     .returns([200, :updated],
-             [400, :error]) \
+             [400, :error],
+             [404, "Not found"]) \
   do
     enum_id = JSONModel(:enumeration).id_for(params[:migration].enum_uri)
     enum = Enumeration.get_or_die(enum_id)

--- a/backend/app/lib/exceptions.rb
+++ b/backend/app/lib/exceptions.rb
@@ -39,6 +39,8 @@ end
 class MergeRequestFailed < StandardError
 end
 
+class EnumerationMigrationFailed < StandardError
+end
 
 class BatchDeleteFailed < StandardError
   attr_accessor :errors
@@ -178,6 +180,11 @@ module Exceptions
         end
 
         error MergeRequestFailed do
+          Log.exception(request.env['sinatra.error'])
+          json_response({:error => request.env['sinatra.error']}, 400)
+        end
+
+        error EnumerationMigrationFailed do
           Log.exception(request.env['sinatra.error'])
           json_response({:error => request.env['sinatra.error']}, 400)
         end

--- a/backend/app/model/enumeration.rb
+++ b/backend/app/model/enumeration.rb
@@ -29,6 +29,11 @@ class Enumeration < Sequel::Model(:enumeration)
   # Find all database records that refer to the enumeration value identified by
   # 'source_id' and repoint them to 'destination_id'.
   def migrate(old_value, new_value)
+    is_editable = ( self.editable === 1 or self.editable == true )
+    if !is_editable
+      raise AccessDeniedException.new("Can't migrate values for non-editable enumeration #{self.id}")
+    end
+
     old_enum_value = self.enumeration_value.find {|val| val[:value] == old_value}
 
     if old_enum_value.readonly != 0

--- a/backend/app/model/enumeration.rb
+++ b/backend/app/model/enumeration.rb
@@ -36,6 +36,10 @@ class Enumeration < Sequel::Model(:enumeration)
 
     old_enum_value = self.enumeration_value.find {|val| val[:value] == old_value}
 
+    if old_enum_value.nil?
+      raise NotFoundException.new("Can't find a value '#{old_value}' in enumeration #{self.id}")
+    end
+
     if old_enum_value.readonly != 0
       raise EnumerationMigrationFailed.new("Can't transfer from a read-only enumeration value")
     end

--- a/backend/app/model/enumeration.rb
+++ b/backend/app/model/enumeration.rb
@@ -31,13 +31,13 @@ class Enumeration < Sequel::Model(:enumeration)
   def migrate(old_value, new_value)
     is_editable = ( self.editable === 1 or self.editable == true )
     if !is_editable
-      raise AccessDeniedException.new("Can't migrate values for non-editable enumeration #{self.id}")
+      raise EnumerationMigrationFailed.new("Can't migrate values for non-editable enumeration #{self.id}")
     end
 
     old_enum_value = self.enumeration_value.find {|val| val[:value] == old_value}
 
     if old_enum_value.readonly != 0
-      raise AccessDeniedException.new("Can't transfer from a read-only enumeration value")
+      raise EnumerationMigrationFailed.new("Can't transfer from a read-only enumeration value")
     end
 
     new_enum_value = self.enumeration_value.find {|val| val[:value] == new_value}


### PR DESCRIPTION
## Description

- Referenced the possibility of 404 in the `/config/enumerations/migration` endpoint
- Added an `EnumerationMigrationFailed` exception for getting error messages from failed enumeration migrations.
- Swapped the original `"Can't transfer from a read-only enumeration value"` error so it uses the new exception class, so users can see the reason for a failed migration instead of `"Access denied"`.
- Added an exception for cases where a request attempts to merge values in a not-editable enumeration.
- Added an exception for cases where `old_value` does not refer to an existing value.

## Related JIRA Ticket or GitHub Issue

#1167 

## How Has This Been Tested?

```python
import aspace
client = aspace.client.ASpaceClient(auto_auth=False)
client.authenticate()
### <Response [200]>

client.enumerations.get(2)['editable']
### False
client.enumerations.get(2)['values']
### ['outcome', 'source', 'transfer', 'context', 'requested']
client.enumerations.merge(2, 'outcome', 'transfer')
### {'error': "Can't migrate values for non-editable enumeration 2"}

client.enumerations.get(41)['editable']
### True
client.enumerations.get(41)['values']
### ['aiff', 'avi', 'gif', 'jpeg', 'mp3', 'pdf', 'tiff', 'txt']
client.enumerations.merge(41, 'not-aiff', 'gif')
### {'error': "Can't find a value 'not-aiff' in enumeration 41"}
client.enumerations.merge(41, 'aiff', 'not-gif')
### {'error': "Can't find a value 'not-gif' in enumeration 41"}

editable_enums_with_readonly_values = []
for e in client.enumerations.get_all():
    if e['editable'] and any(e['readonly_values']):
        editable_enums_with_readonly_values.append(e)

len(editable_enums_with_readonly_values)
### 3
editable_enums_with_readonly_values[0]['values']
### ['authorizer', 'executing_program', 'implementer', 'recipient', 'transmitter', 'validator', 'requester']
editable_enums_with_readonly_values[0]['readonly_values']
### ['requester']
client.enumerations.merge(editable_enums_with_readonly_values[0]['uri'], 'requester', 'validator')
### {'error': "Can't transfer from a read-only enumeration value"}
```

