### PR TITLE
ANW-1053 Reset PUI print button

### DIFF
--- a/public/app/assets/javascripts/print.js
+++ b/public/app/assets/javascripts/print.js
@@ -1,22 +1,4 @@
-$(function () {
-    /* The PDF controller sets a cookie containing a `token` nonce when the
-       download starts.  Poll until we see it. */
-    var whenDownloadBegins = function(token, callback) {
-        var attempt = 0;
-        var max_attempts = 60;
-        var delay = 1000;
-
-        var next = function () {
-            if (document.cookie.indexOf("pdf_generated_" + token) >= 0 || attempt >= max_attempts) {
-                callback();
-            } else {
-                setTimeout(next, delay);
-            }
-        }
-
-        setTimeout(next, delay);
-    };
-
+$(function () {    
     $('#print_button').on('click', function (e) {
         var self = $(this);
 
@@ -25,20 +7,24 @@ $(function () {
 
         var token = (base_token + new Date().getTime());
         form.find("input[name='token']").attr('value', token);
+        
+        function resetPrintBtn() {
+            self.find('.generating-label').hide();
+            self.find('.print-label').show();
+            self.removeAttr('disabled');
+        }
 
         self.find('.print-label').hide();
         self.find('.generating-label').show();
         self.attr('disabled', 'disabled');
 
-        whenDownloadBegins(token, function () {
-            self.find('.print-label').show();
-            self.find('.generating-label').hide();
-            self.attr('disabled', null);
-        });
-
         setTimeout(function () {
             form.submit();
         }, 0);
+
+        setTimeout(function() {
+            resetPrintBtn();
+        }, 1000)
 
         return false;
     });

--- a/public/app/controllers/pdf_controller.rb
+++ b/public/app/controllers/pdf_controller.rb
@@ -16,7 +16,6 @@ class PdfController <  ApplicationController
 
       if token
         token.gsub!(/[^a-f0-9]/, '')
-        cookies["pdf_generated_#{token}"] = { value: token, expires: 5.minutes.from_now, httponly: true }
       end
 
       respond_to do |format|


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This PR resets the PUI print-to-pdf button after it's clicked. It also removes an unneeded function whose callback never ran due to httponly cookies.

![screenshot showing print button resetting](https://raw.githubusercontent.com/brianzelip/archivesspace/ANW-1053-zelip/zelip/reset-print-btn2.gif)


## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

[ANW-1053](https://archivesspace.atlassian.net/browse/ANW-1053)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In browser testing.

## Screenshots (if appropriate):

See above.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
