### PR TITLE
ANW-1089: Fix regex for extracting barcodes from label attributes in containers in EAD importer

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -774,7 +774,7 @@ class EADConverter < Converter
 
       instance_type = att('label') || 'mixed_materials'
 
-      if instance_type =~ /(.*)\s+?[\(\[] *(.*) *[\)\]]$/
+      if instance_type =~ /(.*)\s+?[\(\[]\s*(.*?)\s*[\)\]]$/
         instance_type = $1
         barcode = $2
       end


### PR DESCRIPTION
## Description
Adds a `?` quantifier to stop the `.*` part of the regular expression pattern, which matches barcodes, from being greedy and overriding the part of the pattern intended to match spaces. This prevents trailing spaces from being regarded as part of the barcode.

This, in turn, avoids the EAD importer failing when multiple container elements have the same barcode in their label attributes, but with an extra space. See the related JIRA ticket.

Also changed ` *` to `\s*` so other forms of whitespace (tabs, newlines) are also not included at the start or end of the barcode.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1089

## How Has This Been Tested?
Tested on a development system using a real EAD file which was failing on our production system.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
