### PR TITLE
Update docs sidebar and begin redirects to tech_docs page

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -170,7 +170,7 @@ git push --force-with-lease ANW-123-descriptive-short-title
 
 ### Documentation
 
-ArchivesSpace Technical Documentation is maintained in the [tech-docs repository](https://github.com/archivesspace/tech-docs) and can also be accessed [here](http://archivesspace.github.io/archivesspace/).
+ArchivesSpace Technical Documentation is maintained in the [tech-docs repository](https://github.com/archivesspace/tech-docs).
 
 ### YouTube channels/videos
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Built for archives by archivists, ArchivesSpace is the open source archives info
 
 * [archivesspace.org](http://archivesspace.org)
 * [User Documentation](https://docs.archivesspace.org/)
-* [Technical Documentation](http://archivesspace.github.io/archivesspace/)
+* [Technical Documentation](https://archivesspace.github.io/tech-docs/)
 * [API](http://archivesspace.github.io/archivesspace/api)
 * [Wiki](http://wiki.archivesspace.org)
 * [Issue Tracker](http://development.archivesspace.org)
 
-The latest technical documentation is managed in a separate GitHub repository [ArchivesSpace tech-docs](https://github.com/archivesspace/tech-docs) and is published along with the API documentation and architecture notes, at
-[http://archivesspace.github.io/archivesspace/](http://archivesspace.github.io/archivesspace/).
+The latest technical documentation is managed in a separate GitHub repository [ArchivesSpace tech-docs](https://github.com/archivesspace/tech-docs) and is published at
+[https://archivesspace.github.io/tech-docs/](https://archivesspace.github.io/tech-docs/).
 
 # License
 

--- a/common/db/db_migrator.rb
+++ b/common/db/db_migrator.rb
@@ -258,7 +258,7 @@ latest ArchivesSpace version as normal.
 For more information on upgrading to ArchivesSpace 2.0.1, please see the upgrade
 guide:
 
-  https://archivesspace.github.io/archivesspace/user/upgrading-to-a-new-release-of-archivesspace/
+  https://archivesspace.github.io/tech-docs/administration/upgrading.html
 
 The upgrade guide for version 1.5.0 also contains specific instructions for
 the container upgrade that you will be performing, and the steps in this guide

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -23,6 +23,7 @@
         <li><a href="/archivesspace/user/getting-started-with-archivesspace/">Getting started with ArchivesSpace</a></li>
         <li><a href="/archivesspace/user/running-archivesspace-as-a-unix-daemon/">ArchivesSpace as a Unix daemon</a></li>
         <li><a href="/archivesspace/user/running-archivesspace-as-a-windows-service/">ArchivesSpace as a Windows Service</a></li>
+        <li><a href="/archivesspace/user/log-rotation/">Log Rotation</a></li>
         <li><a href="/archivesspace/user/backup-and-recovery/">Backup and Recovery</a></li>
         <li><a href="/archivesspace/user/re-creating-indexes/">Re-creating Indexes</a></li>
         <li><a href="/archivesspace/user/resetting-passwords/">Resetting Passwords</a></li>
@@ -41,11 +42,22 @@
         <li><a href="/archivesspace/user/archivesspace-architecture-and-components">Architecture Overview</a></li>
         <li><a href="/archivesspace/user/jsonmodel----a-validated-archivesspace-record/">JSONModel -- a validated ArchivesSpace record</a></li>
         <li><a href="/archivesspace/user/the-archivesspace-backend/">ArchivesSpace backend</a></li>
+        <li><a href="/archivesspace/user/the-archivesspace-staff-interface">The ArchivesSpace Staff Interface</a></li>
         <li><a href="/archivesspace/user/background-jobs/">Background Jobs</a></li>
-        <li><a href="/archivesspace/user/working-with-the-archivesspace-api/">ArchivesSpace API</a></li>
         <li><a href="/archivesspace/user/search-indexing/">Search Indexing</a></li>
         <li><a href="/archivesspace/user/the-archivesspace-public-user-interface/">ArchivesSpace Public User Interface</a></li>
         <li><a href="/archivesspace/user/oai-pmh-interface/">OAI-PMH Interface</a></li>
+      </ul>
+      <h2>Working with the ArchivesSpace API</h2>
+      <ul>
+        <li><a href="/archivesspace/user/working-with-the-archivesspace-api/">ArchivesSpace API</a>
+          <ul style="margin-left: 10px;">
+            <li><a href="/archivesspace/user/performing-get-requests/">Performing GET requests</a></li>
+            <li><a href="/archivesspace/user/performing-post-requests/">Performing POST requests</a></li>
+            <li><a href="/archivesspace/user/performing-delete-requests/">Performing DELETE requests</a></li>
+            <li><a href="http://archivesspace.github.io/archivesspace/api/">API Reference</a></li>
+          </ul>
+        </li>
       </ul>
       <h2>Customization and configuration</h2>
       <ul>
@@ -56,6 +68,7 @@
         <li><a href="/archivesspace/user/customizing-text-in-archivesspace/">Customizing Text in ArchivesSpace</a></li>
         <li><a href="/archivesspace/user/theming-archivesspace/">Theming ArchivesSpace</a></li>
         <li><a href="/archivesspace/user/managing-frontend-assets-with-bower/">Managing Frontend Assets with Bower</a></li>
+        <li><a href="/archivesspace/user/reports/">Reports</a></li>
       </ul>
       <h2>Provisioning and server configuration</h2>
       <ul>
@@ -66,23 +79,18 @@
         <li><a href="/archivesspace/user/running-archivesspace-against-mysql/">Running ArchivesSpace Against MySQL</a></li>
         <li><a href="/archivesspace/user/application-monitoring-with-new-relic/">Application Monitoring with New Relic</a></li>
         <li><a href="/archivesspace/user/running-archivesspace-under-a-prefix/">ArchivesSpace under a Prefix</a></li>
+        <li><a href="/archivesspace/user/archivesspace-robots.txt/">ArchivesSpace robots.txt</a></li>
         <li><a href="/archivesspace/user/running-archivesspace-with-external-solr/">ArchivesSpace with External Solr</a></li>
         <li><a href="/archivesspace/user/tuning-archivesspace/">Tuning ArchivesSpace</a></li>
       </ul>
       <h2>Information for developers and code contributors</h2>
       <ul>
-        <li><a href="/archivesspace/user/archivesspace-build-system/">ArchivesSpace Build System</a></li>
+        <li><a href="/archivesspace/user/archivesspace-developer-docs/">ArchivesSpace Developer Docs</a></li>
         <li><a href="/archivesspace/user/building-an-archivesspace-release/">Building an ArchivesSpace Release</a></li>
-        <li><a href="/archivesspace/user/public-test-suite/">Public Test Suite</a></li>
-        <li><a href="/archivesspace/user/selenium-test-suite/">Selenium Test Suite</a></li>
-        <li><a href="/archivesspace/user/using-supervisord-for-development/">Using supervisord for Development</a></li>
+        <li><a href="/archivesspace/user/ui-test-suites/">UI test suites</a></li>
         <li><a href="/archivesspace/user/docker/">Docker</a></li>
-        <li><a href="/archivesspace/user/reports/">Reports</a></li>
-        <li><a href="https://archivesspace.atlassian.net/wiki/spaces/ADC/pages/16449553/Contributing">Contributing to ArchivesSpace</a>
-          <ul style="margin-left: 10px;">
-            <li><a href="/archivesspace/user/contributor-license-agreements/">Contributor License Agreements</a></li>
-          </ul>
-        </li>
+        <li><a href="/archivesspace/user/archivesspace-releases-and-database-versions/">ArchivesSpace releases and database versions</a></li>
+        <li><a href="https://archivesspace.atlassian.net/wiki/spaces/ADC/pages/16449553/Contributing">Contributing to ArchivesSpace</a></li>
         <li><a href="{{ site.baseurl }}/api">The API</a></li>
         <li><a href="{{ site.baseurl }}/doc">Ruby YARD Documentation</a></li>
         <li><div class="status-circle status">Status:</div>

--- a/plugins/hello_world/README.md
+++ b/plugins/hello_world/README.md
@@ -3,8 +3,8 @@
 The `hello_world` exemplar plug-in may be referenced as a model plug-in for implementing an ArchivesSpace customization that overrides or extends the application without changing the core codebase. `hello_world` modifies the 
 ArchivesSpace backend, frontend, and indexer applications, in addition to modifying the ArchivesSpace database and JSONModel schema.
 
-This README provides an explanation for each file that makes up the `hello_world` plug-in, arranged in alphabetical order by directory. For a more general explanation of how plug-ins can be configured in ArchivesSpace, refer to 
-the [ArchivesSpace Plug-ins README](http://archivesspace.github.io/archivesspace/user/archivesspace-plug-ins-readme/)
+This README provides an explanation for each file that makes up the `hello_world` plug-in, arranged in alphabetical order by directory. For a more general explanation of how plug-ins can be configured in ArchivesSpace, refer to
+the [ArchivesSpace Plug-ins README](https://archivesspace.github.io/tech-docs/customization/plugins.html)
 
 ## backend
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
High level attempt to fix broken links on existing docs sidebar that resulted from reorganization within the tech-docs repo; remove references to `archivesspace.github.io/archivesspace` and replace with references to `archivesspace.github.io/tech-docs site`.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
