### PR TITLE
ANW-1126: Add alt text to logo images in staff and PUI

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -480,6 +480,7 @@ AppConfig[:record_inheritance] = {
 
 AppConfig[:pui_search_results_page_size] = 10
 AppConfig[:pui_branding_img] = 'archivesspace.small.png'
+AppConfig[:pui_branding_img_alt_text] = 'ArchivesSpace logo'
 AppConfig[:pui_block_referrer] = true # patron privacy; blocks full 'referrer' when going outside the domain
 
 # The number of PDFs that can be generated (in the background) at the same time.

--- a/frontend/app/views/site/_branding.html.erb
+++ b/frontend/app/views/site/_branding.html.erb
@@ -1,3 +1,3 @@
 <div class="container-fluid navbar-branding">
-  <%= image_tag "archivesspace/archivesspace.small.png", :class=>"img-responsive" %>
+  <%= image_tag "archivesspace/archivesspace.small.png", :class=>"img-responsive", :alt=>"ArchivesSpace logo" %>
 </div>

--- a/public/app/views/shared/_header.html.erb
+++ b/public/app/views/shared/_header.html.erb
@@ -11,6 +11,6 @@
         <% end %>
       </h1>
     </div>
-    <div class="col-sm-3 hidden-xs"><img class="logo" src="<%= asset_path(AppConfig[:pui_branding_img]) %>" alt="" /></div>
+    <div class="col-sm-3 hidden-xs"><img class="logo" src="<%= asset_path(AppConfig[:pui_branding_img]) %>" alt="<%= AppConfig[:pui_branding_img_alt_text] %>" /></div>
   </div>
 </section>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Upstream changes introduced via the Rails upgrade (5.0.x to 5.2.x) included in #1953  resulted in the loss of alt text for the logo image on the staff interface.  Previously, Rails' `image_tag` method would fallback to using a filename as the source of automatically generated alt tags, however that behavior was removed in Rails 5.2 as it doesn't actually generate useful alt text in most cases.  See: https://github.com/rails/rails/commit/9a74c7b99bf0ac901f86bb38372a68e157cf9c73 .

Moving forward we'll have to explicitly include alt text in `_branding.html.erb` (or explicitly define blank alt text if the image is purely for decorative purposes).

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
I've also added an `AppConfig` controlled alt text to the PUI to attempt to keep the staff/PUI behavior the same, however I'm happy to reconsider this if we don't like this change.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1126

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually confirmed presence of alt text.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15144646/96301764-aa981680-0fc5-11eb-900b-4fe5478a990d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
