### PR TITLE
Enable Luke request handler

### DIFF
--- a/solr/solrconfig.xml
+++ b/solr/solrconfig.xml
@@ -417,4 +417,8 @@
     <defaultQuery>*:*</defaultQuery>
   </admin>
 
+  <!-- Turn on Luke request handler so features in the Solr web interface like analysis
+       and term info in the schema browser will work. -->
+  <requestHandler name="/admin/luke" class="org.apache.solr.handler.admin.LukeRequestHandler" />
+
 </config>


### PR DESCRIPTION
## Description
Turn on Luke request handler so features in the Solr web interface like analysis and term info in the schema browser will work. This makes it easier to diagnose search issues and for developers to experiment with things like alternative tokenizers, stemming, etc. It has no effect on the ArchivesSpace application.

## Related JIRA Ticket or GitHub Issue
None.

But this is the sort of issue it might help with: http://lyralists.lyrasis.org/pipermail/archivesspace_users_group/2020-April/007531.html

## How Has This Been Tested?
We've had this enabled on all our Solr servers, used by ArchivesSpace and other systems, for years. I am not aware of any security or stability issues with having it enabled.

## Screenshots (if appropriate):
![analysis](https://user-images.githubusercontent.com/33721187/79843129-b9549680-83b1-11ea-8d3a-670f4e84a6de.png)
![schema_browser](https://user-images.githubusercontent.com/33721187/79843138-bc4f8700-83b1-11ea-8c40-641c1c958761.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
