### PR TITLE
Agent form enhancements

### DIFF
--- a/frontend/app/views/agents/_form.html.erb
+++ b/frontend/app/views/agents/_form.html.erb
@@ -29,7 +29,6 @@
   <%= render_aspace_partial :partial => "notes/form", :locals => {:form => form, :all_note_types => note_types_for(form['jsonmodel_type']), :section_id => "#{@agent.agent_type}_notes"} %>
   <%= render_aspace_partial :partial => "related_agents/form", :locals => {:form => form} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents", :section_id => "#{@agent.agent_type}_external_documents", :help_topic => "#{@agent.agent_type}_external_documents"} %>
-  <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_ids", :hidden => true} %>
 
 <%= form_plugins_for("agent", form) %>
 

--- a/frontend/app/views/agents/show.html.erb
+++ b/frontend/app/views/agents/show.html.erb
@@ -105,9 +105,6 @@
           <%= render_aspace_partial :partial => "external_documents/show", :locals => { :external_documents => @agent.external_documents, :section_id => "#{@agent.agent_type}_external_documents" } %>
         <% end %>
 
-        <%= show_plugins_for(@agent, readonly) %>
-
-
         <%= render_aspace_partial :partial => "search/embedded", :locals => {:filter_term => {"agent_uris" => @agent.uri}.to_json, :heading_text => I18n.t("agent._frontend.section.search_embedded")} %>
 
         <%= render_aspace_partial :partial => "search/embedded", :locals => {:filter_term => {"rights_statement_agent_uris" => @agent.uri}.to_json, :heading_text => I18n.t("agent._frontend.section.linked_via_rights_statement")} %>
@@ -119,6 +116,7 @@
           <%= render_aspace_partial :partial => "assessments/embedded", :locals => { :record => @agent, :filter_term => {"assessment_reviewer_uris" => @agent.uri}.to_json, :heading_text => I18n.t("assessment._frontend.linked_records.linked_via_assessment_reviewer"), :section_id => 'linked_assessments_reviewer'} %>
         <% end %>
 
+        <%= show_plugins_for(@agent, readonly) %>
       <% end %>
     </div>
   </div>

--- a/frontend/app/views/agents/show.html.erb
+++ b/frontend/app/views/agents/show.html.erb
@@ -114,9 +114,10 @@
 
         <%= render_aspace_partial :partial => "search/embedded", :locals => { :record => @agent, :filter_term => {"linked_record_uris" => @agent.uri}.to_json, :heading_text => I18n.t("event._plural")} %>
 
-        <%= render_aspace_partial :partial => "assessments/embedded", :locals => { :record => @agent, :filter_term => {"assessment_surveyor_uris" => @agent.uri}.to_json, :heading_text => I18n.t("assessment._frontend.linked_records.linked_via_assessment_surveyed_by"), :section_id => 'linked_assessments_surveyed_by'} %>
-
-        <%= render_aspace_partial :partial => "assessments/embedded", :locals => { :record => @agent, :filter_term => {"assessment_reviewer_uris" => @agent.uri}.to_json, :heading_text => I18n.t("assessment._frontend.linked_records.linked_via_assessment_reviewer"), :section_id => 'linked_assessments_reviewer'} %>
+        <% if @agent.agent_type == 'agent_person' %>
+          <%= render_aspace_partial :partial => "assessments/embedded", :locals => { :record => @agent, :filter_term => {"assessment_surveyor_uris" => @agent.uri}.to_json, :heading_text => I18n.t("assessment._frontend.linked_records.linked_via_assessment_surveyed_by"), :section_id => 'linked_assessments_surveyed_by'} %>
+          <%= render_aspace_partial :partial => "assessments/embedded", :locals => { :record => @agent, :filter_term => {"assessment_reviewer_uris" => @agent.uri}.to_json, :heading_text => I18n.t("assessment._frontend.linked_records.linked_via_assessment_reviewer"), :section_id => 'linked_assessments_reviewer'} %>
+        <% end %>
 
       <% end %>
     </div>

--- a/frontend/spec/selenium/spec/assessments_spec.rb
+++ b/frontend/spec/selenium/spec/assessments_spec.rb
@@ -261,4 +261,21 @@ describe 'Assessments' do
     @driver.wait_for_ajax
     expect(@driver.find_elements(:css, '#linked_assessments #tabledSearchResults tbody tr').length).to eq(1)
   end
+
+  it 'shows linked assessments on agent_person page' do
+    @driver.clear_and_send_keys([id: 'global-search-box'], "#{@archivist_user.username}")
+    @driver.find_element(:id, 'global-search-button').click
+    @driver.click_and_wait_until_gone(:link, 'View')
+    @driver.wait_for_ajax
+    expect(@driver.find_elements(:css, '#linked_assessments_surveyed_by #tabledSearchResults tbody tr').length).to eq(1)
+  end
+
+  it 'does not show linked assessments on agent_corporate_entity page' do
+    @driver.navigate.to("#{$frontend}/agents")
+    @driver.wait_for_ajax
+    @driver.find_element(:link, 'Corporate Entity').click
+    @driver.wait_for_ajax
+    @driver.click_and_wait_until_element_gone(@driver.find_element_with_text('//tr', /assessments_test_/).find_element(:link, 'View'))
+    expect(@driver.find_elements(:css, '#linked_assessments_surveyed_by').length).to eq(0)
+  end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Includes three commits from the larger #1896 written by @payten and funded by Queensland State Archives.

- 9de3b837c579596b085f25fa050067590f3986df: Only show Linked Assessment Reviewer/Surveyed By on agent_person records
- 586097be5973472a50d2b1eb6412f950c8618d93: Ensure plugin sections are displayed at the end of agents readonly page
- dc769d5ddcda7fcd10c8dad404f25b1f931c47c2: Agents don't link to external_ids, so the form is not required

Also includes two new tests in `assessments_spec.rb` to add test coverage for 9de3b837c579596b085f25fa050067590f3986df.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Includes modifications to the staff-side agents form/show templates, including:

- Only adding a linked assessment reviewer/surveyor subrecords to the show pages for agent_persons (other agent types - corporate entities, families, and software) can not be linked as assessment reviewers or surveyors.
- Move plugin section to the bottom of the agent show page.
- Remove the (already hidden/not usable) external_ids section from the agent form.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass, new tests added.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
