### PR TITLE
Generalized table improvements to core

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/tables.less
+++ b/frontend/app/assets/stylesheets/archivesspace/tables.less
@@ -179,3 +179,9 @@ table.table-spreadsheet {
 .table > thead > tr > th {
     vertical-align: top;
 }
+
+/* Fields with linked records should not display markers if there's only one linked record */
+.linked-records-listing.count-1 {
+    list-style: none;
+    padding: 0;
+}

--- a/frontend/app/assets/stylesheets/archivesspace/top_containers_bulk.less
+++ b/frontend/app/assets/stylesheets/archivesspace/top_containers_bulk.less
@@ -42,11 +42,8 @@
     margin: 0;
     list-style-position: inside;
 }
-#bulk_operation_results .linked-records-listing.count-1,
-#bulkActionBarcodeRapidEntryModal .linked-records-listing.count-1 {
-    list-style: none;
-    padding: 0;
-}
+
+/* See .linked-records-listing.count-1 in tables.less for handling of linked records cells */
 
 .tablesorter-header-inner {
   padding: 0 !important;

--- a/frontend/app/controllers/search_controller.rb
+++ b/frontend/app/controllers/search_controller.rb
@@ -6,68 +6,6 @@ class SearchController < ApplicationController
   # as JSON or HTML fragments to be rendered into tables in the application,
   # either directly in templates, or as responses to ajax calls.
 
-
-  module Formatter
-    # Formatters are procs that take a fieldname, and return a proc usable as the
-    # value_block argument in SearchHelper::ExtraColumn#new
-    #
-    # Usage:
-    #       Formatter[formatter, field].call(field)
-    #
-    # FORMATTERS is customized to return a default formatter if passed a format it doesn't understand,
-    # which will produce the value as returned from the field without alteration.
-    #
-    # Because these formatters are referenced as methods, names must be valid ruby identifiers
-    class << self
-      def [](meth, field)
-        self.send(meth.to_sym, field)
-      end
-
-      def stringify(field)
-        proc {|record| record[field].to_s }
-      end
-
-      def linked_records_listing(field)
-        proc {|record|
-          identifiers = Array(record[field])
-          out_html = %Q|<ul class="linked-records-listing count-#{identifiers.length}">|
-          out_html << identifiers.map {|identifier|
-            %Q|<li><span class="collection-identifier">#{identifier}</span></li>|
-          }.join("")
-          out_html << '</ul>'
-
-          out_html.html_safe
-        }
-      end
-
-      def combined_identifier(field)
-        proc {|record|
-          identifiers = Array(record['collection_identifier_stored_u_sstr'])
-          displays = Array(record['collection_display_string_u_sstr'])
-          out_html = %Q|<ul class="linked-records-listing count-#{identifiers.length}">|
-          out_html << identifiers.zip(displays).map {|identifier, display|
-            %Q|<li><span class="collection-identifier">#{identifier}</span> <span class="collection-display-string">#{display}</span></li>|
-          }.join('')
-          out_html << '</ul>'
-
-          out_html.html_safe
-        }
-      end
-
-      # Default to stringify, alias method so successive lookups skip method_missing
-      def method_missing(meth, *args)
-        new_name = meth.to_sym
-
-        Rails.logger.warn("Defining default SearchController::Formatter #{new_name}, please define explicit formatter")
-        define_singleton_method(new_name) do |field|
-          stringify(field)
-        end
-        method(new_name).call(args.first)
-      end
-    end
-  end
-
-
   set_access_control  "view_repository" => [:do_search, :advanced_search]
 
   include ExportHelper
@@ -142,7 +80,7 @@ class SearchController < ApplicationController
       @search_data = Search.all(session[:repo_id], params_for_backend_search.merge({"facet[]" => SearchResultData.BASE_FACETS.concat(params[:facets]||[]).uniq}))
       if params[:extra_columns]
         @extra_columns = params[:extra_columns].map do |opts|
-          SearchHelper::ExtraColumn.new(I18n.t(opts['title'], default: opts['title']), Formatter[opts['formatter'], opts['field']], opts['sort_options'] || {}, @search_data)
+          SearchHelper::ExtraColumn.new(I18n.t(opts['title'], default: opts['title']), SearchHelper::Formatter[opts['formatter'], opts['field']], opts['sort_options'] || {}, @search_data)
         end
       end
       @display_identifier = params.fetch(:display_identifier, false) == 'true'

--- a/frontend/app/controllers/search_controller.rb
+++ b/frontend/app/controllers/search_controller.rb
@@ -19,7 +19,7 @@ class SearchController < ApplicationController
   FORMATTERS.merge!(
     {
       'stringify' => proc {|field| proc {|record| record[field].to_s } },
-      'accession/resource' => proc {|field|
+      'linked-records-listing' => proc {|field|
         proc {|record|
           identifiers = Array(record[field])
           out_html = %Q|<ul class="linked-records-listing count-#{identifiers.length}">|

--- a/frontend/app/controllers/search_controller.rb
+++ b/frontend/app/controllers/search_controller.rb
@@ -30,6 +30,19 @@ class SearchController < ApplicationController
 
           out_html.html_safe
         }
+      },
+      'combined-identifier' => proc {|field| # field is ignored, specialized formatter for combined record type
+        proc {|record|
+          identifiers = Array(record['collection_identifier_stored_u_sstr'])
+          displays = Array(record['collection_display_string_u_sstr'])
+          out_html = %Q|<ul class="linked-records-listing count-#{identifiers.length}">|
+          out_html << identifiers.zip(displays).map {|identifier, display|
+            %Q|<li><span class="collection-identifier">#{identifier}</span> <span class="collection-display-string">#{display}</span></li>|
+          }.join('')
+          out_html << '</ul>'
+
+          out_html.html_safe
+        }
       }
     }
   )

--- a/frontend/app/controllers/search_controller.rb
+++ b/frontend/app/controllers/search_controller.rb
@@ -1,9 +1,27 @@
 require 'advanced_query_builder'
 
 class SearchController < ApplicationController
+  # This class provides search functionality through the frontend.  Methods
+  # here generally perform a search against the backend, then render those search results
+  # as JSON or HTML fragments to be rendered into tables in the application,
+  # either directly in templates, or as responses to ajax calls.
+
+  # Formatters are procs that take a fieldname, and return a proc usable as the
+  # value_block argument in SearchHelper::ExtraColumn#new
+  #
+  # Usage:
+  #       FORMATTERS[formatter].call(field)
+  #
+  # FORMATTERS is customized to return a default formatter if passed a format it doesn't understand,
+  # which will produce the value as returned from the field without alteration.
+  FORMATTERS = Hash.new do |key| proc {|field| proc {|record| Rails.logger.debug('default formatter called');record[field] } } end
+
+  FORMATTERS.merge!({
+    'stringify' => proc {|field| proc {|record| record[field].to_s } }
+  })
 
   set_access_control  "view_repository" => [:do_search, :advanced_search]
-  
+
   include ExportHelper
 
   def advanced_search
@@ -37,24 +55,50 @@ class SearchController < ApplicationController
         @search_data = Search.all(session[:repo_id], criteria)
         render "search/do_search"
       }
-      format.csv { 
+      format.csv {
         uri = "/repositories/#{session[:repo_id]}/search"
         csv_response( uri, criteria )
-      }  
+      }
     end
   end
 
   def do_search
+    # Execute a backend search, rendering results as JSON/HTML fragment/HTML/CSS
+    #
+    # In addition to params handled by ApplicationController#params_for_backend_search, takes:
+    #   :extra_columns - hash with keys 'title', 'field', sort_options (hash with keys 'sortable', 'sort_by')
+    #   :display_identifier - whether to display the identifier column
+    #
+    # For example to add uri to the data-browse field of an AJAX-backed table:
+    #
+    #    data-browse-url="<%= url_for :controller => :search, :action => :do_search,
+    #                                 :extra_columns => [{
+    #                                    'title' => 'uri',
+    #                                    'formatter' =>'stringify',
+    #                                    'field'=> 'uri',
+    #                                    'sort_options' => {'sortable' => true, 'sort_by' => 'uri'}
+    #                                  }],
+    #                                  :format => :json, :facets => [], :sort => "title_sort asc" %>"
+    #
+    # The date-browse-url field would be identical, but with :format => :js
+    #
+    # Note: you will need to add an entry to frontend/config/locales under the search_sorting key for the title of any column you add
+
+    unless request.format.css?
+      @search_data = Search.all(session[:repo_id], params_for_backend_search.merge({"facet[]" => SearchResultData.BASE_FACETS.concat(params[:facets]||[]).uniq}))
+      if params[:extra_columns]
+        @extra_columns = params[:extra_columns].map do |opts|
+          SearchHelper::ExtraColumn.new(opts['title'], FORMATTERS[opts['formatter']].call(opts['field']), opts['sort_options'] || {}, @search_data)
+        end
+      end
+      @display_identifier = params[:display_identifier] ? params[:display_identifier] : false
+    end
 
     respond_to do |format|
       format.json {
-        @search_data = Search.all(session[:repo_id], params_for_backend_search.merge({"facet[]" => SearchResultData.BASE_FACETS.concat(params[:facets]||[]).uniq}))
-        @display_identifier = params[:display_identifier] ? params[:display_identifier] : false
         render :json => @search_data
       }
       format.js {
-        @search_data = Search.all(session[:repo_id], params_for_backend_search.merge({"facet[]" => SearchResultData.BASE_FACETS.concat(params[:facets]||[]).uniq}))
-        @display_identifier = params[:display_identifier] ? params[:display_identifier] : false
         if params[:listing_only]
           render_aspace_partial :partial => "search/listing"
         else
@@ -62,15 +106,15 @@ class SearchController < ApplicationController
         end
       }
       format.html {
-        @search_data = Search.all(session[:repo_id], params_for_backend_search.merge({"facet[]" => SearchResultData.BASE_FACETS.concat(params[:facets]||[]).uniq}))
-        @display_identifier = params[:display_identifier] ? params[:display_identifier] : false
+        # default render
       }
-      format.csv { 
+      format.csv {
         criteria = params_for_backend_search.merge({"facet[]" => SearchResultData.BASE_FACETS})
         uri = "/repositories/#{session[:repo_id]}/search"
         csv_response( uri, criteria )
-      }  
+      }
     end
   end
+
 
 end

--- a/frontend/app/controllers/search_controller.rb
+++ b/frontend/app/controllers/search_controller.rb
@@ -91,7 +91,9 @@ class SearchController < ApplicationController
           SearchHelper::ExtraColumn.new(opts['title'], FORMATTERS[opts['formatter']].call(opts['field']), opts['sort_options'] || {}, @search_data)
         end
       end
-      @display_identifier = params[:display_identifier] ? params[:display_identifier] : false
+      @display_identifier = params.fetch(:display_identifier, false)
+      @hide_audit_info = params.fetch(:hide_audit_info, false)
+      @display_context = params.fetch(:show_context_column, false)
     end
 
     respond_to do |format|

--- a/frontend/app/controllers/search_controller.rb
+++ b/frontend/app/controllers/search_controller.rb
@@ -111,9 +111,9 @@ class SearchController < ApplicationController
           SearchHelper::ExtraColumn.new(I18n.t(opts['title'], default: opts['title']), FORMATTERS[opts['formatter']].call(opts['field']), opts['sort_options'] || {}, @search_data)
         end
       end
-      @display_identifier = params.fetch(:display_identifier, false)
-      @hide_audit_info = params.fetch(:hide_audit_info, false)
-      @display_context = params.fetch(:show_context_column, false)
+      @display_identifier = params.fetch(:display_identifier, false) == 'true'
+      @hide_audit_info = params.fetch(:hide_audit_info, false) == 'true'
+      @display_context = params.fetch(:show_context_column, false) == 'true'
     end
 
     respond_to do |format|

--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -286,4 +286,54 @@ module SearchHelper
     end
 
   end
+
+  module Formatter
+    # Formatters are procs that take a fieldname, and return a proc usable as the
+    # value_block argument in SearchHelper::ExtraColumn#new
+    #
+    # Usage:
+    #       Formatter[formatter, field].call(field)
+    #
+    # FORMATTERS is customized to return a default formatter if passed a format it doesn't understand,
+    # which will produce the value as returned from the field without alteration.
+    #
+    # Because these formatters are referenced as methods, names must be valid ruby identifiers
+    class << self
+      def [](meth, field)
+        self.send(meth.to_sym, field)
+      end
+
+      def stringify(field)
+        proc {|record| record[field].to_s }
+      end
+
+      def linked_records_listing(field)
+        proc {|record|
+          identifiers = Array(record[field])
+          out_html = %Q|<ul class="linked-records-listing count-#{identifiers.length}">|
+          out_html << identifiers.map {|identifier|
+            %Q|<li><span class="collection-identifier">#{identifier}</span></li>|
+          }.join("")
+          out_html << '</ul>'
+
+          out_html.html_safe
+        }
+      end
+
+      def combined_identifier(field)
+        proc {|record|
+          identifiers = Array(record['collection_identifier_stored_u_sstr'])
+          displays = Array(record['collection_display_string_u_sstr'])
+          out_html = %Q|<ul class="linked-records-listing count-#{identifiers.length}">|
+          out_html << identifiers.zip(displays).map {|identifier, display|
+            %Q|<li><span class="collection-identifier">#{identifier}</span> <span class="collection-display-string">#{display}</span></li>|
+          }.join('')
+          out_html << '</ul>'
+
+          out_html.html_safe
+        }
+      end
+    end
+  end
+
 end

--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -27,9 +27,10 @@ module SearchHelper
 
     search_params["multiplicity"] = params["multiplicity"] if params["multiplicity"]
     search_params["display_identifier"] = true if params[:display_identifier] || show_identifier_column?
-    search_params["hide_audit_info"] = hide_audit_info?
+    search_params["hide_audit_info"] = opts["hide_audit_info"] ? opts["hide_audit_info"] : hide_audit_info?
     search_params["extra_columns"] = params["extra_columns"] if params["extra_columns"]
-    search_params["show_context_column"] = show_context_column?
+    search_params["extra_columns"].concat(opts["extra_columns"]) if opts["extra_columns"]
+    search_params["show_context_column"] = opts["show_context_column"] ? opts["show_context_column"] : show_context_column?
 
     sort = (opts["sort"] || params["sort"])
 

--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -25,15 +25,11 @@ module SearchHelper
     search_params["filter_term"].concat(Array(opts["add_filter_term"])) if opts["add_filter_term"]
     search_params["filter_term"] = search_params["filter_term"].reject{|f| Array(opts["remove_filter_term"]).include?(f)} if opts["remove_filter_term"]
 
-    if params["multiplicity"]
-      search_params["multiplicity"] = params["multiplicity"]
-    end
+    search_params["multiplicity"] = params["multiplicity"] if params["multiplicity"]
+    search_params["display_identifier"] = true if show_identifier_column?
+    search_params["extra_columns"] = params["extra_columns"] if params["extra_columns"]
 
     sort = (opts["sort"] || params["sort"])
-
-    if show_identifier_column?
-      search_params["display_identifier"] = true
-    end
 
     # if the browse list was sorted by default
     if sort.nil? && !@search_data.nil? && @search_data.sorted?

--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -29,7 +29,7 @@ module SearchHelper
     search_params["display_identifier"] = true if params[:display_identifier] || show_identifier_column?
     search_params["hide_audit_info"] = hide_audit_info?
     search_params["extra_columns"] = params["extra_columns"] if params["extra_columns"]
-    search_params["show_context_column"] = params["show_context_column"] if params["show_context_column"]
+    search_params["show_context_column"] = show_context_column?
 
     sort = (opts["sort"] || params["sort"])
 

--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -26,8 +26,10 @@ module SearchHelper
     search_params["filter_term"] = search_params["filter_term"].reject{|f| Array(opts["remove_filter_term"]).include?(f)} if opts["remove_filter_term"]
 
     search_params["multiplicity"] = params["multiplicity"] if params["multiplicity"]
-    search_params["display_identifier"] = true if show_identifier_column?
+    search_params["display_identifier"] = true if params[:display_identifier] || show_identifier_column?
+    search_params["hide_audit_info"] = hide_audit_info?
     search_params["extra_columns"] = params["extra_columns"] if params["extra_columns"]
+    search_params["show_context_column"] = params["show_context_column"] if params["show_context_column"]
 
     sort = (opts["sort"] || params["sort"])
 
@@ -97,6 +99,9 @@ module SearchHelper
     @display_context
   end
 
+  def hide_audit_info?
+    @hide_audit_info
+  end
 
   def context_column_header_label
     @context_column_header or I18n.t("search_results.context")
@@ -237,6 +242,9 @@ module SearchHelper
     !@extra_columns.empty?
   end
 
+  def has_identifier? type
+    IDENTIFIER_FOR_SEARCH_RESULT_LOOKUP.key? type
+  end
 
   class ExtraColumn
 

--- a/frontend/app/models/search.rb
+++ b/frontend/app/models/search.rb
@@ -15,8 +15,6 @@ class Search
 
     criteria["page"] = 1 if not criteria.has_key?("page")
 
-    search_data = JSONModel::HTTP::get_json("/repositories/#{repo_id}/search", criteria)
-
     #If the criteria contains a 'blank_facet_query_fields' field,
     #we want to add a facet to filter on items WITHOUT an entry in the facet
     if (criteria.has_key?("blank_facet_query_fields"))
@@ -42,6 +40,7 @@ class Search
 
     end
 
+    search_data = JSONModel::HTTP::get_json("/repositories/#{repo_id}/search", criteria)
     search_data[:criteria] = criteria
 
     SearchResultData.new(search_data)

--- a/frontend/app/models/search.rb
+++ b/frontend/app/models/search.rb
@@ -16,6 +16,32 @@ class Search
     criteria["page"] = 1 if not criteria.has_key?("page")
 
     search_data = JSONModel::HTTP::get_json("/repositories/#{repo_id}/search", criteria)
+
+    #If the criteria contains a 'blank_facet_query_fields' field,
+    #we want to add a facet to filter on items WITHOUT an entry in the facet
+    if (criteria.has_key?("blank_facet_query_fields"))
+      blank_facet_query = ""
+      delimiter = ""
+      criteria["blank_facet_query_fields"].each {|query_field|
+        blank_facet_query = "-" + query_field + ":*"
+        sub_criteria = criteria.clone
+        if (sub_criteria.has_key?("q"))
+          sub_criteria["q"] = criteria["q"] + " AND " + blank_facet_query
+        else
+          sub_criteria["q"] = blank_facet_query
+        end
+
+        search_data_with_blank_facet = JSONModel::HTTP::get_json("/repositories/#{repo_id}/search", sub_criteria)
+        if (!search_data["facets"]["facet_fields"].has_key?(query_field))
+          search_data["facets"]["facet_fields"][query_field] = ["none", search_data_with_blank_facet["total_hits"]]
+        else
+          search_data["facets"]["facet_fields"][query_field] << "none"
+          search_data["facets"]["facet_fields"][query_field] << search_data_with_blank_facet["total_hits"]
+        end
+      }
+
+    end
+
     search_data[:criteria] = criteria
 
     SearchResultData.new(search_data)

--- a/frontend/app/views/agents/show.html.erb
+++ b/frontend/app/views/agents/show.html.erb
@@ -112,7 +112,10 @@
 
         <%= render_aspace_partial :partial => "search/embedded", :locals => {:filter_term => {"rights_statement_agent_uris" => @agent.uri}.to_json, :heading_text => I18n.t("agent._frontend.section.linked_via_rights_statement")} %>
 
-        <%= render_aspace_partial :partial => "search/embedded", :locals => { :extra_columns => [ "event_type"], :record => @agent, :filter_term => {"linked_record_uris" => @agent.uri}.to_json, :heading_text => I18n.t("event._plural")} %>
+        <%= render_aspace_partial :partial => "search/embedded", :locals => { 
+              :extra_columns => [ { "title" => "event.event_type", "field" => "title", "formatter" => "stringify", "sort_options" => { "sortable" => true, "sort_by" => "title" } }], 
+              :record => @agent, 
+              :filter_term => {"linked_record_uris" => @agent.uri}.to_json, :heading_text => I18n.t("event._plural")} %>
 
         <%= render_aspace_partial :partial => "assessments/embedded", :locals => { :record => @agent, :filter_term => {"assessment_surveyor_uris" => @agent.uri}.to_json, :heading_text => I18n.t("assessment._frontend.linked_records.linked_via_assessment_surveyed_by"), :section_id => 'linked_assessments_surveyed_by'} %>
 

--- a/frontend/app/views/locations/show.html.erb
+++ b/frontend/app/views/locations/show.html.erb
@@ -56,20 +56,14 @@
         :filter_term => {"location_uris" => @location.uri}.to_json,
         :heading_text => I18n.t("location._frontend.section.search_embedded"),
         :type => "top_container",
-        :show_context_column => true,
         :extra_columns => [
           {
             'title' => 'top_container._frontend.bulk_operations.collection_singular',
-            'field' => 'collection_identifier_stored_u_sstr',
+            'field' => 'collection_display_string_u_sstr',
             'formatter' => 'linked-records-listing',
-          },
-          {
-            'title' => 'top_container.barcode',
-            'field' => 'barcode_u_ssort',
-            'formatter' => 'stringify',
             'sort_options' => {
               'sortable' => true,
-              'sort_by' => 'barcode_u_ssort',
+              'sort_by' => 'collection_display_string_stored_u_ssort'
             }
           },
           {
@@ -79,6 +73,24 @@
             'sort_options' => {
               'sortable' => true,
               'sort_by' => 'type_u_ssort'
+            }
+          },
+          {
+            'title' => 'top_container.indicator',
+            'field' => 'indicator_stored_u_ssort',
+            'formatter' => 'stringify',
+            'sort_options' => {
+              'sortable' => true,
+              'sort_by' => 'indicator_stored_u_ssort'
+            }
+          },
+          {
+            'title' => 'top_container.barcode',
+            'field' => 'barcode_u_ssort',
+            'formatter' => 'stringify',
+            'sort_options' => {
+              'sortable' => true,
+              'sort_by' => 'barcode_u_ssort',
             }
           }
         ],

--- a/frontend/app/views/locations/show.html.erb
+++ b/frontend/app/views/locations/show.html.erb
@@ -58,14 +58,30 @@
         :type => "top_container",
         :show_context_column => true,
         :extra_columns => [
-          {'title' => 'top_container._frontend.bulk_operations.collection_singular',
-           'field' => 'collection_identifier_stored_u_sstr',
-           'formatter' => 'accession/resource',
-           'sort_options' => {
-             'sortable' => true,
-             'sort_by' => 'collection_identifier_stored_u_typeahead_usort'
-           }
-        }],
+          {
+            'title' => 'top_container._frontend.bulk_operations.collection_singular',
+            'field' => 'collection_identifier_stored_u_sstr',
+            'formatter' => 'linked-records-listing',
+            'sort_options' => {
+              'sortable' => true,
+              'sort_by' => 'collection_identifier_stored_u_typeahead_usort'
+            }
+          },
+          {
+            'title' => 'top_container.barcode',
+            'field' => 'barcode_u_sstr',
+            'formatter' => 'linked-records-listing',
+            'sort_options' => {
+            }
+          },
+          {
+            'title' => 'top_container.type',
+            'field' => 'type_enum_s',
+            'formatter' => 'linked-records-listing',
+            'sort_options' => {
+            }
+          }
+        ],
         :sort => 'title_sort asc'
       } %>
 

