### PR TITLE
Fix bug in public search results display where truncated abstracts ar…

### DIFF
--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -23,7 +23,7 @@
            <% if note_struct['note_text'].length > AppConfig[:abstract_note_length] %>
              <% truncated_note = note_struct['note_text'][0..AppConfig[:abstract_note_length]-1] %>
              <% end_index = truncated_note.rindex(' ') || AppConfig[:abstract_note_length]-1 %>
-             <%= strip_tags(truncated_note[0..end_index - 1]) + '...' %>
+             <%= (strip_tags(truncated_note[0..end_index - 1]) + '...').html_safe %>
            <% else %>
 	     <%= note_struct['note_text'].html_safe %>
            <% end %>


### PR DESCRIPTION
…e not html_safed

Call .html_safe on the truncated content.

## Description
User noticed an html entity displaying in its escaped form

## Related JIRA Ticket or GitHub Issue
None known

## How Has This Been Tested?
Ran it, looked at it.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have authority to submit this code.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
