### PR TITLE
Fixes/enhancements to staff side pdfs

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -19,7 +19,7 @@ gem 'rufus-lru', '1.0.5'
 gem 'rufus-scheduler', '~> 2.0.24'
 gem 'rubyXL', '~> 3.4', '>= 3.4.9'
 gem 'saxerator', '= 0.9.2'
-gem 'saxon-rb', '~> 0.6'
+gem 'saxon-rb', '~> 0.8.3'
 gem 'sequel', '~> 5.9.0'
 gem 'sinatra', '2.0.5', require: false
 gem 'sinatra-contrib', '2.0.5', require: false

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -185,7 +185,7 @@ DEPENDENCIES
   rufus-lru (= 1.0.5)
   rufus-scheduler (~> 2.0.24)
   saxerator (= 0.9.2)
-  saxon-rb (~> 0.6)
+  saxon-rb (~> 0.8.3)
   sequel (~> 5.9.0)
   simplecov (= 0.7.1)
   sinatra (= 2.0.5)

--- a/backend/app/lib/AS_fop.rb
+++ b/backend/app/lib/AS_fop.rb
@@ -39,9 +39,12 @@ class ASFop
   def to_fo(sax_handler)
     transformer = saxon_processor.xslt_compiler.compile(Saxon::Source.create(File.join(ASUtils.find_base_directory, 'stylesheets', 'as-ead-pdf.xsl')))
     sax_destination = Saxon::S9API::SAXDestination.new(sax_handler)
-    input = Saxon::Source.create(@source)
+    input = saxon_processor.document_builder.build(Saxon::Source.create(@source))
     params = {"pdf_image" => @pdf_image}
-    transformer.apply_templates(input, {initial_template_parameters: params}).to_destination(sax_destination)
+    transformer.apply_templates(input, {
+      global_parameters: params,
+      global_context_item: input
+    }).to_destination(sax_destination)
   end
 
   def fop_processor

--- a/stylesheets/as-ead-pdf.xsl
+++ b/stylesheets/as-ead-pdf.xsl
@@ -274,11 +274,15 @@
         i.e. src="myicon.png"
     -->
     <xsl:template name="icon">
-        <fo:block text-align="left" margin-left="-.75in" margin-top="-.5in">
-            <fo:external-graphic content-height="75%" content-width="75%">
+      <fo:block-container max-width="6.5in" max-height="4in">
+        <fo:block text-align="left">
+            <fo:external-graphic content-width="scale-down-to-fit"
+              content-height="scale-down-to-fit" width="100%" height="100%"
+              scaling="uniform">
               <xsl:attribute name="src"><xsl:value-of select="$pdf_image"/></xsl:attribute>
             </fo:external-graphic>
         </fo:block>
+      </fo:block-container>
     </xsl:template>
 
     <!-- Generates PDF Bookmarks -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR includes two bug fixes and a minor feature enhancement, as follows (with heavy thanks to @fordmadox ):

- Restores the missing `pdf_image` to the top of the staff-side PDF (either the web-accessible image set in a repository's `branding_image_url` or the default archivesspace logo);
- Ensures that properly-set global variables in custom xslts don't break PDF generation; and, 
- Minorly tweaks the default `as-ead-pdf.xsl` to more gracefully handle overly large logos provided in `branding_image_url`.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
#1813 introduced new changes in Saxon which resulted in global context items and global variables/parameters not being set by default.  This resulted in the first two bullets above.  For more information on the changes/the fix provided here, see: https://github.com/fidothe/saxon-rb/issues/20

Since we were already tweaking the staff side PDF process, I also introduced a minor update to the xsl itself to scale down branding images too large to fit on the PDF cover page (this does occasionally pop up as a problem on the user list).  This does not alter the intrinsic size of images that fit in the new 6.5x4in container for logos (e.g. the default ArchivesSpace image will not be altered).

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
End user reports of missing branding images and previously working stylesheets resulting in export errors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests passing, manually confirmed fixes/enhancements.

## Screenshots (if appropriate):
Previously, an overly large image would break the PDF cover page:
![image](https://user-images.githubusercontent.com/15144646/90825082-6dd1db00-e306-11ea-857f-b9349216ec3d.png)

Now, larger images will scale as needed:
![image](https://user-images.githubusercontent.com/15144646/90825159-83df9b80-e306-11ea-8554-1e1e08ecc961.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