--- a/frontend/app/views/locations/show.html.erb
+++ b/frontend/app/views/locations/show.html.erb
@@ -62,23 +62,23 @@
             'title' => 'top_container._frontend.bulk_operations.collection_singular',
             'field' => 'collection_identifier_stored_u_sstr',
             'formatter' => 'linked-records-listing',
-            'sort_options' => {
-              'sortable' => true,
-              'sort_by' => 'collection_identifier_stored_u_typeahead_usort'
-            }
           },
           {
             'title' => 'top_container.barcode',
-            'field' => 'barcode_u_sstr',
-            'formatter' => 'linked-records-listing',
+            'field' => 'barcode_u_ssort',
+            'formatter' => 'stringify',
             'sort_options' => {
+              'sortable' => true,
+              'sort_by' => 'barcode_u_ssort',
             }
           },
           {
             'title' => 'top_container.type',
-            'field' => 'type_enum_s',
-            'formatter' => 'linked-records-listing',
+            'field' => 'type_u_ssort',
+            'formatter' => 'stringify',
             'sort_options' => {
+              'sortable' => true,
+              'sort_by' => 'type_u_ssort'
             }
           }
         ],

--- a/frontend/app/views/locations/show.html.erb
+++ b/frontend/app/views/locations/show.html.erb
@@ -60,7 +60,7 @@
           {
             'title' => 'top_container._frontend.bulk_operations.collection_singular',
             'field' => 'collection_display_string_u_sstr',
-            'formatter' => 'linked-records-listing',
+            'formatter' => 'linked_records_listing',
             'sort_options' => {
               'sortable' => true,
               'sort_by' => 'collection_display_string_stored_u_ssort'

--- a/frontend/app/views/locations/show.html.erb
+++ b/frontend/app/views/locations/show.html.erb
@@ -51,7 +51,7 @@
         <%= render_aspace_partial :partial => "location_functions/show", :locals => { :functions => @location.functions, :section_id => "location_functions_" } %>
       <% end %>
 
-      <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @location, :filter_term => {"location_uris" => @location.uri}.to_json, :heading_text => I18n.t("location._frontend.section.search_embedded")} %>
+      <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @location, :filter_term => {"location_uris" => @location.uri}.to_json, :heading_text => I18n.t("location._frontend.section.search_embedded"), :type => "top_container", :hide_audit_info => true, :show_context_column => true} %>
 
       <%= readonly_context :location, @location do |readonly| %>
         <%= show_plugins_for(@location, readonly) %>

