### PR TITLE
Fix for broken typeahead search, resolves #1835

### DIFF
--- a/backend/app/model/solr.rb
+++ b/backend/app/model/solr.rb
@@ -237,7 +237,11 @@ class Solr
       end
 
       if @show_published_only
+        # public ui
         add_solr_param(:fq, "publish:true")
+      else
+        # staff ui
+        add_solr_param(:fq, "-types:pui_only")
       end
 
 

--- a/backend/spec/model_archival_object_spec.rb
+++ b/backend/spec/model_archival_object_spec.rb
@@ -161,7 +161,7 @@ describe 'ArchivalObject model' do
 
   it "auto generates a 'label' based on the date (when no title)" do
     # if an expression that will display
-    date = build(:json_date)
+    date = build(:json_date, :date_type => 'inclusive')
     ao = ArchivalObject.create_from_json(
       build(:json_archival_object, {
         :title => nil,
@@ -172,7 +172,7 @@ describe 'ArchivalObject model' do
     expect(ArchivalObject[ao[:id]].display_string).to eq(date['expression'])
 
     # try with begin and end
-    date = build(:json_date, :expression => nil)
+    date = build(:json_date, :date_type => 'inclusive', :expression => nil)
     ao = ArchivalObject.create_from_json(
       build(:json_archival_object, {
         :title => nil,
@@ -181,6 +181,27 @@ describe 'ArchivalObject model' do
       :repo_id => $repo_id)
 
     expect(ArchivalObject[ao[:id]].display_string).to eq("#{date['begin']} - #{date['end']}")
+
+    date = build(:json_date, :date_type => 'bulk')
+    ao = ArchivalObject.create_from_json(
+      build(:json_archival_object, {
+        :title => nil,
+        :dates => [date]
+      }),
+      :repo_id => $repo_id)
+
+    expect(ArchivalObject[ao[:id]].display_string).to eq("bulk: #{date['expression']}")
+
+    # try with begin and end
+    date = build(:json_date, :date_type => 'bulk', :expression => nil)
+    ao = ArchivalObject.create_from_json(
+      build(:json_archival_object, {
+        :title => nil,
+        :dates => [date]
+      }),
+      :repo_id => $repo_id)
+
+    expect(ArchivalObject[ao[:id]].display_string).to eq("bulk: #{date['begin']} - #{date['end']}")
   end
 
   it "auto generates a 'label' based on the date and title when both are present" do

--- a/backend/spec/model_solr_spec.rb
+++ b/backend/spec/model_solr_spec.rb
@@ -80,6 +80,7 @@ describe 'Solr model' do
     expect(http.request.body).to match(/pf=title%5E10/)
     expect(http.request.body).to match(/ps=0/)
     expect(http.request.body).to match(/fq=publish%3Atrue/)
+    expect(http.request.body).to_not match(/fq=-types%3Apui_only/)
 
 
     expect(response['offset_first']).to eq(1)
@@ -90,6 +91,21 @@ describe 'Solr model' do
     expect(response['this_page']).to eq(1)
     expect(response['last_page']).to eq(1)
     expect(response['results'][0]['title']).to eq("A Resource")
+
+    # repeat with show_published_only false i.e. a sui search
+    query = Solr::Query.create_keyword_search("hello world").
+                        pagination(1, 10).
+                        set_repo_id(@repo_id).
+                        set_excluded_ids(%w(alpha omega)).
+                        set_record_types(['optional_record_type']).
+                        show_published_only(false).
+                        highlighting
+
+    Solr.search(query)
+
+    expect(http.request.body).to match(/hello\+world/)
+    expect(http.request.body).to_not match(/fq=publish%3Atrue/)
+    expect(http.request.body).to match(/fq=-types%3Apui_only/)
   end
 
   it "adjusts date searches for the local timezone" do

--- a/frontend/app/models/search.rb
+++ b/frontend/app/models/search.rb
@@ -68,26 +68,23 @@ class Search
       queries.and(filter.keys[0], filter.values[0])
     end
 
-    # The staff interface shouldn't show records that were only created for the
-    # Public User Interface.
-    queries.and('types', 'pui_only', 'text', literal = true, negated = true)
-
-    new_filter = queries.build
+    new_filter = queries.empty? ? {} : queries.build
 
     if criteria['filter']
       # Combine our new filter with any existing ones
       existing_filter = ASUtils.json_parse(criteria['filter'])
+      subqueries = [existing_filter['query']]
+      subqueries << new_filter['query'] if new_filter['query']
 
       new_filter['query'] = JSONModel(:boolean_query)
                               .from_hash({
                                            :jsonmodel_type => 'boolean_query',
                                            :op => 'AND',
-                                           :subqueries => [existing_filter['query'], new_filter['query']]
+                                           :subqueries => subqueries
                                          })
-
     end
 
-    criteria['filter'] = new_filter.to_json
+    criteria['filter'] = new_filter['query'] ? new_filter.to_json : nil
   end
 
 end


### PR DESCRIPTION
The merged PR for #1699 to improve PUI search disabled the match all
clause for "purely negative expression groups" (arguing that Solr does
support such a search without the clause appended). However typeahead
search at least fails with the clause removed.

This PR retains the improved PUI search and fixes the typeahead behavior
by moving the negated types fq param from the advanced search query to a
separate param.

Here's a gist with debug queries:

https://gist.github.com/mark-cooper/63e7fdec57c9cf60211054ee041e3454
