### PR TITLE
ANW-631 cont'd: Also include the doid in a digital object typeahead

### DIFF
--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -392,6 +392,9 @@ $(function() {
         if (object.four_part_id !== undefined) {
           // Data comes from Solr index
           return output(object.four_part_id.split(' ').join('-'));
+        } else if (object.digital_object_id !== undefined) {
+          // Data comes from Solr index
+          return output(object.digital_object_id);
         } else {
           // Data comes from JSON property on data from Solr index
           var idProperties = ['id_0', 'id_1', 'id_2', 'id_3'];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Continuation of #1906 to also prefix digital object typeaheads with the digital object identifier.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-631

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually confirmed that typeahead is prepended with identifiers of all types.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15144646/96311328-38303200-0fd7-11eb-86be-e6b2a564baaf.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
