### PR TITLE
Browse location by repository facet

### DIFF
--- a/backend/app/model/location.rb
+++ b/backend/app/model/location.rb
@@ -22,6 +22,7 @@ class Location < Sequel::Model(:location)
                     :contains_records_of_type => :location_function,
                     :corresponding_to_association  => :location_function)
 
+
   def self.generate_title(json)
     title = ""
 
@@ -78,7 +79,7 @@ class Location < Sequel::Model(:location)
     locations = generate_locations_for_batch(batch)
     locations.map{|location| self.create_from_json(location)}
   end
-  
+
   def self.batch_update(location)
     location[:record_uris].map do |uri|
       id = JSONModel.parse_reference(uri)[:id]

--- a/common/config/search_browse_column_config.rb
+++ b/common/config/search_browse_column_config.rb
@@ -62,6 +62,7 @@ module SearchAndBrowseColumnConfig
       "area" => {:field => "area", :sortable => true},
       "location_holdings" => {:field => "location_holdings"},
       "location_profile_display_string_u_ssort" => {:field => "location_profile_display_string_u_ssort"},
+      "owner_repo_display_string_u_ssort" => {:field => "owner_repo_display_string_u_ssort"},
       "temporary" => {:field => "temporary", :sortable => true},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]}
     },

--- a/frontend/app/controllers/locations_controller.rb
+++ b/frontend/app/controllers/locations_controller.rb
@@ -11,10 +11,10 @@ class LocationsController < ApplicationController
   def index
     respond_to do |format| 
       format.html {   
-        @search_data = Search.for_type(session[:repo_id], "location", params_for_backend_search.merge({"facet[]" => SearchResultData.LOCATION_FACETS}))
+        @search_data = Search.for_type(session[:repo_id], "location", params_for_backend_search.merge({"facet[]" => SearchResultData.LOCATION_FACETS, "blank_facet_query_fields" => ["owner_repo_display_string_u_ssort"]}))
       }
       format.csv { 
-        search_params = params_for_backend_search.merge({"facet[]" => SearchResultData.LOCATION_FACETS})
+        search_params = params_for_backend_search.merge({"facet[]" => SearchResultData.LOCATION_FACETS, "blank_facet_query_fields" => ["owner_repo_display_string_u_ssort"]})
         search_params["type[]"] = "location"
         uri = "/repositories/#{session[:repo_id]}/search"
         csv_response( uri, search_params )

--- a/frontend/app/models/search.rb
+++ b/frontend/app/models/search.rb
@@ -17,6 +17,31 @@ class Search
     criteria["sort"] ||= sort(criteria["type[]"] || (criteria["filter_term[]"] || []).collect { |term| ASUtils.json_parse(term)['primary_type'] }.compact)
 
     search_data = JSONModel::HTTP::get_json("/repositories/#{repo_id}/search", criteria)
+    #If the criteria contains a 'blank_facet_query_fields' field,
+    #we want to add a facet to filter on items WITHOUT an entry in the facet
+    if (criteria.has_key?("blank_facet_query_fields"))
+      blank_facet_query = ""
+      delimiter = ""
+      criteria["blank_facet_query_fields"].each {|query_field|
+        blank_facet_query = "-" + query_field + ":*"
+        sub_criteria = criteria.clone
+        if (sub_criteria.has_key?("q"))
+          sub_criteria["q"] = criteria["q"] + " AND " + blank_facet_query
+        else
+          sub_criteria["q"] = blank_facet_query
+        end
+            
+        search_data_with_blank_facet = JSONModel::HTTP::get_json("/repositories/#{repo_id}/search", sub_criteria)
+        if (!search_data["facets"]["facet_fields"].has_key?(query_field))
+          search_data["facets"]["facet_fields"][query_field] = ["none", search_data_with_blank_facet["total_hits"]]
+        else
+          search_data["facets"]["facet_fields"][query_field] << "none"
+          search_data["facets"]["facet_fields"][query_field] << search_data_with_blank_facet["total_hits"]
+        end
+      }
+              
+    end
+        
     search_data[:criteria] = criteria
 
     SearchResultData.new(search_data)

--- a/frontend/app/models/search_result_data.rb
+++ b/frontend/app/models/search_result_data.rb
@@ -16,12 +16,26 @@ class SearchResultData
       facets.each_slice(2).each {|facet_and_count|
         next if facet_and_count[1] === 0
 
-        @facet_data[facet_group][facet_and_count[0]] = {
-          :label => facet_label_string(facet_group, facet_and_count[0]),
-          :count => facet_and_count[1],
-          :filter_term => facet_query_string(facet_group, facet_and_count[0]),
-          :display_string => facet_display_string(facet_group, facet_and_count[0])
-        }
+        
+        if (facet_and_count[0] == "none")
+          query = facet_query_string(facet_group, facet_and_count[0])
+          if (@search_data[:criteria].has_key?('q'))
+            query = @search_data[:criteria]['q'] + ' AND ' + query
+          end
+          @facet_data[facet_group][facet_and_count[0]] = {
+              :label => facet_label_string(facet_group, facet_and_count[0]),
+              :count => facet_and_count[1],
+              :q => query,
+              :display_string => facet_display_string(facet_group, facet_and_count[0])
+            }
+        else
+          @facet_data[facet_group][facet_and_count[0]] = {
+              :label => facet_label_string(facet_group, facet_and_count[0]),
+              :count => facet_and_count[1],
+              :filter_term => facet_query_string(facet_group, facet_and_count[0]),
+              :display_string => facet_display_string(facet_group, facet_and_count[0])
+            }
+        end
       }
     }
   end
