### PR TITLE
GH-1920 --A-- Fix duplicate js imports, but not xhr sync warning

### DIFF
--- a/frontend/app/assets/javascripts/locations.location_holdings.js
+++ b/frontend/app/assets/javascripts/locations.location_holdings.js
@@ -9,11 +9,6 @@ $(function() {
 
     $this.data("initialised", true);
    
-    var resultsFormatter = function(json) {
-     console.log(json); 
-      return ;
-    }
-   
     $.getJSON($this.data('url'), function(json) {
       var output; 
       itemCount = json["search_data"]["total_hits"];

--- a/frontend/app/views/locations/_location_holdings_cell.html.erb
+++ b/frontend/app/views/locations/_location_holdings_cell.html.erb
@@ -6,7 +6,6 @@ ajax_search_url = url_for({:controller => :search, :action => :do_search, :forma
 
 %>
 
-<%= javascript_include_tag 'locations.location_holdings' %>
 <div class='location-holdings' data-url='<%= ajax_search_url %>'>
 	<i class='spinner'></i>
 </div>

--- a/frontend/app/views/search/_listing.html.erb
+++ b/frontend/app/views/search/_listing.html.erb
@@ -30,6 +30,8 @@
       <% end %>
     </tbody>
   </table>
+  
+  <%= javascript_include_tag("locations.location_holdings") %>
 
   <%= render_aspace_partial :partial => "shared/pagination" %>
 <% else %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR is the first of 3 proposed solutions to #1920 (see there for info about all 3 PRs).

This only fixes the duplicated imports by moving the `include_tag` up the DOM and out of the template loop.

This does not fix the synchronous xhr warning.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

#1920 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

See #1920 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
