### PR TITLE
Update to account for id.loc.gov moving from http to https

### DIFF
--- a/plugins/lcnaf/frontend/assets/lcnaf.js
+++ b/plugins/lcnaf/frontend/assets/lcnaf.js
@@ -104,7 +104,7 @@ $(function() {
     error: function(err) {
       $(".btn", $searchForm).removeAttr("disabled").removeClass("disabled").removeClass("busy");
       var errBody = err.hasOwnProperty("responseText") ? err.responseText.replace(/\n/g, "") : "<pre>" + JSON.stringify(err) + "</pre>";
-      AS.openQuickModal(AS.renderTemplate("template_lcnaf_search_error_title"), JSON.stringify(errBody));
+      AS.openQuickModal(AS.renderTemplate("template_lcnaf_search_error_title"), AS.renderTemplate("template_lcnaf_search_error_message"));
     }
   });
 

--- a/plugins/lcnaf/frontend/controllers/lcnaf_controller.rb
+++ b/plugins/lcnaf/frontend/controllers/lcnaf_controller.rb
@@ -48,9 +48,9 @@ class LcnafController < ApplicationController
   def searcher
     case params[:lcnaf_service]
     when  'lcnaf'
-      OpenSearcher.new('http://id.loc.gov/search/', 'http://id.loc.gov/authorities/names')
+      OpenSearcher.new('https://id.loc.gov/search/', 'http://id.loc.gov/authorities/names')
     when 'lcsh'
-      OpenSearcher.new('http://id.loc.gov/search/', 'http://id.loc.gov/authorities/subjects')
+      OpenSearcher.new('https://id.loc.gov/search/', 'http://id.loc.gov/authorities/subjects')
     end
   end
 end

--- a/plugins/lcnaf/frontend/locales/en.yml
+++ b/plugins/lcnaf/frontend/locales/en.yml
@@ -18,6 +18,7 @@ en:
         import_success_message: Redirecting to the job status page...
         import_error: Error while importing from LCNAF
         search_error: Search Error
+        search_error_message: A problem was encountered while completing this search.  Please ensure the third-party service is still available.
         service_locked: Items already selected
         service_locked_message: Please import or remove your selected items before switching record service
         service_warning: This plugin depends on 3rd party services that may or may not be available or supported.

--- a/plugins/lcnaf/frontend/locales/fr.yml
+++ b/plugins/lcnaf/frontend/locales/fr.yml
@@ -18,6 +18,7 @@ fr:
         import_success_message: Redirection vers la page de statut de tâche...
         import_error: Erreur lors de l'import à partir de LCNAF
         search_error: Erreur de recherche
+        search_error_message: Un problème a été rencontré tout en complétant cette recherche. S'il vous plaît assurer le service tiers est toujours disponible.
         service_locked: Items déjà sélectionnés
         service_locked_message: Veuillez importer ou enlever les items sélectionnés avant de changer de service d'enregistrement
         service_warning: Ce plugin dépend de services tiers qui peuvent être ou non disponibles ou maintenus.

--- a/plugins/lcnaf/frontend/spec/lcnaf_client_spec.rb
+++ b/plugins/lcnaf/frontend/spec/lcnaf_client_spec.rb
@@ -7,7 +7,7 @@ require_relative '../models/http_request.rb'
 describe "id.loc.gov clientware" do
 
   let(:loc_searcher) {
-    OpenSearcher.new('http://id.loc.gov/search/', 'http://id.loc.gov/authorities/names')
+    OpenSearcher.new('https://id.loc.gov/search/', 'http://id.loc.gov/authorities/names')
   }
 
 

--- a/plugins/lcnaf/frontend/views/lcnaf/index.html.erb
+++ b/plugins/lcnaf/frontend/views/lcnaf/index.html.erb
@@ -12,13 +12,13 @@
       <div class="radio">
         <label for="lcnaf_service_loc">
           <input type="radio" name="lcnaf_service" value="lcnaf" id="lcnaf_service_loc" checked="true">
-          LCNAF - http://id.loc.gov/authorities/names
+          LCNAF - https://id.loc.gov/authorities/names
         </label>
       </div>
       <div class="radio">
           <label for="lcsh_service_loc">
               <input type="radio" name="lcnaf_service" value="lcsh" id="lcsh_service_loc">
-           LCSH - http://id.loc.gov/authorities/subjects
+           LCSH - https://id.loc.gov/authorities/subjects
           </label>
       </div>
     </div>
@@ -131,3 +131,5 @@
 <div id="template_lcnaf_search_error_title"><!--
   <%= I18n.t("plugins.lcnaf.messages.search_error") %>
 --></div>
+
+<div id="template_lcnaf_search_error_message"><!--<%= I18n.t("plugins.lcnaf.messages.search_error_message") %>--></div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This plugin was checking for a 200 status code and throwing an exception for anything other than a 200. id.loc.gov now throws a 301 for http://id.loc.gov redirecting to https://id.loc.gov. While we can (and have) updated the hardcoded search links in `lcnaf_controller`, we can't handle the fact that the entry uri's returned by that search also point to now 301'd uris (e.g. http://id.loc.gov/authorities/names/n86828140.marcxml.xml). Just to get things working again, I've added a check for 301/Net::HTTPMovedPermanently before the check for anything other than 200/Net::HTTPOK.

Also, quickly provided better user feedback in the Search Error modal since the Internal Server Error that was getting thrown there was unlikely to ever by helpful to anyone. This can/should be improved upon in the future, but for the time being this at least gets the plugin up and running again.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
LCNAF plugin currently inoperable due to changes at id.loc.gov

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
