### PR TITLE
Hm qsa 090220 mc

### DIFF
--- a/common/aspace_i18n.rb
+++ b/common/aspace_i18n.rb
@@ -15,6 +15,8 @@ end
 # Add report i18n locales
 I18n.load_path += Dir[File.join(ASUtils.find_base_directory, 'reports', '**', '*.yml')]
 
+I18n.default_locale = AppConfig[:locale]
+
 
 module I18n
 

--- a/frontend/app/helpers/aspace_form_helper.rb
+++ b/frontend/app/helpers/aspace_form_helper.rb
@@ -862,6 +862,11 @@ module AspaceFormHelper
     s << "</div>".html_safe
 
     s
+  rescue
+    Rails.logger.error("Failure generating templates for JS: #{$!}")
+    Rails.logger.error("Stacktrace:\n%s" % [$@.join("\n")])
+
+    raise $!
   end
 
 

--- a/frontend/app/views/container_locations/_show.html.erb
+++ b/frontend/app/views/container_locations/_show.html.erb
@@ -9,8 +9,8 @@
       <%= read_only_view(container_location, :label_css => "col-md-4") %>
       <% if container_location['_resolved'] %>
         <div class="form-group">
-          <div class="control-label"><%= I18n.t("container_location.location") %></div>
-          <div class="controls token-list">
+          <div class="control-label col-sm-2"><%= I18n.t("container_location.location") %></div>
+          <div class="controls token-list col-sm-8">
             <%= render_token :object => container_location['_resolved'],
                              :label => container_location['_resolved']['title'],
                              :type => "location",

--- a/frontend/app/views/dates/_template.html.erb
+++ b/frontend/app/views/dates/_template.html.erb
@@ -39,7 +39,7 @@
   <div class="subrecord-form-fields">
     <div class="date-container">
       <%= form.label_and_select "label", form.possible_options_for("label", false, :include => ["existence"]) %>
-      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
+      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date._frontend.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
 			<%= form.label_and_select "date_type", form.possible_options_for("date_type", true, :exclude => ["bulk", "inclusive"]), :required => true %>
       <%form.emit_template("date_fields") %>
     </div>
@@ -51,7 +51,7 @@
   <div class="subrecord-form-fields">
     <div class="date-container">
       <%= form.label_and_select "label", form.possible_options_for("label", false, :include => ["usage"]) %>
-      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
+      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date._frontend.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
 			<%= form.label_and_select "date_type", form.possible_options_for("date_type", true, :exclude => ["bulk", "inclusive"]), :required => true %>
       <%form.emit_template("date_fields") %>
     </div>
@@ -63,7 +63,7 @@
   <div class="subrecord-form-fields">
     <div class="date-container">
       <%= form.label_and_select "label", form.possible_options_for("label") %>
-      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
+      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date._frontend.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
 			<%= form.label_and_select "date_type", form.possible_options_for("date_type", true, :exclude => ["bulk", "inclusive"]), :required => true %>
       <%form.emit_template("date_fields") %>
     </div>
@@ -75,7 +75,7 @@
   <div class="subrecord-form-fields">
     <div class="date-container">
       <%= form.label_and_select "label", form.possible_options_for("label"), :field_opts => {:default => "creation"} %>
-			<%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
+			<%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date._frontend.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
 			<%= form.label_and_select "date_type", form.possible_options_for("date_type", true,:exclude => ["range"] ), :required => true %>
       <%form.emit_template("date_fields") %>
     </div>
@@ -87,7 +87,7 @@
   <div class="subrecord-form-fields">
     <div class="date-container">
       <%= form.label_and_select "label", form.possible_options_for("label") %>
-      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
+      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date._frontend.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
 			<%= form.label_and_select "date_type", form.possible_options_for("date_type", true, :exclude => (exclude ||= [])), :required => true %>
       <%form.emit_template("date_fields") %>
     </div>

--- a/frontend/app/views/dates/_template.html.erb
+++ b/frontend/app/views/dates/_template.html.erb
@@ -39,7 +39,7 @@
   <div class="subrecord-form-fields">
     <div class="date-container">
       <%= form.label_and_select "label", form.possible_options_for("label", false, :include => ["existence"]) %>
-      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => "Describe the date or date range"}, :required => :conditionally} %>
+      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
 			<%= form.label_and_select "date_type", form.possible_options_for("date_type", true, :exclude => ["bulk", "inclusive"]), :required => true %>
       <%form.emit_template("date_fields") %>
     </div>
@@ -51,7 +51,7 @@
   <div class="subrecord-form-fields">
     <div class="date-container">
       <%= form.label_and_select "label", form.possible_options_for("label", false, :include => ["usage"]) %>
-      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => "Describe the date or date range"}, :required => :conditionally} %>
+      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
 			<%= form.label_and_select "date_type", form.possible_options_for("date_type", true, :exclude => ["bulk", "inclusive"]), :required => true %>
       <%form.emit_template("date_fields") %>
     </div>
@@ -63,7 +63,7 @@
   <div class="subrecord-form-fields">
     <div class="date-container">
       <%= form.label_and_select "label", form.possible_options_for("label") %>
-      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => "Describe the date or date range"}, :required => :conditionally} %>
+      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
 			<%= form.label_and_select "date_type", form.possible_options_for("date_type", true, :exclude => ["bulk", "inclusive"]), :required => true %>
       <%form.emit_template("date_fields") %>
     </div>
