### PR TITLE
Ensure that top_container records index all linked locations

### DIFF
--- a/frontend/app/views/top_containers/bulk_operations/_bulk_action_templates.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_bulk_action_templates.html.erb
@@ -126,7 +126,7 @@
             <td>${container.row.find(".top-container-profile").html()}</td>
             <td>${container.row.find(".top-container-indicator").html()}</td>
             <td>${container.row.find(".top-container-barcode").text().trim()}</td>
-            <td>${container.row.find(".top-container-current-location").text().trim()}</td>
+            <td>${container.row.find(".top-container-current-location").html()}</td>
             <td>
               <%= render_aspace_partial :partial => "top_containers/bulk_operations/location_linker", :locals => { :path => "${container.uri}", :show_create_link => true } %>
               <input type="hidden" name="update_uris[]" value="${container.uri}"/>

--- a/frontend/app/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_results.html.erb
@@ -73,7 +73,15 @@
         <td class="top-container-type"><%= container_json['type'] %></td>
         <td class="top-container-indicator"><%= container_json['indicator'] %></td>
         <td class="top-container-barcode"><%= container_json['barcode'] %></td>
-        <td class="top-container-current-location"><%= Array(doc['location_display_string_u_sstr']).first %></td>
+        <td class="top-container-current-location">
+          <% if doc['location_display_string_u_sstr'] %>
+            <ul class="linked-records-listing count-<%= Array(doc['location_uri_u_sstr']).length %>">
+              <% Array(doc['location_display_string_u_sstr']).each do |location| %>
+                <li><span class="collection-location"><%= location %></span></li>
+              <% end %>
+            </ul>
+          <% end %>
+        </td>
         <td><%= container_json['ils_holding_id'] %></td>
         <td><%= I18n.t("boolean.#{container_json['restricted']}") %></td>
         <% if container_json['exported_to_ils'].blank? %>

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -648,11 +648,14 @@ class IndexerCommon
 
         if record['record']['container_locations'].length > 0
           doc['has_location_u_sbool'] = true
+          doc['location_uri_u_sstr'] = []
+          doc['location_uris'] = []
+          doc['location_display_string_u_sstr'] = []
           record['record']['container_locations'].each do |container_location|
             if container_location['status'] == 'current'
-              doc['location_uri_u_sstr'] = container_location['ref']
-              doc['location_uris'] = container_location['ref']
-              doc['location_display_string_u_sstr'] = container_location['_resolved']['title']
+              doc['location_uri_u_sstr'] << container_location['ref']
+              doc['location_uris'] << container_location['ref']
+              doc['location_display_string_u_sstr'] << container_location['_resolved']['title']
             end
           end
         else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Top containers may be linked to multiple locations (and this all works properly at the db layer), however the index never stores more than one location.  This implements a fix in `indexer_common` that adds all linked locations to the top_container solr record.  This also includes associated UI fixes to account for the fact there may now be more than one location present in the Manage Top Containers results table and on the Bulk Update Locations (Multiple) table.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Changes to `indexer_common` to ensure all locations are attached to a top_container.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Issue discovered during v2.8.0-RC1 testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Confirmed changes to index as necessary; all existing tests pass.

## Screenshots (if appropriate):
Multiple locations listed on the Manage Top Containers result page:
![image](https://user-images.githubusercontent.com/15144646/86284606-286c1980-bbb1-11ea-9299-dc7cff82464e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
