### PR TITLE
Minor changes to routes and spec in response to syncing plugin versions

### DIFF
--- a/plugins/lcnaf/frontend/routes.rb
+++ b/plugins/lcnaf/frontend/routes.rb
@@ -1,7 +1,11 @@
 ArchivesSpace::Application.routes.draw do
-  scope AppConfig[:frontend_proxy_prefix] do
-    match('/plugins/lcnaf' => 'lcnaf#index', :via => [:get])
-    match('/plugins/lcnaf/search' => 'lcnaf#search', :via => [:get])
-    match('/plugins/lcnaf/import' => 'lcnaf#import', :via => [:post])
+
+  [AppConfig[:frontend_proxy_prefix], AppConfig[:frontend_prefix]].uniq.each do |prefix|
+
+    scope prefix do
+      match('/plugins/lcnaf' => 'lcnaf#index', :via => [:get])
+      match('/plugins/lcnaf/search' => 'lcnaf#search', :via => [:get])
+      match('/plugins/lcnaf/import' => 'lcnaf#import', :via => [:post])
+    end
   end
 end

--- a/plugins/lcnaf/frontend/spec/lcnaf_client_spec.rb
+++ b/plugins/lcnaf/frontend/spec/lcnaf_client_spec.rb
@@ -23,16 +23,20 @@ describe "id.loc.gov clientware" do
       expect(results.items_per_page).to eq(20)
 
       expect(results.entries[0]['title']).to eq('Franklin')
-      expect(results.entries[0]['uri']).to match(/http:\/\/id\.loc\.gov\/authorities\/names\/n\d+/)
+      expect(results.entries[0]['uri']).to match(/http:\/\/id\.loc\.gov\/authorities\/names\/n\S+/)
     end
 
 
     it "can get the second page" do
       results = loc_searcher.search('franklin', 2, 20)
+
+      expect(results.class.name).to eq('OpenSearchResultSet')
+
+      expect(results.total_results.to_s).to match (/^\d+$/)
       expect(results.start_index).to eq(21)
-      # TO-DO: This is hardcoded but these responses are liable to change over
-      # time. This test should be refactored.
-      expect(results.entries[0]['title']).to eq('Franklin Falls (Franklin, N.H.)')
+      expect(results.items_per_page).to eq(20)
+
+      expect(results.entries[0]['uri']).to match(/http:\/\/id\.loc\.gov\/authorities\/names\/n\S+/)
     end
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Minor updates to the embedded lcnaf plugin to keep this version and https://github.com/archivesspace-plugins/lcnaf in sync

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
-Opted to preserve the external plugins routes file.
- Updated spec locations so they can be run with `build/run plugin:frontend:test`
- Fixed regularly failing second page test so that it's not pinned to a specific search result
- Fixed regex in spec to account for valid lcnaf identifiers that may have more than a single alpha character at the start of the identifier

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
