### PR TITLE
Update the release notes task to highlight deprecated endpoints

### DIFF
--- a/scripts/tasks/release_notes.rb
+++ b/scripts/tasks/release_notes.rb
@@ -79,6 +79,15 @@ module ReleaseNotes
     def make_doc
       doc << "# Release notes for #{version}\n"
       doc << "__TODO: add release summary__\n"
+      doc << "## Configurations and Migrations\n"
+      doc << "__TODO: add config changes and migrations as denoted by PR labels__\n"
+      doc << "## API Deprecations\n"
+      doc << "The following API endpoints have been newly deprecated as part of
+this release. For the time being, they will work and you may continue to
+use them, however they will be removed from the core code of ArchivesSpace
+on or after **#{DateTime.now.next_year(1).to_date}**.  For more information see
+the [ArchivesSpace API documentation](https://archivesspace.github.io/archivesspace/api/).\n"
+      doc << find_deprecations
       doc << "## Community Contributions\n"
       doc << "Our thanks go out to these members of the community for their code contributions: \n"
       doc.concat contributors.sort_by { |k, _| k }.map { |c| "- #{c[0]}: #{c[1]}" }
@@ -93,5 +102,20 @@ module ReleaseNotes
 
       "[#{pr_number}](#{PR_URL}/#{pr_number})"
     end
+
+    def find_deprecations
+      deprecated_endpoints = []
+      Dir.glob('backend/app/controllers/*').each do |controller_file|
+        File.foreach(controller_file, "Endpoint") do |ep|
+          if ep.include?(".deprecated")
+            d_ep = ep.lines.first
+            deprecated_endpoints << "Endpoint#{d_ep}"
+          end
+        end
+      end
+
+      deprecated_endpoints
+    end
+
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Back of house update to `release_notes` task to find and call out deprecated endpoints in release notes.  This is currently setup to find all deprecations and state that the endpoints will be removed on or after 1 year from the date on which the release notes are generated.  As such, this section will still require some manual cleanup for previously deprecated endpoints that are still around in that 1 year grace period.  At the very least, this gets something in place so that we won't forget to call them out when writing up the release notes.

Also added a heading and to-do section for noting configuration changes and new migrations, though some of this could be automated in the future as well.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

After running the task, the following is returned:
```

## Configurations and Migrations

__TODO: add config changes and migrations as denoted by PR labels__

## API Deprecations

The following API endpoints have been newly deprecated as part of
this release. For the time being, they will work and you may continue to
use them, however they will be removed from the core code of ArchivesSpace
on or after **2021-08-05**.  For more information see
the [ArchivesSpace API documentation](https://archivesspace.github.io/archivesspace/api/).

Endpoint.get('/repositories/:repo_id/resources/:id/tree')

Endpoint.get('/repositories/:repo_id/digital_objects/:id/tree')

Endpoint.get('/repositories/:repo_id/classifications/:id/tree')

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
