### PR TITLE
ANW-462 cont: Reindex target post merge

### DIFF
--- a/backend/app/model/mixins/relationships.rb
+++ b/backend/app/model/mixins/relationships.rb
@@ -157,6 +157,14 @@ AbstractRelationship = Class.new(Sequel::Model) do
         end
       end
     end
+
+    # Finally, reindex the target record for good measure (and, in the case of
+    # top containers, to update the associated collections)
+    target[:system_mtime] = Time.now
+    target[:user_mtime] = Time.now
+
+    target.save
+
   end
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When merging top containers from the Manage Top Containers area (functionality added with #1764 ), relationships and associated/dependent records are reindexed post-merge, but the surviving top container target itself is not.  Since the top container document in the index stores information about attached collections (e.g. `collection_display_string_u_sstr`, `collection_identifier_stored_u_sstr`, etc.) failing to trigger a reindex of the target/surviving top container results in necessary information about newly related records being absent in the index.  From the user perspective, this means that a user who searches for an attached resource/accession on Manage Top Containers will be presented with inaccurate results.

While, at present, this bug only impacts top containers, the reindex of targets has been added to the `transfer` method for all mergeable record types since it likely is a case of "can't hurt, might help."  

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Updates a target record's `system_mtime` and `user_mtime` following a successful merge.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Continuation of https://archivesspace.atlassian.net/browse/ANW-462

Issue discovered during 2.8.0RC-1 testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested (merging records triggers a reindex of those target records and, in the case of top containers, the Manage Top Containers search functionality returns anticipated/accurate results); existing tests pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
