### PR TITLE
Add subcontainer barcodes with test

### DIFF
--- a/backend/app/model/large_tree_resource.rb
+++ b/backend/app/model/large_tree_resource.rb
@@ -19,6 +19,7 @@ class LargeTreeResource
               Sequel.as(:top_container__barcode, :top_container_barcode),
               Sequel.as(:type_2__value, :type_2),
               Sequel.as(:sub_container__indicator_2, :indicator_2),
+              Sequel.as(:sub_container__barcode_2, :barcode_2),
               Sequel.as(:type_3__value, :type_3),
               Sequel.as(:sub_container__indicator_3, :indicator_3))
     .each do |row|
@@ -31,6 +32,7 @@ class LargeTreeResource
         container_data['top_container_barcode'] = row[:top_container_barcode] if row[:top_container_barcode]
         container_data['type_2'] = row[:type_2] if row[:type_2]
         container_data['indicator_2'] = row[:indicator_2] if row[:indicator_2]
+        container_data['barcode_2'] = row[:barcode_2] if row[:barcode_2]
         container_data['type_3'] = row[:type_3] if row[:type_3]
         container_data['indicator_3'] = row[:indicator_3] if row[:indicator_3]
 
@@ -103,6 +105,7 @@ class LargeTreeResource
               Sequel.as(:top_container__barcode, :top_container_barcode),
               Sequel.as(:type_2__value, :type_2),
               Sequel.as(:sub_container__indicator_2, :indicator_2),
+              Sequel.as(:sub_container__barcode_2, :barcode_2),
               Sequel.as(:type_3__value, :type_3),
               Sequel.as(:sub_container__indicator_3, :indicator_3))
       .each do |row|
@@ -118,6 +121,7 @@ class LargeTreeResource
       container_data['top_container_barcode'] = row[:top_container_barcode] if row[:top_container_barcode]
       container_data['type_2'] = row[:type_2] if row[:type_2]
       container_data['indicator_2'] = row[:indicator_2] if row[:indicator_2]
+      container_data['barcode_2'] = row[:barcode_2] if row[:barcode_2]
       container_data['type_3'] = row[:type_3] if row[:type_3]
       container_data['indicator_3'] = row[:indicator_3] if row[:indicator_3]
 

--- a/backend/app/model/mixins/resource_trees.rb
+++ b/backend/app/model/mixins/resource_trees.rb
@@ -39,6 +39,7 @@ module ResourceTrees
         properties["type_2"] = BackendEnumSource.value_for_id("container_type",
                                                               sub_container.type_2_id)
         properties["indicator_2"] = sub_container.indicator_2
+        properties["barcode_2"] = sub_container.barcode_2
         properties["type_3"] = BackendEnumSource.value_for_id("container_type",
                                                               sub_container.type_3_id)
         properties["indicator_3"] = sub_container.indicator_3

--- a/backend/app/model/top_container.rb
+++ b/backend/app/model/top_container.rb
@@ -165,6 +165,16 @@ class TopContainer < Sequel::Model(:top_container)
     [container_bit, container_profile, location, resource, series_label].compact.join(", ")
   end
 
+  def find_subcontainer_barcodes
+    sub_container_barcodes = ""
+    found_subcontainers = related_records(:top_container_link)
+    found_subcontainers.each do |found_subcontainer|
+      if found_subcontainer.barcode_2
+        sub_container_barcodes = sub_container_barcodes + found_subcontainer.barcode_2 + " "
+      end
+    end
+    sub_container_barcodes
+  end
 
   def self.sequel_to_jsonmodel(objs, opts = {})
     jsons = super
@@ -176,6 +186,8 @@ class TopContainer < Sequel::Model(:top_container)
 
       json['display_string'] = obj.display_string
       json['long_display_string'] = obj.long_display_string
+
+      json['subcontainer_barcodes'] = obj.find_subcontainer_barcodes
 
       obj.series.each do |series|
         json['series'] ||= []

--- a/common/db/migrations/133_add_barcodes_to_sub_container.rb
+++ b/common/db/migrations/133_add_barcodes_to_sub_container.rb
@@ -1,0 +1,16 @@
+require_relative 'utils'
+
+Sequel.migration do
+  up do
+    $stderr.puts("Add barcode fields to sub_container")
+    alter_table(:sub_container) do
+    	add_column(:barcode_2, String)
+    end
+  end
+
+  down do
+    alter_table(:sub_container) do
+      drop_column(:barcode_2)
+    end
+  end
+end 

--- a/common/schemas/sub_container.rb
+++ b/common/schemas/sub_container.rb
@@ -22,6 +22,7 @@
 
       "type_2" => {"type" => "string", "dynamic_enum" => "container_type"},
       "indicator_2" => {"type" => "string", "maxLength" => 255},
+      "barcode_2" => {"type" => "string", "maxLength" => 255},
 
       "type_3" => {"type" => "string", "dynamic_enum" => "container_type"},
       "indicator_3" => {"type" => "string", "maxLength" => 255},

--- a/common/schemas/top_container.rb
+++ b/common/schemas/top_container.rb
@@ -16,6 +16,7 @@
       "display_string" => {"type" => "string", "readonly" => true},
       "long_display_string" => {"type" => "string", "readonly" => true},
 
+      "subcontainer_barcodes" => {"type" => "string", "required" => false},
 
       "ils_holding_id" => {"type" => "string", "maxLength" => 255, "required" => false},
       "ils_item_id" => {"type" => "string", "maxLength" => 255, "required" => false},

