### PR TITLE
PUI breadcrumb updates

### DIFF
--- a/public/app/controllers/accessions_controller.rb
+++ b/public/app/controllers/accessions_controller.rb
@@ -92,8 +92,16 @@ class AccessionsController <  ApplicationController
       @result =  archivesspace.get_record(uri, @criteria)
       @page_title = @result.display_string
       @context = []
-      @context.unshift({:uri => @result.resolved_repository['uri'], :crumb =>  @result.resolved_repository['name']})
-      @context.push({:uri => '', :crumb => @result.display_string })
+      @context.unshift({
+        :uri => @result.resolved_repository['uri'],
+        :crumb => @result.resolved_repository['name'],
+        :type => 'repository'
+      })
+      @context.push({
+        :uri => '',
+        :crumb => @result.display_string,
+        :type => 'accession'
+      })
       fill_request_info
     rescue RecordNotFound
       record_not_found(uri, 'accession')

--- a/public/app/controllers/objects_controller.rb
+++ b/public/app/controllers/objects_controller.rb
@@ -99,7 +99,9 @@ class ObjectsController <  ApplicationController
       begin
         @repo_info =  @result.repository_information
         @page_title = @result.display_string
-        @context = [{:uri => @repo_info['top']['uri'], :crumb => @repo_info['top']['name']}].concat(@result.breadcrumb)
+        @context = [
+          {:uri => @repo_info['top']['uri'], :crumb => @repo_info['top']['name'], :type => 'repository'}
+        ].concat(@result.breadcrumb)
         fill_request_info
         if @result['primary_type'] == 'digital_object' || @result['primary_type'] == 'digital_object_component'
           @dig = process_digital(@result['json'])

--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -152,7 +152,10 @@ class ResourcesController < ApplicationController
       @result =  archivesspace.get_record(uri, @criteria)
       @repo_info = @result.repository_information
       @page_title = "#{I18n.t('resource._singular')}: #{strip_mixed_content(@result.display_string)}"
-      @context = [{:uri => @repo_info['top']['uri'], :crumb => @repo_info['top']['name']}, {:uri => nil, :crumb => process_mixed_content(@result.display_string)}]
+      @context = [
+        {:uri => @repo_info['top']['uri'], :crumb => @repo_info['top']['name'], :type => 'repository'},
+        {:uri => nil, :crumb => process_mixed_content(@result.display_string), :type => 'resource'}
+      ]
 #      @rep_image = get_rep_image(@result['json']['instances'])
       fill_request_info
     rescue RecordNotFound

--- a/public/app/models/classification.rb
+++ b/public/app/models/classification.rb
@@ -25,7 +25,8 @@ class Classification < Record
     [
       {
         :uri => '',
-        :crumb => display_string
+        :crumb => display_string,
+        :type => 'classification'
       }
     ]
   end

--- a/public/app/models/concerns/tree_nodes.rb
+++ b/public/app/models/concerns/tree_nodes.rb
@@ -8,7 +8,8 @@ module TreeNodes
       crumbs << {
         :uri => breadcrumb_uri_for_node(node),
         :type => node['jsonmodel_type'],
-        :crumb => breadcrumb_title_for_node(node, level)
+        :crumb => breadcrumb_title_for_node(node, level),
+        :identifier => breadcrumb_identifier(node, node['jsonmodel_type'])
       }
     end
 
@@ -16,10 +17,19 @@ module TreeNodes
     crumbs << {
       :uri => '',
       :type => primary_type,
-      :crumb => display_string
+      :crumb => display_string,
+      :identifier => breadcrumb_identifier(self, primary_type)
     }
 
     crumbs
+  end
+
+
+  def breadcrumb_identifier(record, type)
+    case type
+    when 'resource'
+      resolved_resource['id_0'] if resolved_resource
+    end
   end
 
 

--- a/public/app/views/shared/_breadcrumbs.html.erb
+++ b/public/app/views/shared/_breadcrumbs.html.erb
@@ -3,9 +3,15 @@
     <nav aria-label="hierarchical navigation">
       <ul class="breadcrumb">
 	<% @context.each do |bread| %>
-	<% if bread[:crumb] %>
-	<li><% if bread[:uri].blank? %><%= process_mixed_content(bread[:crumb]).html_safe %>
-	  <% else %> <a href='<%=app_prefix(bread[:uri]) %>'><%=  process_mixed_content(bread[:crumb]).html_safe %></a>
+	<% if bread[:crumb]; crumb = bread[:crumb]; crumb += " (#{bread[:identifier]})" if bread[:identifier] %>
+	<li>
+	  <%= badge_for_type(bread[:type]) %>
+	  <% if bread[:uri].blank? %>
+	    <%= process_mixed_content(crumb).html_safe %>
+	  <% else %>
+	    <a href='<%=app_prefix(bread[:uri]) %>'>
+		<%= process_mixed_content(crumb).html_safe %>
+	    </a>
 	  <% end %>
 	</li>
 	<% end %>


### PR DESCRIPTION
Append the resource identifier when displaying a resource
breadcrumb in a context that includes the resolved resource
(such as when viewing an archival object).

Use the defined record type font awesome icon for breadcrumb items.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes. _Cosmetic only_.
- [x] All new and existing tests passed.
