### PR TITLE
UI/relationships mixin changes for merging containers with profiles

### DIFF
--- a/backend/app/model/mixins/relationships.rb
+++ b/backend/app/model/mixins/relationships.rb
@@ -92,6 +92,13 @@ AbstractRelationship = Class.new(Sequel::Model) do
 
     victims_by_model = victims.reject {|v| (v.class == target.class) && (v.id == target.id)}.group_by(&:class)
 
+    # We're going to have to handle container profiles separately since victim
+    # cp relationships have to be compared against one another prior to merging.
+    # We'll just use this method to store container profile relationships then
+    # actually handle container profile relationships in the separate
+    # `cleanup_container_profile_relationships` method below
+    victim_container_profiles = []
+
     victims_by_model.each do |victim_model, vics|
 
       confirm_accepts_target(victim_model, vics)
@@ -133,14 +140,16 @@ AbstractRelationship = Class.new(Sequel::Model) do
                 elsif relationship.is_a?(Relationships::SubContainerTopContainerLink)
                   identify_duplicate_containers(target, relationship, target_col, dups)
 
+                elsif relationship.is_a?(Relationships::ContainerProfileTopContainerProfile)
+                  victim_container_profiles << relationship
+
                 else
                   target_pre.each do |pre|
                     if pre[parent_col] == relationship[parent_col]
                       dups << relationship
                     end
                   end
-                  # Found a free column.  Store our updated reference here.
-                  relationship[target_col] = target.id
+                  transfer_relationship_to_target(relationship, target_col, target, true)
                   break
                 end
 
@@ -157,6 +166,8 @@ AbstractRelationship = Class.new(Sequel::Model) do
         end
       end
     end
+
+    cleanup_container_profile_relationships(victim_container_profiles, target)
 
     # Finally, reindex the target record for good measure (and, in the case of
     # top containers, to update the associated collections)
@@ -178,6 +189,17 @@ AbstractRelationship = Class.new(Sequel::Model) do
       unless found.empty?
         raise ReferenceError.new("#{victim_model} to be merged has data for relationship #{self}, but target record doesn't support it.")
       end
+    end
+  end
+
+
+  def self.transfer_relationship_to_target(relationship, target_col, target, skip_refresh=false)
+    relationship[target_col] = target.id
+    unless skip_refresh
+      relationship[:system_mtime] = Time.now
+      relationship[:user_mtime] = Time.now
+
+      relationship.save
     end
   end
 
@@ -210,19 +232,62 @@ AbstractRelationship = Class.new(Sequel::Model) do
             dups << instance
             break
           else
-            # Found a free column.  Store our updated reference here.
-            relationship[target_col] = target.id
+            transfer_relationship_to_target(relationship, target_col, target, true)
             break
           end
         end
       else
-        # Found a free column.  Store our updated reference here.
-        relationship[target_col] = target.id
+        transfer_relationship_to_target(relationship, target_col, target, true)
         break
       end
     end
   end
 
+
+  # When merging top containers there is the possibility that multiple container
+  # profiles might be relinked to the surviving top container, despite the fact
+  # that top containers should only ever have on linked container profile.
+  # While future work should actually make db-level/schema-level changes to
+  # prohibit linking multiple container profiles to a single top container, in the
+  # interim, this method ensures that container profile relationships are handled
+  # separately from other linked record transfers and ensures only one container
+  # profile (or, conditionally, no container profiles) survives the merge process.
+  def self.cleanup_container_profile_relationships(victim_container_profiles, target)
+    target_relationship = nil
+    find_by_participant(target).each do |target_rlshp|
+      if !target_rlshp.nil? && target_rlshp.is_a?(Relationships::ContainerProfileTopContainerProfile)
+        target_relationship = target_rlshp
+      end
+    end
+    victim_container_profiles_unique = victim_container_profiles.map {|v| v[:container_profile_id]}
+    # If the target has a linked container profile already, delete all victim
+    # container profile relationships
+    if !target_relationship.nil?
+      cleanup_duplicates(victim_container_profiles)
+    else
+      # If the array of victims only has one container profile relationship
+      # transfer that relationship over to the merge target
+      if victim_container_profiles.count == 1
+        victim_container_profile = victim_container_profiles.first
+        transfer_relationship_to_target(victim_container_profile, :top_container_id, target)
+      elsif victim_container_profiles.count > 1
+        # If the array of victims has multiple container profile relationships
+        # but they all link to the same container profile, transfer the first
+        # relationship to the merge target and delete the rest
+        if victim_container_profiles_unique.uniq.count == 1
+          victim_container_profile = victim_container_profiles.first
+          transfer_relationship_to_target(victim_container_profile, :top_container_id, target)
+          victim_container_profiles.shift
+          cleanup_duplicates(victim_container_profiles)
+        # If the array of victims has multiple container profile relationships
+        # and they link to different container profiles, delete all victim
+        # container profile relationships
+        else
+          cleanup_duplicates(victim_container_profiles)
+        end
+      end
+    end
+  end
 
   # Return the value of 'property' for any relationship involving 'obj'.
   def self.values_for_property(obj, property)