--- a/frontend/app/views/locations/show.html.erb
+++ b/frontend/app/views/locations/show.html.erb
@@ -35,9 +35,9 @@
             <div class="control-label col-sm-2"><%= I18n.t("location.owner_repo") %></div>
             <div class="label-only col-sm-8">
               <%= render_token :object => @location["owner_repo"]["_resolved"],
-                               :label => @location["owner_repo"]["_resolved"]["display_string"],
-                               :type => "repository",
-                               :uri => @location["owner_repo"]["ref"] %>
+               :label => @location["owner_repo"]["_resolved"]["display_string"],
+               :type => "repository",
+               :uri => @location["owner_repo"]["ref"] %>
             </div>
           </div>
         </div>
@@ -51,7 +51,23 @@
         <%= render_aspace_partial :partial => "location_functions/show", :locals => { :functions => @location.functions, :section_id => "location_functions_" } %>
       <% end %>
 
-      <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @location, :filter_term => {"location_uris" => @location.uri}.to_json, :heading_text => I18n.t("location._frontend.section.search_embedded"), :type => "top_container", :hide_audit_info => true, :show_context_column => true} %>
+      <%= render_aspace_partial :partial => "search/embedded", :locals => {
+        :record => @location,
+        :filter_term => {"location_uris" => @location.uri}.to_json,
+        :heading_text => I18n.t("location._frontend.section.search_embedded"),
+        :type => "top_container",
+        :show_context_column => true,
+        :extra_columns => [
+          {'title' => 'top_container._frontend.bulk_operations.collection_singular',
+           'field' => 'collection_identifier_stored_u_sstr',
+           'formatter' => 'accession/resource',
+           'sort_options' => {
+             'sortable' => true,
+             'sort_by' => 'collection_identifier_stored_u_typeahead_usort'
+           }
+        }],
+        :sort => 'title_sort asc'
+      } %>
 
       <%= readonly_context :location, @location do |readonly| %>
         <%= show_plugins_for(@location, readonly) %>

