### PR TITLE
Add Has Location to Top Container search page

### DIFF
--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -286,6 +286,10 @@ class TopContainersController < ApplicationController
       builder.and('empty_u_sbool', (params['empty'] == "yes" ? true : false), 'boolean')
     end
 
+    unless params['has_location'].blank?
+      builder.and('has_location_u_sbool', (params['has_location'] == "yes" ? true : false), 'boolean')
+    end
+
     unless params['barcodes'].blank?
       barcode_query = AdvancedQueryBuilder.new
 

--- a/frontend/app/views/top_containers/bulk_operations/_search_criteria.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_search_criteria.html.erb
@@ -58,6 +58,12 @@
         </div>
       </div>
       <div class="form-group">
+        <label class="control-label col-sm-2" for="has_location"><%= I18n.t("top_container.has_location") %></label>
+        <div class="controls col-sm-4">
+          <select name="has_location" id="has_location" class="form-control"><option></option><option value="yes"><%= I18n.t("top_container._frontend.bulk_operations.has_location_true") %></option><option value="no"><%= I18n.t("top_container._frontend.bulk_operations.has_location_false") %></option></select>
+        </div>
+      </div>
+      <div class="form-group">
         <div class="controls">
           <%= submit_tag I18n.t("top_container._frontend.bulk_operations.search"), :class => "btn btn-primary pull-right" %>
         </div>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1135,7 +1135,7 @@ en:
         <p>An alphanumeric expression for indicating the ID of the second-level container, which may also indicate the second-level container's position within a sequence of such containers. Bulk ranges of second-level containers are also permissible, e.g. Folders 1-16.</p>
     barcode_2: Child Container Barcode
     barcode_2_tooltip: |
-        <p>A barcode to identify the second-level container in which the described material is housed.</p>    
+        <p>A barcode to identify the second-level container in which the described material is housed.</p>
     type_3: Grandchild Type
     type_3_tooltip: |
         <p>The type of the third-level container in which the described material is housed.</p>
@@ -1173,6 +1173,7 @@ en:
     not_exported: Not exported
     restricted: Restricted?
     parent: Parent Container
+    has_location: Has Location
 
     managed_container_2_type: Child Container Type
     managed_container_2_type_tooltip: |
@@ -1269,6 +1270,8 @@ en:
         delete_n_records: "Delete %{n} records"
         update_locations_current_location: Current Location
         update_locations_new_location: New Location
+        has_location_true: "Yes"
+        has_location_false: "No"
 
   container_profile:
     _singular: Container Profile

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -1168,6 +1168,7 @@ es:
     not_exported: No exportado
     restricted: Restringido?
     parent: Contenedor padre
+    has_location: Tiene ubicación
 
     managed_container_2_type: Tipo de contenedor hijo
     managed_container_2_type_tooltip: |
@@ -1264,6 +1265,8 @@ es:
         delete_n_records: "Borrar %{n} registros"
         update_locations_current_location: Ubicación actual
         update_locations_new_location: Nueva ubicación
+        has_location_true: "Si"
+        has_location_false: "No"
 
   container_profile:
     _singular: Perfil de contenedor
@@ -1286,7 +1289,7 @@ es:
         merge_select_target: Seleccionar objetivo de fusión
         confirm_merge: Confirmar perfiles de contenedor de fusión
         confirm_merge_question: ¿Está seguro de que desea fusionar los perfiles del contenedor como se enumeran a continuación? Esta acción es irreversible.
-        confirm_merge_victims: "Combinar los siguientes perfiles de contenedor:" 
+        confirm_merge_victims: "Combinar los siguientes perfiles de contenedor:"
         confirm_merge_target: "En este perfil de contenedor:"
     name: Nombre
     name_tooltip: |

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -1166,6 +1166,7 @@ fr:
     not_exported: Non exporté
     restricted: Soumis à des restrictions?
     parent: conditionnement parent
+    has_location: A un emplacement
 
     managed_container_2_type: Type de conditionnement fils
     managed_container_2_type_tooltip: |
@@ -1262,6 +1263,8 @@ fr:
         delete_n_records: "Supprimer %{n} notices"
         update_locations_current_location: Localisation actuelle
         update_locations_new_location: Nouvelle localisation