@@ -38,6 +52,9 @@ class SearchResultData
 
 
   def facet_query_string(facet_group, facet)
+    if (facet == "none")
+      return "-" + facet_group + ":*"
+    end
     {facet_group => facet}.to_json
   end
 
@@ -95,6 +112,8 @@ class SearchResultData
   end
 
   def facet_label_string(facet_group, facet)
+    return I18n.t("search.location.none") if facet == "none"
+    return facet.upcase if facet_group == "owner_repo_display_string_u_ssort"
     return I18n.t("#{facet}._singular", :default => I18n.t("plugins.#{facet}._singular", :default => facet)) if facet_group === "primary_type"
     return I18n.t("enumerations.name_source.#{facet}", :default => I18n.t("enumerations.subject_source.#{facet}", :default => facet)) if facet_group === "source"
     return I18n.t("enumerations.name_rule.#{facet}", :default => facet) if facet_group === "rules"
@@ -267,7 +286,18 @@ class SearchResultData
   end
 
   def facet_label_for_query
-    "#{I18n.t("search.multi.query")}: #{@search_data[:criteria]["q"]}"
+    label = @search_data[:criteria]["q"]
+    query_array = @search_data[:criteria]["q"].split(" AND ") 
+    query_array.each do |query|
+      label = ""
+      delimiter = ""
+      if (query.match(/\-.+\:\*/))
+        value = query.tr("-:*", "")
+        label += delimiter + I18n.t("search.blank_facet_query_fields."+value)+":None"
+        delimiter = " AND "
+      end
+    end  
+    "#{I18n.t("search.multi.query")}: #{label}"
   end
 
   def self.BASE_SORT_FIELDS
@@ -299,7 +329,7 @@ class SearchResultData
   end
 
   def self.LOCATION_FACETS
-    ["temporary", "building", "floor", "room", "area", "location_profile_display_string_u_ssort"]
+    ["temporary", "owner_repo_display_string_u_ssort", "building", "floor", "room", "area", "location_profile_display_string_u_ssort"]
   end
 
   def self.SUBJECT_FACETS

--- a/frontend/app/views/locations/show.html.erb
+++ b/frontend/app/views/locations/show.html.erb
@@ -32,7 +32,7 @@
       <% if @location['owner_repo'] %>
         <div class="form-horizontal">
           <div class="form-group token-list">
-            <div class="control-label col-sm-2"><%= I18n.t("location.owner_repo") %></div>
+            <div class="control-label col-sm-2"><%= I18n.t("repository._singular") %></div>
             <div class="label-only col-sm-8">
               <%= render_token :object => @location["owner_repo"]["_resolved"],
                                :label => @location["owner_repo"]["_resolved"]["display_string"],

--- a/frontend/app/views/search/_filter.html.erb
+++ b/frontend/app/views/search/_filter.html.erb
@@ -48,7 +48,11 @@
   <ul>
     <% facets.each do |facet, facet_map| %>
       <li>
-        <% opts = {"add_filter_term" => facet_map[:filter_term]} %>
+      	<% if facet_map.has_key?(:q) %>
+        	<% opts = {"q" => facet_map[:q]} %>
+      	<% else %>
+			<% opts = {"add_filter_term" => facet_map[:filter_term]} %>
+      	<% end %>
         <% opts['facets'] = SearchResultData.facets_for(facet) if facet_group == 'primary_type' %>
         <%= link_to facet_map[:label], build_search_params(opts) %> <span class="badge"><%= facet_map[:count] %></span>
       </li>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -294,6 +294,8 @@ en:
       area: Area
       location_holdings: Holdings for Current Repository
       location_profile_display_string_u_ssort: Location Profile
+      owner_repo_display_string_u_ssort: Repository
+      none: None
       audit_info: Audit Information
       temporary: Temporary
       user_mtime: Modified
@@ -439,6 +441,8 @@ en:
       extents: Extent
       asc: Ascending
       desc: Descending
+    blank_facet_query_fields:
+      owner_repo_display_string_u_ssort: Repository
 
 
   advanced_search:

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -414,7 +414,12 @@ class IndexerCommon
         doc['floor'] = record['record']['floor']
         doc['room'] = record['record']['room']
         doc['area'] = record['record']['area']
-      end
+       if record['record']['owner_repo']
+         repo = JSONModel::HTTP.get_json(record['record']['owner_repo']['ref'])
+          doc['owner_repo_uri_u_sstr'] = record['record']['owner_repo']['ref']
+          doc['owner_repo_display_string_u_ssort'] = repo["repo_code"]
+       end
+       end
     }
 
     add_document_prepare_hook {|doc, record|


### PR DESCRIPTION
## Description
On the Browse Locations results page, this creates a facet by the Location record Repository field to make it easier for a staff user to limit their view to desired records.  Also adds a 'None' option for the Repository.  

This allows a broader faceting option for the Locations.

## Related JIRA Ticket or GitHub Issue

## How Has This Been Tested?
This has been manually tested.  

## Screenshots (if appropriate):
<img width="433" alt="Screen Shot 2020-05-08 at 3 24 50 PM" src="https://user-images.githubusercontent.com/6585049/81441699-3d43a800-9140-11ea-9833-fc52027e1c08.png">

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have authority to submit this code.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
