### PR TITLE
ANW-750: Update MARCXML 544 field import

### DIFF
--- a/backend/app/converters/lib/marcxml_base_map.rb
+++ b/backend/app/converters/lib/marcxml_base_map.rb
@@ -1055,7 +1055,7 @@ module MarcXMLBaseMap
                                             {Type of unit--$o. }{Owner--$f. }{Purchase price--$h}.|),
 
         "datafield[@tag='544']" => multipart_note('relatedmaterial', 'Related Archival Materials', %q|
-                                            {@ind1--}{$3: }{Title--$t. }{Custodian--$a: }
+                                            {$3: }{Title--$d. }{Custodian--$a: }
                                             {Address--$b, }{Country--$c. }{Provenance--$e. }{Note--$n}.|,
                                                   {'ind1'=>{'1'=>'Associated Materials', '2'=>'Related Materials'}}),
 

--- a/backend/spec/lib_marcxml_converter_spec.rb
+++ b/backend/spec/lib_marcxml_converter_spec.rb
@@ -318,7 +318,7 @@ END
         expect(@notes).to include('Source of acquisition--Resource-ImmediateSourceAcquisition.')
       end
 
-      it "maps datafield[@tag='544'] to resource.notes[] using template 'Indicator 1 [ Associated Materials | Related Materials]--$3: Title--$t. Custodian--$a: Address--$b, Country--$c. Provenance--$e. Note--$n.'" do
+      it "maps datafield[@tag='544'] to resource.notes[] using template '[ Associated Materials | Related Materials]--$3: Title--$d. Custodian--$a: Address--$b, Country--$c. Provenance--$e. Note--$n.'" do
         expect(@notes).to include('Custodian--Resource-RelatedArchivalMaterials-AT.')
       end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change fixes an issue with processing data in the MARC 544 field during MARCXML import. Previously, on import, the value of indicator 1 was prepended to the data in the note text, and subfield d (title) was ignored. This change removes the value of indicator 1 from the note text, and includes subfield d.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-750

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Backend unit tests (build/run backend:test) passed on Windows Subsystem for Linux (Ubuntu 18.04)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
