### PR TITLE
Define relationships for container_locations

### DIFF
--- a/backend/app/model/container_location.rb
+++ b/backend/app/model/container_location.rb
@@ -3,4 +3,8 @@ class ContainerLocation < Sequel::Model(:container_location)
   include ASModel
   corresponds_to JSONModel(:container_location)
 
+  define_relationship(:name => :top_container_housed_at,
+                      :contains_references_to_types => proc {[TopContainer, Location]}
+                      )
+
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds a defined relationship to the container_location model with references to top containers and locations.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
With this defined relationship missing, calling `relationship_dependencies` never returns a `top_container_housed_at` relationship for top containers.  In the context of a top container merge, this means that locations relationships are not transferred to the surviving top container during the merge process.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Discovered during 2.8.0-RC1 testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests passed, additional test added to confirm locations now transfer to the surviving top container during a top container merge.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