--- a/frontend/app/views/search/_embedded.html.erb
+++ b/frontend/app/views/search/_embedded.html.erb
@@ -1,8 +1,17 @@
 <%
-  ajax_search_url = url_for({:controller => :search, :action => :do_search, :format => :js, :listing_only => true}.merge(build_search_params({"add_filter_term" => filter_term})))
-  html_search_url = url_for({:controller => :search, :action => :do_search}.merge(build_search_params({"add_filter_term" => filter_term})))
+base_opts = {:controller => :search, :action => :do_search}.merge(build_search_params({"add_filter_term" => filter_term}))
 
-  heading_text = "Linked Records" if heading_text.blank?
+base_opts[:hide_audit_info] = hide_audit_info if defined? hide_audit_info
+base_opts[:type] = type if defined? type
+base_opts[:extra_columns] = extra_columns if defined? extra_columns
+base_opts[:display_identifier] = display_identifier if defined? display_identifier
+
+ajax_opts = base_opts.merge({:format => :js, :listing_only => true})
+
+ajax_search_url = url_for(ajax_opts)
+html_search_url = url_for(base_opts)
+
+heading_text = "Linked Records" if heading_text.blank?
 %>
 
 <section id="search_embedded" class="subrecord-form-dummy">

--- a/frontend/app/views/search/_embedded.html.erb
+++ b/frontend/app/views/search/_embedded.html.erb
@@ -1,3 +1,20 @@
+<%#
+This is an version of the search results table for embedding an ajax-loaded table of search results.
+It corresponds to the non-ajax table produced by search/result
+partial (app/views/search/_result.html.erb).
+
+Values passed into the locals here are then passed into search as parameters, and get turned into
+the controller instance variables that control the output of 'search/_listing.html.erb'
+
+locals:
+  filter_term,
+  hide_audit_info,
+  type,
+  extra_columns,
+  display_identifier,
+  show_context_column
+
+%>
 <%
 base_opts = {:controller => :search, :action => :do_search}.merge(build_search_params({"add_filter_term" => filter_term}))
 