@@ -75,7 +75,7 @@
   <div class="subrecord-form-fields">
     <div class="date-container">
       <%= form.label_and_select "label", form.possible_options_for("label"), :field_opts => {:default => "creation"} %>
-			<%= form.label_and_textarea "expression", {:field_opts => {:placeholder => "Describe the date or date range"}, :required => :conditionally} %>
+			<%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
 			<%= form.label_and_select "date_type", form.possible_options_for("date_type", true,:exclude => ["range"] ), :required => true %>
       <%form.emit_template("date_fields") %>
     </div>
@@ -87,7 +87,7 @@
   <div class="subrecord-form-fields">
     <div class="date-container">
       <%= form.label_and_select "label", form.possible_options_for("label") %>
-      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => "Describe the date or date range"}, :required => :conditionally} %>
+      <%= form.label_and_textarea "expression", {:field_opts => {:placeholder => I18n.t('date.expression_placeholder', "Describe the date or date range")}, :required => :conditionally} %>
 			<%= form.label_and_select "date_type", form.possible_options_for("date_type", true, :exclude => (exclude ||= [])), :required => true %>
       <%form.emit_template("date_fields") %>
     </div>

--- a/frontend/app/views/locations/show.html.erb
+++ b/frontend/app/views/locations/show.html.erb
@@ -13,8 +13,6 @@
 
       <%= read_only_view(@location.to_hash) %>
 
-      <%= display_audit_info(@location) %>
-
       <% if @location['location_profile'] %>
         <div class="form-horizontal">
           <div class="form-group token-list">
@@ -42,6 +40,9 @@
           </div>
         </div>
       <% end %>
+
+
+      <%= display_audit_info(@location) %>
 
       <% if @location.external_ids.length > 0 && show_external_ids? %>
         <%= render_aspace_partial :partial => "external_ids/show", :locals => { :external_ids => @location.external_ids, :section_id => "location_external_ids_" } %>

--- a/frontend/app/views/shared/_largetree.html.erb
+++ b/frontend/app/views/shared/_largetree.html.erb
@@ -13,7 +13,7 @@
 <div id="object_container"></div>
 
 <div id="tree_toolbar_transfer_action"><!--
-  <a class="btn btn-xs btn-default dropdown-toggle transfer-node" data-toggle="dropdown" href="#" title="<%= I18n.t "actions.transfer" %>">
+  <a class="btn btn-xs btn-default transfer-node" onclick="$('.tree-transfer-form').toggle()" href="#" title="<%= I18n.t "actions.transfer" %>">
     <%= I18n.t "actions.transfer" %> <span class="caret"></span>
   </a>
   <ul class="dropdown-menu tree-transfer-form">
@@ -27,7 +27,7 @@
           </fieldset>
           <div class="form-actions">
             <button class="btn btn-default btn-primary pull-left transfer-button"><%= I18n.t("actions.transfer") %></button>
-            <a class="btn btn-default btn-cancel pull-right" href="#"><%= I18n.t("actions.cancel") %></a>
+            <a class="btn btn-default btn-cancel pull-right" onclick="$('.tree-transfer-form').toggle()" href="#"><%= I18n.t("actions.cancel") %></a>
           </div>
         <% end %>
       <% end %>

--- a/frontend/app/views/user_defined/_show.html.erb
+++ b/frontend/app/views/user_defined/_show.html.erb
@@ -1,6 +1,7 @@
 <%
   section_id = "user_defined" if section_id.blank?
- 
+
+  render_aspace_partial :partial => "user_defined/template"
 %>
 
 <section id="<%= section_id %>" class="subrecord-form-dummy">
@@ -8,7 +9,9 @@
 
   <div class="subrecord-form-container">
     <div class="subrecord-form-fields">
-      <%= read_only_view(user_defined) %>
+      <%= readonly_context(:user_defined, user_defined) do |readonly| %>
+        <%= readonly.emit_template("user_defined") %>
+      <% end %>
     </div>
   </div>
 </section>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -786,6 +786,7 @@ en:
 
   date:
     _frontend:
+      expression_placeholder: Describe the date or date range
       action:
         add: Add Date
 


### PR DESCRIPTION
Includes seven commits from the larger #1896 funded by Queensland State Archives and written by:

- @jambun
- @marktriggs

## Commits

- 76ef79d650413dc73aafae8d0f9c60a7b58091af: Use the form template for user_defined fields
- a894eb63b39e059ca6794f85dce3e0870b4b810d: Fix a bug where the transfer dropdown is closed when the linker modal is closed
- cae9e05b81a1648ea575a9cb75809c4063f90b7d: Report a useful stacktrace if generating JS templates fails
- 0e8f31aac12cadc2b97fa6ff8c30226691cb282e: ensure all components respect AppConfig[:locale]
- 1d03cf9c9d938d97f85955518731c40e50011a88: Fix small layout issue with "Location" in top_container/show
- 6405369a1972bebac216c73b7af52c732c3bf285:  Layout fix: show audit info at the bottom of basic information
- 095a89df4b0b13cb3b6182c229d1d1fb7210ce08: Add I18n entry for date expression placeholder text

## Description
Includes a number of cleanups and fixes to the staff-side ui.

## How Has This Been Tested?
Ran locally, checked them all out.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
