### PR TITLE
Enable mysql for ui tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Run Backend tests
       env:
-        ASPACE_TEST_DB_URL: jdbc:mysql://localhost:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false
+        ASPACE_TEST_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false
       run: |
         wget -P ./common/lib https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar
         ./build/run backend:test

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -34,11 +34,17 @@ jobs:
     - name: Bootstrap ArchivesSpace
       run: |
         ./build/run bootstrap
+        wget -P ./common/lib https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar
+
+    - name: Migrate ArchivesSpace DB
+      env:
+        APPCONFIG_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false
+      run: |
+        ./build/run db:migrate
 
     - name: Run Frontend tests
       env:
-        ASPACE_TEST_DB_URL: jdbc:mysql://localhost:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false
+        ASPACE_TEST_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false
       run: |
-        wget -P ./common/lib https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar
         ./build/run frontend:selenium
         ./build/run frontend:test

--- a/.github/workflows/public.yml
+++ b/.github/workflows/public.yml
@@ -34,10 +34,16 @@ jobs:
     - name: Bootstrap ArchivesSpace
       run: |
         ./build/run bootstrap
+        wget -P ./common/lib https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar
+
+    - name: Migrate ArchivesSpace DB
+      env:
+        APPCONFIG_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false
+      run: |
+        ./build/run db:migrate
 
     - name: Run Public tests
       env:
-        ASPACE_TEST_DB_URL: jdbc:mysql://localhost:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false
+        ASPACE_TEST_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false
       run: |
-        wget -P ./common/lib https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar
         ./build/run public:test

--- a/build/run
+++ b/build/run
@@ -36,6 +36,7 @@ if [ "$orig" != "$1" ]; then
     fi
 
     echo "INTEGRATION MODE FOR: $orig" # just a pointer we are here
+    echo "INTEGRATION ARGS: $@"
     exec java -cp "ant/*" org.apache.tools.ant.launch.Launcher $orig -Daspace.integration=true ${1+"$@"} >>"$INTEGRATION_LOGFILE" 2>&1
 else
     exec java -cp "ant/*" org.apache.tools.ant.launch.Launcher ${1+"$@"}

--- a/frontend/spec/selenium/spec/resources_spec.rb
+++ b/frontend/spec/selenium/spec/resources_spec.rb
@@ -436,7 +436,7 @@ describe 'Resources and archival objects' do
     assert(5) { expect(@driver.find_element(:css, 'h2').text).to eq('save this please Archival Object') }
     assert(5) { expect(@driver.find_element(css: 'div.alert.alert-success').text).to eq('Archival Object save this please updated') }
     @driver.clear_and_send_keys([:id, 'archival_object_title_'], @archival_object.title)
-    @driver.click_and_wait_until_gone(css: "form .record-pane button[type='submit']")
+    @driver.click_and_wait_until_gone(css: "form .save-changes button[type='submit']")
   end
 
   it 'can add a assign, remove, and reassign a Subject to an archival object' do

--- a/frontend/spec/selenium/spec_helper.rb
+++ b/frontend/spec/selenium/spec_helper.rb
@@ -22,7 +22,7 @@ $backend_start_fn = proc {
                                 solr_port: $solr_port,
                                 session_expire_after_seconds: $expire,
                                 realtime_index_backlog_ms: 600_000,
-                                db_url: AppConfig.demo_db_url)
+                                db_url: ENV.fetch('ASPACE_TEST_DB_URL', AppConfig.demo_db_url))
 
   AppConfig[:backend_url] = $backend
 

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -49,7 +49,9 @@ $backend_start_fn = proc {
   TestUtils.start_backend($backend_port,
                           solr_port: $solr_port,
                           session_expire_after_seconds: $expire,
-                          realtime_index_backlog_ms: 600_000)
+                          realtime_index_backlog_ms: 600000,
+                          db_url: ENV.fetch('ASPACE_TEST_DB_URL', AppConfig.demo_db_url)
+  )
 }
 
 ENV['RAILS_ENV'] ||= 'test'

--- a/public/spec/spec_helper.rb
+++ b/public/spec/spec_helper.rb
@@ -51,7 +51,8 @@ $backend_start_fn = proc {
                            {
                              :solr_port => $solr_port,
                              :session_expire_after_seconds => $expire,
-                             :realtime_index_backlog_ms => 600000
+                             :realtime_index_backlog_ms => 600000,
+                             :db_url => ENV.fetch('ASPACE_TEST_DB_URL', AppConfig.demo_db_url)
                            })
 }
 


### PR DESCRIPTION
Support use of `ASPACE_TEST_DB_URL` for the frontend and public tests.
Update workflows to use MySQL for the sui and pui.