@@ -6,6 +23,7 @@ base_opts[:type] = type if defined? type
 base_opts[:extra_columns] = extra_columns if defined? extra_columns
 base_opts[:display_identifier] = display_identifier if defined? display_identifier
 base_opts[:show_context_column] = show_context_column if defined? show_context_column
+
 ajax_opts = base_opts.merge({:format => :js, :listing_only => true})
 
 ajax_search_url = url_for(ajax_opts)

--- a/frontend/app/views/search/_embedded.html.erb
+++ b/frontend/app/views/search/_embedded.html.erb
@@ -5,7 +5,7 @@ base_opts[:hide_audit_info] = hide_audit_info if defined? hide_audit_info
 base_opts[:type] = type if defined? type
 base_opts[:extra_columns] = extra_columns if defined? extra_columns
 base_opts[:display_identifier] = display_identifier if defined? display_identifier
-
+base_opts[:show_context_column] = show_context_column if defined? show_context_column
 ajax_opts = base_opts.merge({:format => :js, :listing_only => true})
 
 ajax_search_url = url_for(ajax_opts)

--- a/frontend/app/views/search/_listing.html.erb
+++ b/frontend/app/views/search/_listing.html.erb
@@ -26,7 +26,8 @@
           <%= context_column_header_label %>
         </th>
       <% end %>
-      <% if request.path =~ /\/(advanced_)*search/ %>
+
+      <% if (request.path =~ /\/(advanced_)?search/ && !(@search_data.single_type? && !has_identifier?(@search_data[:criteria]['type[]'].first))) %>
         <th class="col identifier sortable <% if @search_data.sorted_by === "identifier"%>sort-<%= @search_data.current_sort_direction %><% end %>">
           <%= link_to I18n.t("search_results.result_identifier"), build_search_params("sort" => @search_data.sort_filter_for("identifier")) %>
         </th>
@@ -42,7 +43,9 @@
           </th>
         <% end %>
       <% end %>
-      <th class="col audit-info"><span class="sr-only">Audit information</span></th>
+      <% unless hide_audit_info? %>
+        <th class="col audit-info"><span class="sr-only">Audit information</span></th>
+      <% end %>
       <% if !params[:linker] || params[:linker] === 'false' %>
         <th class="col actions"><span class="sr-only"><%= I18n.t("search_results.actions") %></span><!-- actions --></th>
       <% end %>
@@ -90,7 +93,7 @@
             <%= render_aspace_partial :partial => "search/context", :locals => {:result => result} %>
           </td>
         <% end %>
-        <% if request.path =~ /\/(advanced_)*search/ %>
+        <% if request.path =~ /\/(advanced_)*search/ && !(@search_data.single_type? && !has_identifier?(@search_data[:criteria]['type[]'].first)) %>
           <td>
             <%= identifier_for_search_result(result) %>
           </td>
@@ -100,9 +103,11 @@
             <td><%= col.value_for(result) %></td>
           <% end %>
         <% end %>
+        <% unless hide_audit_info? %>
         <td>
           <%= display_audit_info(result, :format => 'compact') %>
         </td>
+        <% end %>
         <% if !params[:linker] || params[:linker] === 'false' %>
           <td class="table-record-actions">
             <% if not deleted %>

--- a/frontend/app/views/search/_results.html.erb
+++ b/frontend/app/views/search/_results.html.erb
@@ -1,3 +1,12 @@
+<%#
+Partial for rendering tables of search results direct to the browser (for ajax-loaded tables,
+see app/views/search/_embedded.html.erb).
+
+Expects to be rendered from a controller that sets an instance variable @search_data, and aspects
+of the display are controlled by other instance variables, most of which are accessed through helper
+methods in the SearchHelper class.
+
+%>
 <%
   title = I18n.t("search_results.title") if title.nil?
   @display_context = true

--- a/frontend/app/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_results.html.erb
@@ -55,7 +55,7 @@
           <% if doc['collection_identifier_stored_u_sstr'] %>
             <ul class="linked-records-listing count-<%= Array(doc['collection_identifier_stored_u_sstr']).length %>">
               <% Array(doc['collection_identifier_stored_u_sstr']).zip(Array(doc['collection_display_string_u_sstr'])).each do |identifier, display| %>
-                <li><span class="collection-identifier"><%= identifier %></span>, <span class="collection-display-string"><%= display %></span</li>
+                <li><span class="collection-identifier"><%= identifier %></span> <span class="collection-display-string"><%= display %></span></li>
               <% end %>
             </ul>
           <% end %>
@@ -81,7 +81,6 @@
         <% else %>
           <td><%= container_json['exported_to_ils'] %></td>
         <% end %>
