### PR TITLE
ANW-292: Correct conflicting record error on authority id collision

### DIFF
--- a/backend/app/lib/crud_helpers.rb
+++ b/backend/app/lib/crud_helpers.rb
@@ -75,7 +75,7 @@ module CrudHelpers
       yield
     rescue Sequel::ValidationFailed => e
       if e.errors && e.errors.any? {|key, errors| errors[0].end_with?("must be unique")}
-        existing_record = model.find_matching(json)
+        existing_record = e.errors.any? {|key, errors| errors[0].include?("Authority ID")} ? model.find_matching_id(json) : model.find_matching(json)
 
         if existing_record
           e.errors[:conflicting_record] = [existing_record.uri]

--- a/backend/app/model/mixins/agent_manager.rb
+++ b/backend/app/model/mixins/agent_manager.rb
@@ -231,6 +231,15 @@ module AgentManager
       end
 
 
+      def find_matching_id(json)
+        authorized_id = json['names'].find {|name| name['authority_id']}
+        existing_link = NameAuthorityId.find(:authority_id => authorized_id['authority_id'])
+        existing_name_record = my_agent_type[:name_model].find(:id => existing_link[:"#{authorized_id['jsonmodel_type']}_id"])
+
+        find(:id => existing_name_record[:"#{json['jsonmodel_type']}_id"])
+      end
+
+
       def find_matching(json)
         find(:agent_sha1 => calculate_hash(json))
       end

--- a/backend/spec/controller_agent_software_spec.rb
+++ b/backend/spec/controller_agent_software_spec.rb
@@ -48,16 +48,17 @@ describe 'Software agent controller' do
 
 
   it "auto-generates the sort name if one is not provided" do
-    id = create_software({:names => [build(:json_name_software,{:software_name => "ArchivesSpace", :sort_name_auto_generate => true})]}).id
+    id = create_software({:names => [build(:json_name_software,
+                                           {:software_name => "ArchivesSpace", :sort_name_auto_generate => true})]}).id
 
     agent = JSONModel(:agent_software).find(id)
 
-    expect(agent.names.first['sort_name']).to eq("ArchivesSpace")
+    expect(agent.names.first['sort_name']).to match(/\AArchivesSpace/)
 
     agent.names.first['version'] = "1.0"
     agent.save
 
-    expect(JSONModel(:agent_software).find(id).names.first['sort_name']).to eq("ArchivesSpace 1.0")
+    expect(JSONModel(:agent_software).find(id).names.first['sort_name']).to match(/\AArchivesSpace.*1\.0/)
 
   end
 

--- a/backend/spec/controller_conflict_reporting_spec.rb
+++ b/backend/spec/controller_conflict_reporting_spec.rb
@@ -49,6 +49,22 @@ describe "Conflicting record handling" do
       expect(exception).not_to be_nil
       expect(exception.errors['conflicting_record']).to eq([subject_a.uri])
     end
+
+
+    it "reports conflicting record authority ids on update" do
+      subject_a = create(:json_subject, subject_properties)
+      subject_b = create(:json_subject, subject_properties.merge(:terms => [build(:json_term, "term" => "Non-conflicting")]))
+
+      exception = begin
+                    subject_b['authority_id'] = subject_a['authority_id']
+                    subject_b.save
+                    nil
+                  rescue JSONModel::ValidationException => e
+                    e
+                  end
+
+      expect(exception).not_to be_nil
+    end
   end
 
 
@@ -104,6 +120,28 @@ describe "Conflicting record handling" do
         expect(exception.errors['conflicting_record']).to eq([agent_a.uri])
       end
     end
+
+
+    it "reports conflicting record authority ids on update" do
+      AgentManager.registered_agents.each do |agent_type|
+        jsonmodel = agent_type.fetch(:jsonmodel)
+        agent_archetype = build(:"json_#{jsonmodel}")
+        agent_a = create(:"json_#{jsonmodel}", agent_archetype.to_hash)
+        agent_b = create(:"json_#{jsonmodel}", agent_archetype.to_hash.merge('names' => build(:"json_#{jsonmodel}")[:names]))
+
+        exception = begin
+                      agent_b[:names][0]['authority_id'] = agent_archetype[:names][0]['authority_id']
+                      agent_b.save
+                      nil
+                    rescue JSONModel::ValidationException => e
+                      e
+                    end
+
+        expect(exception).not_to be_nil, "No exception on update for #{agent_type}"
+        expect(exception.errors['conflicting_record']).to eq([agent_a.uri])
+      end
+    end
+
   end
 
 

--- a/backend/spec/factories.rb
+++ b/backend/spec/factories.rb
@@ -560,9 +560,13 @@ FactoryBot.define do
 
   factory :json_name_software, class: JSONModel(:name_software) do
     rules { generate(:name_rule) }
+    source { generate(:name_source) }
     software_name { generate(:generic_name) }
     sort_name { generate(:sort_name) }
     sort_name_auto_generate { true }
+    dates { generate(:alphanumstr) }
+    qualifier { generate(:alphanumstr) }
+    authority_id { generate(:url) }
   end
 
   factory :json_collection_management, class: JSONModel(:collection_management) do

--- a/backend/spec/model_agent_software_spec.rb
+++ b/backend/spec/model_agent_software_spec.rb
@@ -35,10 +35,18 @@ describe 'Agent model' do
 
 
   it "requires a source to be set if an authority id is provided" do
