### PR TITLE
ANW-347 and ANW-897 Better linker dropdown

### DIFF
--- a/frontend/app/assets/javascripts/jquery.tokeninput.js
+++ b/frontend/app/assets/javascripts/jquery.tokeninput.js
@@ -424,9 +424,20 @@ $.TokenList = function (input, url_or_data, settings) {
         .append(input_box);
 
     // The list to store the dropdown items in
+    /**
+     * ANW-897: The plugin appends dropdown to <body>, preventing
+     * scrolling when at the bottom of the viewport.
+     * Let's override this unmaintained plugin by 
+     * appending the dropdown to a relative parent. 
+     * Let's also adjust dropdown styles (see show_dropdown() below).
+     */
+    var dropdown_parent = $("<section>")
+        .insertAfter(token_list)
+        .css({position: 'relative'});
+
     var dropdown = $("<div>")
         .addClass($(input).data("settings").classes.dropdown)
-        .appendTo("body")
+        .appendTo(dropdown_parent)
         .hide();
 
     // Magic element to help us resize the text input
@@ -767,11 +778,19 @@ $.TokenList = function (input, url_or_data, settings) {
     }
 
     function show_dropdown() {
+      /**
+       * ANW-897: The plugin appends dropdown to <body>, preventing
+       * scrolling when at the bottom of the viewport.
+       * Let's override this unmaintained plugin by 
+       * appending the dropdown to a relative parent
+       * (see dropdown_parent above). Let's also adjust dropdown 
+       * styles.
+       */
         dropdown
             .css({
                 position: "absolute",
-                top: $(token_list).offset().top + $(token_list).outerHeight(),
-                left: $(token_list).offset().left,
+                top: $(token_list).outerHeight(),
+                left: 0,
                 width: $(token_list).outerWidth(),
                 'z-index': $(input).data("settings").zindex
             })

--- a/frontend/app/assets/stylesheets/archivesspace/rde.less
+++ b/frontend/app/assets/stylesheets/archivesspace/rde.less
@@ -276,3 +276,9 @@
     }
   }
 }
+
+// ANW-897 and ANW-347: Override jquery.kiketable.colsizable-1.1
+// Show overflow on linker <td>
+.kiketable-colsizable td.overflow-visible {
+  overflow: visible;
+}

--- a/frontend/app/views/archival_objects/_rde_templates.html.erb
+++ b/frontend/app/views/archival_objects/_rde_templates.html.erb
@@ -189,7 +189,7 @@
         <%= form.select "instance_type", jsonmodel_definition(:instance).options_for(form, 'instance_type', true).reject{|option_arr| option_arr[1] === 'digital_object'} %>
       <% end %>
     </td>
-    <td data-col="colCTop" class="form-group">
+    <td data-col="colCTop" class="form-group overflow-visible">
       <% form.push(form.set_index("instances[]", 0), begin archival_object["instances"][0] || {} rescue {} end) do %>
         <% form.push(form.set_index("sub_container", 0), form["sub_container"] || {}) do %>
           <% form.push("top_container", form.obj["top_container"] || {}) do %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR enables scrolling on the linker dropdown when the linker is positioned at the bottom of the viewport (which happens when the linker is at the bottom of a modal form) ([ANW-897](https://archivesspace.atlassian.net/browse/ANW-897)).

⚠️ This PR overrides the Token Input jquery plugin file directly ⚠️

While editing 3rd party files is icky, I feel it is ok in this case since the plugin has been unmaintained for 6 years, and [the repo is archived](https://github.com/loopj/jquery-tokeninput) in read only mode. It's safe to assume there won't be anymore updates to this plugin.

![screenshot showing linker scroll at bottom of screen](https://raw.githubusercontent.com/brianzelip/archivesspace/ANW-897-zelip/zelip/linker-scroll-at-bottom-of-screen.png)

This PR also overrides the jquery.kiketable.colsizable plugin's CSS to enable linker scroll in the Rapid Data Entry form (which is required after
 the changes mentioned above) ([ANW-347](https://archivesspace.atlassian.net/browse/ANW-347)).

![screenshot showing linker scroll at bottom of screen](https://raw.githubusercontent.com/brianzelip/archivesspace/ANW-897-zelip/zelip/linker-rde-scroll.png)

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

- [ANW-347](https://archivesspace.atlassian.net/browse/ANW-347)
- [ANW-897](https://archivesspace.atlassian.net/browse/ANW-897)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In-browser testing

## Screenshots (if appropriate):

See above

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