--- a/frontend/app/views/top_containers/bulk_operations/_bulk_action_templates.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_bulk_action_templates.html.erb
@@ -213,7 +213,7 @@
           {for container in selection}
             <% container_uri = "${container.uri}" %>
             <div id="chkPref" role="radio" tabindex="0">
-              <%= radio_button_tag "target[]", "${container.uri}", false, :"data-object" => container_uri, :"aria-label" => "${container.display_string}", :"id" => "${container.uri}",  :onclick => "activateBtn()", :onKeyPress => "activateBtn()" %>
+              <%= radio_button_tag "target[]", "${container.uri}", false, :"data-object" => container_uri, :"aria-label" => "${container.display_string}", :"id" => "${container.uri}",  :"container_profile_uri" => "${container.container_profile_uri}", :onclick => "activateBtn()", :onKeyPress => "activateBtn()" %>
               <span>${container.display_string}</span>
             </div>
           {/for}
@@ -248,6 +248,12 @@
           <li>${victim}</li>
         {/for}
       </ul>
+      <p class='alert alert-warning' style='<%= "${mergeWarning.tooManyVisibility}" %>; margin-left:40px' id="alertBucket" role="alert" aria-hidden='<%= "${mergeWarning.tooManyHidden}" %>'>
+        <%= I18n.t("top_container._frontend.bulk_operations.batch_merge_container_profile_too_many_warning") %>
+      </p>
+      <p class='alert alert-warning' style='<%= "${mergeWarning.mismatchVisibility}" %>; margin-left:40px' id="alertBucket" role="alert" aria-hidden='<%= "${mergeWarning.mismatchHidden}" %>'>
+        <%= I18n.t("top_container._frontend.bulk_operations.batch_merge_container_profile_mismatch_warning") %>
+      </p>
       <h4><%= I18n.t("top_container._frontend.bulk_operations.batch_merge_confirm_target") %></h4>
       <ul>
         <li>${target.display_string}</li>

--- a/frontend/app/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_results.html.erb
@@ -45,7 +45,7 @@
           <% if multiselect %>
           <label>
             <span class="sr-only"><%= I18n.t("search_results.selected") %></span>
-            <%= check_box_tag "uri", container_json['uri'], false, "data-display-string" => doc['title'] %>
+            <%= check_box_tag "uri", container_json['uri'], false, :"data-display-string" => doc['title'], :"data-container-profile-uri" => doc['container_profile_uri_u_sstr'] %>
           </label>
           <% else %>
             <%= radio_button_tag "linker-item", container_json["uri"], false, :"data-object" => container_json.to_json %>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1427,6 +1427,8 @@ en:
         batch_merge_instructions: Select the top container into which all of the other listed top container(s) will merge. Any linked records will be re-linked to this container and all information for the other top container(s) will be deleted.
         batch_merge_confirm: Confirm Merge Top Containers
         batch_merge_confirm_question: Are you sure you want to merge the top containers as listed below? This action is irreversible.
+        batch_merge_container_profile_too_many_warning: These top containers have different container profiles. None of these container profiles will merge into the target container.
+        batch_merge_container_profile_mismatch_warning: These top containers have a different container profile than the target top container. The container profile will not merge into the target container.
         batch_merge_confirm_victims: "Merge the following top container(s):"
         batch_merge_confirm_target: "Into this top container:"
         batch_delete: Delete Top Containers

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -1429,6 +1429,8 @@ es:
         batch_merge_instructions: Seleccione el contenedor superior en el que se fusionarán todos los demás contenedores superiores enumerados. Los registros vinculados se volverán a vincular a este contenedor y se eliminará toda la información de los otros contenedores principales.
         batch_merge_confirm: Confirmar combinación de contenedores superiores
         batch_merge_confirm_question: ¿Está seguro de que desea fusionar los contenedores superiores como se enumeran a continuación? Esta acción es irreversible.
