### PR TITLE
ANW-921: Make citation tab configurable, use translations

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -524,6 +524,11 @@ AppConfig[:pui_page_actions_cite] = true
 AppConfig[:pui_page_actions_request] = true
 AppConfig[:pui_page_actions_print] = true
 
+# Set default/active tab for PUI citation modal. If set to 'true' item citation
+# tab will be active by default; if 'false' item description tab will be active.
+# AppConfig[:pui_page_actions_cite] must be set to true for this to take effect.
+AppConfig[:pui_active_citation_tab_item] = true
+
 # Enable / disable search-in-collection form in sidebar when viewing records
 AppConfig[:pui_search_collection_from_archival_objects] = false
 AppConfig[:pui_search_collection_from_collection_organization] = false

--- a/public/app/views/cite/_modal_tabbed.html.erb
+++ b/public/app/views/cite/_modal_tabbed.html.erb
@@ -9,22 +9,22 @@
       <div class="modal-body">
         <!-- Nav tabs via https://getbootstrap.com/docs/3.4/javascript/#markup -->
         <ul class="nav nav-tabs" role="tablist">
-          <li role="presentation" class="active">
-            <a href="#item" aria-controls="item" role="tab" data-toggle="tab" >Cite Item</a>
+          <li role="presentation" class="<%='active' if AppConfig[:pui_active_citation_tab_item]%>">
+            <a href="#item" aria-controls="item" role="tab" data-toggle="tab" ><%= I18n.t("actions.cite_item") %></a>
           </li>
-          <li role="presentation">
-            <a href="#description" aria-controls="description" role="tab" data-toggle="tab">Cite Item Description</a>
+          <li role="presentation" class="<%='active' if !AppConfig[:pui_active_citation_tab_item]%>">
+            <a href="#description" aria-controls="description" role="tab" data-toggle="tab"><%= I18n.t("actions.cite_item_description") %></a>
           </li>
         </ul>
 
         <!-- Tab panes -->
         <section class="tab-content" style="margin-top: 15px;">
-          <p role="tabpanel" class="tab-pane active" data-js="citation" id="item"><%= item %></p>
-          <p role="tabpanel" class="tab-pane" data-js="citation" id="description"><%= description %></p>
-        </section> 
+          <p role="tabpanel" class="tab-pane <%='active' if AppConfig[:pui_active_citation_tab_item]%>" data-js="citation" id="item"><%= item %></p>
+          <p role="tabpanel" class="tab-pane <%='active' if !AppConfig[:pui_active_citation_tab_item]%>" data-js="citation" id="description"><%= description %></p>
+        </section>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-default" data-dismiss="modal"><%= I18n.t("actions.close") %></button>
         <button type="button" class="btn btn-primary action-btn"></button>
       </div>
     </div>

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -39,11 +39,15 @@ en:
     new_search: New Search
     refine_search: Refine Search
     browse: Browse
+    close: Close
     show_advanced_search: Show Advanced Search
     hide_advanced_search: Hide Advanced Search
     backup:  Return to the previous page
     backup_abbr: Go back
     cite: Citation
+    cite_item: Cite Item
+    cite_item_description: Cite Item Description
+    bookmark: Bookmark
     request: Request
     print: Print
     print-generating: Generating

--- a/public/config/locales/es.yml
+++ b/public/config/locales/es.yml
@@ -20,11 +20,14 @@ es:
     new_search: Nueva búsqueda
     refine_search: Refinar busqueda
     browse: Vistazo
+    close: Cerca
     show_advanced_search: Mostrar búsqueda avanzada
     hide_advanced_search: Ocultar búsqueda avanzada
     backup: Regresar a la página anterior
     backup_abbr: Regresa
     cite: Mención
+    cite_item: Cite artículo
+    cite_item_description: Cite Descripción del artículo
     request: Solicitud
     print: Imprimir
     print-generating: Generando
@@ -367,7 +370,7 @@ es:
         description_rules: Reglas de Descripción
         identifier: Identificador
         language: Lengua del instrumento de descripción
-        script: Escritura de la descripción 
+        script: Escritura de la descripción
         language_note: Idioma de la descripción nota
         sponsor: Patrocinador
         edition_statement: Mención de edición

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -39,11 +39,15 @@ fr:
     new_search: Nouvelle recherche
     refine_search: Affiner la recherche
     browse: Parcourir
+    close: Fermer
     show_advanced_search: Afficher Recherche avancée
     hide_advanced_search: Masquer Recherche avancée
     backup:  Revenir à la page précédente
     backup_abbr: Retour
     cite: Citation
+    cite_item: Cité article
+    cite_item_description: Cité Élément Description
+    bookmark: Signet
     request: Requête
     print: Impression
     print-generating: Génération

--- a/public/config/locales/ja.yml
+++ b/public/config/locales/ja.yml
@@ -17,11 +17,15 @@ ja:
     new_search: 新しい検索
     refine_search: 絞り込み検索
     browse: ブラウズ
+    close: 閉じる
     show_advanced_search: 高度な検索を表示する
     hide_advanced_search: 高度な検索を隠す
     backup: 前のページに戻る
     backup_abbr: 戻る
     cite: 引用
+    cite_item: 項目を引用
+    cite_item_description: アイテムの説明を引用
+    bookmark: ブックマーク
     request: 要求
     print: 印刷
     print-generating: 生成

--- a/public/spec/features/cite_spec.rb
+++ b/public/spec/features/cite_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Citation modal', js: true do
+  it 'should be visible' do
+    visit('/')
+    click_link 'Collections'
+    expect(current_path).to eq ('/repositories/resources')
+    resource = first("a[class='record-title']", text: 'Resource with scope note')
+    visit(resource['href'])
+    within '.page_actions' do
+      expect(page).to have_css('#cite_sub')
+    end
+  end
+
+
+  it 'should default to item citation' do
+    visit('/')
+    click_link 'Collections'
+    expect(current_path).to eq ('/repositories/resources')
+    resource = first("a[class='record-title']", text: 'Resource with scope note')
+    visit(resource['href'])
+    within '.page_actions' do
+      click_button('Citation')
+    end
+    within '#cite_modal' do
+      active_tab = first('li.active')
+      expect(active_tab).to have_selector('a', exact_text: 'Cite Item')
+      expect(active_tab).not_to have_selector('a', exact_text: 'Cite Item Description')
+      active_panel = first('p.active')
+      expect(active_panel).not_to have_text('http')
+    end
+  end
+
+
+  it 'should have functioning tab for item description citation' do
+    visit('/')
+    click_link 'Collections'
+    expect(current_path).to eq ('/repositories/resources')
+    resource = first("a[class='record-title']", text: 'Resource with scope note')
+    visit(resource['href'])
+    within '.page_actions' do
+      click_button('Citation')
+    end
+    within '#cite_modal' do
+      click_link('Cite Item Description')
+      finished_all_ajax_requests?
+      active_tab = first('li.active')
+      expect(active_tab).to have_selector('a', exact_text: 'Cite Item Description')
+      expect(active_tab).not_to have_selector('a', exact_text: 'Cite Item')
+      active_panel = first('p.active')
+      expect(active_panel).to have_text('http')
+    end
+  end
+
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Extends #1941 by implementing the following:

- Makes default active Citation tab configurable with the addition of a new `AppConfig[:pui_active_citation_tab_item]` config option;
- Removes hardcoded English language labels/headings from the citation modal and employs translations instead; and,
- Adds 3 new citation modal tests to the public test suite.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/projects/ANW/issues/ANW-921

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested, existing tests pass, new tests added.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15144646/89460632-979cd680-d738-11ea-8d61-1c65a77bee6d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
