### PR TITLE
Small refactor to relationships mixin; update subject merge test

### DIFF
--- a/backend/spec/controller_merge_request_spec.rb
+++ b/backend/spec/controller_merge_request_spec.rb
@@ -44,6 +44,8 @@ describe 'Merge request controller' do
 
       # Victim is gone
       expect(JSONModel(:"#{type}").find(parent.id).subjects.count).to eq(1)
+      # Target still there
+      expect(JSONModel(:"#{type}").find(parent.id).subjects).to include("ref" => target.uri)
     end
 
 


### PR DESCRIPTION
Small adjustments following 3/18 call:

- Add a `next if` to relationships mixin to remove one indent;
- Add check to confirm desired subject remains linked in the subject merge request spec.