### PR TITLE
Ensure sort_2 works from browse pages

### DIFF
--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -45,7 +45,7 @@ module SearchHelper
     search_params["filter_term"] = search_params["filter_term"].reject{|f| Array(opts["remove_filter_term"]).include?(f)} if opts["remove_filter_term"]
     search_params["filter_term"] = search_params["filter_term"].select{|f| SearchResultData.BASE_FACETS.include?(ASUtils.json_parse(f).keys.first)} if removing_record_type_filter
 
-    sort = (opts["sort"] || params["sort"])
+    sort = (opts["sort"] || params["sort"] || (@search_data ? @search_data.sorted? : nil))
 
     if sort
       sort = sort.split(', ')
@@ -309,15 +309,15 @@ module SearchHelper
     params.has_key?("deleted_uri") and Array(params["deleted_uri"]).include?(record["id"])
   end
 
-  def get_ancestor_title(field) 
-    field_json = JSONModel::HTTP.get_json(field)  
-    unless field_json.nil?  
-      if field.include?('resources') || field.include?('digital_objects') 
-        clean_mixed_content(field_json['title'])  
-      else  
-        clean_mixed_content(field_json['display_string']) 
-      end 
-    end 
+  def get_ancestor_title(field)
+    field_json = JSONModel::HTTP.get_json(field)
+    unless field_json.nil?
+      if field.include?('resources') || field.include?('digital_objects')
+        clean_mixed_content(field_json['title'])
+      else
+        clean_mixed_content(field_json['display_string'])
+      end
+    end
   end
 
   def context_separator(result)
@@ -328,21 +328,21 @@ module SearchHelper
     end
   end
 
-  def context_ancestor(result)  
-    case  
-    when result['ancestors']  
-      ancestors = result['ancestors'] 
-    when result['linked_instance_uris'] 
-      ancestors = result['linked_instance_uris']  
-    when result['linked_record_uris'] 
-      ancestors = result['linked_record_uris']  
-    when result['primary_type'] == 'top_container'  
-      ancestors = Array(result['collection_uri_u_sstr'])  
-    when result['primary_type'] == 'digital_object_component' 
-      ancestors = result['digital_object'].split  
-    else  
-      ancestors = ['']  
-    end 
+  def context_ancestor(result)
+    case
+    when result['ancestors']
+      ancestors = result['ancestors']
+    when result['linked_instance_uris']
+      ancestors = result['linked_instance_uris']
+    when result['linked_record_uris']
+      ancestors = result['linked_record_uris']
+    when result['primary_type'] == 'top_container'
+      ancestors = Array(result['collection_uri_u_sstr'])
+    when result['primary_type'] == 'digital_object_component'
+      ancestors = result['digital_object'].split
+    else
+      ancestors = ['']
+    end
   end
 
   def column_opts

--- a/frontend/spec/selenium/spec/accessions_spec.rb
+++ b/frontend/spec/selenium/spec/accessions_spec.rb
@@ -494,6 +494,18 @@ describe 'Accessions' do
     end.not_to raise_error
   end
 
+  it 'can define a second level sort for a browse list of Accessions' do
+    @driver.go_home
+    @driver.find_element(:link, 'Browse').click
+    @driver.click_and_wait_until_gone(:link, 'Accessions')
+
+    @driver.find_element(:xpath, "//div/span[contains(text(),'Select')]").click
+    @driver.wait_for_dropdown
+    @driver.click_and_wait_until_gone(:link, 'Identifier')
+
+    assert(5) { expect(@driver.find_element(:xpath, "(//div/span[@class='btn btn-xs btn-default'])[last()]").text).to eq('Identifier Descending') }
+  end
+
   it 'can delete multiple Accessions from the listing' do
     # first login as someone with access to delete
     @driver.login_to_repo(@manager_user, @repo)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes from #1913 resulted in the second level sort from browse pages being present, but never actually working/sticking/successfully resorting the results.  This seems to stem from the sort variable in `build_search_params` being unaware of the existing first level sort on browse index pages.  This change adds that existing sort from `@search_data.sorted?` to that variable.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Also added a simple test to `accessions_spec`.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Discovered during internal testing of #1925 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Now, selecting an option for the second level sort on browse pages will actually do something other than reload the same page:
![image](https://user-images.githubusercontent.com/15144646/85292033-4cb94f00-b469-11ea-9d23-b55b4f67ef22.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
