### PR TITLE
ANW-969: Export <langusage> from finding aid language if no note

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -918,12 +918,12 @@ class EADSerializer < ASpaceExport::Serializer
         if (val = data.finding_aid_language_note)
           xml.langusage (fragments << val)
 				else
-					xml.langusage() {
-						xml.text("Description is written in: ")
-						xml.language({langcode: "#{data.finding_aid_language}"}) {
-							xml.text(I18n.t("enumerations.language_iso639_2.#{data.finding_aid_language}"))
-						}
-						xml.text(".")
+          xml.langusage() {
+            xml.text("Description is written in: ")
+            xml.language({langcode: "#{data.finding_aid_language}"}) {
+              xml.text(I18n.t("enumerations.language_iso639_2.#{data.finding_aid_language}"))
+            }
+          xml.text(".")
 					}
         end
 

--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -917,6 +917,14 @@ class EADSerializer < ASpaceExport::Serializer
 
         if (val = data.finding_aid_language_note)
           xml.langusage (fragments << val)
+				else
+					xml.langusage() {
+						xml.text("Description is written in: ")
+						xml.language({langcode: "#{data.finding_aid_language}"}) {
+							xml.text(I18n.t("enumerations.language_iso639_2.#{data.finding_aid_language}"))
+						}
+						xml.text(".")
+					}
         end
 
         if (val = data.descrules)

--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -920,9 +920,11 @@ class EADSerializer < ASpaceExport::Serializer
         else
           xml.langusage() {
             xml.text(I18n.t("resource.finding_aid_langusage_label"))
-            xml.language({langcode: "#{data.finding_aid_language}"}) {
-              xml.text(I18n.t("enumerations.language_iso639_2.#{data.finding_aid_language}"))
-            }
+            xml.language({langcode: "#{data.finding_aid_language}", :scriptcode => "#{data.finding_aid_script}"}) {
+              xml.text(I18n.t("enumerations.language_iso639_2.#{data.finding_aid_language}")) 
+              xml.text(", ")
+              xml.text(I18n.t("enumerations.script_iso15924.#{data.finding_aid_script}"))
+              xml.text(" script")}
           xml.text(".")
 					}
         end

--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -917,9 +917,9 @@ class EADSerializer < ASpaceExport::Serializer
 
         if (val = data.finding_aid_language_note)
           xml.langusage (fragments << val)
-				else
+        else
           xml.langusage() {
-            xml.text("Description is written in: ")
+            xml.text(I18n.t("resource.finding_aid_langusage_label"))
             xml.language({langcode: "#{data.finding_aid_language}"}) {
               xml.text(I18n.t("enumerations.language_iso639_2.#{data.finding_aid_language}"))
             }

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -1592,6 +1592,7 @@ en:
     finding_aid_language: Language of Description
     finding_aid_language_tooltip: |
         <p>Indicates all the languages present in the finding aid generated from the resource description.</p>
+    finding_aid_langusage_label: "Description is written in: " 
     finding_aid_script: Script of Description
     finding_aid_script_tooltip: |
         <p>Indicates all the scripts present in the finding aid generated from the resource description.</p>


### PR DESCRIPTION
## Description
Fix for ANW-969, exporting an EAD2002 <langusage> note based on find_aid_language if there's no finding_aid_language_note

The JIRA calls for exporting <script> as well, but EAD2002 doesn't have a script tag.

## Related JIRA Ticket or GitHub Issue
[ANW-969](https://archivesspace.atlassian.net/browse/ANW-969)

## How Has This Been Tested?
Tried several exports, with and without finding aid language note

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
