### PR TITLE
Continuation of #1889 to add migration, test, label changes

### DIFF
--- a/common/db/migrations/137_reindex_locations.rb
+++ b/common/db/migrations/137_reindex_locations.rb
@@ -1,0 +1,15 @@
+require_relative 'utils'
+
+Sequel.migration do
+
+  up do
+    [:location].each do |table|
+      self[table].update(:system_mtime => Time.now)
+    end
+  end
+
+
+  down do
+  end
+
+end

--- a/frontend/app/models/search.rb
+++ b/frontend/app/models/search.rb
@@ -25,7 +25,7 @@ class Search
       criteria["blank_facet_query_fields"].each {|query_field|
         blank_facet_query = "-" + query_field + ":*"
         sub_criteria = criteria.clone
-        if (sub_criteria.has_key?("q"))
+        if (sub_criteria.has_key?("q") && sub_criteria["q"] != blank_facet_query)
           sub_criteria["q"] = criteria["q"] + " AND " + blank_facet_query
         else
           sub_criteria["q"] = blank_facet_query

--- a/frontend/app/models/search_result_data.rb
+++ b/frontend/app/models/search_result_data.rb
@@ -285,19 +285,13 @@ class SearchResultData
     not @search_data[:criteria]["q"].blank?
   end
 
-  def facet_label_for_query
-    label = @search_data[:criteria]["q"]
-    query_array = @search_data[:criteria]["q"].split(" AND ") 
-    query_array.each do |query|
-      label = ""
-      delimiter = ""
-      if (query.match(/\-.+\:\*/))
-        value = query.tr("-:*", "")
-        label += delimiter + I18n.t("search.blank_facet_query_fields."+value)+":None"
-        delimiter = " AND "
-      end
-    end  
-    "#{I18n.t("search.multi.query")}: #{label}"
+  def facet_label_for_query(query)
+    if (query.match(/\-.+\:\*/))
+      value = query.tr("-:*", "")
+      "#{I18n.t("search.blank_facet_query_fields."+value)+": None"}"
+    else
+      "#{I18n.t("search.multi.query")}: #{query}"
+    end
   end
 
   def self.BASE_SORT_FIELDS

--- a/frontend/app/views/search/_filter.html.erb
+++ b/frontend/app/views/search/_filter.html.erb
@@ -6,10 +6,12 @@
     </h3>
     <ul>
       <% if @search_data.query? %>
-        <li>
-          <%= link_to @search_data.facet_label_for_query, build_search_params({"q" => ""}) %>
-          <%= link_to '<span class="glyphicon glyphicon-remove"></span>'.html_safe, build_search_params({"q" => ""}) %>
-        </li>
+        <% query_array = @search_data[:criteria]["q"].split(" AND ") %>
+        <% query_array.each do | query | %>
+          <li>
+            <%= link_to "#{h(@search_data.facet_label_for_query(query))} <span class='glyphicon glyphicon-remove'></span>".html_safe, build_search_params({"q" => query_array.reject{ |k| k==query}.join(' AND ')}) %>
+          </li>
+        <% end %>
       <% end %>
       <% if @search_data.filtered_terms? %>
         <% @search_data[:criteria]["filter_term[]"].each do | filter_term | %>
@@ -24,7 +26,8 @@
 
 <% if params["advanced"] != "true" %>
   <%= form_tag({}, :method => :get) do %>
-    <% build_search_params.reject{|k, v| k === "q"}.each do |k, v| %>
+    <% query_array = @search_data.query? ? @search_data[:criteria]["q"] : ''%>
+    <% build_search_params({"q" => query_array}).each do |k, v| %>
       <% if v.kind_of? Array %>
         <% v.each do |val| %>
           <%= hidden_field_tag "#{k}[]", val %>

--- a/frontend/spec/selenium/spec/locations_spec.rb
+++ b/frontend/spec/selenium/spec/locations_spec.rb
@@ -66,6 +66,24 @@ describe 'Locations' do
     @driver.find_paginated_element(xpath: "//tr[.//*[contains(text(), '329 W. 81st St, 5, 5A [Box XYZ: XYZ0001]')]]")
   end
 
+  it 'saves a valid repository-owned location' do
+    @driver.find_element(:link, 'Create').click
+    @driver.find_element(:link, 'Location').click
+    @driver.click_and_wait_until_gone(:link, 'Single Location')
+    expect(@driver.find_element(:css, 'h2').text).to eq('New Location Location')
+
+    @driver.clear_and_send_keys([:id, 'location_building_'], 'Repo Building')
+    @driver.clear_and_send_keys([:id, 'location_coordinate_1_label_'], 'Section')
+    @driver.clear_and_send_keys([:id, 'location_coordinate_1_indicator_'], '0001')
+
+    token_input = @driver.find_element(:id, 'token-input-location_owner_repo__ref_')
+    @driver.typeahead_and_select(token_input, "locations_test_")
+
+    @driver.click_and_wait_until_gone(css: 'form#new_location .btn-primary')
+
+    @driver.find_element_with_text('//div[contains(@class, "alert-success")]', /Location Created/)
+  end
+
   it 'allows the new location to be viewed in non-edit mode' do
     @driver.get($frontend)
 
@@ -156,6 +174,19 @@ describe 'Locations' do
     expect do
       @driver.find_paginated_element(xpath: "//tr[.//*[contains(text(), '329 W. 81st St, 5, 5A [Box XYZ: XYZ0001]')]]")
     end.not_to raise_error
+  end
+
+  it 'lists then filters locations by repository' do
+    run_all_indexers
+
+    @driver.find_element(:link, 'Browse').click
+    @driver.wait_for_dropdown
+    @driver.click_and_wait_until_gone(:link, 'Locations')
+
+    assert(5) { @driver.find_element_with_text('//h3', /Repository/) }
+    assert(5) { @driver.find_element_with_text('//a', /LOCATIONS_TEST_/) }
+    @driver.find_element_with_text('//a', /LOCATIONS_TEST_/).click
+    assert(5) { @driver.find_element_with_text('//div', /Showing .*1.* of.*Results/) }
   end
 
   describe 'Location batch' do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Continuation of #1889 to add/update the following:

- Add migration to reindex all locations due to owner repo additions;
- Adds two new Selenium tests;
- Adds additional check to `search.rb` after witnessing a lot of doubling up of blank facet queries (e.g. `http://localhost:3000/locations?q=-owner_repo_display_string_u_ssort%3A%2A&-owner_repo_display_string_u_ssort%3A%2A&-owner_repo_display_string_u_ssort%3A%2A&sort=title_sort+asc`)
- Moved `query_array` creation to `_filter.html.erb` and modified the searches there to allow individual addition/removal of a blank owner repo "filter" and/or a normal text query;
- Updated `facet_label_for_query` to resolve the fact that "normal" filter text queries weren't displaying a full label and changing the blank repo query label a bit to make it mimic a "real" filter query for an existing owner repo.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Continuation of #1889.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests passing, added new passing tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
