### PR TITLE
Don't show files unless job complete, show bulk_import form fields

### DIFF
--- a/frontend/app/views/jobs/_show_templates.html.erb
+++ b/frontend/app/views/jobs/_show_templates.html.erb
@@ -135,7 +135,7 @@
 
 <%# Now create a template for all job types not handled above - eg from plugins %>
 <% job_types.keys.each do |type| %>
-  <% next if ['container_labels_job', 'find_and_replace_job', 'print_to_pdf_job', 'import_job', 'report_job'].include?(type) %>
+  <% next if ['container_labels_job', 'find_and_replace_job', 'print_to_pdf_job', 'import_job', 'bulk_import_job', 'report_job'].include?(type) %>
   <% define_template(type, jsonmodel_definition(type.intern)) do |form, job| %>
 
     <% begin %>

--- a/frontend/app/views/jobs/show.html.erb
+++ b/frontend/app/views/jobs/show.html.erb
@@ -21,25 +21,27 @@
         <%= readonly.emit_template "job_status", @job %>
         <%= readonly.emit_template "job", @job %>
 
-        <% unless @files.empty? %>
-          <section id="files" class="subrecord-form-dummy" >
-            <h3 class="subrecord-form-heading">
-              <%= I18n.t("job._frontend.section.files") %>
-            </h3>
-            <div class="subrecord-form-container">
-              <ul>
-              <% if @job["job_type"] == "bulk_import_job"
-                   @files.shift if @files.length == 2
-                end
-              %>
-                 <% @files.each do |file| %>
-                   <li><%= link_to file_label(@job["job_type"]), :controller =>  :jobs, :action => :download_file, :id => file, :job_id => @job.id %></li>
-                <% end %> 
-              </ul>
-            </div>
-          </section>
-
+        <% if !["queued", "running"].include?(@job.status) %>
+          <% unless @files.empty? %>
+            <section id="job_files" class="subrecord-form-dummy" >
+              <h3 class="subrecord-form-heading">
+                <%= I18n.t("job._frontend.section.files") %>
+              </h3>
+              <div class="subrecord-form-container">
+                <ul>
+                <% if @job["job_type"] == "bulk_import_job"
+                     @files.shift if @files.length == 2
+                  end
+                %>
+                   <% @files.each do |file| %>
+                     <li><%= link_to file_label(@job["job_type"]), :controller =>  :jobs, :action => :download_file, :id => file, :job_id => @job.id %></li>
+                  <% end %>
+                </ul>
+              </div>
+            </section>
+          <% end %>
         <% end %>
+
         <% if !["queued"].include?(@job.status) %>
           <section id="logs" class="subrecord-form-dummy" data-poll-url="<%= url_for(:controller => :jobs, :action => :log, :id => @job.id) %>">
             <h3 class="subrecord-form-heading">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Following feedback from #1980, have implemented the following:

- Don't display "Files" section with downloadable files/reports when a job is queued or running (this applies globally for all import job types);
- Bulk import jobs were using the default/fallback form template, and not the bulk import job template with bulk import specific form fields -- now they are; and,
- Fixed a long-standing style thing that has bothered me wherein the `#files` section of a completed job was styled the same as the drag and drop `#files` div in a file upload form.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Only show "Download Report" when job is complete.  Show bulk import job specific "Basic Information" info:
![image](https://user-images.githubusercontent.com/15144646/96870734-55ce2300-143f-11eb-9ed5-4026c651a3e3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
