### PR TITLE
ANW-172: Add all dates to ao and do records h2

### DIFF
--- a/backend/app/model/archival_object.rb
+++ b/backend/app/model/archival_object.rb
@@ -65,15 +65,15 @@ class ArchivalObject < Sequel::Model(:archival_object)
     display_string = json['title'] || ""
 
     date_label = json.has_key?('dates') && json['dates'].length > 0 ?
-                   lambda {|date|
+                   json['dates'].map do |date|
                      if date['expression']
-                       date['expression']
+                       date['date_type'] == 'bulk' ? "#{I18n.t("date_type_bulk.bulk")}: #{date['expression']}" : date['expression']
                      elsif date['begin'] and date['end']
-                       "#{date['begin']} - #{date['end']}"
+                       date['date_type'] == 'bulk' ? "#{I18n.t("date_type_bulk.bulk")}: #{date['begin']} - #{date['end']}" : "#{date['begin']} - #{date['end']}"
                      else
-                       date['begin']
+                       date['date_type'] == 'bulk' ? "#{I18n.t("date_type_bulk.bulk")}: #{date['begin']}" : date['begin']
                      end
-                   }.call(json['dates'].first) : false
+                   end.join(', ') : false
 
     display_string += ", " if json['title'] && date_label
     display_string += date_label if date_label

--- a/backend/app/model/digital_object_component.rb
+++ b/backend/app/model/digital_object_component.rb
@@ -31,28 +31,15 @@ class DigitalObjectComponent < Sequel::Model(:digital_object_component)
 
   auto_generate :property => :display_string,
                 :generator => proc { |json|
-                  display_string = json['title'] || json['label'] || nil
-
-                  date_label = json.has_key?('dates') && json['dates'].length > 0 ?
-                                lambda {|date|
-                                  if date['expression']
-                                    date['expression']
-                                  elsif date['begin'] and date['end']
-                                    "#{date['begin']} - #{date['end']}"
-                                  else
-                                    date['begin']
-                                  end
-                                }.call(json['dates'].first) : nil
-
-                  "#{[display_string, date_label].compact.join(", ")}"
+                  DigitalObjectComponent.produce_display_string(json)
                 }
 
   auto_generate :property => :slug,
                 :generator => proc { |json|
                   if AppConfig[:use_human_readable_urls]
                     if json["is_slug_auto"]
-                      AppConfig[:auto_generate_slugs_with_id] ? 
-                        SlugHelpers.id_based_slug_for(json, DigitalObjectComponent) : 
+                      AppConfig[:auto_generate_slugs_with_id] ?
+                        SlugHelpers.id_based_slug_for(json, DigitalObjectComponent) :
                         SlugHelpers.name_based_slug_for(json, DigitalObjectComponent)
                     else
                       json["slug"]
@@ -61,6 +48,25 @@ class DigitalObjectComponent < Sequel::Model(:digital_object_component)
                 }
 
 
