### PR TITLE
ANW-851: Fix temporary location lost on update

### DIFF
--- a/frontend/app/controllers/locations_controller.rb
+++ b/frontend/app/controllers/locations_controller.rb
@@ -73,14 +73,26 @@ class LocationsController < ApplicationController
   end
 
   def update
+    obj = JSONModel(:location).find(params[:id])
+    check_for_temporary_location(obj)
     handle_crud(:instance => :location,
                 :model => JSONModel(:location),
-                :obj => JSONModel(:location).find(params[:id]),
+                :obj => obj,
                 :on_invalid => ->(){ return render :action => :edit },
                 :on_valid => ->(id){
                   flash[:success] = I18n.t("location._frontend.messages.updated")
                   redirect_to :controller => :locations, :action => :edit, :id => id
                 })
+  end
+
+  # temporary_location is unusual in that when set it's a disabled field so does not get submitted
+  # in params, so add it back if available otherwise it gets nilled
+  def check_for_temporary_location(obj)
+    if params[:location][:temporary_question]
+      # don't use .blank? here -- "" is a valid selection (and will unset correctly)
+      temporary = !params[:location][:temporary].nil? ? params[:location][:temporary] : obj["temporary"]
+      params[:location][:temporary] = temporary
+    end
   end
 
   def defaults

--- a/frontend/app/views/locations/_form.html.erb
+++ b/frontend/app/views/locations/_form.html.erb
@@ -2,7 +2,13 @@
   <fieldset>
     <section id="basic_information">
     <%= form.label_and_boolean "temporary_question", {}, false %> 
-    <%= form.label_and_select "temporary", form.possible_options_for("temporary", true), :field_opts =>  { :disabled => true, :class => "location_temporary" } %>
+    <%= form.label_and_select "temporary",
+        form.possible_options_for("temporary", true),
+        :field_opts =>  {
+          :disabled => true, :class => "location_temporary",
+          :onchange => "$('#location_temporary_question_').prop('checked', true)"
+        }
+    %>
       <hr/>
       <%= form.label_and_textfield "building" %>
       <%= form.label_and_textfield "floor" %>

--- a/frontend/spec/selenium/spec/locations_spec.rb
+++ b/frontend/spec/selenium/spec/locations_spec.rb
@@ -49,9 +49,18 @@ describe 'Locations' do
 
   it 'allows locations to be edited' do
     @driver.clear_and_send_keys([:id, 'location_room_'], '5A')
+    @driver.find_element(id: 'location_temporary_question_').click
+    @driver.find_element(id: 'location_temporary_').select_option('conservation')
     @driver.click_and_wait_until_gone(css: 'form#new_location .btn-primary')
-
     @driver.find_element_with_text('//div[contains(@class, "alert-success")]', /Location Saved/)
+    expect(@driver.find_element(id: "location_temporary_").get_select_value).to eq('conservation')
+  end
+
+  it 'persists the temporary location' do
+    @driver.click_and_wait_until_gone(css: 'a.hide-alert')
+    @driver.click_and_wait_until_gone(css: 'form#new_location .btn-primary')
+    @driver.find_element_with_text('//div[contains(@class, "alert-success")]', /Location Saved/)
+    expect(@driver.find_element(id: "location_temporary_").get_select_value).to eq('conservation')
   end
 
   it 'lists the new location in the browse list' do


### PR DESCRIPTION
The disabled input means params are not sent to the controller, so
the data is lost on update. Instead, if a temporary location flag
is submitted, check for a value in the params or for a pre-existing
value in the location record. Also ensure that when a temporary
location is selected the flag is checked.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-851

## How Has This Been Tested?
Manual UI wrangling and updated location specs.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