--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -291,6 +291,9 @@ class TopContainersController < ApplicationController
 
       ASUtils.wrap(params['barcodes'].split(" ")).each do |barcode|
         barcode_query.or('barcode_u_sstr', barcode)
+
+        # Subcontainer string contains barcode
+        barcode_query.or('subcontainer_barcodes_u_sstr', barcode)
       end
 
       unless barcode_query.empty?

--- a/frontend/app/views/sub_containers/_show.html.erb
+++ b/frontend/app/views/sub_containers/_show.html.erb
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-<% unless sub_container["type_2"] || sub_container["indicator_2"] ||
+<% unless sub_container["type_2"] || sub_container["indicator_2"] || sub_container["barcode_2"] ||
           sub_container["type_3"] || sub_container["indicator_3"] %>
   <br/><br/>
 <% end %>
@@ -16,6 +16,7 @@
 <% define_template "sub_container", jsonmodel_definition(:sub_container) do |form| %>
   <%= form.label_and_select "type_2", form.possible_options_for('type_2', true) %>
   <%= form.label_and_textfield  "indicator_2" %>
+  <%= form.label_and_textfield  "barcode_2" %>
   <%= form.label_and_select "type_3", form.possible_options_for('type_3', true) %>
   <%= form.label_and_textfield  "indicator_3" %>
 <% end %>

--- a/frontend/app/views/sub_containers/_template.html.erb
+++ b/frontend/app/views/sub_containers/_template.html.erb
@@ -10,6 +10,7 @@
 
     <%= form.label_and_select "type_2", form.possible_options_for('type_2', true) %>
     <%= form.label_and_textfield  "indicator_2" %>
+    <%= form.label_and_textfield  "barcode_2" %>
 
     <hr/>
 

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1123,6 +1123,9 @@ en:
     indicator_2: Child Indicator
     indicator_2_tooltip: |
         <p>An alphanumeric expression for indicating the ID of the second-level container, which may also indicate the second-level container's position within a sequence of such containers. Bulk ranges of second-level containers are also permissible, e.g. Folders 1-16.</p>
+    barcode_2: Child Container Barcode
+    barcode_2_tooltip: |
+        <p>A barcode to identify the second-level container in which the described material is housed.</p>    
     type_3: Grandchild Type
     type_3_tooltip: |
         <p>The type of the third-level container in which the described material is housed.</p>

--- a/frontend/spec/selenium/spec/instances_and_containers_spec.rb
+++ b/frontend/spec/selenium/spec/instances_and_containers_spec.rb
@@ -198,11 +198,26 @@ describe 'Resource instances and containers' do
     # re-find our original modal
     @driver.scroll_into_view(@driver.find_element_with_text('//button', /Create and Link to Top Container/)).click
 
+    #add a subcontainer_barcode
+    @driver.clear_and_send_keys([:css, '#resource_instances__0__sub_container__barcode_2_'], 'test_child_container_barcode')
+
     @driver.find_element(css: "form .record-pane button[type='submit']").click
 
     expect do
       @driver.find_element_with_text('//div[contains(@class, "alert-success")]', /Resource .+ updated/)
     end.not_to raise_error
+  end
+
+  it 'can find the top container by its associated sub_container barcode' do
+    run_all_indexers
+    @driver.navigate.to("#{$frontend}/top_containers")
+
+    @driver.clear_and_send_keys([:css, '#barcodes'], 'test_child_container_barcode')
+    @driver.find_element(css: 'input.btn').click
+
+    results = @driver.find_element(id: 'bulk_operation_results')
+
+    expect(results.find_elements(css: 'tbody tr').length).to eq(1)
   end
 
   it 'can also attach instances to accessions and create containers and locations along the way' do

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -592,6 +592,7 @@ class IndexerCommon
 
         doc['type_u_ssort'] = record['record']['type']
 
+        doc['subcontainer_barcodes_u_sstr'] = record["record"]["subcontainer_barcodes"]
         doc['created_for_collection_u_sstr'] = record['record']['created_for_collection']
       end
     }
@@ -609,11 +610,11 @@ class IndexerCommon
             doc['top_container_uri_u_sstr'] << instance['sub_container']['top_container']['ref']
             if instance['sub_container']['type_2']
               doc['child_container_u_sstr'] ||= []
-              doc['child_container_u_sstr'] << "#{instance['sub_container']['type_2']} #{instance['sub_container']['indicator_2']}"
+              doc['child_container_u_sstr'] << "#{instance['sub_container']['type_2']} #{instance['sub_container']['indicator_2']} #{instance['sub_container']['barcode_2']}"
             end
             if instance['sub_container']['type_3']
               doc['grand_child_container_u_sstr'] ||= []
-              doc['grand_child_container_u_sstr'] << "#{instance['sub_container']['type_3']} #{instance['sub_container']['indicator_2']}"
+              doc['grand_child_container_u_sstr'] << "#{instance['sub_container']['type_3']} #{instance['sub_container']['indicator_3']}"
             end
           end
         }


### PR DESCRIPTION
## Description
This adds a barcode to subcontainers. It is able to be searched for in both the general search, and on the top containers page using the keyword and barcode fields. It is optional, turning on/off using an AppConfig option. Previous PR received comments to remove AppConfig options and to add Selenium test from @mark-cooper . These comments have been addressed.

## Related JIRA Ticket or GitHub Issue

## How Has This Been Tested?
Manual testing of up/down migrations, addition/subtraction of barcodes, and searching for barcodes in all abovementioned fields.
A Selenium test covers adding a subcontainer barcode and searching for it from the Top Containers page.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