+        batch_merge_container_profile_too_many_warning: Estos contenedores superiores tienen diferentes perfiles de contenedores. Ninguno de estos perfiles de contenedores se fusionará con el contenedor de destino.
+        batch_merge_container_profile_mismatch_warning: Estos contenedores superiores tienen un perfil de recipiente diferente que el recipiente superior objetivo. El perfil contenedor no se fusionará con el contenedor de destino.
         batch_merge_confirm_victims: "Combinar los siguientes contenedores superiores:"
         batch_merge_confirm_target: "En este contenedor superior:"
         batch_delete: Borrar Contenedores Top

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -1427,6 +1427,8 @@ fr:
         batch_merge_instructions: Sélectionnez le conteneur supérieur dans lequel tous les autres conteneurs répertoriés vont fusionner. Tous les enregistrements liés seront liés à ce conteneur et toutes les informations relatives au (x) autre (s) conteneur (s) supérieur (s) seront supprimées.
         batch_merge_confirm: Confirmer la fusion des conteneurs supérieurs
         batch_merge_confirm_question: Voulez-vous vraiment fusionner les conteneurs supérieurs comme indiqué ci-dessous? Cette action est irréversible.
+        batch_merge_container_profile_too_many_warning: Ces conteneurs haut ont des profils de conteneurs. Aucun de ces profils de conteneurs se fondre dans le conteneur cible.
+        batch_merge_container_profile_mismatch_warning: Ces conteneurs supérieurs ont un profil différent de récipient que le récipient supérieur du cadre. Le profil de conteneur ne fusionnera pas dans le conteneur cible.
         batch_merge_confirm_victims: "Fusionner les conteneurs supérieurs suivants:"
         batch_merge_confirm_target: "Dans ce conteneur supérieur:"
         batch_delete: Supprimer Top conditionnements

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -1425,6 +1425,8 @@ ja:
         batch_merge_instructions: リストされている他のすべてのトップコンテナがマージされるトップコンテナを選択します。リンクされたレコードはすべてこのコンテナに再リンクされ、他のトップコンテナのすべての情報が削除されます。
         batch_merge_confirm: 上位コンテナのマージの確認
         batch_merge_confirm_question: 以下にリストされているように、最上位のコンテナーをマージしてもよろしいですか？ このアクションは元に戻せません。
+        batch_merge_container_profile_too_many_warning: これらのトップコンテナが別のコンテナプロファイルを有します。これらのコンテナプロファイルはいずれも、ターゲットコンテナにマージしません。
+        batch_merge_container_profile_mismatch_warning: これらのトップコンテナは、ターゲットトップ容器とは異なるコンテナプロファイルを持っています。コンテナプロファイルは、ターゲットコンテナにマージしません。
         batch_merge_confirm_victims: "次の上位コンテナをマージします:"
         batch_merge_confirm_target: "この一番上のコンテナに:"
         batch_delete: トップコンテナの削除


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Provides two major enhancements/bug fixes related to #1764 :

 - Conditionally shows a warning to users in the top container merge confirmation modal when merging containers will result in deleting container profile relationships (e.g. when the merge victims are linked to different container profiles or when the target container already has an existing container profile that is different from the ones related to the merge victims);
- Separately handles transferring container profile relationships in the `relationships` mixin to account for the fact that no merge can result in a container that relates to multiple container profiles

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Ultimately, additional work should be performed to make it impossible at the db/schema level (and in the index too!) to attach more than one container profile record to a top container, but this is a necessary first step to ensuring the work delivered in #1764 doesn't accidentally create multiple container profile relationships for a single top container.

Setting this PR as a draft as two items must still be addressed:
1. Part of a new test has been commented out pending a decision on how locations should be handled during the top container merge process (that work will be forthcoming in a separate PR).
2. Additional translations are needed (once the alert language is given the go ahead).

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Issue identified via feedback from 2.8.0-RC1 testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Current backend tests passing and additional backend tests added.  Frontend only tested visually.

## Screenshots (if appropriate):
![Kapture 2020-07-14 at 17 27 46](https://user-images.githubusercontent.com/15144646/87478253-73495080-c5f7-11ea-8a07-e60272cecf85.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
