### PR TITLE
Change the default sort of jobs index to time_submitted

### DIFF
--- a/common/config/preference_defaults.rb
+++ b/common/config/preference_defaults.rb
@@ -167,8 +167,8 @@ module PreferenceConfig
       'job_browse_column_5' => '',
       'job_browse_column_6' => '',
       'job_browse_column_7' => '',
-      'job_sort_column' => 'status',
-      'job_sort_direction' => 'asc',
+      'job_sort_column' => 'time_submitted',
+      'job_sort_direction' => 'desc',
       'locale' => AppConfig[:locale].to_s,
       'note_order' => [],
     }

--- a/common/config/search_browse_column_config.rb
+++ b/common/config/search_browse_column_config.rb
@@ -178,6 +178,7 @@ module SearchAndBrowseColumnConfig
       "job_data" => {:field => "job_data"},
       "time_started" => {:field => "time_started", :sortable => true},
       "time_finished" => {:field => "time_finished", :sortable => true},
+      "time_submitted" => {:field => "time_submitted", :sortable => true},
       "audit_info" => {:field => "audit_info", :sort_by => ["time_started", "time_finished"]}
     }
   }

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -2050,10 +2050,15 @@ en:
     time_submitted: Time Submitted
     time_started: Time Started
     time_finished: Time Completed
+    time_submitted: Time Submitted
     owner: Owner
     show_description: Show Description
     input_file: Input File
     output_file: Output File
+
+  container_labels_job:
+    source: Source
+    format: Format
 
   report_job:
     report_type: Report Type

--- a/common/locales/es.yml
+++ b/common/locales/es.yml
@@ -2029,10 +2029,15 @@ es:
     time_submitted: Tiempo sometida
     time_started: Tiempo comenzado
     time_finished: Tiempo terminado
+    time_submitted: Hora enviada
     owner: Propietario
     show_description: Muestra descripción
     input_file: Archivo de entrada
     output_file: Archivo de salida
+
+  container_labels_job:
+    source: Fuente
+    format: Formato
 
   report_job:
     report_type: Tipo de informe

--- a/common/locales/fr.yml
+++ b/common/locales/fr.yml
@@ -2049,10 +2049,15 @@ fr:
     time_submitted: Heure de soumission
     time_started: Heure de commencement
     time_finished: Heure d'achèvement
+    time_submitted: Heure de soumission
     owner: Owner
     show_description: Montrer description
     input_file: Fichier d'entrée
     output_file: Fichier de sortie
+
+  container_labels_job:
+    source: Source
+    format: Format
 
   report_job:
     report_type: Type de rapport

--- a/common/locales/ja.yml
+++ b/common/locales/ja.yml
@@ -1573,10 +1573,15 @@ ja:
     time_submitted: 提出された時間
     time_started: 時間の開始
     time_finished: 完了した時間
+    time_submitted: 提出された時間
     owner: オーナー
     show_description: 説明を表示する
     input_file: 入力ファイル
     output_file: 出力ファイル
+
+  container_labels_job:
+    source: ソース
+    format: フォーマット
 
   report_job:
     report_type: レポートタイプ

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -398,6 +398,7 @@ en:
       job_report_type: Job Type
       time_started: Time Started
       time_finished: Time Completed
+      time_submitted: Time Submitted
       job_data: Job Information
       audit_info: Audit Information
       user_mtime: Modified

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -400,6 +400,7 @@ es:
       job_report_type: Tipo de tarea
       time_started: Tiempo comenzado
       time_finished: Tiempo terminado
+      time_submitted: Hora enviada
       job_data: Informacion del trabajo
       audit_info: Datos de auditoría
       user_mtime: Modificado

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -398,6 +398,7 @@ fr:
       job_report_type: Type de tâche
       time_started: Heure de commencement
       time_finished: Heure d'achèvement
+      time_submitted: Heure de soumission
       job_data: Information de tâche
       audit_info: Audit Information
       user_mtime: Modifié

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -406,6 +406,7 @@ ja:
       job_report_type: ジョブの種類
       time_started: 時間の開始
       time_finished: 完了した時間
+      time_submitted: 提出された時間
       job_data: ジョブ情報
       audit_info: 監査データ
       user_mtime: 更新しました


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Set the default sort for the jobs index page to `time_submitted`.

Also, add new required translations for `time_submitted` sort value, and also fix #1879 oversight of not providing translations for the core-shipped background job container labels job parameters that are now listed in the index's job_data column.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Fix stemming from initial internal 2.8.0RC testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests passed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
