### PR TITLE
ANW 1002:  Map MARC 245$g to bulk dates on import

### DIFF
--- a/backend/app/converters/lib/marcxml_base_map.rb
+++ b/backend/app/converters/lib/marcxml_base_map.rb
@@ -770,15 +770,24 @@ module MarcXMLBaseMap
         "datafield[@tag='245']" => -> resource, node {
           resource.title = subfield_template("{$a : }{$b }{[$h] }{$k , }{$n , }{$p , }{$s }{/ $c}", node)
 
-          expression = concatenate_subfields(%w(f g), node, '-')
-          unless expression.empty?
-            if resource.dates[0]
+          expression = subfield_template("{$f}", node)
+          bulk = subfield_template("{$g}", node)
+          unless expression.empty? && bulk.empty?
+            if resource.dates[0] && !expression.empty?
               resource.dates[0]['expression'] = expression
-            else
+            elsif !expression.empty?
               make(:date)  do |date|
                 date.label = 'creation'
                 date.date_type = 'inclusive'
                 date.expression = expression
+                resource.dates << date
+              end
+            end
+            unless bulk.empty?
+              make(:date)  do |date|
+                date.label = 'creation'
+                date.date_type = 'bulk'
+                date.expression = bulk
                 resource.dates << date
               end
             end

--- a/backend/app/converters/lib/marcxml_base_map.rb
+++ b/backend/app/converters/lib/marcxml_base_map.rb
@@ -717,6 +717,9 @@ module MarcXMLBaseMap
 
               if control[7..10] && control[7..10].match(/^\d{4}$/)
                 date.begin = control[7..10]
+              elsif control[7..10]
+                #somewhat hackish, but lets us cope with e.g. 19uu 
+                date.expression = control[7..10]
               end
 
               if control[11..14] && control[11..14].match(/^\d{4}$/)
@@ -773,7 +776,7 @@ module MarcXMLBaseMap
           expression = subfield_template("{$f}", node)
           bulk = subfield_template("{$g}", node)
           unless expression.empty? && bulk.empty?
-            if resource.dates[0] && !expression.empty?
+            if resource.dates[0] && resource.dates[0]['date_type'] != 'bulk' && !expression.empty?
               resource.dates[0]['expression'] = expression
             elsif !expression.empty?
               make(:date)  do |date|
@@ -781,14 +784,18 @@ module MarcXMLBaseMap
                 date.date_type = 'inclusive'
                 date.expression = expression
                 resource.dates << date
-              end
+             end
             end
             unless bulk.empty?
-              make(:date)  do |date|
-                date.label = 'creation'
-                date.date_type = 'bulk'
-                date.expression = bulk
-                resource.dates << date
+              if resource.dates[0] && resource.dates[0]['date_type'] == 'bulk'
+                 resource.dates[0]['expression'] = bulk
+              else
+                make(:date)  do |date|
+                  date.label = 'creation'
+                  date.date_type = 'bulk'
+                  date.expression = bulk
+                  resource.dates << date
+                end
               end
             end
           else

--- a/backend/app/exporters/examples/marc/at-tracer-marc-1.xml
+++ b/backend/app/exporters/examples/marc/at-tracer-marc-1.xml
@@ -25,8 +25,8 @@
         </datafield>
         <datafield tag="245" ind2=" " ind1="1">
             <subfield code="a">Resource--Title-AT</subfield>
-            <subfield code="f">Resource-Date-Expression-AT</subfield>
-            <subfield code="g">1960 - 1970</subfield>
+            <subfield code="f">Resource-Date-Expression-AT-1960 - 1970</subfield>
+            <subfield code="g">Resource-Date-Expression-AT-1965 - 1968</subfield>
         </datafield>
         <datafield tag="260" ind1=" " ind2=" ">
           <subfield code="a">[S.l. :</subfield>

--- a/backend/spec/lib_marcxml_converter_spec.rb
+++ b/backend/spec/lib_marcxml_converter_spec.rb
@@ -270,6 +270,7 @@ END
 
       it "maps datafield[@tag='245']/subfield[@code='f' or @code='g'] to resources.dates[]" do
         expect(@resource['dates'][0]['expression']).to eq("Resource-Date-Expression-AT-1960 - 1970")
+        expect(@resource['dates'][1]['expression']).to eq("Resource-Date-Expression-AT-1965 - 1968")
       end
 
       it "maps datafield[@tag='300'] to resource.extents[].container_summary using template '$3: $a ; $b, $c ($e, $f, $g)'" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix for ANW-1002, MARC 245$g should import into a bulk date field

## Related JIRA Ticket or GitHub Issue
[ANW-1002](https://archivesspace.atlassian.net/browse/ANW-1002)

## How Has This Been Tested?
Tested with the Columbia example MARC record set https://github.com/ASpace-Metadata-Standards/marc-examples/tree/master/ColumbiaUniversityMARC

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
