### PR TITLE
Top Container Sticky Search

### DIFF
--- a/frontend/app/assets/javascripts/top_containers.bulk.js
+++ b/frontend/app/assets/javascripts/top_containers.bulk.js
@@ -145,7 +145,7 @@ BulkContainerSearch.prototype.setup_table_sorter = function() {
       currentSort = JSON.parse(currentSort);
     }
   }
-  
+
   var tablesorter_opts = {
     // only sort on the second row of header columns
     selectorHeaders: "thead tr.sortable-columns th",

--- a/frontend/app/controllers/repositories_controller.rb
+++ b/frontend/app/controllers/repositories_controller.rb
@@ -104,6 +104,9 @@ class RepositoriesController < ApplicationController
   end
 
   def select
+    # Clear top container previous search when switching repositories
+    session[:top_container_previous_search] = {}
+
     selected = @repositories.find {|r| r.id.to_s == params[:id]}
     self.class.session_repo(session, selected.uri, selected.slug)
     set_user_repository_cookie selected.uri

--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -10,6 +10,31 @@ class TopContainersController < ApplicationController
 
 
   def index
+    # If there was a previous top_container search, we prepopulate the form with the filled-in linkers and a search is executed in top_containers.bulk.js
+    @top_container_previous_search = {}
+
+    if session[:top_container_previous_search] && session[:top_container_previous_search] != {}
+      if session[:top_container_previous_search]["resource"]
+        @top_container_previous_search["resource"] = session[:top_container_previous_search]["resource"]
+        @top_container_previous_search["resource"]["id"] = @top_container_previous_search["resource"]["uri"]
+      end
+
+      if session[:top_container_previous_search]["accession"]
+        @top_container_previous_search["accession"] = session[:top_container_previous_search]["accession"]
+        @top_container_previous_search["accession"]["id"] = @top_container_previous_search["accession"]["uri"]
+      end
+
+      if session[:top_container_previous_search]["container_profile"]
+        @top_container_previous_search["container_profile"] = session[:top_container_previous_search]["container_profile"]
+        @top_container_previous_search["container_profile"]["id"] = @top_container_previous_search["container_profile"]["uri"]
+      end
+
+      if session[:top_container_previous_search]["location"]
+        @top_container_previous_search["location"] = session[:top_container_previous_search]["location"]
+        @top_container_previous_search["location"]["id"] = @top_container_previous_search["location"]["uri"]
+      end
+    end
+
   end
 
 
@@ -119,6 +144,46 @@ class TopContainersController < ApplicationController
 
 
   def bulk_operation_search
+    session[:top_container_previous_search] = {}
+    
+    # Store ONLY needed information from linkers in rails session so it can be repopulated for another search later
+    # (The whole record is not saved because they are too big for the rails session and only a few pieces of info are used)
+    if params['collection_resource']
+      previous_resource = JSON.parse(params["collection_resource"]["_resolved"])
+      session[:top_container_previous_search]["resource"] = {
+          "uri" => previous_resource["uri"],
+          "title" => previous_resource["title"],
+          "jsonmodel_type" => previous_resource["jsonmodel_type"]
+        }
+    end
+
+    if params["collection_accession"]
+      previous_accession  = JSON.parse(params['collection_accession']['_resolved'])
+      session[:top_container_previous_search]["accession"] = {
+        "uri" => previous_accession["uri"],
+        "title" => previous_accession["title"],
+        "jsonmodel_type" => previous_accession["jsonmodel_type"]
+      }
+    end
+
+    if params["container_profile"]
+      previous_container_profile = JSON.parse(params['container_profile']['_resolved'])
+      session[:top_container_previous_search]["container_profile"] = {
+        "uri" => previous_container_profile["uri"],
+        "title" => previous_container_profile["title"],
+        "jsonmodel_type" => previous_container_profile["jsonmodel_type"]
+      }
+    end
+
+    if params["location"]
+      previous_location = JSON.parse(params['location']['_resolved'])
+      session[:top_container_previous_search]['location'] = {
+        "uri" => previous_location["uri"],
+        "title" => previous_location["title"],
+        "jsonmodel_type" => previous_location["jsonmodel_type"]
+      }
+    end
+
     begin
       results = perform_search
     rescue MissingFilterException

--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -195,6 +195,8 @@ class TopContainersController < ApplicationController
 
 
   def bulk_operations_browse
+    @top_container_previous_search = {}
+    
     begin
       results = perform_search if params.has_key?("q")
     rescue MissingFilterException

--- a/frontend/app/views/top_containers/bulk_operations/_collection_accession_linker.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_collection_accession_linker.erb
@@ -1,10 +1,11 @@
 <%
-   if params['collection_accession'].blank?
+   if params['collection_accession'].blank? && !@top_container_previous_search["accession"]
      selected_json = "{}"
+   elsif @top_container_previous_search["accession"]
+     selected_json = @top_container_previous_search["accession"].to_json
    else
      selected_json = params['collection_accession']['_resolved']
    end
-
 %>
 
 <div class="input-group linker-wrapper">

--- a/frontend/app/views/top_containers/bulk_operations/_collection_resource_linker.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_collection_resource_linker.erb
@@ -1,10 +1,11 @@
 <%
-   if params['collection_resource'].blank?
+   if params['collection_resource'].blank? && !@top_container_previous_search["resource"]
      selected_json = "{}"
+   elsif @top_container_previous_search["resource"]
+     selected_json = @top_container_previous_search["resource"].to_json
    else
      selected_json = params['collection_resource']['_resolved']
    end
-
 %>
 
 <div class="input-group linker-wrapper">

--- a/frontend/app/views/top_containers/bulk_operations/_container_profile_linker.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_container_profile_linker.html.erb
@@ -1,12 +1,13 @@
 <%
-   if params['container_profile'].blank?
-     selected_json = "{}"
-   else
-     selected_json = params['container_profile']['_resolved']
-   end
+  if params['container_profile'].blank? && !@top_container_previous_search["container_profile"]
+    selected_json = "{}"
+  elsif @top_container_previous_search["container_profile"]
+    selected_json = @top_container_previous_search["container_profile"].to_json
+  else
+    selected_json = params['container_profile']['_resolved']
+  end
 
-   linkable_types = ["container_profile"]
-
+  linkable_types = ["container_profile"]
 %>
 
 <div class="input-group linker-wrapper">

--- a/frontend/app/views/top_containers/bulk_operations/_location_linker.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_location_linker.html.erb
@@ -1,11 +1,13 @@
 <%
-   if params['location'].blank?
-     selected_json = "{}"
-   else
-     selected_json = params['location']['_resolved']
-   end
+  if params['location'].blank? && !@top_container_previous_search["location"]
+    selected_json = "{}"
+  elsif @top_container_previous_search["location"]
+    selected_json = @top_container_previous_search["location"].to_json
+  else
+    selected_json = params['location']['_resolved']
+  end
 
-   linkable_types = ["location"]
+  linkable_types = ["location"]
 
   path = "location" if path.blank?
   show_create_link = false if show_create_link.blank?

--- a/frontend/spec/selenium/spec/instances_and_containers_spec.rb
+++ b/frontend/spec/selenium/spec/instances_and_containers_spec.rb
@@ -140,7 +140,7 @@ describe 'Resource instances and containers' do
   it 'remembers the search after leaving the page' do
     @driver.navigate.to("#{$frontend}/top_containers")
 
-    @driver.find_element(id: 'q').send_keys('Letter')
+    @driver.clear_and_send_keys([:css, '#q'], 'Letter')
     @driver.find_element(css: 'input.btn').click
 
     @driver.wait_for_ajax
@@ -233,7 +233,10 @@ describe 'Resource instances and containers' do
     run_all_indexers
     @driver.navigate.to("#{$frontend}/top_containers")
 
+    @driver.clear_and_send_keys([:css, '#q'], '')
+    @driver.find_element(:css, '#empty').select_option('')
     @driver.clear_and_send_keys([:css, '#barcodes'], 'test_child_container_barcode')
+
     @driver.find_element(css: 'input.btn').click
 
     results = @driver.find_element(id: 'bulk_operation_results')

--- a/frontend/spec/selenium/spec/instances_and_containers_spec.rb
+++ b/frontend/spec/selenium/spec/instances_and_containers_spec.rb
@@ -137,6 +137,27 @@ describe 'Resource instances and containers' do
   end
 
 
+  it 'remembers the search after leaving the page' do
+    @driver.navigate.to("#{$frontend}/top_containers")
+
+    @driver.find_element(id: 'q').send_keys('Letter')
+    @driver.find_element(css: 'input.btn').click
+
+    @driver.wait_for_ajax
+
+    results = @driver.find_element(id: 'bulk_operation_results')
+    resultsLength = results.find_elements(css: 'tbody tr').length
+
+    @driver.navigate.refresh
+
+    expect(target = @driver.find_element(css: '#q').attribute('value')).to eq('Letter')
+
+    resultsAfterRefresh = @driver.find_element(id: 'bulk_operation_results')
+    resultsAfterRefreshLength = resultsAfterRefresh.find_elements(css: 'tbody tr').length
+
+    expect(resultsLength).to eq(resultsAfterRefreshLength)
+  end
+
   it 'can attach instances to resources and create containers and locations along the way' do
     @driver.navigate.to("#{$frontend}#{@resource.uri.sub(%r{/repositories/\d+}, '')}/edit")
     @driver.find_element(css: '#resource_instances_ .subrecord-form-heading .btn[data-instance-type="sub-container"]').click


### PR DESCRIPTION
## Description
This addition adds sticky search functionality to the Top Containers search. After executing a search and leaving the search page, your search will repopulate upon revisiting the search page and automatically get the search's results. 

## Related JIRA Ticket or GitHub Issue

## How Has This Been Tested?
This has been both manually tested, and a Selenium test covers the feature.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