-
         <% if show_edit_actions %>
         <td>
           <div class="btn-group pull-right">

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -255,6 +255,10 @@ en:
     assessment_survey_begin: Survey Begin Date
     assessment_survey_end: Survey Completed Date
     assessment_id: ID
+    barcode_u_ssort: 'Barcode'
+    type_u_ssort: 'Container Type'
+    indicator_stored_u_ssort: 'Indicator'
+    collection_display_string_stored_u_ssort: 'Resource/Accession'
 
   advanced_search:
     operator:
@@ -356,7 +360,7 @@ en:
     heading: Welcome to ArchivesSpace
     message: Your friendly archives management tool.
     message_logged_in: Your friendly archives management tool.
-  
+
   login:
     login: Sign In
     login_please: Please Sign In

--- a/frontend/spec/controllers/search_controller_spec.rb
+++ b/frontend/spec/controllers/search_controller_spec.rb
@@ -61,7 +61,7 @@ HTML
 
   it "formats 'combined_identifier' extra columns in records correctly" do
     expect(SearchController::Formatter['combined_identifier', 'field_not_actually_used'].call(record)).to eq(<<-HTML.chomp)
-<ul class="linked-records-listing count-3"><li><span class="collection-identifier">COLL 1</span> <span class="collection-display-string">Good Papers</span></li><li><span class="collection-identifier">COLL 2</span> <span class="collection-display-string"> Bad Papers</span></li><li><span class="collection-identifier">COLL 3</span> <span class="collection-display-string"> Indifferent Papers</span></li></ul>
+<ul class="linked-records-listing count-3"><li><span class="collection-identifier">COLL 1</span> <span class="collection-display-string">Good Papers</span></li><li><span class="collection-identifier">COLL 2</span> <span class="collection-display-string">Bad Papers</span></li><li><span class="collection-identifier">COLL 3</span> <span class="collection-display-string">Indifferent Papers</span></li></ul>
 HTML
   end
 

--- a/frontend/spec/controllers/search_controller_spec.rb
+++ b/frontend/spec/controllers/search_controller_spec.rb
@@ -35,7 +35,7 @@ describe SearchController, type: :controller do
   end
 
   it 'returns search results with extra columns correctly' do
