### PR TITLE
Allow repository contact to be indexed

### DIFF
--- a/indexer/app/lib/indexer_common_config.rb
+++ b/indexer/app/lib/indexer_common_config.rb
@@ -74,46 +74,40 @@ class IndexerCommonConfig
   def self.do_not_index
     # ANW-1065
     # #sanitize_json uses this hash to clean up sensitive data, preventing it from being indexed in the json field in the indexer doc.
-    # the first 3 entries will set json["agent_contacts"] to [] for agent_person, corp, etc records
-    # the last entry will set json["agent_representation"]["_resolved"]["agent_contacts"] for repository records
-    {  
-        "agent_person"           => {:location => [], 
-                                     :to_clean => "agent_contacts"}, 
+    {
+        "agent_person"           => {:location => [],
+                                     :to_clean => "agent_contacts"},
         "agent_family"           => {:location => [],
                                      :to_clean => "agent_contacts"},
         "agent_corporate_entity" => {:location => [],
                                      :to_clean => "agent_contacts"},
         "agent_software"         => {:location => [],
                                      :to_clean => "agent_contacts"},
-        "repository"             => {:location => ["agent_representation", 
-                                                   "_resolved"],
-                                     :to_clean => "agent_contacts"},
         "resource"               => {:location => ["repository",
                                                    "_resolved",
-                                                   "agent_representation", 
+                                                   "agent_representation",
                                                    "_resolved"],
                                      :to_clean => "agent_contacts"},
         "archival_object"        => {:location => ["repository",
                                                    "_resolved",
-                                                   "agent_representation", 
+                                                   "agent_representation",
                                                    "_resolved"],
                                      :to_clean => "agent_contacts"},
         "digital_object"         => {:location => ["repository",
                                                    "_resolved",
-                                                   "agent_representation", 
+                                                   "agent_representation",
                                                    "_resolved"],
                                      :to_clean => "agent_contacts"},
         "digital_object_component" => {:location => ["repository",
                                                    "_resolved",
-                                                   "agent_representation", 
+                                                   "agent_representation",
                                                    "_resolved"],
                                      :to_clean => "agent_contacts"},
         "accession"              => {:location => ["repository",
                                                    "_resolved",
-                                                   "agent_representation", 
+                                                   "agent_representation",
                                                    "_resolved"],
                                      :to_clean => "agent_contacts"},
     }
-
   end
 end

--- a/indexer/spec/indexer_common_spec.rb
+++ b/indexer/spec/indexer_common_spec.rb
@@ -461,18 +461,6 @@ describe "indexer common" do
 
       expect(agent["agent_contacts"].empty?).to be_truthy
     end
-
-    it "removes agent_contact data from associated agent when indexing repository" do
-      repo = build(:json_repository)
-      repo["agent_representation"] = {}
-      repo["agent_representation"]["_resolved"] = build(:json_agent_corporate_entity)
-
-
-      expect(repo["agent_representation"]["_resolved"]["agent_contacts"].length).to_not eq(0)
-      sanitized_repo = @ic.sanitize_json(repo)
-
-      expect(sanitized_repo["agent_representation"]["_resolved"]["agent_contacts"].empty?).to be_truthy
-    end
   end
 
 end


### PR DESCRIPTION
It is a corporate agent used to display repository contact info in the pui.
