### PR TITLE
ANW-138: Save changes that don't involve cursor activity

### DIFF
--- a/frontend/app/assets/javascripts/mixed_content.js
+++ b/frontend/app/assets/javascripts/mixed_content.js
@@ -37,6 +37,7 @@ $(function() {
                 $wrapWithActionSelect.append("<option>" + tag + "</option>");                 
             }); 
         }, 
+        onChange: function(){$editor.save()},
         mode: 'text/html',
         smartIndent: false,
         extraKeys: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds a save function to the CodeMirror-controlled notes textarea triggered by an onChange event to ensure that updated note content is saved even when the change does not result in a change in cursor position (e.g. when using the delete key, or any other forward changing key combo like ctrl+delete or alt+delete).

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Add save to all onChange events.  Fuller description of CodeMirror events here: https://codemirror.net/doc/manual.html#events. (Note: though this is the manual for a much newer release, the onChange event binding does not seem to have changed much.)

Also, this CodeMirror bug report helped me suss out/track down this issue:  https://github.com/codemirror/CodeMirror/issues/73. ArchivesSpace's `mixed_content.js` does currently call a save function on the else of `onCursorActivity`, but that doesn't update the hidden CodeMirror text field when the user input doesn't actually involve a change in cursor position.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-138

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested and confirmed modifications that do not involve a cursor position change do appear to work.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
