### PR TITLE
Improvements to top container indicator column sort

### DIFF
--- a/frontend/app/assets/javascripts/top_containers.bulk.js
+++ b/frontend/app/assets/javascripts/top_containers.bulk.js
@@ -116,32 +116,29 @@ BulkContainerSearch.prototype.setup_table_sorter = function() {
       return value
     }
 
-    let letterOrNumber = isNaN(parseInt(value[0])) ? "letter" : "number"
+    let isNumber = isNaN(parseInt(value[0])) ? false : true
 
     let valueArray = [value[0]]
     let valueArrayCurrentIndex = 0;
     for (i = 1; i < value.length; i++) {
-      switch (letterOrNumber) {
-        case "letter":
-          if (isNaN(parseInt(value[i]))) {
-            valueArray[valueArrayCurrentIndex] += value[i]
-          } else {
-            valueArray[valueArrayCurrentIndex] = valueArray[valueArrayCurrentIndex].trim()
-            valueArrayCurrentIndex += 1
-            valueArray[valueArrayCurrentIndex] = value[i]
-            letterOrNumber = "number"
-          }
-          break;
-        case "number":
-          if (isNaN(parseInt(value[i]))) {
-            valueArray[valueArrayCurrentIndex] = padNumber(valueArray[valueArrayCurrentIndex])
-            valueArrayCurrentIndex += 1
-            valueArray[valueArrayCurrentIndex] = value[i]
-            letterOrNumber = "letter"
-          } else {
-            valueArray[valueArrayCurrentIndex] += value[i]
-          }
-          break;
+      if (!isNumber) {
+        if (isNaN(parseInt(value[i]))) {
+          valueArray[valueArrayCurrentIndex] += value[i]
+        } else {
+          valueArray[valueArrayCurrentIndex] = valueArray[valueArrayCurrentIndex].trim()
+          valueArrayCurrentIndex += 1
+          valueArray[valueArrayCurrentIndex] = value[i]
+          isNumber = true
+        }
+      } else {
+        if (isNaN(parseInt(value[i]))) {
+          valueArray[valueArrayCurrentIndex] = padNumber(valueArray[valueArrayCurrentIndex])
+          valueArrayCurrentIndex += 1
+          valueArray[valueArrayCurrentIndex] = value[i]
+          isNumber = false
+        } else {
+          valueArray[valueArrayCurrentIndex] += value[i]
+        }
       }
     }
 
@@ -179,7 +176,8 @@ BulkContainerSearch.prototype.setup_table_sorter = function() {
       } else if ($node.hasClass("top-container-indicator")) {
         var value = $node.text().trim();
         
-        // pad the indicator values so they sort correctly with digit and alpha values
+        // turn the indicator into a string of alternating non-number/padded-number values separated by commas for sorting
+        // eg "box,#############11,folder,#############4"
         return parseIndicator(value);
       }
 

--- a/frontend/app/assets/javascripts/top_containers.bulk.js
+++ b/frontend/app/assets/javascripts/top_containers.bulk.js
@@ -116,7 +116,7 @@ BulkContainerSearch.prototype.setup_table_sorter = function() {
       return value
     }
 
-    let isNumber = isNaN(parseInt(value[0])) ? false : true
+    let isNumber = !isNaN(parseInt(value[0]))
 
     let valueArray = [value[0]]
     let valueArrayCurrentIndex = 0;


### PR DESCRIPTION
## Description
This change improves the sorting of the indicator column when viewing the results of a search for top containers. It especially improves results on mixed alphabetical + numeric indicators, and no longer sorts by string length.

## Related JIRA Ticket or GitHub Issue

## How Has This Been Tested?
Manual testing, and this passes the indicator sort test that already exists in the "searches containers and performs bulk operations" block.

## Screenshots (if appropriate):
old behavior:
![indicatorsort_old](https://user-images.githubusercontent.com/46659222/81446258-8d266d00-9148-11ea-8b8a-372c225f708b.png)

new behavior:
<img width="649" alt="indicatorsort_new" src="https://user-images.githubusercontent.com/46659222/81446263-90b9f400-9148-11ea-8538-d7d804641e8e.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
