### PR TITLE
Fix indexer errors after deleting a repository which contains resource records

### DIFF
--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -937,6 +937,8 @@ class IndexerCommon
     repo_id = get_record_scope(uri)
 
     return false if (repo_id == "global")
+    return true unless values['repository'].has_key?('_resolved')
+    return true unless values['repository']['_resolved'].has_key?('publish')
 
     values['repository']['_resolved']['publish'] == false
   end


### PR DESCRIPTION
## Description
This prevents ```NoMethodError: undefined method `[]' for nil:NilClass``` errors which happen because the deleted parent repository can no longer be resolved when the indexer checks if it is published while processing a record with. The return value is not important as the record(s) being indexed - resources in deleted repository - are about to be deleted themselves anyway. This allows the indexer to proceed, and complete their deletion from Solr.

Possibly a _begin...rescue...end_ block to catch the error that can happen in the last line of the _is_repository_unpublished?_ method would be better? But the effect would be the same. I don't think this is something that needs to be logged, just a technicality to be avoided.

## Related JIRA Ticket or GitHub Issue
Possibly http://lyralists.lyrasis.org/pipermail/archivesspace_users_group/2020-June/007696.html but that could be unrelated. This fixes the error caused when trying to replicate that problem on a development system, but the full circumstances of the original problem are not known.

## How Has This Been Tested?
Fixes the observed no-method errors on a development system. I haven't tested any other scenarios because I cannot think of any other circumstances when the conditions added could be triggered. The indexer:test suite passes.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
