### PR TITLE
Add langcode value+translation back into yml files

### DIFF
--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -201,7 +201,7 @@ en:
       level: Level
       identifier: Identifier
       resource_type: Resource Type
-      language: Language
+      langcode: Language of Materials
       restrictions: Restrictions
       ead_id: EAD ID
       finding_aid_status: Finding Aid Status
@@ -225,7 +225,7 @@ en:
       ref_id: Ref ID
       level: Level
       audit_info: Audit Information
-      language: Language
+      langcode: Language of Materials
       dates: Dates
       extents: Extent
       user_mtime: Modified
@@ -253,7 +253,7 @@ en:
       digital_object_id: Digital Object ID
       restrictions: Restrictions
       audit_info: Audit Information
-      language: Language
+      langcode: Language of Materials
       dates: Dates
       extents: Extent
       user_mtime: Modified
@@ -266,7 +266,7 @@ en:
       publish: Published
       context: Found in
       audit_info: Audit Information
-      language: Language
+      langcode: Language of Materials
       dates: Dates
       extents: Extent
       user_mtime: Modified

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -203,7 +203,7 @@ es:
       level: Nivel de Descripción
       identifier: Identificador
       resource_type: Tipo de fondo
-      language: Idioma
+      langcode: Lenguaje de materiales
       restrictions: Restricciones
       ead_id: Identificador EAD
       finding_aid_status: Estado del instrumento de descripción
@@ -227,7 +227,7 @@ es:
       ref_id: Ref ID
       level: Nivel de Descripción
       audit_info: Datos de auditoría
-      language: Idioma
+      langcode: Lenguaje de materiales
       dates: Fechas
       extents: Extensión
       user_mtime: Modificado
@@ -255,7 +255,7 @@ es:
       digital_object_id: ID de objeto digital
       restrictions: Restricciones
       audit_info: Datos de auditoría
-      language: Idioma
+      langcode: Leguaje de materiales
       dates: Fechas
       extents: Extensión
       user_mtime: Modificado
@@ -268,7 +268,7 @@ es:
       publish: Publicado
       context: Encontrado en
       audit_info: Datos de auditoría
-      language: Idioma
+      langcode: Lenguaje de materiales
       dates: Fechas
       extents: Extensión
       user_mtime: Modificado

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -201,7 +201,7 @@ fr:
       level: Niveau
       identifier: Identifiant
       resource_type: Type de Ressource
-      language: Langue
+      langcode: Langue des matériaux
       restrictions: Restrictions
       ead_id: Identifiant EAD
       finding_aid_status: Statut de l'instrument de recherche
@@ -225,7 +225,7 @@ fr:
       ref_id: Ref ID
       level: Niveau
       audit_info: Audit Information
-      language: Langue
+      langcode: Langue des matériauxLangue
       dates: Dates
       extents: Importance matérielle
       user_mtime: Modifié
@@ -253,7 +253,7 @@ fr:
       digital_object_id: Identifiant d'objet numérique
       restrictions: Restrictions
       audit_info: Audit Information
-      language: Langue
+      langcode: Langue des matériaux
       dates: Dates
       extents: Importance matérielle
       user_mtime: Modifié
@@ -266,7 +266,7 @@ fr:
       publish: Publié
       context: Trouvé dans
       audit_info: Audit Information
-      language: Langue
+      langcode: Langue des matériaux
       dates: Dates
       extents: Importance matérielle
       user_mtime: Modifié

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -225,7 +225,7 @@ fr:
       ref_id: Ref ID
       level: Niveau
       audit_info: Audit Information
-      langcode: Langue des matériauxLangue
+      langcode: Langue des matériaux
       dates: Dates
       extents: Importance matérielle
       user_mtime: Modifié

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -209,7 +209,7 @@ ja:
       level: レベル
       identifier: 識別
       resource_type: リソースタイプ
-      language: 言語
+      langcode: 材料の言語
       restrictions: 制限事項
       ead_id: EAD ID
       finding_aid_status: 援助の状況を見つける
@@ -233,7 +233,7 @@ ja:
       ref_id: Ref ID
       level: レベル
       audit_info: 監査データ
-      language: 言語
+      langcode: 材料の言語
       dates: 日付
       extents: エクステント
       user_mtime: 更新しました
@@ -261,7 +261,7 @@ ja:
       digital_object_id: デジタルオブジェクトID
       restrictions: 制限事項
       audit_info: 監査データ
-      language: 言語
+      langcode: 材料の言語
       dates: 日付
       extents: エクステント
       user_mtime: 更新しました
@@ -274,7 +274,7 @@ ja:
       publish: 発行済み
       context: 見つかった
       audit_info: 監査データ
-      language: 言語
+      langcode: 材料の言語
       dates: 日付
       extents: エクステント
       user_mtime: 更新しました


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
A facet for language (langcode) was added via https://github.com/archivesspace/archivesspace/pull/1792 and additional translations for the staff interface were added via https://github.com/archivesspace/archivesspace/pull/1827. Although the facet still works, the translations appear to have been removed prior to 2.8.0. This adds them back in, though in different place(s) from the original pull requests. (I'm putting this in draft in case my solution is way off base.)


## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1125

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
