### PR TITLE
Issue #1384: Use correct method for classification_terms/parent endpoint

### DIFF
--- a/backend/app/controllers/classification_term.rb
+++ b/backend/app/controllers/classification_term.rb
@@ -36,7 +36,7 @@ class ArchivesSpaceService < Sinatra::Base
              [400, :error]) \
   do
     obj = ClassificationTerm.get_or_die(params[:id])
-    obj.update_position_only(params[:parent], params[:position])
+    obj.set_parent_and_position(params[:parent], params[:position])
 
     updated_response(obj)
   end

--- a/backend/app/model/classification_term.rb
+++ b/backend/app/model/classification_term.rb
@@ -89,12 +89,6 @@ class ClassificationTerm < Sequel::Model(:classification_term)
   end
 
 
-  def update_position_only(parent_id, position)
-    super
-    self.reindex_children
-  end
-
-
   def validate
     validates_unique([:parent_name, :title_sha1],
                      :message => "must be unique to its level in the tree")

--- a/backend/spec/controller_classification_spec.rb
+++ b/backend/spec/controller_classification_spec.rb
@@ -66,4 +66,26 @@ describe 'Classification controllers' do
     expect { JSONModel(:classification_term).find(term2.id) }.to raise_error(RecordNotFound)
   end
 
+
+  it "lets you reorder classification terms" do
+    classification = create(:json_classification)
+
+    term_1 = create(:json_classification_term, :classification => {:ref => classification.uri}, :title=> "TERM1", :position => 0)
+    create(:json_classification_term, :classification => {:ref => classification.uri}, :title=> "TERM2", :position => 1)
+
+    tree = JSONModel(:classification_tree).find(nil, :classification_id => classification.id)
+
+    expect(tree.children[0]["title"]).to eq("TERM1")
+    expect(tree.children[1]["title"]).to eq("TERM2")
+
+    term_1 = JSONModel(:classification_term).find(term_1.id)
+    term_1.position = 1
+    term_1.save
+
+    tree = JSONModel(:classification_tree).find(nil, :classification_id => classification.id)
+
+    expect(tree.children[0]["title"]).to eq("TERM2")
+    expect(tree.children[1]["title"]).to eq("TERM1")
+  end
+
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves #1384 by routing the `/repositories/:repo_id/classification_terms/:id/parent` endpoint through the same `set_parent_and_position` method used in other ordered hierarchy type records (e.g. archival objects, digital object components, etc.).  It appears that implementation of the `/parent` endpoint was never fully implemented for classification terms leading to a longstanding bug as described in #1384.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Also, since the existing `update_position_only` method appeared to do nothing/not be used elsewhere in the classification_terms universe, it has been removed.  (Seems like this method was probably initially copied from the enumerations controlled, but never really finished.)

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://github.com/archivesspace/archivesspace/issues/1384

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Backend tests passing and one new test added.  API performs repositioning as expected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
