### PR TITLE
Fix container profile merge modal to re-add display strings

### DIFF
--- a/frontend/app/assets/javascripts/browse_merge.js
+++ b/frontend/app/assets/javascripts/browse_merge.js
@@ -1,7 +1,7 @@
 get_selection = function() {
   var results = [];
 
-  $(document).find(".multiselect-column :input:checked").each(function(i, checkbox) {
+  $(document).find("td.multiselect-column :input:checked").each(function(i, checkbox) {
     results.push({
       uri: checkbox.value,
       display_string: $(checkbox).data("display-string"),

--- a/frontend/app/views/shared/_multiselect.html.erb
+++ b/frontend/app/views/shared/_multiselect.html.erb
@@ -1,4 +1,4 @@
 <label>
   <span class="sr-only"><%= I18n.t("search_results.selected") %></span>
-  <%= check_box_tag "multiselect-item", record["id"], false, "autocomplete" => "off" %>
+  <%= check_box_tag "multiselect-item", record["id"], false, "autocomplete" => "off", "data-display-string" => "#{clean_mixed_content(record["title"]).html_safe || clean_mixed_content(record['display_string']).html_safe}" %>
 </label>

--- a/frontend/spec/selenium/spec/container_profiles_spec.rb
+++ b/frontend/spec/selenium/spec/container_profiles_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+describe 'Container Profiles' do
+  before(:all) do
+    @repo = create(:repo, repo_code: "container_profiles_test_#{Time.now.to_i}")
+    set_repo @repo
+
+    @archivist_user = create_user(@repo => ['repository-archivists'])
+    @manager_user = create_user(@repo => ['repository-managers'])
+
+    run_all_indexers
+
+    @driver = Driver.get.login_to_repo(@manager_user, @repo)
+  end
+
+  after(:all) do
+    @driver ? @driver.quit : next
+  end
+
+  it 'can create a container profile' do
+    @driver.login_to_repo(@archivist_user, @repo)
+    @driver.find_element(:link, 'Create').click
+    @driver.click_and_wait_until_gone(:link, 'Container Profile')
+
+    @driver.clear_and_send_keys([:id, 'container_profile_name_'], 'An itty bitty box')
+    @driver.find_element(id: 'container_profile_dimension_units_').select_option('millimeters')
+    @driver.find_element(id: 'container_profile_extent_dimension_').select_option('depth')
+    @driver.clear_and_send_keys([:id, 'container_profile_depth_'], 1)
+    @driver.clear_and_send_keys([:id, 'container_profile_height_'], 1)
+    @driver.clear_and_send_keys([:id, 'container_profile_width_'], 0.2)
+
+    @driver.click_and_wait_until_gone(:css, 'form#new_container_profile .btn-primary')
+
+    @driver.find_element_with_text('//div[contains(@class, "alert-success")]', /Container Profile Created/)
+
+  end
+
+  it 'cannot create a container profile with non-digit dimensions' do
+    @driver.login_to_repo(@archivist_user, @repo)
+    @driver.find_element(:link, 'Create').click
+    @driver.click_and_wait_until_gone(:link, 'Container Profile')
+
+    @driver.clear_and_send_keys([:id, 'container_profile_name_'], 'Not-a-number box')
+    @driver.find_element(id: 'container_profile_dimension_units_').select_option('inches')
+    @driver.find_element(id: 'container_profile_extent_dimension_').select_option('height')
+    @driver.clear_and_send_keys([:id, 'container_profile_depth_'], 12)
+    @driver.clear_and_send_keys([:id, 'container_profile_height_'], 'one')
+    @driver.clear_and_send_keys([:id, 'container_profile_width_'], 18)
+
+    @driver.click_and_wait_until_gone(:css, 'form#new_container_profile .btn-primary')
+
+    expect do
+      @driver.find_element_with_text('//div[contains(@class, "error")]', /Height - Must be a number with no more than 2 decimal places\./, false, true)
+    end.to raise_error(Selenium::WebDriver::Error::NoSuchElementError)
+
+    @driver.clear_and_send_keys([:id, 'container_profile_height_'], 10)
+    @driver.click_and_wait_until_gone(:css, 'form#new_container_profile .btn-primary')
+
+    @driver.find_element_with_text('//div[contains(@class, "alert-success")]', /Container Profile Created/)
+
+  end
+
+  it 'can merge container profiles from browse when a repository manager' do
+
+    run_all_indexers
+
+    @driver.find_element(:link, 'Browse').click
+    @driver.click_and_wait_until_gone(:link, 'Container Profiles')
+
+    # Two container profiles exist
+    @driver.find_element_with_text('//td[contains(@class, "col")]', /An itty bitty box/)
+    @driver.find_element_with_text('//td[contains(@class, "col")]', /Not-a-number box/)
+
+    # Select profiles to merge
+    @driver.find_element(:css, 'th input#select_all').click
+    @driver.find_element(:css, '.record-toolbar .btn#batchMerge').click
+
+    # Selection modal exists and includes selected elements
+    expect do
+      @driver.find_element(:css, '#batchMergeModal')
+      @driver.find_element_with_text('//div[contains(@class, "selected-record-list")]', /An itty bitty box/)
+      @driver.find_element_with_text('//div[contains(@class, "selected-record-list")]', /Not-a-number box/)
+    end.not_to raise_error
+
+    # Select target and merge
+    @driver.find_elements(:css, 'div.selected-record-list input')[0].click
+    @driver.find_element(:css, 'div#batchMergeModal .merge-button').click
+
+    # Confirmation modal exists and merge occurs
+    expect do
+      @driver.find_element(:css, '#bulkMergeConfirmModal')
+    end.not_to raise_error
+
+    @driver.click_and_wait_until_gone(:css, 'div#bulkMergeConfirmModal .merge-button')
+    assert(5) { expect(@driver.find_element(:css, '.alert.alert-success').text).to eq('Container Profiles(s) Merged') }
+
+    run_index_round
+
+    @driver.find_element(:link, 'Browse').click
+    @driver.click_and_wait_until_gone(:link, 'Container Profiles')
+
+    @driver.find_element_with_text('//div', /Showing 1 - 1 of 1 Results/)
+    assert(5) { expect(@driver.find_element_with_text('//tr[1]/td[2]', /An itty bitty box/)).not_to be_nil }
+
+  end
+
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Refactoring done as part of #1913 resulted in the display strings being inadvertently removed from the container profile merge selection modal.  This fix re-adds the display string to the data attributes of the select all buttons in `shared/_multiselect.html.erb` and narrows the scoping of the results list in `browse_merge.js` so that it doesn't inadvertently provide a blank radio button for the header element. 

This also includes a first pass at adding some container profile selenium tests (previously there were none), including a test to confirm the above bug no longer persists.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Issue identified during internal release candidate testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass, new tests added.

## Screenshots (if appropriate):
Existing bug:
<img width="655" alt="cp_modals_before" src="https://user-images.githubusercontent.com/15144646/83934216-18f9dc00-a77d-11ea-931b-99f4dc29c8a5.png">

Fix:
<img width="719" alt="cp_modals_after" src="https://user-images.githubusercontent.com/15144646/83934219-1e572680-a77d-11ea-9d0e-afae319e34e5.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
