### PR TITLE
adds last modified and created date as default sort options

### DIFF
--- a/common/config/search_browse_column_config.rb
+++ b/common/config/search_browse_column_config.rb
@@ -16,6 +16,8 @@ module SearchAndBrowseColumnConfig
       "extents" => {:field => "extents"},
       "processing_priority" => {:field => "processing_priority", :sortable => true},
       "processors" => {:field => "processors", :sortable => true},
+      "create_time" => {:field => "create_time", :sortable => true},
+      "user_mtime" => {:field => "user_mtime", :sortable => true},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]}
     },
     "resource" => {
@@ -31,6 +33,8 @@ module SearchAndBrowseColumnConfig
       "finding_aid_status" => {:field => "finding_aid_status", :sortable => true},
       "processing_priority" => {:field => "processing_priority", :sortable => true},
       "processors" => {:field => "processors", :sortable => true},
+      "create_time" => {:field => "create_time", :sortable => true},
+      "user_mtime" => {:field => "user_mtime", :sortable => true},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]}
     },
     "digital_object" => {
@@ -42,6 +46,8 @@ module SearchAndBrowseColumnConfig
       "restrictions" => {:field => "restrictions", :sortable => true},
       "dates" => {:field => "dates"},
       "extents" => {:field => "extents"},
+      "create_time" => {:field => "create_time", :sortable => true},
+      "user_mtime" => {:field => "user_mtime", :sortable => true},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]}
     },
     "multi" => {
@@ -51,6 +57,8 @@ module SearchAndBrowseColumnConfig
       "identifier" => {:field => "identifier", :sortable => true},
       "dates" => {:field => "dates"},
       "extents" => {:field => "extents"},
+      "create_time" => {:field => "create_time", :sortable => true},
+      "user_mtime" => {:field => "user_mtime", :sortable => true},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]}
     },
     "location" => {


### PR DESCRIPTION
Adds last modified and created date as default sort options for accessions, resources, digital objects, and search. I'm not sure if it would be better to address this along with future preferences work instead of merging this, but it seemed like a simple change to me.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes to the common SearchAndBrowseColumnConfig to add default sort options for last modified and created date. Uses the existing functionality. 

## Related JIRA Ticket or GitHub Issue
N/A, default sorting by last modified date was just a feature we wanted. Save the extra clicks to show which records were most recently update, which I find I do constantly.

## How Has This Been Tested?
Tested the new options with real world data for resources, accessions, digital objects, and the search results pages. When you select preferences, they are stored in the database, so if you, say set resources to sort by Modified and then go back to the original config, anything other than the login page returns an error. This can then be fixed by re-adding the options, preferences back to defaults, and then removing the extra options.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes. (Dunno if there's a good way to test this, but I'd be happy to give it a shot if so.)
- [x] All new and existing tests passed.
