### PR TITLE
ANW-1111 Fixes PUI Print to PDF Fails if &  Followed by a Capital Letter

### DIFF
--- a/public/app/lib/xml_cleaner.rb
+++ b/public/app/lib/xml_cleaner.rb
@@ -40,7 +40,7 @@ class XMLCleaner
         infile.each_with_index do |line, index|
           line = HTMLEntities.new.decode(line)
           # decode turns &amp; into & so need to undo that here for PDF to work
-          if line.match(/&\s+/) || line.match(/&[a-z]+[^;]/)
+          if line.match(/&\s+/) || line.match(/&[A-Za-z]+[^;]/)
             line.gsub!('&', '&amp;')
           end
           outfile.puts(line)


### PR DESCRIPTION
Fix for ANW-1111. The  PUI Print to PDF Fails if `&`  is Immediately Followed by a Capital Letter. This just changes the line.match to match UPPER and lower case letters. 

https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1111