### PR TITLE
Fix to agent handler assigning wrong agents

### DIFF
--- a/backend/app/lib/bulk_import/agent_handler.rb
+++ b/backend/app/lib/bulk_import/agent_handler.rb
@@ -66,7 +66,7 @@ class AgentHandler < Handler
     agent_key = key_for(agent)
     agent_link = validate_link(relator, role, errs)
     report.add_errors(errs) if !errs.empty?
-    if !(agent_obj = stored(@agents, "#{agent[:type]}_#{agent[:id]}", agent_key))
+    if !(agent_obj = stored(@agents, (agent[:id].nil? ? nil : "#{agent[:type]}_#{agent[:id]}"), agent_key))
       unless agent[:id].nil?
         agent_obj = get_by_id(type, agent[:id])
       end

--- a/backend/app/lib/bulk_import/agent_handler.rb
+++ b/backend/app/lib/bulk_import/agent_handler.rb
@@ -66,7 +66,7 @@ class AgentHandler < Handler
     agent_key = key_for(agent)
     agent_link = validate_link(relator, role, errs)
     report.add_errors(errs) if !errs.empty?
-    if !(agent_obj = stored(@agents, (agent[:id].nil? ? nil : "#{agent[:type]}_#{agent[:id]}"), agent_key))
+    if !(agent_obj = stored(@agents, (agent[:id].nil? ? "" : "#{agent[:type]}_#{agent[:id]}"), agent_key))
       unless agent[:id].nil?
         agent_obj = get_by_id(type, agent[:id])
       end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The call to *stored*, the method used to see if an agent has previously been processed (and its information stored locally had an incorrectly created parameter.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This solves the problem of, once an agent of a particular type (person, corporate, family) is created, it is applied as the agent for any subsequent archival objects that have an arbitrary agent of the same type.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ X] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
