### PR TITLE
Style improvements for bulk import modal

### DIFF
--- a/frontend/app/assets/javascripts/bulk_import.js.erb
+++ b/frontend/app/assets/javascripts/bulk_import.js.erb
@@ -122,9 +122,9 @@
 
 	var modalError = function($modal) {
 	    $(".bulkbtn").removeClass("disabled");
-        $(".bulkbtn.btn-cancel").text("<%= I18n.t('actions.close') %>").removeClass("disabled").addClass("close")
+        $(".bulkbtn.btn-cancel").text("<%= I18n.t('actions.close') %>").removeClass("disabled").addClass("btn-close")
 	    $(".clip-btn").removeClass("disabled");
-	    $modal.find(".close").click(function(event) {
+	    $modal.find(".btn-close, .close").click(function(event) {
 		    $("#bulk_messages").html("");
 		    $("#excel_filename").html("");
 		    $modal.hide();
@@ -133,8 +133,8 @@
 	};
 
 	var modalSuccess = function($modal) {
-	    $(".bulkbtn.btn-cancel").text("Close").removeClass("disabled").addClass("close")
-	    $modal.find(".close").click(function(event) {
+	    $(".bulkbtn.btn-cancel").text("<%= I18n.t('actions.close') %>").removeClass("disabled").addClass("btn-close")
+	    $modal.find(".btn-close, .close").click(function(event) {
 		    window.location.reload(true);
 		});
 	}

--- a/frontend/app/assets/stylesheets/archivesspace/buttons.less
+++ b/frontend/app/assets/stylesheets/archivesspace/buttons.less
@@ -8,6 +8,12 @@
   display: none;
 }
 
+.btn-default.bulktypebtn.active {
+  color: #ffffff;
+  background-color: #337ab7;
+  border-color: #2e6da4;
+}
+
 .btn-primary.busy.disabled .btn-busy-icon {
   display: inline;
 }

--- a/frontend/app/views/resources/_bulk_import_form.html.erb
+++ b/frontend/app/views/resources/_bulk_import_form.html.erb
@@ -17,13 +17,13 @@
       <input type='hidden' name='job[job_params][aoid]' id='aoid' value='<%= aoid %>' />
       <input name="job[format]" value="csv" type="hidden"/>
       <section id="bulk_import_filename_">
-        <span class="btn btn-success btn-sm fileinput-button bulkbtn">
+        <label class="btn btn-success btn-sm fileinput-button bulkbtn">
           <span class="glyphicon glyphicon-plus icon-white"></span>
-          <span><%= I18n.t("bulk_import._frontend.actions.add_file")%></span>
+          <%= I18n.t("bulk_import._frontend.actions.add_file")%>
           <input name="files[]" type="file" id="excel_file"/>
           <input name="job[content_type]" id="file_type" type="hidden"/>
           <input name="job[filename]" id="job_filename" type="hidden"/>
-        </span>
+        </label>
 	      <span id="excel_filename"></span>
       </section>
       <div class="form-group">
@@ -31,8 +31,14 @@
           <input type='hidden' value="ao" name="job[load_type]" />
         <% else %>
           <div class="btn-group" data-toggle="buttons">
-          <label class="btn btn-primary active" style="border-radius:4px;"><input type="radio" value="ao" name="job[load_type]" checked="true"/><%= I18n.t('bulk_import._frontend.actions.add_archival_objects') %></label>
-          <label class="btn btn-primary" style="border-radius:4px; margin-left:.5em"><input type="radio" value="digital" name="job[load_type]"/><%= I18n.t('bulk_import._frontend.actions.add_digital_objects') %></label>
+            <label class="btn btn-default bulktypebtn active">
+              <input type="radio" value="ao" name="job[load_type]" checked="true"/>
+              <%= I18n.t('bulk_import._frontend.actions.add_archival_objects') %>
+            </label>
+            <label class="btn btn-default bulktypebtn">
+              <input type="radio" value="digital" name="job[load_type]"/>
+              <%= I18n.t('bulk_import._frontend.actions.add_digital_objects') %>
+            </label>
           </div>
         <% end %>
         <div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In response to feedback from #1980 , this PR adds more dramatic color changes/styling while toggling the job type buttons in the bulk import modal (see screen capture below).

I also addressed the following:
- Changed the forms filename `<span>` into a `<label>` to provide an adequate label for the filename input; and, 
- Updated the class/js for the modal success form to improve stylistic consistency/greater color contrast on the "Close" button after successfully queuing up a bulk import job (see screenshot).

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Feedback received post #1980 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
New color/style on job type toggle:
![Screen-Recording-2020-10-22-at-12 24 20-PM](https://user-images.githubusercontent.com/15144646/96925777-a74bd180-1482-11eb-9594-c13b28bdfafc.gif)

Fixed this faint/poor contrast "Close" button on the success modal:
![image](https://user-images.githubusercontent.com/15144646/96925840-c34f7300-1482-11eb-95ee-3b4582a39010.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
