### PR TITLE
Remove skip links from show pages

### DIFF
--- a/public/app/views/shared/_skipnav.html.erb
+++ b/public/app/views/shared/_skipnav.html.erb
@@ -1,6 +1,6 @@
 <div class="skipnav">
   <%= link_to I18n.t('skipnav.main_content'), '#maincontent', :class => 'sr-only sr-only-focusable' %>
-  <% unless action_name == 'inventory' %>
+  <% unless action_name == 'inventory' || (action_name == 'show' && controller_name != 'repositories') %>
     <% if defined?(@search) %>
       <% if defined?(@results) %>
         <% unless defined?(@no_statement) %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removes skip links from PUI show pages where `#toggleRefineSearch` and `#searchresults` anchors are not present.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
On show pages where an `@search` variable is present (record types that may have linked records including agents, subjects, and classifications), search-related skip links were being added based on the check for `@search` on line 4 of `public/app/views/shared/_skipnav.html.erb`.  This change skips all show pages (aside from repositories, where an embedded search is still present) so that skip links with missing anchors aren't generated for agents, subjects, and classifications pages.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Accessibility errors corrected according to WAVE plugin.  Existing public tests passing.

## Screenshots (if appropriate):
Currently broken skip links:
![image](https://user-images.githubusercontent.com/15144646/80141531-aee3f980-8577-11ea-86ce-31ad0f07647e.png)

Links removed:
![image](https://user-images.githubusercontent.com/15144646/80141460-94118500-8577-11ea-918b-27069d148550.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