-    expect (
+    expect(
       get(:do_search, {'extra_columns': [{'title' => 'uri', 'field' => 'uri', 'formatter' => 'stringify', 'sort_options' => {'sortable' => true, 'sort_by' => 'uri'}}]})
     ).to have_http_status(200)
   end
@@ -50,17 +50,17 @@ describe SearchController, type: :controller do
   end
 
   it "formats 'stringify' extra columns in records correctly" do
-    expect(SearchController::Formatter['stringify', 'type_u_ssort'].call(record)).to equal('Box')
+    expect(SearchController::Formatter['stringify', 'type_u_ssort'].call(record)).to eq('Box')
   end
 
   it "formats 'linked_records_listing' extra columns in records correctly" do
-    expect(SearchController::Formatter['linked_records_listing', 'collection_display_string_stored_u_ssort'].call(record)).to equal(<<-HTML)
+    expect(SearchController::Formatter['linked_records_listing', 'collection_display_string_stored_u_ssort'].call(record)).to eq(<<-HTML)
 <ul class="linked-records-listing count-3"><li><span class="collection-identifier">COLL 1</span></li><li><span class="collection-identifier">COLL 2</span></li><li><span class="collection-identifier">COLL 3</span></li></ul>
 HTML
   end
 
   it "formats 'combined_identifier' extra columns in records correctly" do
-    expect(SearchController::Formatter['combined_identifier', 'field_not_actually_used'].call(record)).to equal(<<-HTML)
+    expect(SearchController::Formatter['combined_identifier', 'field_not_actually_used'].call(record)).to eq(<<-HTML)
 <ul class="linked-records-listing count-3"><li><span class="collection-identifier">COLL 1 Good Papers</span></li><li><span class="collection-identifier">COLL 2 Bad Papers</span></li><li><span class="collection-identifier">COLL 3 Indifferent Papers</span></li></ul>
 HTML
   end

--- a/frontend/spec/controllers/search_controller_spec.rb
+++ b/frontend/spec/controllers/search_controller_spec.rb
@@ -54,7 +54,7 @@ describe SearchController, type: :controller do
   end
 
   it "formats 'linked_records_listing' extra columns in records correctly" do
-    expect(SearchController::Formatter['linked_records_listing', 'collection_display_string_stored_u_ssort'].call(record)).to eq(<<-HTML)
+    expect(SearchController::Formatter['linked_records_listing', 'collection_display_string_u_sstr'].call(record)).to eq(<<-HTML)
 <ul class="linked-records-listing count-3"><li><span class="collection-identifier">Good Papers</span></li><li><span class="collection-identifier">Bad Papers</span></li><li><span class="collection-identifier">Indifferent Papers</span></li></ul>
 HTML
   end

--- a/frontend/spec/controllers/search_controller_spec.rb
+++ b/frontend/spec/controllers/search_controller_spec.rb
@@ -43,7 +43,7 @@ describe SearchController, type: :controller do
   let(:record) do
     {
       'collection_display_string_stored_u_ssort' => 'Good Papers,Bad Papers,Indifferent papers',
-      'collection_display_string_u_sstr' => ['Good Papers', 'Bad Papers, Indifferent Papers'],
+      'collection_display_string_u_sstr' => ['Good Papers', 'Bad Papers', 'Indifferent Papers'],
       'collection_identifier_stored_u_sstr' => ['COLL 1', 'COLL 2', 'COLL 3'],
       'type_u_ssort' => 'Box'
     }

--- a/frontend/spec/controllers/search_controller_spec.rb
+++ b/frontend/spec/controllers/search_controller_spec.rb
@@ -35,9 +35,9 @@ describe SearchController, type: :controller do
   end
 
   it 'returns search results with extra columns correctly' do
-    expect {
+    expect (
       get :do_search, {'extra_columns': [{'title' => 'uri', 'field' => 'uri', 'formatter' => 'stringify', 'sort_options' => {'sortable' => true, 'sort_by' => 'uri'}}]}
-    }.to have_http_status(200)
+    ).to have_http_status(200)
   end
 
   let(:record) do
@@ -50,17 +50,17 @@ describe SearchController, type: :controller do
   end
 
   it "formats 'stringify' extra columns in records correctly" do
-    expect { SearchController::Formatter['stringify', 'type_u_ssort'].call(record) }.to equal('Box')
+    expect(SearchController::Formatter['stringify', 'type_u_ssort'].call(record)).to equal('Box')
   end
 
   it "formats 'linked_records_listing' extra columns in records correctly" do
-    expect { SearchController::Formatter['linked_records_listing', 'collection_display_string_stored_u_ssort'].call(record) }.to equal(<<-HTML)
+    expect(SearchController::Formatter['linked_records_listing', 'collection_display_string_stored_u_ssort'].call(record)).to equal(<<-HTML)
 <ul class="linked-records-listing count-3"><li><span class="collection-identifier">COLL 1</span></li><li><span class="collection-identifier">COLL 2</span></li><li><span class="collection-identifier">COLL 3</span></li></ul>
 HTML
   end
 
   it "formats 'combined_identifier' extra columns in records correctly" do
-    expect { SearchController::Formatter['combined_identifier', 'field_not_actually_used'].call(record) }.to equal(<<-HTML)
+    expect(SearchController::Formatter['combined_identifier', 'field_not_actually_used'].call(record)).to equal(<<-HTML)
 <ul class="linked-records-listing count-3"><li><span class="collection-identifier">COLL 1 Good Papers</span></li><li><span class="collection-identifier">COLL 2 Bad Papers</span></li><li><span class="collection-identifier">COLL 3 Indifferent Papers</span></li></ul>
 HTML
   end

--- a/frontend/spec/controllers/search_controller_spec.rb
+++ b/frontend/spec/controllers/search_controller_spec.rb
@@ -36,7 +36,7 @@ describe SearchController, type: :controller do
 
   it 'returns search results with extra columns correctly' do
     expect (
-      get :do_search, {'extra_columns': [{'title' => 'uri', 'field' => 'uri', 'formatter' => 'stringify', 'sort_options' => {'sortable' => true, 'sort_by' => 'uri'}}]}
+      get(:do_search, {'extra_columns': [{'title' => 'uri', 'field' => 'uri', 'formatter' => 'stringify', 'sort_options' => {'sortable' => true, 'sort_by' => 'uri'}}]})
     ).to have_http_status(200)
   end
 

--- a/frontend/spec/controllers/search_controller_spec.rb
+++ b/frontend/spec/controllers/search_controller_spec.rb
@@ -54,13 +54,13 @@ describe SearchController, type: :controller do
   end
 
   it "formats 'linked_records_listing' extra columns in records correctly" do
-    expect(SearchController::Formatter['linked_records_listing', 'collection_display_string_u_sstr'].call(record)).to eq(<<-HTML)
+    expect(SearchController::Formatter['linked_records_listing', 'collection_display_string_u_sstr'].call(record)).to eq(<<-HTML.chomp)
 <ul class="linked-records-listing count-3"><li><span class="collection-identifier">Good Papers</span></li><li><span class="collection-identifier">Bad Papers</span></li><li><span class="collection-identifier">Indifferent Papers</span></li></ul>
 HTML
   end
 
   it "formats 'combined_identifier' extra columns in records correctly" do
-    expect(SearchController::Formatter['combined_identifier', 'field_not_actually_used'].call(record)).to eq(<<-HTML)
+    expect(SearchController::Formatter['combined_identifier', 'field_not_actually_used'].call(record)).to eq(<<-HTML.chomp)
 <ul class="linked-records-listing count-3"><li><span class="collection-identifier">COLL 1</span> <span class="collection-display-string">Good Papers</span></li><li><span class="collection-identifier">COLL 2</span> <span class="collection-display-string"> Bad Papers</span></li><li><span class="collection-identifier">COLL 3</span> <span class="collection-display-string"> Indifferent Papers</span></li></ul>
 HTML
   end

--- a/frontend/spec/controllers/search_controller_spec.rb
+++ b/frontend/spec/controllers/search_controller_spec.rb
@@ -55,13 +55,13 @@ describe SearchController, type: :controller do
 
   it "formats 'linked_records_listing' extra columns in records correctly" do
     expect(SearchController::Formatter['linked_records_listing', 'collection_display_string_stored_u_ssort'].call(record)).to eq(<<-HTML)
-<ul class="linked-records-listing count-3"><li><span class="collection-identifier">COLL 1</span></li><li><span class="collection-identifier">COLL 2</span></li><li><span class="collection-identifier">COLL 3</span></li></ul>
+<ul class="linked-records-listing count-3"><li><span class="collection-identifier">Good Papers</span></li><li><span class="collection-identifier">Bad Papers</span></li><li><span class="collection-identifier">Indifferent Papers</span></li></ul>
 HTML
   end
 
   it "formats 'combined_identifier' extra columns in records correctly" do
     expect(SearchController::Formatter['combined_identifier', 'field_not_actually_used'].call(record)).to eq(<<-HTML)
-<ul class="linked-records-listing count-3"><li><span class="collection-identifier">COLL 1 Good Papers</span></li><li><span class="collection-identifier">COLL 2 Bad Papers</span></li><li><span class="collection-identifier">COLL 3 Indifferent Papers</span></li></ul>
+<ul class="linked-records-listing count-3"><li><span class="collection-identifier">COLL 1</span> <span class="collection-display-string">Good Papers</span></li><li><span class="collection-identifier">COLL 2</span> <span class="collection-display-string"> Bad Papers</span></li><li><span class="collection-identifier">COLL 3</span> <span class="collection-display-string"> Indifferent Papers</span></li></ul>
 HTML
   end
 

--- a/frontend/spec/controllers/search_controller_spec.rb
+++ b/frontend/spec/controllers/search_controller_spec.rb
@@ -50,17 +50,17 @@ describe SearchController, type: :controller do
   end
 
   it "formats 'stringify' extra columns in records correctly" do
-    expect(SearchController::Formatter['stringify', 'type_u_ssort'].call(record)).to eq('Box')
+    expect(SearchHelper::Formatter['stringify', 'type_u_ssort'].call(record)).to eq('Box')
   end
 
   it "formats 'linked_records_listing' extra columns in records correctly" do
-    expect(SearchController::Formatter['linked_records_listing', 'collection_display_string_u_sstr'].call(record)).to eq(<<-HTML.chomp)
+    expect(SearchHelper::Formatter['linked_records_listing', 'collection_display_string_u_sstr'].call(record)).to eq(<<-HTML.chomp)
 <ul class="linked-records-listing count-3"><li><span class="collection-identifier">Good Papers</span></li><li><span class="collection-identifier">Bad Papers</span></li><li><span class="collection-identifier">Indifferent Papers</span></li></ul>
 HTML
   end
 
   it "formats 'combined_identifier' extra columns in records correctly" do
-    expect(SearchController::Formatter['combined_identifier', 'field_not_actually_used'].call(record)).to eq(<<-HTML.chomp)
+    expect(SearchHelper::Formatter['combined_identifier', 'field_not_actually_used'].call(record)).to eq(<<-HTML.chomp)
 <ul class="linked-records-listing count-3"><li><span class="collection-identifier">COLL 1</span> <span class="collection-display-string">Good Papers</span></li><li><span class="collection-identifier">COLL 2</span> <span class="collection-display-string">Bad Papers</span></li><li><span class="collection-identifier">COLL 3</span> <span class="collection-display-string">Indifferent Papers</span></li></ul>
 HTML
   end

--- a/frontend/spec/controllers/search_controller_spec.rb
+++ b/frontend/spec/controllers/search_controller_spec.rb
@@ -38,4 +38,5 @@ describe SearchController, type: :controller do
     expect {
       get :do_search, {'extra_columns': [{'title' => 'uri', 'field' => 'uri', 'formatter' => 'stringify', 'sort_options' => {'sortable' => true, 'sort_by' => 'uri'}}]}
     }.to have_http_status(200)
+  end
 end

--- a/frontend/spec/controllers/search_controller_spec.rb
+++ b/frontend/spec/controllers/search_controller_spec.rb
@@ -39,4 +39,30 @@ describe SearchController, type: :controller do
       get :do_search, {'extra_columns': [{'title' => 'uri', 'field' => 'uri', 'formatter' => 'stringify', 'sort_options' => {'sortable' => true, 'sort_by' => 'uri'}}]}
     }.to have_http_status(200)
   end
