### PR TITLE
Issue #1877: Fix PDF generation via API

### DIFF
--- a/backend/app/controllers/exports.rb
+++ b/backend/app/controllers/exports.rb
@@ -159,7 +159,16 @@ class ArchivesSpaceService < Sinatra::Base
                               (params[:numbered_cs] || false),
                               (params[:ead3] || false))
 
-    pdf = generate_pdf_from_ead(ead_stream)
+    repo = resolve_references(Repository.get_or_die(params[:repo_id]),
+                              params[:resolve])
+
+    if repo['image_url']
+      image_for_pdf = repo['image_url']
+    else
+      image_for_pdf = nil
+    end
+
+    pdf = generate_pdf_from_ead(ead_stream, image_for_pdf)
     pdf_response(pdf)
   end
 

--- a/backend/app/lib/export.rb
+++ b/backend/app/lib/export.rb
@@ -10,10 +10,10 @@ module ExportHelpers
     [status, {"Content-Type" => "application/pdf"}, pdf ]
   end
 
-  def generate_pdf_from_ead( ead )
+  def generate_pdf_from_ead(ead, image_for_pdf)
     xml = ""
     ead.each { |e| xml << e  }
-    ASFop.new(xml).to_pdf
+    ASFop.new(xml, image_for_pdf).to_pdf
   end
 
   def xml_response(xml)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves #1877 by adding `image_for_pdf` to `generate_pdf_from_ead`.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This change makes it possible to generate PDFs via the `/repositories/:repo_id/resource_descriptions/:id.pdf` endpoint.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://github.com/archivesspace/archivesspace/pull/1480

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass; API returns PDF as anticipated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
