### PR TITLE
Ensure all selenium tests can run independently

### DIFF
--- a/frontend/spec/selenium/spec/events_spec.rb
+++ b/frontend/spec/selenium/spec/events_spec.rb
@@ -45,7 +45,7 @@ describe 'Events' do
     @driver.find_element(:id, 'event_linked_agents__0__role_').select_option('recipient')
 
     token_input = agent_subform.find_element(:id, 'token-input-event_linked_agents__0__ref_')
-    @driver.typeahead_and_select(token_input, 'Admin')
+    @driver.typeahead_and_select(token_input, 'test user_')
 
     @driver.find_element(:id, 'event_linked_records__0__role_').select_option('source')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Continuing work to improve Selenium test suite.  Prior to this change, `events_spec.rb` could not run successfully independent of other tests as it depended on the existence of an admin user that is not created within the `events_spec` itself.  This minor change utilizes the agent created in the before block of the events tests, instead of the admin agent provided by other/prior tests.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
To enable all selenium tests to be pass at the file level at minimum (if not yet at the context or individual example level).

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