+
+  let(:record) do
+    {
+      'collection_display_string_stored_u_ssort' => 'Good Papers,Bad Papers,Indifferent papers',
+      'collection_display_string_u_sstr' => ['Good Papers', 'Bad Papers, Indifferent Papers'],
+      'collection_identifier_stored_u_sstr' => ['COLL 1', 'COLL 2', 'COLL 3'],
+      'type_u_ssort' => 'Box'
+    }
+  end
+
+  it "formats 'stringify' extra columns in records correctly" do
+    expect { SearchController::Formatter['stringify', 'type_u_ssort'].call(record) }.to equal('Box')
+  end
+
+  it "formats 'linked_records_listing' extra columns in records correctly" do
+    expect { SearchController::Formatter['linked_records_listing', 'collection_display_string_stored_u_ssort'].call(record) }.to equal(<<-HTML)
+<ul class="linked-records-listing count-3"><li><span class="collection-identifier">COLL 1</span></li><li><span class="collection-identifier">COLL 2</span></li><li><span class="collection-identifier">COLL 3</span></li></ul>
+HTML
+  end
+
+  it "formats 'combined_identifier' extra columns in records correctly" do
+    expect { SearchController::Formatter['combined_identifier', 'field_not_actually_used'].call(record) }.to equal(<<-HTML)
+<ul class="linked-records-listing count-3"><li><span class="collection-identifier">COLL 1 Good Papers</span></li><li><span class="collection-identifier">COLL 2 Bad Papers</span></li><li><span class="collection-identifier">COLL 3 Indifferent Papers</span></li></ul>
+HTML
+  end
+
 end

--- a/frontend/spec/controllers/search_controller_spec.rb
+++ b/frontend/spec/controllers/search_controller_spec.rb
@@ -33,4 +33,9 @@ describe SearchController, type: :controller do
       get :do_search
     }.to perform_under(15).ms
   end
+
+  it 'returns search results with extra columns correctly' do
+    expect {
+      get :do_search, {'extra_columns': [{'title' => 'uri', 'field' => 'uri', 'formatter' => 'stringify', 'sort_options' => {'sortable' => true, 'sort_by' => 'uri'}}]}
+    }.to have_http_status(200)
 end

--- a/frontend/spec/selenium/spec/events_spec.rb
+++ b/frontend/spec/selenium/spec/events_spec.rb
@@ -20,7 +20,7 @@ describe 'Events' do
 
     @agent = create(:agent_person, names: [name])
 
-    run_index_round
+    run_all_indexers
 
     @driver = Driver.get.login_to_repo(@archivist_user, @repo)
   end
@@ -122,7 +122,7 @@ describe 'Events' do
   end
 
   it 'should be searchable' do
-    run_index_round
+    run_all_indexers
     @driver.find_element(:id, 'global-search-button').click
     @driver.find_element(:link, 'Event').click
     assert(5) { @driver.find_element_with_text('//h3', /Search Results/) }

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require 'test_utils'
 require 'config/config-distribution'
 require 'securerandom'
 require 'nokogiri'
+require 'factory_bot'
 
 require_relative '../../indexer/app/lib/realtime_indexer'
 require_relative '../../indexer/app/lib/periodic_indexer'

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -534,6 +534,10 @@ class IndexerCommon
         doc['title'] = record['record']['long_display_string']
         doc['display_string'] = record['record']['display_string']
 
+        if record['record']['indicator']
+          doc['indicator_stored_u_ssort'] = record['record']['indicator']
+        end
+
         if record['record']['series']
           doc['series_uri_u_sstr'] = record['record']['series'].map {|series| series['ref']}
           doc['series_title_u_sstr'] = record['record']['series'].map {|series| series['display_string']}
@@ -554,7 +558,12 @@ class IndexerCommon
         if record['record']['collection']
           doc['collection_uri_u_sstr'] = record['record']['collection'].map {|collection| collection['ref']}
           doc['collection_display_string_u_sstr'] = record['record']['collection'].map {|collection| collection['display_string']}
+          doc['collection_display_string_stored_u_ssort'] = record['record']['collection'].map {|collection| collection['display_string']}.join(',')
           doc['collection_identifier_stored_u_sstr'] = record['record']['collection'].map {|collection| collection['identifier']}
+          doc['collection_combined_id_u_ssort'] = doc['collection_identifier_stored_u_sstr']
+                                                    .zip(doc['collection_display_string_u_sstr'])
+                                                    .map {|identifier, display| "#{identifier} #{display}"}
+                                                    .join(",")
           doc['collection_identifier_u_stext'] = record['record']['collection'].map {|collection|
             IndexerCommon.generate_permutations_for_identifier(collection['identifier'])
           }.flatten

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -579,6 +579,9 @@ class IndexerCommon
 
         doc['typeahead_sort_key_u_sort'] = record['record']['indicator'].to_s.rjust(255, '#')
         doc['barcode_u_sstr'] = record['record']['barcode']
+        doc['barcode_u_ssort'] = record['record']['barcode']
+
+        doc['type_u_ssort'] = record['record']['type']
 
         doc['created_for_collection_u_sstr'] = record['record']['created_for_collection']
       end


### PR DESCRIPTION
Implementation of generalized table configuration as described in #1843, as well as specific  implementation of enhancements to the linked records table on the LocationController#show page that exercise the implementation.  Some additional solr fields on top_container objects were required to implement the desired improvements to the table.

## Description
`SearchController#do_search` now takes additional arguments which set display variables and allow for specification of extra columns.  A hash of procs usable as "formatters" is provided, so that output of these columns can be customized.  A number of solr fields are added to support specifically sorting top_containers via indicator, display string, and barcode (there is a combined_indicator field as well, which was provided for a previous implementation of the table, but is left in because it would be useful for a future re-write of the "Manage Top Containers" page that leveraged solr rather than sorting on-page.

Views supporting search results now handle display arguments more consistently.

An additional display setting to hide audit columns is supported now.

A migration which changes update time on all rows in top_container to reindex the top_containers is also included. 

## Related JIRA Ticket or GitHub Issue
Issue #1843

## How Has This Been Tested?
Automated test of the search function with additional argument added to spec file, however it is pended as other search tests are all pended.

Manual testing on local dev environments and in a local built QA environment. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
