### PR TITLE
ANW-1130: Don't error when a dig obj comp only has a date

### DIFF
--- a/backend/app/model/digital_object_component.rb
+++ b/backend/app/model/digital_object_component.rb
@@ -49,7 +49,7 @@ class DigitalObjectComponent < Sequel::Model(:digital_object_component)
 
 
   def self.produce_display_string(json)
-    display_string = json['title'] || json['label'] || nil
+    display_string = json['title'] || json['label'] || ""
 
     date_label = json.has_key?('dates') && json['dates'].length > 0 ?
                   json['dates'].map do |date|


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves ANW-1130 and returns the ability to save a digital object component that only includes a date.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Follows the standard used in `backend/app/model/archival_object.rb` and sets the display string as `""` instead of `nil` when there is no title or label for a digital object component.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1130

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually confirms that digital object components without titles or labels can be saved.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15144646/96286138-ed4df480-0fad-11eb-98e4-a37e651d3255.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
