### PR TITLE
Date filter fixes

### DIFF
--- a/public/app/controllers/concerns/searchable.rb
+++ b/public/app/controllers/concerns/searchable.rb
@@ -120,15 +120,14 @@ module Searchable
       advanced_query_builder.and('keyword', value, 'text', false, false)
     end
      # we have to add filtered dates, if they exist
-    unless @search[:dates_searched] || (@search[:filter_to_year].blank? && @search[:filter_from_year].blank?)
-
-      from =  @search[:filter_from_year]
-      to = @search[:filter_to_year]
-      builder = AdvancedQueryBuilder.new
-#      builder.and('keyword','*', 'text', false)
-      builder.and('years', AdvancedQueryBuilder::RangeValue.new(from, to), 'range', false, false)
-      advanced_query_builder.and(builder)
-#      @base_search += "&filter_from_year=#{@search[:filter_from_year]}&filter_to_year=#{@search[:filter_to_year]}"
+    unless @search[:dates_searched]
+      years = get_filter_years(params)
+      unless years['from_year'].blank? && years['to_year'].blank?
+        builder = AdvancedQueryBuilder.new
+        builder.and('years', AdvancedQueryBuilder::RangeValue.new(years['from_year'], years['to_year']), 'range', false, false)
+        advanced_query_builder.and(builder)
+        @base_search = "#{@base_search}&filter_from_year=#{years['from_year']}&filter_to_year=#{years['to_year']}"
+      end
     end
     @criteria = default_search_opts
     @criteria['sort'] = @search[:sort] if @search[:sort]  # sort can be passed as default or via params

--- a/public/app/controllers/concerns/searchable.rb
+++ b/public/app/controllers/concerns/searchable.rb
@@ -47,7 +47,7 @@ module Searchable
       @query +=  "repository:\"#{repo_id}\""
       @base_search = "#{@base_search}&repo_id=#{repo_id.gsub('/','%2f')}"
     end
-    years = get_years(params)
+    years = get_filter_years(params)
     if !years.blank?
       @query = "#{@query} AND years:[#{years['from_year']} TO #{years['to_year']}]"
       @base_search = "#{@base_search}&filter_from_year=#{years['from_year']}&filter_to_year=#{years['to_year']}"
@@ -173,7 +173,7 @@ module Searchable
   end
 
 
-  def get_years(params)
+  def get_filter_years(params)
     params = sanitize_params(params)
     years = {}
     from = params.fetch(:filter_from_year,'').strip

--- a/public/app/models/search.rb
+++ b/public/app/models/search.rb
@@ -54,7 +54,7 @@ class Search < Struct.new(:q, :op, :field, :limit, :from_year, :to_year, :filter
   end
 
   def filters_blank?
-    filter_from_year.blank? && filter_to_year.blank? && filter_q.blank?
+    filter_from_year.blank? && filter_to_year.blank? && filter_q.all?(&:blank?)
   end
  
   def has_query?

--- a/public/app/views/shared/_facets.html.erb
+++ b/public/app/views/shared/_facets.html.erb
@@ -19,7 +19,6 @@
 	  <a href="<%= app_prefix(@page_search.sub("&filter_from_year=#{(from_year=='' ? '*' : from_year)}&filter_to_year=#{(to_year==t('search_results.filter.year_now') ? '*' : to_year)}",""))%>"
 	     title="<%= t('search_results.remove_filter') %> " class="delete_filter">X</a>
       </span></li>
-      </ul>
   <% end  %>
 	<% @filters.each do |k, a| %>
 	  <% a.each do |h| %>

--- a/public/app/views/shared/_search_collection_form.html.erb
+++ b/public/app/views/shared/_search_collection_form.html.erb
@@ -15,15 +15,15 @@
       <%= hidden_field_tag('q[]','*') %>
 
       <div class="col-md-6 year_from">
-        <%= label_tag(:from_year0, "#{t('search_results.filter.from_year')}", :class => 'sr-only') %>
-        <%= text_field_tag('from_year[]', nil, :id=>'from_year0', :size => 4,:maxlength => 4, :placeholder => t('search_results.filter.from_year'),
-                           :class=>"form-control") %>
+        <%= label_tag(:filter_from_year, "#{t('search_results.filter.from_year')}", :class => 'sr-only') %>
+        <%= text_field_tag(:filter_from_year, nil, :id=>nil, :size => 4,:maxlength => 4, :placeholder => t('search_results.filter.from_year'),
+                           :class=>"form-control", 'aria-label' => t('search_results.filter.from_year')) %>
       </div>
 
       <div class="col-md-6 year_to">
-        <%= label_tag(:to_year0, "#{t('search_results.filter.to_year')}", :class=> 'sr-only') %>
-        <%= text_field_tag('to_year[]', nil, :size => 4, :maxlength => 4, :class=> "form-control", :id => 'to_year0',
-                           :placeholder => t('search_results.filter.to_year')) %>
+        <%= label_tag(:filter_to_year, "#{t('search_results.filter.to_year')}", :class=> 'sr-only') %>
+        <%= text_field_tag(:filter_to_year, nil, :size => 4, :maxlength => 4, :class=> "form-control", :id => nil,
+                           :placeholder => t('search_results.filter.to_year'), 'aria-label' => t('search_results.filter.to_year')) %>
       </div>
 
     </div>


### PR DESCRIPTION
## Description
This is primarily a fix for date filter parameters not being included in the base URL used by onward links in search results pages. This causes the following bugs:

- Date filters being lost after the first page of results
- Date filters being lost when another filter is applied

Also, while testing those, I found and fixed the following minor display issues:

- An extra close-ul tag causes invalid HTML and inconsistent indenting in the remove-filter links
- When you apply facets, then remove them all, the "Filtered by" heading remains
- Setting a date range in the search-in-collection form works, but there is no way to remove/edit the date range on the results page.

## Related JIRA Ticket or GitHub Issue
#1610 
https://archivesspace.atlassian.net/browse/ANW-893
https://archivesspace.atlassian.net/browse/ANW-664

## How Has This Been Tested?
Tested on a development machine in the following contexts:

- Searching from the home or search page (/search)
- Searching in a single repository (/repositories/N/search)
- Collections (/repositories/resources)
- Searching in a single resource (/repositories/X/resources/Y/search)
- Digital Materials (/objects?limit=digital_object)
- Unprocessed materials (/accessions)

Date filtering is also possible in the Record Groups view (/classifications) but I do not understand where the dates for those might come from, so I cannot test that.

The public:test suite fails before running any tests, with or without these changes.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
