### PR TITLE
use indexer_log_level instead of backend_log_level

### DIFF
--- a/indexer/app/main.rb
+++ b/indexer/app/main.rb
@@ -106,7 +106,7 @@ class ArchivesSpaceIndexer < Sinatra::Base
     end
 
     set :logging, false 
-    Log.noisiness "Logger::#{AppConfig[:backend_log_level].upcase}".constantize
+    Log.noisiness "Logger::#{AppConfig[:indexer_log_level].upcase}".constantize
 
     main
   end


### PR DESCRIPTION
## Description
Make the indexer honor `AppConfig[:indexer_log_level]` instead of `AppConfig[:backend_log_level]`, allowing for the separate configuration of log levels for these two components.

## Related JIRA Ticket or GitHub Issue
Fixes #1692 

## How Has This Been Tested?
Edited the compose file to add `APPCONFIG_INDEXER_LOG_LEVEL` and `APPCONFIG_BACKEND_LOG_LEVEL` in various configurations and observed that the container log output now matches the levels set for both individually.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
