### PR TITLE
Adds recommendation to restrict API access

### DIFF
--- a/_yard/API.erb
+++ b/_yard/API.erb
@@ -24,6 +24,8 @@ search: true
 
 This is the documentation for the ArchivesSpace RESTful API. This documents the endpoints that are used by the backend server to edit records in the application.
 
+Since not all backend/API end points require authentication, it is best to restrict access to port 8089 to only IP addresses you trust. Your firewall should be used to specify a range of IP addresses that are allowed to call your ArchivesSpace API endpoint. This is commonly called whitelisting or allowlisting.
+
 This example API documentation page was created with [Slate](http://github.com/tripit/slate).
 
 # Authentication
@@ -188,7 +190,7 @@ $env:SESSION="9528190655b979f00817a5d38f9daf07d1686fed99a1d53dd2c9ff2d852a0c6e"
 # https://github.com/archivesspace-labs/ArchivesSnake/#low-level-api
 ```
 
-Most requests to the ArchivesSpace backend require a user to be authenticated.  This can be done with a POST request to the /users/:user_name/login endpoint, with :user_name and :password parameters being supplied.
+Most requests to the ArchivesSpace backend require a user to be authenticated. Since not all requests to the backend require authentication it is important to restrict access to only trusted IP addresses.  Authentication can be done with a POST request to the /users/:user_name/login endpoint, with :user_name and :password parameters being supplied.
 
 The JSON that is returned will have a session key, which can be stored and used for other requests. Sessions will expire after an hour, although you can change this in your config.rb file.
 


### PR DESCRIPTION
Just a small change to the API docs to encourage people to not allow public access to the API endpoint.

