### PR TITLE
Fix select_all deletion

### DIFF
--- a/frontend/app/assets/javascripts/search.js
+++ b/frontend/app/assets/javascripts/search.js
@@ -43,7 +43,7 @@ $(function() {
       if ($table.is($multiselectEffectedWidget.data("multiselect"))) {
         $table.on("multiselectselected.aspace", function() {
           $multiselectEffectedWidget.removeAttr("disabled");
-          var selected_records = $.makeArray($(".multiselect-column :input:checked", $table).map(function() {return $(this).val();}));
+          var selected_records = $.makeArray($("td.multiselect-column :input:checked", $table).map(function() {return $(this).val();}));
           $multiselectEffectedWidget.data("form-data", {
             record_uris: selected_records
           });

--- a/frontend/spec/selenium/spec/accessions_spec.rb
+++ b/frontend/spec/selenium/spec/accessions_spec.rb
@@ -505,9 +505,7 @@ describe 'Accessions' do
     @driver.find_element(:link, 'Browse').click
     @driver.click_and_wait_until_gone(:link, 'Accessions')
 
-    @driver.blocking_find_elements(:css, 'td.multiselect-column input').each do |checkbox|
-      checkbox.click
-    end
+    @driver.blocking_find_elements(:css, 'th.multiselect-column input')[0].click
 
     @driver.find_element(:css, '.record-toolbar .btn.multiselect-enabled').click
     @driver.find_element(:css, '#confirmChangesModal #confirmButton').click


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Style changes implemented in #1913 resulted in the `select_all` box adding an object for the header row of the index table to the `selected_records` array that is used for batch deleting records.  This change narrows the scope of the `selected_records` selection to the table data cells only, and alters an existing test (in `accessions_spec`) to use the select all button.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Allows for record deletion across record types when using the `select_all` checkbox.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Issue identified during internal 2.8.0 release candidate testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Error on current master:
![image](https://user-images.githubusercontent.com/15144646/84693863-3154be00-af16-11ea-885f-8f025a154142.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
