### PR TITLE
Hm qsa 091520 mc

### DIFF
--- a/backend/app/controllers/enumeration.rb
+++ b/backend/app/controllers/enumeration.rb
@@ -10,6 +10,20 @@ class ArchivesSpaceService < Sinatra::Base
   end
 
 
+  Endpoint.get('/config/enumerations/csv')
+    .description("List all defined enumerations as a csv")
+    .params()
+    .permissions([])
+    .returns([200, "(csv)"]) \
+  do
+    [
+      200,
+      {"Content-Type" => "text/csv"},
+      Enumeration.csv
+    ]
+  end
+
+
   Endpoint.post('/config/enumerations')
     .description("Create an enumeration")
     .params(["enumeration", JSONModel(:enumeration), "The record to create", :body => true])
@@ -136,5 +150,6 @@ class ArchivesSpaceService < Sinatra::Base
     sup_state = EnumerationValue.handle_suppressed([ params[:enum_val_id] ], params[:suppressed])
     suppressed_response(params[:enum_val_id], sup_state)
   end
+
 
 end

--- a/backend/app/model/enumeration.rb
+++ b/backend/app/model/enumeration.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 class Enumeration < Sequel::Model(:enumeration)
 
   include ASModel
@@ -182,4 +184,29 @@ class Enumeration < Sequel::Model(:enumeration)
   end
 
 
+  def self.csv
+    out = [
+           'Enumeration code',
+           'Enumeration',
+           'Value code',
+           'Value',
+          ].to_csv
+    Enumeration.sequel_to_jsonmodel(Enumeration.all).each do |enum|
+      out << [
+              enum.name,
+              I18n.t("enumeration_names.#{enum.name}", :default => enum.name),
+             ].to_csv
+
+      enum.values.each do |val|
+        out << [
+                enum.name,
+                I18n.t("enumeration_names.#{enum.name}", :default => enum.name),
+                val,
+                I18n.t("enumerations.#{enum.name}.#{val}", :default => val),
+               ].to_csv
+      end
+    end
+
+    out
+  end
 end

--- a/backend/spec/rest_enumerations_spec.rb
+++ b/backend/spec/rest_enumerations_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+# ./build/run backend:test -Dexample='Enumerations API'
+
+RSpec.describe 'Enumerations API' do
+  describe 'GET /config/enumerations/csv' do
+    it 'retrieves a list of all non-suppressed enumerations as csv' do
+      get '/config/enumerations/csv'
+      csv = CSV.parse(last_response.body)
+      expect(last_response.status).to eq(200)
+      expect(csv[0]).to eq Enumeration::CSV_HEADERS
+      expect(csv.size - 1).to eq EnumerationValue.where(suppressed: 0).count
+    end
+  end
+end

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -675,6 +675,3 @@ AppConfig[:hide_do_load] = false
 AppConfig[:bulk_import_rows] = 1000
 # maximum size (in KiloBytes) for an excel spreadsheet
 AppConfig[:bulk_import_size] = 256
-
-# Enable/disable the View Published links in the frontend record toolbars
-AppConfig[:show_view_published] = true

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -675,3 +675,6 @@ AppConfig[:hide_do_load] = false
 AppConfig[:bulk_import_rows] = 1000
 # maximum size (in KiloBytes) for an excel spreadsheet
 AppConfig[:bulk_import_size] = 256
+
+# Enable/disable the View Published links in the frontend record toolbars
+AppConfig[:show_view_published] = true

--- a/frontend/app/controllers/enumerations_controller.rb
+++ b/frontend/app/controllers/enumerations_controller.rb
@@ -144,7 +144,7 @@ class EnumerationsController < ApplicationController
     @enumerations = JSONModel(:enumeration).all
 
     self.response.headers['Content-Type'] = 'text/csv'
-    self.response.headers['Content-Disposition'] = "attachment; filename=enumerations_#{Time.now.strftime('%Y-%m-%d_%T')}.csv"
+    self.response.headers['Content-Disposition'] = "attachment; filename=enumerations_#{Time.now.strftime('%Y%m%dT%H%M%S')}.csv"
     self.response.headers['Last-Modified'] = Time.now.ctime
 
     self.response_body = Enumerator.new do |stream|

--- a/frontend/app/controllers/enumerations_controller.rb
+++ b/frontend/app/controllers/enumerations_controller.rb
@@ -1,6 +1,6 @@
 class EnumerationsController < ApplicationController
 
-  set_access_control  "update_enumeration_record" => [:new, :create, :index, :delete, :destroy, :merge, :set_default, :update_value]
+  set_access_control  "update_enumeration_record" => [:new, :create, :index, :delete, :destroy, :merge, :set_default, :update_value, :csv]
 
 
   def new
@@ -140,4 +140,19 @@ class EnumerationsController < ApplicationController
   end
 
 
+  def csv
+    @enumerations = JSONModel(:enumeration).all
+
+    self.response.headers['Content-Type'] = 'text/csv'
+    self.response.headers['Content-Disposition'] = "attachment; filename=enumerations_#{Time.now.strftime('%Y-%m-%d_%T')}.csv"
+    self.response.headers['Last-Modified'] = Time.now.ctime
+
+    self.response_body = Enumerator.new do |stream|
+      JSONModel::HTTP.stream("/config/enumerations/csv") do |response|
+        response.read_body do |chunk|
+          stream << chunk
+        end
+      end
+    end
+  end
 end

--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -22,7 +22,7 @@
         <% end %>
         <div class="btn-toolbar pull-right">
           <div class="btn-group">
