### PR TITLE
Search Prepopulation for Current Resource in Top Container Modal

### DIFF
--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -1,6 +1,9 @@
 //= require jquery.tokeninput
 
 $(function() {
+  let resource_edit_path_regex = /^\/resources\/\d+\/edit$/
+  let on_resource_edit_path = window.location.pathname.match(resource_edit_path_regex)
+
   $.fn.linker = function() {
     $(this).each(function() {
       var $this = $(this);
@@ -284,6 +287,42 @@ $(function() {
 
       var tokensForPrepopulation = function() {
         if ($this.data("multiplicity") === "one") {
+
+          // If we are on a resource or archival object edit page, and open a top_container modal with a
+          // collection_resource linker then we prepopulate the collection_resource field with resource
+          // data necessary to perform the search
+          let onResource = $(".label.label-info").text() === "Resource"
+          let onArchivalObject = $(".label.label-info").text() === "Archival Object"
+          let modalHasResource = $(".modal-dialog").find("#collection_resource").length > 0
+          let idMatches = $this[0].id === "collection_resource"
+
+          if (on_resource_edit_path && modalHasResource && idMatches && (onResource || onArchivalObject)) {
+            let currentForm = $("#object_container").find("form").first()
+            if (onResource) {
+              return [{
+                id: currentForm.attr("data-update-monitor-record-uri"),
+                name: $("#resource_title_").text(),
+                json: {
+                  id: currentForm.attr("data-update-monitor-record-uri"),
+                  uri: currentForm.attr("data-update-monitor-record-uri"),
+                  title: $("#resource_title_").text(),
+                  jsonmodel_type: "resource"
+                }
+              }]
+            } else if (onArchivalObject) {
+              return [{
+                id: $("#archival_object_resource_").attr("value"),
+                name: $(".record-title").first().text(),
+                json: {
+                  id: $("#archival_object_resource_").attr("value"),
+                  uri: $("#archival_object_resource_").attr("value"),
+                  title: $(".record-title").first().text(),
+                  jsonmodel_type: "resource"
+                }
+              }]
+            }
+          }
+
           if ($.isEmptyObject($this.data("selected"))) {
             return [];
           }
@@ -415,6 +454,20 @@ $(function() {
           if (config.sortable && config.allow_multiple) {
             enableSorting();
             $linkerWrapper.addClass("sortable");
+          }
+
+          // This is part of automatically executing a search for the current resource on the browse top
+          // containers modal when opened from the edit resource or archival object pages.
+          // If this setTimeout is for the last linker in the modal, only then is it safe to execute the search
+          let lastLinker = $(".modal-dialog").find(".linker").last()
+          let isLastLinker = lastLinker.attr("id") === $this.context.id
+          let onResource = $(".label.label-info").text() === "Resource"
+          let onArchivalObject = $(".label.label-info").text() === "Archival Object"
+          let modalHasResource = $(".modal-dialog").find("#collection_resource").length > 0
+          let resultsEmpty = $(".modal-dialog").find(".table-search-results").length < 1
+
+          if (on_resource_edit_path && modalHasResource && resultsEmpty && isLastLinker && (onResource || onArchivalObject)) {
+            $(".modal-dialog").find("input[type='submit']").click()
           }
         });
 

--- a/frontend/spec/selenium/spec/resources_spec.rb
+++ b/frontend/spec/selenium/spec/resources_spec.rb
@@ -103,6 +103,86 @@ describe 'Resources and archival objects' do
     @driver.click_and_wait_until_gone(:css, 'a.btn.btn-cancel')
   end
 
+  it 'prepopulates the top container modal with search for current resource when linking on the resource edit page' do
+    # Create some top containers
+    location = create(:location)
+    container_location = build(:container_location,
+                               ref: location.uri)
+    container = create(:top_container,
+                        container_locations: [container_location])
+    ('A'..'E').each do |l|
+      create(:top_container,
+             indicator: "Letter #{l}",
+             container_locations: [container_location])
+    end
+
+    run_index_round
+
+    @driver.find_element(:link, 'Browse').click
+    @driver.wait_for_dropdown
+    @driver.click_and_wait_until_gone(:link, 'Resources')
+
+    table_rows = @driver.find_elements(css: "tr")
+    table_rows.each do |row|
+      if (row.text.include? "Resource 1")
+        table_rows[2].click_and_wait_until_gone(:link, 'Edit')
+        break
+      end
+    end
+
+    @driver.find_element(:link, 'Browse').click
+    @driver.find_element_with_text('//button', /Add Container Instance/).click
+
+    resource_title = @driver.find_element(css: 'h2').text[0...-9]
+
+    @driver.find_element(css: '#resource_instances__0__instance_type_').select_option('text')
+
+    add_instance_fields_area = @driver.find_element(css: '#resource_instances__0__container_')
+    add_instance_fields_area.find_element(css: '.btn.btn-default.dropdown-toggle.last').click
+    @driver.wait_for_dropdown
+    @driver.find_elements(:link, 'Browse')[1].click
+
+    sleep 1
+
+    @driver.find_element(css: '.token-input-delete-token').click
+    @driver.clear_and_send_keys([:css, '#q'], '*')
+
+    inputs = @driver.find_element(css: '.modal-content').find_elements(css: 'input')
+    inputs.each do |input|
+      if input.attribute('value') == "Search"
+        input.click
+        break
+      end
+    end
+
+    sleep 2
+
+    @driver.find_element(css: '.modal-content').find_elements(css: 'tr')[1].find_element(css: 'input').click
+
+    @driver.find_element(css: "#addSelectedButton").click
+    @driver.find_element(css: "form#resource_form button[type='submit']").click
+
+    run_periodic_index
+
+    add_instance_fields_area = @driver.find_element(css: '#resource_instances__0__container_')
+    add_instance_fields_area.find_element(css: '.btn.btn-default.dropdown-toggle.last').click
+    @driver.wait_for_dropdown
+    @driver.find_elements(:link, 'Browse')[1].click
+
+    expect(@driver.find_element(css: '.modal-content').find_elements(css: 'tr').length).to eq(2)
+
+    # Clean up after ourselves so the other tests run ok
+    @driver.find_element(css: '.modal-content').find_element(css: '.btn.btn-cancel.btn-default').click
+    sleep 1
+    @driver.find_element(css: '#resource_instances__0_').find_element(css: '.subrecord-form-remove').click
+    sleep 1
+    @driver.find_element(css: '.confirm-removal').click
+
+    @driver.find_element(css: "form#resource_form button[type='submit']").click
+
+    run_periodic_index
+  end
+
   it 'can create a resource' do
     resource_title = "Pony <emph render='italic'>Express</emph>"
     resource_stripped = 'Pony Express'


### PR DESCRIPTION
## Description
This change prepopulates the Top Container search modal with results for the current resource when opening the modal from a Resource or Archival Object page.

## Related JIRA Ticket or GitHub Issue

## How Has This Been Tested?
Selenium test covers the feature.

## Screenshots (if appropriate):
View upon opening the modal:
<img width="725" alt="Screen Shot 2020-07-06 at 11 17 33 AM" src="https://user-images.githubusercontent.com/46659222/86611308-836c8a80-bf7c-11ea-81ef-7de301fe6f5b.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
