### PR TITLE
ANW-903 Fixes EAD uniform title import

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -914,7 +914,8 @@ class EADConverter < Converter
       'genreform' => 'genre_form',
       'geogname' => 'geographic',
       'occupation' => 'occupation',
-      'subject' => 'topical'
+      'subject' => 'topical',
+      'title' => 'uniform_title'
       }.each do |tag, type|
         with "controlaccess/#{tag}" do |*|
           make :subject, {

--- a/backend/spec/lib_ead_converter_spec.rb
+++ b/backend/spec/lib_ead_converter_spec.rb
@@ -385,6 +385,18 @@ ANEAD
       #   IF @authfilenumber != NULL
     end
 
+    it "maps '<title>' correctly" do
+      #   IF nested in <controlaccess>
+      subject = @subjects.find{|s| s['terms'][0]['term_type'] == 'uniform_title'}
+        [@resource, @archival_objects["06"], @archival_objects["12"]].each do |a|
+        expect(a['subjects'].select{|s| s['ref'] == subject['uri']}.count).to eq(1)
+      end
+      #   @source
+      expect(subject['source']).to eq('local')
+      #   ELSE
+      #   IF @authfilenumber != NULL
+    end
+
       # NOTES
       # if other EAD elements that map to a note object are nested in eachother, then those notes will be treated as separate notes;
       # for example, a <scopecontent> may contain another <scopecontent>, etc.;


### PR DESCRIPTION
## Description

Solves problem of EAD importer failing to import <controlaccess><title>

## Related JIRA Ticket or GitHub Issue
ANW-903

## How Has This Been Tested?
Tested by importing several EADs.  Works as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
