### PR TITLE
ANW-1116: Don't update merge target for agent merges

### DIFF
--- a/backend/app/lib/rest.rb
+++ b/backend/app/lib/rest.rb
@@ -31,6 +31,18 @@ module RESTHelpers
       modified_response('Updated', *opts)
     end
 
+
+    def merged_response(target, victims, selections = [])
+      type = target[:type].to_sym
+      response = {:status => 'Merged', :id => target[:id], :selections => selections }
+
+      response[:target_uri] = JSONModel(type).uri_for(target[:id], :repo_id => params[:repo_id])
+      response[:deleted_uris] = victims.map { |v| JSONModel(type).uri_for(v[:id], :repo_id => params[:repo_id]) }
+
+      json_response(response)
+    end
+
+
     def deleted_response(id)
       json_response({:status => 'Deleted', :id => id})
     end

--- a/backend/app/model/mixins/relationships.rb
+++ b/backend/app/model/mixins/relationships.rb
@@ -171,10 +171,15 @@ AbstractRelationship = Class.new(Sequel::Model) do
 
     # Finally, reindex the target record for good measure (and, in the case of
     # top containers, to update the associated collections)
-    target[:system_mtime] = Time.now
-    target[:user_mtime] = Time.now
+    # We need to skip agents because the "replace" functionality does, in some
+    # cases actually lead to modifications to the target record that can lead
+    # to "record modified since" errors.
+    unless target.class.name.include?("Agent")
+      target[:system_mtime] = Time.now
+      target[:user_mtime] = Time.now
 
-    target.save
+      target.save
+    end
 
   end
 

--- a/backend/spec/rest_merge_request_spec.rb
+++ b/backend/spec/rest_merge_request_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+# ./build/run backend:test -Dexample='Merge request API'
+
+MERGEABLE_TYPES = ['subject', 'container_profile', 'top_container', 'resource', 'digital_object']
+MERGEABLE_AGENT_TYPES = ['agent_corporate_entity', 'agent_family', 'agent_person', 'agent_software']
+
+RSpec.describe 'Merge request API' do
+
+  def pluralize_type(type)
+    type = case type
+    when 'agent_corporate_entity'
+      'corporate_entities'
+    when 'agent_family'
+      'families'
+    when 'agent_person'
+      'people'
+    when 'agent_software'
+      'software'
+    end
+  end
+
+  describe 'POST /merge_requests' do
+    MERGEABLE_TYPES.each do |type|
+      it "does a basic #{type} merge request" do
+        repo = create(:repo)
+        target = create(:"json_#{type}")
+        victim = create(:"json_#{type}")
+
+        payload = {'jsonmodel_type'=> "merge_request",
+                   'victims'=> [
+                     {'ref'=> "#{victim.uri}"}
+                   ],
+                   'target'=> {'ref'=> "#{target.uri}"}
+                  }.to_json
+
+        post "/merge_requests/#{type}?repo_id=#{repo.id}", payload
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)['status']).to match "Merged"
+      end
+    end
+  end
+
+  describe 'POST /merge_requests/agent_detail' do
+    MERGEABLE_AGENT_TYPES.each do |type|
+      it "does a detailed #{type} merge request with replacement" do
+        target_name = build(:"json_name_#{type.delete_prefix('agent_')}")
+        victim_name = build(:"json_name_#{type.delete_prefix('agent_')}")
+
+        target = create(:"json_#{type}", :names => [target_name])
+        victim = create(:"json_#{type}", :names => [victim_name])
+
+        get "/agents/#{pluralize_type(type)}/#{victim.id}"
+        victim_source = JSON.parse(last_response.body)['names'][0]['source']
+
+        payload = {'jsonmodel_type'=> "merge_request_detail",
+                   'victims'=> [
+                     {'ref'=> "#{victim.uri}"}
+                   ],
+                   'target'=> {'ref'=> "#{target.uri}"},
+                   'selections'=> { 'names.0.source'=> "REPLACE" }
+                  }.to_json
+
+        post '/merge_requests/agent_detail', payload
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)['status']).to match "Merged"
+
+        # Also confirm the source has been replaced
+        get "/agents/#{pluralize_type(type)}/#{target.id}"
+        expect(JSON.parse(last_response.body)['names'][0]['source']).to match victim_source
+
+      end
+
+      it "does a dry run detailed #{type} merge request with replacement" do
+        target_name = build(:"json_name_#{type.delete_prefix('agent_')}")
+        victim_name = build(:"json_name_#{type.delete_prefix('agent_')}")
+
+        target = create(:"json_#{type}", :names => [target_name])
+        victim = create(:"json_#{type}", :names => [victim_name])
+
+        get "/agents/#{pluralize_type(type)}/#{victim.id}"
+        victim_source = JSON.parse(last_response.body)['names'][0]['source']
+
+        payload = {'jsonmodel_type'=> "merge_request_detail",
+                   'victims'=> [
+                     {'ref'=> "#{victim.uri}"}
+                   ],
+                   'target'=> {'ref'=> "#{target.uri}"},
+                   'selections'=> { 'names.0.source'=> "REPLACE" }
+                  }.to_json
+
+        post '/merge_requests/agent_detail?dry_run=true', payload
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)['status']).to match "Merged"
+
+        # But the dry run merge didn't actually delete the victim
+        get "/agents/#{pluralize_type(type)}/#{victim.id}"
+        expect(last_response.status).to eq(200)
+
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes ANW-1116 by restoring replace functionality to detailed agent merges.  

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Skips the step of saving the updated target record in the relationships mixin that was added with #1939 .  Since the detailed merge can result in changes to the target record, attempting to resave the record in the relationships mixin will throw a `"The record you tried to update has been modified since you fetched it."` error.

Also introduces a more robust `merged_response` to rest.rb to provide greater/more consistent feedback about the merge activity completed via the API.  New REST tests make use of this `merged_response`.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1116

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass, new REST tests added.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
