### PR TITLE
removing some duplicate values related to container bulk operations

### DIFF
--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1246,13 +1246,6 @@ en:
         batch_merge_confirm_question: Are you sure you want to merge the top containers as listed below? This action is irreversible.
         batch_merge_confirm_victims: "Merge the following top container(s):"
         batch_merge_confirm_target: "Into this top container:"
-        rapid_barcode_entry_help: Enter a barcode for each selected container.  Leave the New Barcode field blank to remove the current barcode without replacing it with a new value.
-        batch_merge: Merge Top Containers
-        batch_merge_instructions: Select the top container into which all of the other listed top container(s) will merge. Any linked records will be re-linked to this container and all information for the other top container(s) will be deleted.
-        batch_merge_confirm: Confirm Merge Top Containers
-        batch_merge_confirm_question: Are you sure you want to merge the top containers as listed below? This action is irreversible.
-        batch_merge_confirm_victims: "Merge the following top container(s):"
-        batch_merge_confirm_target: "Into this top container:"
         batch_delete: Delete Top Containers
         batch_delete_help: Delete all selected containers.
         update_n_records: "Update %{n} records"

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -1249,13 +1249,6 @@ es:
         batch_merge_confirm_question: ¿Está seguro de que desea fusionar los contenedores superiores como se enumeran a continuación? Esta acción es irreversible.
         batch_merge_confirm_victims: "Combinar los siguientes contenedores superiores:"
         batch_merge_confirm_target: "En este contenedor superior:"
-        rapid_barcode_entry_help: Ingrese un código de barras para cada contenedor seleccionado. Deje en blanco el campo Nuevo código de barras para eliminar el código de barras actual sin reemplazarlo por un nuevo valor.
-        batch_merge: Fusionar contenedores superiores
-        batch_merge_instructions: Seleccione el contenedor superior en el que se fusionarán todos los demás contenedores superiores enumerados. Los registros vinculados se volverán a vincular a este contenedor y se eliminará toda la información de los otros contenedores principales.
-        batch_merge_confirm: Confirmar combinación de contenedores superiores
-        batch_merge_confirm_question: ¿Está seguro de que desea fusionar los contenedores superiores como se enumeran a continuación? Esta acción es irreversible.
-        batch_merge_confirm_victims: "Combinar los siguientes contenedores superiores:"
-        batch_merge_confirm_target: "En este contenedor superior:"
         batch_delete: Borrar Contenedores Top
         batch_delete_help: Borrar todos los contenedores seleccionados.
         update_n_records: "Actualizar %{n} registros"

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -1247,13 +1247,6 @@ fr:
         batch_merge_confirm_question: Voulez-vous vraiment fusionner les conteneurs supérieurs comme indiqué ci-dessous? Cette action est irréversible.
         batch_merge_confirm_victims: "Fusionner les conteneurs supérieurs suivants:"
         batch_merge_confirm_target: "Dans ce conteneur supérieur:"
-        rapid_barcode_entry_help: Entrez un code-barres pour chaque conteneur sélectionné. Laissez le champ Nouveau code-barres vide pour supprimer le code-barres actuel sans le remplacer par une nouvelle valeur.
-        batch_merge: Fusionner les conteneurs
-        batch_merge_instructions: Sélectionnez le conteneur supérieur dans lequel tous les autres conteneurs répertoriés vont fusionner. Tous les enregistrements liés seront liés à ce conteneur et toutes les informations relatives au (x) autre (s) conteneur (s) supérieur (s) seront supprimées.
-        batch_merge_confirm: Confirmer la fusion des conteneurs supérieurs
-        batch_merge_confirm_question: Voulez-vous vraiment fusionner les conteneurs supérieurs comme indiqué ci-dessous? Cette action est irréversible.
-        batch_merge_confirm_victims: "Fusionner les conteneurs supérieurs suivants:"
-        batch_merge_confirm_target: "Dans ce conteneur supérieur:"
         batch_delete: Supprimer Top conditionnements
         batch_delete_help: Supprimer tous les conditionnements sélectionnés.
         update_n_records: "Actualiser %{n} notices"

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -1245,13 +1245,6 @@ ja:
         batch_merge_confirm_question: 以下にリストされているように、最上位のコンテナーをマージしてもよろしいですか？ このアクションは元に戻せません。
         batch_merge_confirm_victims: "次の上位コンテナをマージします:"
         batch_merge_confirm_target: "この一番上のコンテナに:"
-        rapid_barcode_entry_help: 選択した各コンテナのバーコードを入力します。 [新しいバーコード]フィールドを空白のままにして、現在のバーコードを新しい値に置き換えずに削除します。
-        batch_merge: 上位コンテナのマージ
-        batch_merge_instructions: リストされている他のすべてのトップコンテナがマージされるトップコンテナを選択します。リンクされたレコードはすべてこのコンテナに再リンクされ、他のトップコンテナのすべての情報が削除されます。
-        batch_merge_confirm: 上位コンテナのマージの確認
-        batch_merge_confirm_question: 以下にリストされているように、最上位のコンテナーをマージしてもよろしいですか？ このアクションは元に戻せません。
-        batch_merge_confirm_victims: "次の上位コンテナをマージします:"
-        batch_merge_confirm_target: "この一番上のコンテナに:"
         batch_delete: トップコンテナの削除
         batch_delete_help: 選択したすべてのコンテナを削除します。
         update_n_records: "%{n}レコードを更新する"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Values for a few of the container bulk operations are listed twice. This is unnecessary and interferes with using automated translation software to parse the file.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
