### PR TITLE
Use correct search controller from top container location browse

### DIFF
--- a/frontend/app/views/top_containers/bulk_operations/_location_linker.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_location_linker.html.erb
@@ -19,7 +19,7 @@
          data-name="ref"
          data-path="<%= path %>"
          data-url="<%= url_for  :controller => :search, :action => :do_search, :format => :json %>"
-         data-browse-url="<%= url_for :controller => :locations, :action => :search, :format => :js, :facets => [], :sort => "title_sort asc" %>"
+         data-browse-url="<%= url_for :controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.LOCATION_FACETS %>"
          data-selected="<%= selected_json %>"
          data-multiplicity="one"
          data-types='<%= linkable_types.to_json %>'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#1913 requires browse to go through the generic `search_controller` instead of record-type-specific controllers.  This changes the `location_linker` used by top_containers to follow that new model.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Resolves bug introduced by #1913.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Discovered during initial internal 2.8.0RC testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Prior to fix a locations browse from top containers shows no results:
![image](https://user-images.githubusercontent.com/15144646/84186633-d1b26a80-aa5e-11ea-8cdf-05651c9b7517.png)

Following fix:
![image](https://user-images.githubusercontent.com/15144646/84187354-eba07d00-aa5f-11ea-9da3-431191cffc74.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
