### PR TITLE
Hide bulk import from create dropdown menu

### DIFF
--- a/frontend/app/views/shared/_header_repository.html.erb
+++ b/frontend/app/views/shared/_header_repository.html.erb
@@ -101,6 +101,8 @@
                       <% job_types.each do |type, perms| %>
                         <% next if type == 'generate_slugs_job' && !AppConfig[:use_human_readable_urls] %>
                         <% next if type == 'generate_arks_job' && !AppConfig[:arks_enabled] %>
+                        <%# We only want to trigger bulk imports from within a resource record %>
+                        <% next if type == 'bulk_import_job' %>
                         <% if perms['create_permissions'].reject{|perm| user_can?(perm)}.empty? %>
                           <li><%= link_to I18n.t("job.types.#{type}", :default => type), :controller => :jobs, :action => :new, :job_type => type %></li>
                         <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Bulk import background jobs should only be triggered from resource records, so it can be skipped in the top level create dropdown.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Found via user testing of #1980 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually confirmed fix.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