-    n1 = build(:json_name_software, :authority_id => 'wooo')
+
+    test_opts = {:names => [
+                   {
+                     "authority_id" => "itsame",
+                     "software_name" => "Mario Teaches Typing",
+                     "sort_name" => "Mario Teaches Typing"
+                   }
+                 ]
+                }
 
     expect {
-      n1.to_hash
+      AgentSoftware.create_from_json(build(:json_agent_software, test_opts))
      }.to raise_error(JSONModel::ValidationException)
   end
 
@@ -89,7 +97,6 @@ describe 'Agent model' do
         end
 
         it "autogenerates a slug via identifier when configured to generate by id" do
-          pending "failing due to a validation error that is not showing any validation messages when generating agent_software json"
           AppConfig[:auto_generate_slugs_with_id] = true
 
           agent_name_software = build(:json_name_software, :authority_id => rand(100000).to_s)
@@ -99,7 +106,7 @@ describe 'Agent model' do
                 :names => [agent_name_software])
           )
 
-          expected_slug = clean_slug(agent_name_software[:software_name])
+          expected_slug = clean_slug(agent_name_software[:authority_id])
 
           expect(agent_software[:slug]).to eq(expected_slug)
 
@@ -127,9 +134,8 @@ describe 'Agent model' do
         end
 
         it "dedupes slug when autogenerating by name" do
-          pending "failing due to a validation error that is not showing any validation messages when generating agent_software json"
           AppConfig[:auto_generate_slugs_with_id] = false
-          agent_name_software1 = build(:json_name_software, :authority_id => "foo")
+          agent_name_software1 = build(:json_name_software, :software_name => "foo")
           agent_software1 = AgentSoftware.create_from_json(
             build(:json_agent_software,
                 :is_slug_auto => true,
@@ -149,7 +155,6 @@ describe 'Agent model' do
 
 
         it "cleans slug when autogenerating by id" do
-          pending "failing due to a validation error that is not showing any validation messages when generating agent_software json"
           AppConfig[:auto_generate_slugs_with_id] = true
 
           agent_name_software = build(:json_name_software, :authority_id => "Foo Bar Baz&&&&")
@@ -163,7 +168,6 @@ describe 'Agent model' do
         end
 
         it "dedupes slug when autogenerating by id" do
-          pending "failing due to a validation error that is not showing any validation messages when generating agent_software json"
           AppConfig[:auto_generate_slugs_with_id] = true
 
           agent_name_software1 = build(:json_name_software, :authority_id => "foo")

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -1971,6 +1971,7 @@ en:
   validation_errors:
     agent_must_be_unique: Agent records cannot be identical
     subject_must_be_unique: Subject records cannot be identical
+    subject_heading_identifier_must_be_unique_within_source: Subject heading identifier must be unique within source
     conflicting_record: Conflicting record
     missing_required_property: Property is required but was missing
     missing_property: Property was missing

--- a/common/locales/es.yml
+++ b/common/locales/es.yml
@@ -1951,6 +1951,7 @@ es:
   validation_errors:
     agent_must_be_unique: Registros de autoridad no pueden ser idénticos
     subject_must_be_unique: Los registros de sujetos no pueden ser idénticos
+    subject_heading_identifier_must_be_unique_within_source: El identificador de encabezado de asunto debe ser único dentro de la fuente
     conflicting_record: Registro conflictivo
     missing_required_property: Propiedad es necesaria pero falta
     missing_property: Faltaba propiedad

--- a/common/locales/fr.yml
+++ b/common/locales/fr.yml
@@ -1971,6 +1971,7 @@ fr:
   validation_errors:
     agent_must_be_unique: Il ne peut y avoir deux notices d'agents identiques
     subject_must_be_unique: Il ne peut y avoir deux notices sujets identiques
+    subject_heading_identifier_must_be_unique_within_source: L'identifiant de la vedette-matière doit être unique dans la source
     conflicting_record: Enregistrement contradictoire
     missing_required_property: Propriété requise qui manquait
     missing_property: Propriété manquante

--- a/common/locales/ja.yml
+++ b/common/locales/ja.yml
@@ -1497,6 +1497,7 @@ ja:
   validation_errors:
     agent_must_be_unique: エージェントレコードは同一ではありません
     subject_must_be_unique: 件名のレコードは同一ではありません
+    subject_heading_identifier_must_be_unique_within_source: 件名の見出し識別子はソース内で一意である必要があります
     conflicting_record: 競合するレコード
     missing_required_property: プロパティは必須ですが行方不明です
     missing_property: プロパティが見つかりませんでした


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Returns the correct conflicting record uri when a user attempts to post an agent record with an authority ID that conflicts with an existing authority ID.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Adds the following to fix the bug described in ANW-292:
- A conditional check in `crud_helpers` to determine if the conflict stems from an authority id or other piece of metadata (e.g. conflicting name);
- Add a new method to `agent_manager` to find a conflicting record based on authority id, as the existing method used to find conflicting records relies on the agent_sha1 which doesn't take into account the value of the authority id.

This fix also required changes to the factory for `agent_software` as it was the only mock agent type that was being created without an authority_id.  Changing this factory also required a few updates to existing backend tests (namely, un-pending several slug tests that were previously failing only with agent_software agent types).

Finally, this work identified a missing translation in the staff UI, so that has also been added.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-292

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test written and passing; updated existing tests.  Confirmed working manually via the API and staff interface.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15144646/78591421-66a3a800-7811-11ea-9616-b71f500f63b8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