+  def self.produce_display_string(json)
+    display_string = json['title'] || json['label'] || nil
+
+    date_label = json.has_key?('dates') && json['dates'].length > 0 ?
+                  json['dates'].map do |date|
+                    if date['expression']
+                      date['date_type'] == 'bulk' ? "#{I18n.t("date_type_bulk.bulk")}: #{date['expression']}" : date['expression']
+                    elsif date['begin'] and date['end']
+                      date['date_type'] == 'bulk' ? "#{I18n.t("date_type_bulk.bulk")}: #{date['begin']} - #{date['end']}" : "#{date['begin']} - #{date['end']}"
+                    else
+                      date['date_type'] == 'bulk' ? "#{I18n.t("date_type_bulk.bulk")}: #{date['begin']}" : date['begin']
+                    end
+                  end.join(', ') : false
+
+    display_string += ", " if json['title'] && date_label
+    display_string += date_label if date_label
+
+    display_string
+  end
 
   def validate
     validates_unique([:root_record_id, :component_id],

--- a/backend/spec/model_archival_object_spec.rb
+++ b/backend/spec/model_archival_object_spec.rb
@@ -185,16 +185,17 @@ describe 'ArchivalObject model' do
 
   it "auto generates a 'label' based on the date and title when both are present" do
     title = "Just a title"
-    date = build(:json_date)
+    date1 = build(:json_date, :date_type => 'inclusive')
+    date2 = build(:json_date, :date_type => 'bulk')
 
     ao = ArchivalObject.create_from_json(
       build(:json_archival_object, {
         :title => title,
-        :dates => [date]
+        :dates => [date1, date2]
       }),
       :repo_id => $repo_id)
 
-    expect(ArchivalObject[ao[:id]].display_string).to eq("#{title}, #{date['expression']}")
+    expect(ArchivalObject[ao[:id]].display_string).to eq("#{title}, #{date1['expression']}, #{I18n.t("date_type_bulk.bulk")}: #{date2['expression']}")
   end
 
 

--- a/backend/spec/model_digital_object_component_spec.rb
+++ b/backend/spec/model_digital_object_component_spec.rb
@@ -12,6 +12,21 @@ describe 'DigitalObjectComponent model' do
     expect(DigitalObjectComponent[doc.id].title).to eq(doc.title)
   end
 
+  it "auto generates a 'label' based on the date and title when both are present" do
+    title = "Just a title"
+    date1 = build(:json_date, :date_type => 'inclusive')
+    date2 = build(:json_date, :date_type => 'bulk')
+
+    doc = DigitalObjectComponent.create_from_json(
+      build(:json_digital_object_component, {
+        :title => title,
+        :dates => [date1, date2]
+      }),
+      :repo_id => $repo_id)
+
+    expect(DigitalObjectComponent[doc[:id]].display_string).to eq("#{title}, #{date1['expression']}, #{I18n.t("date_type_bulk.bulk")}: #{date2['expression']}")
+  end
+
   describe "slug tests" do
     before(:all) do
       AppConfig[:use_human_readable_urls] = true

--- a/common/db/migrations/132_update_display_string.rb
+++ b/common/db/migrations/132_update_display_string.rb
@@ -1,0 +1,51 @@
+require_relative 'utils'
+
+Sequel.migration do
+
+  up do
+    $stderr.puts("Reconstructing display strings for archival objects and digital object components with multiple dates.")
+
+    bulk_date = self[:enumeration_value].filter(:value => 'bulk').get(:id)
+
+    ['archival_object', 'digital_object_component'].each do |component_type|
+      component_id = self[:date].group_and_count(:"#{component_type}_id").having{count.function.* > 1}.select(:"#{component_type}_id")
+      components_with_dates = self[:date].where(:"#{component_type}_id" => component_id).select(:"#{component_type}_id")
+
+      components_with_dates.distinct.each do |component_with_dates|
+        components = self[:"#{component_type}"].where(id: component_with_dates[:"#{component_type}_id"])
+        # Save the old display string for later logging
+        old_display_string = self[:"#{component_type}"].where(id: component_with_dates[:"#{component_type}_id"]).get(:display_string)
+        components.each do |component|
+          date_recs = self[:date].where("#{component_type}_id": component[:id])
+          date_parts = []
+          # Date logic used in archival object and digital object component model autogenerate proc
+          date_recs.each do |date_rec|
+            if date_rec[:expression] != nil
+              date_parts << (date_rec[:date_type_id] == bulk_date ? "bulk: #{date_rec[:expression]}" : date_rec[:expression])
+            elsif date_rec[:begin] && date_rec[:end]
+              date_parts << (date_rec[:date_type_id] == bulk_date ? "bulk: #{date_rec[:begin]} - #{date_rec[:end]}" : "#{date_rec[:begin]} - #{date_rec[:end]}")
+            else
+              date_parts << (date_rec[:date_type_id] == bulk_date ? "bulk: #{date_rec[:begin]}" : date_rec[:begin])
+            end
+          end
+          date_label = date_parts.join(", ")
+          # Title logic used in archival object and digital object component model autogenerate proc
+          display_string = component[:title] || component[:label] || ""
+          display_string += ", " if component[:title] || component[:label]
+          display_string += date_label if date_label
+          # Update the display string to include all dates
+          self[:"#{component_type}"].where(id: component[:id]).update(:display_string => display_string)
+          new_display_string = self[:"#{component_type}"].where(id: component[:id]).get(:display_string)
+          $stderr.puts "Updating display string for #{component_type} #{component[:id]}"
+          $stderr.puts "Original display string: #{old_display_string}"
+          $stderr.puts "New display string: #{new_display_string}"
+        end
+      end
+    end
+  end
+
+
+  down do
+  end
+
+end

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -1128,6 +1128,7 @@ en:
 
   date_type_bulk:
     <<: *date_attributes
+    bulk: bulk
 
   date_type_inclusive:
     <<: *date_attributes

--- a/common/locales/es.yml
+++ b/common/locales/es.yml
@@ -1124,6 +1124,7 @@ es:
 
   date_type_bulk:
     <<: *date_attributes
+    bulk: abultar
 
   date_type_inclusive:
     <<: *date_attributes

--- a/common/locales/fr.yml
+++ b/common/locales/fr.yml
@@ -1128,6 +1128,7 @@ fr:
 
   date_type_bulk:
     <<: *date_attributes
+    bulk: masse
 
   date_type_inclusive:
     <<: *date_attributes

--- a/common/locales/ja.yml
+++ b/common/locales/ja.yml
@@ -882,6 +882,7 @@ ja:
 
   date_type_bulk:
     <<: *date_attributes
+    bulk: バルク
 
   date_type_inclusive:
     <<: *date_attributes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds all available dates to the headings of archival object and digital object component records in the staff side and, if published, public side interfaces.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Modifies the archival object and digital object component models to include all dates in the autogenerated record display string.  Because this behavior only happens on create or update from JSON, changes to these models only impacts newly created/updated archival components, therefore migration 132 has also been added to identify and, via information stored in the database, recreate these display strings to address previously created archival components.  Additionally, behavior has been added to prepend dates with a date_type of bulk with "bulk: " in the new record headings.  Translations were also added for this prepended bulk label; however, because translations aren't available to migrations a default of "bulk: " has been set for existing headings.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Partially completes https://archivesspace.atlassian.net/browse/ANW-172. See also #1845 for display of multiple dates in resource/digital object trees.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing archival object backend spec updated; new digital object spec added.

## Screenshots (if appropriate):
Staff side:
![image](https://user-images.githubusercontent.com/15144646/79022035-113a0480-7b4b-11ea-87a8-b0d72db16acf.png)

PUI:
![image](https://user-images.githubusercontent.com/15144646/79022127-3fb7df80-7b4b-11ea-978a-a937107aa53e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
