### PR TITLE
ANW-803: Make file_size_bytes a bigint

### DIFF
--- a/common/db/migrations/136_alter_file_size_bytes.rb
+++ b/common/db/migrations/136_alter_file_size_bytes.rb
@@ -1,0 +1,11 @@
+require_relative 'utils'
+
+Sequel.migration do
+  up do
+    $stderr.puts("Change file_size_bytes from int to bigint")
+    alter_table(:file_version) do
+      set_column_type(:file_size_bytes, 'bigint')
+    end
+  end
+
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
ANW-803 requests that the `file_size_bytes` column of the `file_version` table be changed from `int` to `bigint` to allow 64-bit integers to be stored in this field.  Since this field stores file sizes in bytes, the current int type doesn't support storing file sizes above a few GB.  Additionally, while there are db size considerations in changing this field from `int` to `bigint` this is unlikely to greatly impact many users as this change only applies to an optional field in a `file_version` subrecord inside a parent `digital_object` or `digital_object_component` record.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Add a db migration to change column type to `bigint`.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-803

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested with both mysql and embedded Derby dbs.  Existing backend tests pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
