### PR TITLE
ANW-806-pui-and-search

### DIFF
--- a/backend/spec/model_solr_spec.rb
+++ b/backend/spec/model_solr_spec.rb
@@ -65,6 +65,7 @@ describe 'Solr model' do
                         set_repo_id(@repo_id).
                         set_excluded_ids(%w(alpha omega)).
                         set_record_types(['optional_record_type']).
+                        show_published_only(true).
                         highlighting
 
     response = Solr.search(query)
@@ -78,6 +79,7 @@ describe 'Solr model' do
     expect(http.request.body).to match(/bq=title%3A%22hello\+world%22\*/)
     expect(http.request.body).to match(/pf=title%5E10/)
     expect(http.request.body).to match(/ps=0/)
+    expect(http.request.body).to match(/fq=publish%3Atrue/)
 
 
     expect(response['offset_first']).to eq(1)

--- a/indexer/app/lib/large_tree_doc_indexer.rb
+++ b/indexer/app/lib/large_tree_doc_indexer.rb
@@ -39,7 +39,7 @@ class LargeTreeDocIndexer
                                       :parent_node => parent_uri,
                                       :published_only => true)
 
-      
+
       batch << {
         'id' => "#{root_record_uri}/tree/waypoint_#{parent_uri}_#{waypoint_number}",
         'pui_parent_id' => (parent_uri || root_record_uri),

--- a/public/app/controllers/concerns/searchable.rb
+++ b/public/app/controllers/concerns/searchable.rb
@@ -85,7 +85,6 @@ module Searchable
     end
     set_search_statement
     raise I18n.t('navbar.error_no_term') unless @search.has_query?
-    queries = @search[:q]
     have_query = false
     advanced_query_builder = AdvancedQueryBuilder.new
     @search[:q].each_with_index { |query, i|
@@ -154,8 +153,6 @@ module Searchable
 
       advanced_query_builder.and(this_repo)
     end
-    advanced_query_builder.and('types', 'pui')
-    advanced_query_builder.and('publish', true)
     @base_search += "&limit=#{@search[:limit]}" unless @search[:limit].blank?
 
     @facet_filter = FacetFilter.new(default_facets, @search[:filter_fields],  @search[:filter_values])


### PR DESCRIPTION
ANW-806-pui-and-search

These changes allow solr_params to apply to PUI as they do for SUI.

- Remove duplicate publish from q param (it's in fq)
- Remove types pui from q (types pui covered by publish true)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