+        has_location_true: "Oui"
+        has_location_false: "Non"
 
   container_profile:
     _singular: Profil de conditionnement
@@ -1284,7 +1287,7 @@ fr:
         merge_select_target: Sélectionner la cible de fusion
         confirm_merge: Confirmer les profils de conteneur de fusion
         confirm_merge_question: Voulez-vous vraiment fusionner les profils de conteneur comme indiqué ci-dessous? Cette action est irréversible.
-        confirm_merge_victims: "Fusionner les profils de conteneur suivants:" 
+        confirm_merge_victims: "Fusionner les profils de conteneur suivants:"
         confirm_merge_target: "Dans ce profil de conteneur:"
     name: Nom
     name_tooltip: |

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -1170,6 +1170,8 @@ ja:
     not_exported: エクスポートされません
     restricted: 制限されていますか？
     parent: 親コンテナ
+    has_location: 場所がある
+
     managed_container_2_type: 子コンテナタイプ
     managed_container_2_type_tooltip: "<p>記載された材料が格納されている第2レベルコンテナのタイプ。 </p><p>この管理された値リストの値は変更することができます。
       </p>"
@@ -1260,6 +1262,8 @@ ja:
         delete_n_records: "%{n}レコードを削除する"
         update_locations_current_location: 現在位置
         update_locations_new_location: 新しい場所
+        has_location_true: はい
+        has_location_false: 番号
 
   container_profile:
     _singular: コンテナプロファイル
@@ -1282,7 +1286,7 @@ ja:
         merge_select_target: マージターゲットを選択
         confirm_merge: マージコンテナプロファイルの確認
         confirm_merge_question: 以下にリストされているように、コンテナープロファイルをマージしてもよろしいですか？ このアクションは元に戻せません。
-        confirm_merge_victims: "次のコンテナプロファイルをマージします:" 
+        confirm_merge_victims: "次のコンテナプロファイルをマージします:"
         confirm_merge_target: "このコンテナプロファイルに:"
     name: 名
     name_tooltip: "<p>必要なフィールド。コンテナプロファイルの名前。ジェネリックまたは特定のものがあります。 </p><p>例： </p><ul><li>ドキュメントボックス</li><li>ページ15

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -509,7 +509,7 @@ class IndexerCommon
     add_document_prepare_hook {|doc, record|
       if doc['primary_type'] == 'job'
         report_type = record['record']['job']['report_type']
-        doc['title'] = (report_type ? t("reports.#{report_type}.title", :default => report_type) : 
+        doc['title'] = (report_type ? t("reports.#{report_type}.title", :default => report_type) :
           t("job.types.#{record['record']['job_type']}"))
         doc['types'] << record['record']['job_type']
         doc['types'] << report_type
@@ -621,6 +621,7 @@ class IndexerCommon
         end
 
         if record['record']['container_locations'].length > 0
+          doc['has_location_u_sbool'] = true
           record['record']['container_locations'].each do |container_location|
             if container_location['status'] == 'current'
               doc['location_uri_u_sstr'] = container_location['ref']
@@ -628,6 +629,8 @@ class IndexerCommon
               doc['location_display_string_u_sstr'] = container_location['_resolved']['title']
             end
           end
+        else
+          doc['has_location_u_sbool'] = false
         end
         doc['exported_u_sbool'] = record['record'].has_key?('exported_to_ils')
         doc['empty_u_sbool'] = record['record']['collection'].empty?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This change adds a new select box "Has Location" on the Manage Top Containers search page. The new search field has_location returns true if a Top Container has one or more locations.

## Description
<!--- Describe your changes in detail -->
The Solr wildcard index *u_sbool is being used to index the value. The markup is consistent with existing code and all translations have been provided for the input label and select options text.

<!--- Why is this change required? What problem does it solve? -->


## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
ARCSPC-907 in Harvard Library JIRA

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually in multiple browsers by using the new select box on the Manage Top Containers search page. Also tested adding and removing a location from a top container and making sure the indexer updates the has_location value correctly.

## Screenshots (if appropriate):
![ARCSPC_907_ManageTopContainers_HasLocation](https://user-images.githubusercontent.com/13367900/81458865-d38cc380-916a-11ea-9e7a-2be57478f5c0.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
