### PR TITLE
removing two duplicate values in the public locales file

### DIFF
--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -140,8 +140,6 @@ en:
     created: Created
     text_placeholder: Filter by text
     clear_all: Clear All
-    created: Created
-    modified: Modified
     component_switch: Include Components
     more_facets: more
     fewer_facets: less

--- a/public/config/locales/es.yml
+++ b/public/config/locales/es.yml
@@ -121,8 +121,6 @@ es:
     created: Created
     text_placeholder: Filter by text
     clear_all: Clear All
-    created: Created
-    modified: Modified
     component_switch: Include Components
     more_facets: more
     fewer_facets: less

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -140,8 +140,6 @@ fr:
     created: Créé
     text_placeholder: Filtrer par texte
     clear_all: Tout effacer
-    created: Créé
-    modified: Modifié
     component_switch: Inclure composants
     more_facets: plus
     fewer_facets: moins


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Values for created and modified are listed twice in the search_results section of the public locales file. This is unnecessary and interferes with using automated translation software to parse the file. For some reason these weren't duplicated in the Japanese file, so there are only updates to the English, French, and Spanish files here.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