-            <% if AppConfig[:show_view_published] && @accession.publish %>
+            <% if AppConfig[:enable_public] %>
               <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => @accession} %>
             <% end %>
             <% if user_can?('update_event_record') && !@accession.suppressed %>

--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -22,9 +22,9 @@
         <% end %>
         <div class="btn-toolbar pull-right">
           <div class="btn-group">
-
-            <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => @accession} %>
-
+            <% if AppConfig[:show_view_published] && @accession.publish %>
+              <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => @accession} %>
+            <% end %>
             <% if user_can?('update_event_record') && !@accession.suppressed %>
               <%= render_aspace_partial :partial => "shared/event_dropdown", :locals => {:record => @accession } %>
             <% end %>

--- a/frontend/app/views/agents/_toolbar.html.erb
+++ b/frontend/app/views/agents/_toolbar.html.erb
@@ -26,7 +26,7 @@
         <div class="btn btn-inline-form">
           <%= link_to I18n.t("actions.export_eac"), {:controller => :exports, :action => :download_eac, :id => @agent.id, :type => @agent.agent_type}, :class => "btn btn-sm btn-default" %>
         </div>
-        <% if AppConfig[:show_view_published] && @agent.publish %>
+        <% if AppConfig[:enable_public] %>
           <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => @agent} %>
         <% end %>
         <% if user_can?('merge_agent_record') %>

--- a/frontend/app/views/agents/_toolbar.html.erb
+++ b/frontend/app/views/agents/_toolbar.html.erb
@@ -26,9 +26,9 @@
         <div class="btn btn-inline-form">
           <%= link_to I18n.t("actions.export_eac"), {:controller => :exports, :action => :download_eac, :id => @agent.id, :type => @agent.agent_type}, :class => "btn btn-sm btn-default" %>
         </div>
-
-        <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => @agent} %>
-
+        <% if AppConfig[:show_view_published] && @agent.publish %>
+          <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => @agent} %>
+        <% end %>
         <% if user_can?('merge_agent_record') %>
           <%=
           render_aspace_partial :partial => "agents/merge_dropdown",

--- a/frontend/app/views/enumerations/index.html.erb
+++ b/frontend/app/views/enumerations/index.html.erb
@@ -2,6 +2,13 @@
 
 <div class="row">
   <div class="col-md-12">
+    <div class="record-toolbar">
+      <div class="pull-right btn-group">
+        <%= link_to I18n.t('enumeration._frontend.action.download_csv'), {:controller => 'enumerations', :action => 'csv'}, :class => 'btn btn-default btn-sm' %>
+      </div>
+      <div class="clearfix"></div>
+    </div>
+
     <div class="record-pane">
       <%= link_to_help :topic => "enumeration" %>
 

--- a/frontend/app/views/shared/_component_toolbar.html.erb
+++ b/frontend/app/views/shared/_component_toolbar.html.erb
@@ -31,7 +31,7 @@
           <% end %>
 
           <% if ['archival_object', 'digital_object_component'].include?(record.jsonmodel_type) %>
-            <% unless record.has_unpublished_ancestor %>
+            <% if AppConfig[:enable_public] && !record.has_unpublished_ancestor %>
               <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => record} %>
             <% end %>
           <% end %>

--- a/frontend/app/views/shared/_resource_toolbar.html.erb
+++ b/frontend/app/views/shared/_resource_toolbar.html.erb
@@ -33,7 +33,7 @@
                           :"data-confirm-btn-class" => "btn-primary",
                         }) %>
           </div>
-          <% if AppConfig[:show_view_published] && record.publish %>
+          <% if AppConfig[:enable_public] %>
             <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => record} %>
           <% end %>
           <div class="btn-group">

--- a/frontend/app/views/shared/_resource_toolbar.html.erb
+++ b/frontend/app/views/shared/_resource_toolbar.html.erb
@@ -33,9 +33,9 @@
                           :"data-confirm-btn-class" => "btn-primary",
                         }) %>
           </div>
-
-          <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => record} %>
-
+          <% if AppConfig[:show_view_published] && record.publish %>
+            <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => record} %>
+          <% end %>
           <div class="btn-group">
             <a class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);">
               <%= I18n.t("actions.export") %>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -866,6 +866,7 @@ en:
         create_value: Create Value
         delete_value: Delete Value
         merge_value: Merge Value
+        download_csv: Download CSV
 
   event:
     _frontend:

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -205,6 +205,7 @@ ArchivesSpace::Application.routes.draw do
     match 'resolve/readonly' => 'resolver#resolve_readonly', :via => [:get]
 
     match 'enumerations/list' => 'enumerations#list', :via => [:get]
+    match 'enumerations/csv' => 'enumerations#csv', :via => [:get]
     match 'enumerations/delete' => 'enumerations#delete', :via => [:get]
     match 'enumerations/set_default/:id' => 'enumerations#set_default', :via => [:post]
     match 'enumerations/destroy/:id' => 'enumerations#destroy', :via => [:post]


### PR DESCRIPTION
Includes two commits from the larger #1896 funded by Queensland State Archives and written by:

- @jambun
- @payten

## Commits

- 52c17d1c27e41affd75e76019adba62011d85b40: Only render View Published toolbar action if AppConfig[:show_view_published]
- 9078049affaf29a10331369570dc201c6d7a38d0: Add the ability to download a CSV of all enumerations with their values

There are a couple of small updates applied to the above commits:

- Use existing appconfig setting to determine visibility of view published (rather than a new one)
- Added position and readonly columns to enumeration csv export
- Exported csv filename does not include spaces

## How Has This Been Tested?
Manually, and test added for csv export endpoint.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
