### PR TITLE
ANW-757: Stop mapping dao titles to captions

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -948,7 +948,6 @@ class EADConverter < Converter
           :xlink_actuate_attribute => att('actuate'),
           :xlink_show_attribute => att('show'),
           :publish => att('audience') != 'internal',
-          :caption => att( 'title' )
         }
         set ancestor(:instance), :digital_object, obj
       end
@@ -1014,7 +1013,6 @@ class EADConverter < Converter
            fv_attrs[:file_uri] = daoloc['xlink:href'] if daoloc['xlink:href']
            fv_attrs[:use_statement] = daoloc['xlink:role'] if daoloc['xlink:role']
            fv_attrs[:publish] = daoloc['audience'] != 'internal'
-           fv_attrs[:caption] = daoloc['xlink:title'] if daoloc['xlink:title']
 
            obj.file_versions << fv_attrs
          end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Stop trying to map DAO titles to the much smaller caption field

## Related JIRA Ticket or GitHub Issue
[ANW-757](https://archivesspace.atlassian.net/browse/ANW-757)

## How Has This Been Tested?
Imported test file with dao titles > 255 characters. Imports no longer break.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
