### PR TITLE
Continuation of #1923 to deprecate search/subjects endpoint

### DIFF
--- a/backend/app/controllers/search.rb
+++ b/backend/app/controllers/search.rb
@@ -122,6 +122,8 @@ class ArchivesSpaceService < Sinatra::Base
 
   Endpoint.get_or_post('/search/subjects')
     .description("Search across subjects")
+    .deprecated("Deprecated in favor of calling the general search endpoint with an " +
+                " optional type parameter. For example: /repositories/:repo_id/search?type[]=subject")
     .params(*BASE_SEARCH_PARAMS)
     .permissions([])
     .paged(true)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
During work on #1923 the non-standard and duplicative `search/subjects` endpoint was discovered.  As part of #1923, the only use of `search/subjects` in the codebase (in `frontend/app/controllers/subjects_controller.rb`) was refactored to use the general `/repositories/#{session[:repo_id]}/search` endpoint instead.  As such, `search/subjects` should be considered deprecated and removed in future releases.

This (tiny) PR notes this deprecation in the search controller.  

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
