### PR TITLE
Updates for pui search

### DIFF
--- a/backend/app/model/search.rb
+++ b/backend/app/model/search.rb
@@ -80,8 +80,9 @@ class Search
     boolean_query = JSONModel.JSONModel(:boolean_query)
                     .from_hash('op' => 'OR',
                                'subqueries' => uris.map {|uri|
+                                 field = uri.end_with?('#pui') ? 'id' : 'uri'
                                  JSONModel.JSONModel(:field_query)
-                                   .from_hash('field' => 'id',
+                                   .from_hash('field' => field,
                                               'value' => uri,
                                               'literal' => true)
                                    .to_hash

--- a/backend/app/model/solr.rb
+++ b/backend/app/model/solr.rb
@@ -239,6 +239,7 @@ class Solr
       if @show_published_only
         # public ui
         add_solr_param(:fq, "publish:true")
+        add_solr_param(:fq, "types:pui")
       else
         # staff ui
         add_solr_param(:fq, "-types:pui_only")

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -766,6 +766,7 @@ class IndexerCommon
         parent_type = JSONModel.parse_reference(record['uri'])[:type]
         docs << {
           'id' => cm['uri'],
+          'uri' => cm['uri'],
           'parent_id' => record['uri'],
           'parent_title' => record['record']['title'] || record['record']['display_string'],
           'parent_type' => parent_type,
@@ -773,7 +774,6 @@ class IndexerCommon
           'types' => ['collection_management'],
           'primary_type' => 'collection_management',
           'json' => cm.to_json(:max_nesting => false),
-          'cm_uri' => cm['uri'],
           'processing_priority' => cm['processing_priority'],
           'processing_status' => cm['processing_status'],
           'processing_hours_total' => cm['processing_hours_total'],

--- a/indexer/app/lib/large_tree_doc_indexer.rb
+++ b/indexer/app/lib/large_tree_doc_indexer.rb
@@ -20,9 +20,11 @@ class LargeTreeDocIndexer
 
       batch << {
         'id' => "#{node_uri}/tree/root",
+        'uri' => "#{node_uri}/tree/root",
         'pui_parent_id' => node_uri,
         'publish' => "true",
         'primary_type' => "tree_root",
+        'types' => ['pui'],
         'json' => ASUtils.to_json(json)
       }
 
@@ -42,9 +44,11 @@ class LargeTreeDocIndexer
 
       batch << {
         'id' => "#{root_record_uri}/tree/waypoint_#{parent_uri}_#{waypoint_number}",
+        'uri' => "#{root_record_uri}/tree/waypoint_#{parent_uri}_#{waypoint_number}",
         'pui_parent_id' => (parent_uri || root_record_uri),
         'publish' => "true",
         'primary_type' => "tree_waypoint",
+        'types' => ['pui'],
         'json' => ASUtils.to_json(json)
       }
 
@@ -70,9 +74,11 @@ class LargeTreeDocIndexer
 
       batch << {
         'id' => "#{root_record_uri}/tree/node_#{json.fetch('uri')}",
+        'uri' => "#{root_record_uri}/tree/node_#{json.fetch('uri')}",
         'pui_parent_id' => json.fetch('uri'),
         'publish' => "true",
         'primary_type' => "tree_node",
+        'types' => ['pui'],
         'json' => ASUtils.to_json(json)
       }
 
@@ -97,9 +103,11 @@ class LargeTreeDocIndexer
       node_paths.each do |node_id, path|
         batch << {
           'id' => "#{root_uri}/tree/node_from_root_#{node_id}",
+          'uri' => "#{root_uri}/tree/node_from_root_#{node_id}",
           'pui_parent_id' => node_id_to_uri.fetch(Integer(node_id)),
           'publish' => "true",
           'primary_type' => "tree_node_from_root",
+          'types' => ['pui'],
           'json' => ASUtils.to_json({node_id => path})
         }
       end

--- a/indexer/app/lib/pui_indexer.rb
+++ b/indexer/app/lib/pui_indexer.rb
@@ -106,9 +106,11 @@ class PUIIndexer < PeriodicIndexer
 
       batch << {
         'id' => "#{resource_uri}/ordered_records",
+        'uri' => "#{resource_uri}/ordered_records",
         'pui_parent_id' => resource_uri,
         'publish' => "true",
         'primary_type' => "resource_ordered_records",
+        'types' => ['pui'],
         'json' => ASUtils.to_json(json)
       }
     end

--- a/public/app/helpers/view_helper.rb
+++ b/public/app/helpers/view_helper.rb
@@ -1,4 +1,18 @@
 module ViewHelper
+  def inherited?(item)
+    (item.key?('_inherited') && item['_inherited']) || (item.key?('is_inherited') && item['is_inherited'])
+  end
+
+  def all_inherited?(items)
+    items.all? { |item| inherited?(item) }
+  end
+
+  def display_component_id(record, infinite_item)
+    return nil if record.identifier.blank? || (infinite_item && record.json.key?('component_id_inherited'))
+
+    record.identifier
+  end
+
   #TODO: figure out a clever way to DRY these helpers up.
 
   # returns repo URL via slug if defined, via ID it not.

--- a/public/app/models/finding_aid_pdf.rb
+++ b/public/app/models/finding_aid_pdf.rb
@@ -72,7 +72,7 @@ class FindingAidPDF
         raise TimeoutError.new("PDF generation timed out.  Sorry!")
       end
 
-      uri_set = entry_set.map(&:uri).map {|s| s + "#pui"}
+      uri_set = entry_set.map(&:uri)
       record_set = archivesspace.search_records(uri_set, {}, true).records
 
       record_set.zip(entry_set).each do |record, entry|

--- a/public/app/models/record.rb
+++ b/public/app/models/record.rb
@@ -83,15 +83,15 @@ class Record
     build_request_item
   end
 
-  private
-
-  def parse_full_title
+  def parse_full_title(infinite_item = false)
     ft =  process_mixed_content(json['display_string'] || json['title'], :preserve_newlines => true)
-    unless json['title_inherited'].blank? || (json['display_string'] || '') == json['title']
+    unless infinite_item || json['title_inherited'].blank? || (json['display_string'] || '') == json['title']
       ft = I18n.t('inherited', :title => process_mixed_content(json['title'], :preserve_newlines => true), :display => ft)
     end
     ft
   end
+
+  private
 
   def parse_identifier
     json.dig('_composite_identifier') || json.dig('component_id') ||

--- a/public/app/services/archives_space_client.rb
+++ b/public/app/services/archives_space_client.rb
@@ -63,6 +63,7 @@ class ArchivesSpaceClient
 
     SolrResults.new(results)
   end
+
   # calls the '/search/records' endpoint
   def search_records(record_list, search_opts = {}, full_notes = false)
     search_opts = DEFAULT_SEARCH_OPTS.merge(search_opts)
@@ -71,7 +72,7 @@ class ArchivesSpaceClient
     results = do_search(url)
 
     # Ensure that the order of our results matches the order of `record_list`
-    results['results'] = results['results'].sort_by {|result| record_list.index(result.fetch('id'))}
+    results['results'] = results['results'].sort_by {|result| record_list.index(result.fetch('uri'))}
 
     SolrResults.new(results, search_opts, full_notes)
   end

--- a/public/app/views/resources/_infinite_item.html.erb
+++ b/public/app/views/resources/_infinite_item.html.erb
@@ -3,25 +3,30 @@
 %>
 <div class="infinite-item infinite-item-indent-<%= indent_level %>">
   <div class="information" style="overflow: hidden;">
-      <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => false} } %>
+      <%=
+        render partial: 'shared/idbadge', locals: {
+          :props => { :full => false, :infinite_item => true },
+          :result => @result,
+        }
+      %>
   </div>
 
   <% scopecontent_note = @result.note('scopecontent') %>
-  <% if scopecontent_note %>
+  <% if scopecontent_note && !inherited?(scopecontent_note) %>
     <%= render partial: 'shared/single_note', locals: {:type => 'abstract', :note_struct => scopecontent_note, :notitle => true} %>
   <% end %>
 
   <dl class="dl-horizontal">
 
     <% accessrestrict_note = @result.note('accessrestrict') %>
-    <% if accessrestrict_note && !accessrestrict_note['note_text'].blank? %>
+    <% if accessrestrict_note && !accessrestrict_note['note_text'].blank? && !inherited?(accessrestrict_note) %>
       <dt><%= accessrestrict_note['label'] %></dt>
       <dd>
         <%= render partial: 'shared/single_note', locals: {:type => 'accessrestrict', :note_struct => accessrestrict_note, :notitle => true} %>
       </dd>
     <% end %>
 
-    <% unless @result.dates.blank? %>
+    <% unless @result.dates.blank? || all_inherited?(@result.dates) %>
         <dt><%= t('resource._public.dates') %></dt>
         <% @result.dates.each do |date| %>
         <dd>
@@ -31,7 +36,7 @@
         <% end %>
     <% end %>
 
-    <% unless @result.extents.blank? %>
+    <% unless @result.extents.blank? || all_inherited?(@result.extents) %>
         <dt><%= t('resource._public.extent') %></dt>
         <% @result.extents.each do |extent| %>
           <dd>
@@ -41,7 +46,7 @@
         <% end %>
     <% end %>
 
-    <% unless @result.agents.blank? %>
+    <% unless @result.agents.blank? || all_inherited?(@result.agents.collect(&:last).flatten) %>
       <dt><%= t('pui_agent.related') %></dt>
         <% @result.agents.collect(&:last).flatten.each do |relationship| %>
           <dd>
@@ -51,7 +56,7 @@
     <% end %>
 
     <% if @result.lang_materials %>
-      <% @result.lang_materials.each do |lang_material| %>
+      <% @result.lang_materials.reject { |lm| inherited?(lm) }.each do |lang_material| %>
         <dt><%= t('resource._public.lang')%></dt>
         <dd><%= t('enumerations.language_iso639_2.' + lang_material['language']) %></dd>
         <% unless lang_material['script'].blank? %>
@@ -61,7 +66,7 @@
       <% end %>
     <% else %>
       <% langmaterial_note = @result.note('langmaterial') %>
-      <% if langmaterial_note && !langmaterial_note['note_text'].blank? %>
+      <% if langmaterial_note && !langmaterial_note['note_text'].blank? && !inherited?(langmaterial_note) %>
         <dt><%= t('resource._public.lang')%></dt>
         <dd>
           <%= render partial: 'shared/single_note', locals: {:type => 'langmaterial', :note_struct => langmaterial_note, :notitle => false} %>

--- a/public/app/views/shared/_idbadge.html.erb
+++ b/public/app/views/shared/_idbadge.html.erb
@@ -10,7 +10,6 @@ if result.level
 else
     badge_label = t("#{result.primary_type}._singular")
 end
-
 %>
 
 <%# build URL with slugs depending on the primary type %>
@@ -41,7 +40,9 @@ end
 
 <%= (props.fetch(:full,false)? '<h1>' : '<h3>').html_safe %>
   <% if !props.fetch(:full,false) %>
-    <a class="record-title" href="<%= app_prefix(url) %>">  <%== result.display_string %></a>
+    <a class="record-title" href="<%= app_prefix(url) %>">
+      <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>
+    </a>
   <% else %>
     <%== result.display_string %>
   <% end %>
@@ -52,7 +53,7 @@ end
   <div class="record-type-badge <%= (result.primary_type.start_with?('agent') ? 'agent' : result.primary_type) %>">
     <i class="<%= icon_for_type(result.primary_type) %>"></i>&#160;<%= badge_label %> <% if result.container_summary_for_badge %> &mdash; <%= result.container_summary_for_badge %><% end %>
   </div>
-    <% comp_id = result.identifier %>
+  <% comp_id = display_component_id(result, props.fetch(:infinite_item, false)) %>
   <% unless comp_id.blank? %>
     <div class="identifier">
       <span class="id-label"><%= t('search_sorting.identifier') %>:</span>&#160;<span class="component"><%= comp_id %></span>

--- a/solr/schema-6.6.xml
+++ b/solr/schema-6.6.xml
@@ -176,7 +176,6 @@
    <field name="outcome" type="string" indexed="true" stored="true" multiValued="false" />
 
    <!-- Collection Management fields -->
-   <field name="cm_uri" type="string" indexed="true" stored="true" multiValued="false" />
    <field name="parent_title" type="text_general" indexed="true" stored="true" multiValued="false" />
    <field name="parent_type" type="string" indexed="true" stored="true" multiValued="false" />
    <field name="processing_priority" type="string" indexed="true" stored="true" multiValued="false" />

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -178,7 +178,6 @@
    <field name="outcome" type="string" indexed="true" stored="true" multiValued="false" />
 
    <!-- Collection Management fields -->
-   <field name="cm_uri" type="string" indexed="true" stored="true" multiValued="false" />
    <field name="parent_title" type="text_general" indexed="true" stored="true" multiValued="false" />
    <field name="parent_type" type="string" indexed="true" stored="true" multiValued="false" />
    <field name="processing_priority" type="string" indexed="true" stored="true" multiValued="false" />


### PR DESCRIPTION
Add fq for types pui to all pui searches, this eliminates duplicates results
with record types using inheritance (i.e. where there are 2 published records
but only 1 with type pui, commonly this applies to archival objects).

Add types pui to tree and scroll docs so the pui can continue to access them.
This is required for the Collection Organization functionality to work.

Update all record types to include a uri. This is for consistency and also
so that the records_for_uris method can always search by uri except when
using a pui id (in that case use the id field as before). This is also
required for Collection Organization as it uses both forms (id and uri).

Cleanup unused cm_uri for Collection Management.