### PR TITLE
ANW-631 and ANW-700 add id prefixes to linker records

### DIFF
--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -64,7 +64,7 @@ $(function() {
 
                 $this.tokenInput("add", {
                   id: response.uri,
-                  name: response.display_string || response.title,
+                  name: tokenName(response),
                   json: response
                 });
                 $this.triggerHandler("change");
@@ -209,7 +209,7 @@ $(function() {
           $.each(currentlySelected, function(uri, object) {
             $this.tokenInput("add", {
               id: uri,
-              name: object.display_string || object.title,
+              name: tokenName(object),
               json: object
             });
           });
@@ -234,10 +234,9 @@ $(function() {
 
         $.each(searchData.search_data.results, function(index, obj) {
           // only allow selection of unselected items
-
           if ($.inArray(obj.uri, currentlySelectedIds) === -1) {
             formattedResults.push({
-              name: obj.display_string || obj.title,
+              name: tokenName(obj),
               id: obj.id,
               json: obj
             });
@@ -289,7 +288,7 @@ $(function() {
           }
           return [{
               id: $this.data("selected").uri,
-              name: $this.data("selected").display_string || $this.data("selected").title,
+              name: tokenName($this.data("selected")),
               json: $this.data("selected")
           }];
         } else {
@@ -303,7 +302,7 @@ $(function() {
             }
             return {
               id: item.uri,
-              name: item.display_string || item.title,
+              name: tokenName(item),
               json: item
             };
           });
@@ -342,6 +341,33 @@ $(function() {
           return "";
         }
       };
+
+      // ANW-631, ANW-700: Add four_part_id to token name via data source
+      function tokenName(object) {
+        var title = object.display_string || object.title;
+
+        function output(id) {
+          return id + ': ' + title;
+        }
+
+        if (object.four_part_id !== undefined) {
+          // Data comes from Solr index
+          return output(object.four_part_id.split(' ').join('-'));
+        } else {
+          // Data comes from JSON property on data from Solr index
+          var idProperties = ['id_0', 'id_1', 'id_2', 'id_3'];
+          var fourPartIdArr = idProperties.reduce(function (acc, id) {
+            if (object[id] !== undefined) {
+              acc.push(object[id]);
+            }
+            return acc;
+          }, []);
+
+          return fourPartIdArr.length > 0
+            ? output(fourPartIdArr.join('-'))
+            : title;
+        }
+      }
 
       var init = function() {
         var tokenInputConfig = $.extend({}, AS.linker_locales, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR adds id prefixes to linker-rendered records in record edit views and Top Container search view in staff UI. Doing so provides greater context to staff about records that can often have the same display string but different ids.

![screenshot of resource-record-showing-ids](https://raw.githubusercontent.com/brianzelip/archivesspace/ANW-700-bzelip/zelip/resource-record-showing-ids.png)

![screenshot of top-container-search-showing-ids](https://raw.githubusercontent.com/brianzelip/archivesspace/ANW-700-bzelip/zelip/top-container-search-showing-ids.png)

![screenshot of hyphen separators in linker id prefix](https://raw.githubusercontent.com/brianzelip/archivesspace/ANW-700-bzelip/zelip/hyphen%20separator%20for%20linker%20subrecord%20ids.png)

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

- [ANW-631](https://archivesspace.atlassian.net/browse/ANW-631)
- [ANW-700](https://archivesspace.atlassian.net/browse/ANW-700)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
