### PR TITLE
Use top_container_u_icusort for container inventory.

### DIFF
--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -271,7 +271,7 @@ class ResourcesController < ApplicationController
     qry = "collection_uri_u_sstr:\"#{resource_uri}\" AND (#{CONTAINER_QUERY})"
     @base_search = "#{page_uri}?"
     search_opts =  default_search_opts({
-      'sort' => 'typeahead_sort_key_u_sort asc',
+      'sort' => 'top_container_u_icusort asc',
       'facet.mincount' => 1
     })
     search_opts['fq']=[qry]

--- a/public/app/views/containers/show.html.erb
+++ b/public/app/views/containers/show.html.erb
@@ -18,10 +18,10 @@
     <% end %>
   </div>
 
-  <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
-    <% unless @results.blank? || @results['total_hits'] == 0 %>
+  <% unless @results.blank? || @results['total_hits'] == 0 || @facets.blank? %>
+    <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
       <%= render partial: 'shared/facets' %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>
 </div>

--- a/public/app/views/resources/inventory.html.erb
+++ b/public/app/views/resources/inventory.html.erb
@@ -24,11 +24,11 @@
       <%= render partial: 'shared/pagination', locals: {:pager  => @pager}  %>
     <% end %>
   </div>
-  <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
-    <% unless @results.blank? || @results['total_hits'] == 0 %>
+  <% unless @results.blank? || @results['total_hits'] == 0 || @facets.blank? %>
+    <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
       <%= render partial: 'shared/facets' %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>
 
 <%= render partial: 'shared/modal_actions' %>


### PR DESCRIPTION
Also don't display empty rectangle when no facets are available.

## Description

Default sort for container inventory isn't useful at all. Replace with something that is at least first
pass acceptable.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
