### PR TITLE
GH-1920 --C-- Fix bugs, listen for modal

### DIFF
--- a/frontend/app/assets/javascripts/locations.location_holdings.js
+++ b/frontend/app/assets/javascripts/locations.location_holdings.js
@@ -9,11 +9,6 @@ $(function() {
 
     $this.data("initialised", true);
    
-    var resultsFormatter = function(json) {
-     console.log(json); 
-      return ;
-    }
-   
     $.getJSON($this.data('url'), function(json) {
       var output; 
       itemCount = json["search_data"]["total_hits"];
@@ -32,6 +27,16 @@ $(function() {
   $(".location-holdings").each(init_locationHoldingsSearch);
   $(document).bind("loadedrecordform.aspace", function(event, $container) {
     $(".location-holdings", $container).each(init_locationHoldingsSearch);
+  });
+
+  // GH-1920, listen for Browse Locations modal
+  var $locationBrowseBtn = $('input[data-label="Location"]').siblings().find('.linker-browse-btn');
+
+  $locationBrowseBtn.on("click", function() {
+    setTimeout(function() {
+      // Wait for appended modal DOM
+      $(".location-holdings").each(init_locationHoldingsSearch);
+    }, 300);
   });
 
 });

--- a/frontend/app/views/locations/_linker.html.erb
+++ b/frontend/app/views/locations/_linker.html.erb
@@ -55,3 +55,5 @@
        </div>
    </div>
 </div>
+
+<%= javascript_include_tag("locations.location_holdings") %>

--- a/frontend/app/views/locations/_location_holdings_cell.html.erb
+++ b/frontend/app/views/locations/_location_holdings_cell.html.erb
@@ -6,7 +6,6 @@ ajax_search_url = url_for({:controller => :search, :action => :do_search, :forma
 
 %>
 
-<%= javascript_include_tag 'locations.location_holdings' %>
 <div class='location-holdings' data-url='<%= ajax_search_url %>'>
 	<i class='spinner'></i>
 </div>

--- a/frontend/app/views/locations/index.html.erb
+++ b/frontend/app/views/locations/index.html.erb
@@ -33,6 +33,8 @@
       <%= render_aspace_partial :partial => "shared/flash_messages" %>
 
       <%= render_aspace_partial :partial => "search/listing" %>
+
+      <%= javascript_include_tag("locations.location_holdings") %>
     </div>
   </div>
 </div>

--- a/frontend/app/views/top_containers/bulk_operations/_location_linker.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_location_linker.html.erb
@@ -34,3 +34,5 @@
     </ul>
   </div>
 </div>
+
+<%= javascript_include_tag("locations.location_holdings") %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR is the third of 3 proposed solutions to #1920 (see there for info about all 3 PRs).

This fixes both the duplicated imports and the synchronous request warning by listening for the "Browse Locations" modal to open after a totally arbitrary amount of time I made up (300ms).

This is the solution to #1920 that I recommend, but it may be brittle at 300ms? The server is waiting for a response with modal DOM from itself, is it possible for it to take longer than this?

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

#1920 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

See #1920 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
