### PR TITLE
ANW-1099, ANW-776, ANW-1008: Search/browse column improvements

### DIFF
--- a/common/config/search_browse_column_config.rb
+++ b/common/config/search_browse_column_config.rb
@@ -72,6 +72,7 @@ module SearchAndBrowseColumnConfig
       "extents" => {:field => "extents"},
       "ead_id" => {:field => "ead_id", :sortable => true},
       "finding_aid_status" => {:field => "finding_aid_status", :sortable => true},
+      "langcode" => {:field => "langcode", :sortable => false},
       "processing_priority" => {:field => "processing_priority", :sortable => true},
       "processors" => {:field => "processors", :sortable => true},
       "create_time" => {:field => "create_time", :sortable => true},
@@ -87,6 +88,7 @@ module SearchAndBrowseColumnConfig
       "restrictions" => {:field => "restrictions", :sortable => true},
       "dates" => {:field => "dates"},
       "extents" => {:field => "extents"},
+      "langcode" => {:field => "langcode", :sortable => false},
       "create_time" => {:field => "create_time", :sortable => true},
       "user_mtime" => {:field => "user_mtime", :sortable => true},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]}
@@ -98,6 +100,7 @@ module SearchAndBrowseColumnConfig
       "identifier" => {:field => "identifier", :sortable => true},
       "dates" => {:field => "dates"},
       "extents" => {:field => "extents"},
+      "langcode" => {:field => "langcode", :sortable => false},
       "create_time" => {:field => "create_time", :sortable => true},
       "user_mtime" => {:field => "user_mtime", :sortable => true},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]}
@@ -134,6 +137,7 @@ module SearchAndBrowseColumnConfig
       "level" => {:field => "level", :sortable => true},
       "dates" => {:field => "dates"},
       "extents" => {:field => "extents"},
+      "langcode" => {:field => "langcode", :sortable => false},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]}
     },
     "assessment" => {
@@ -167,7 +171,6 @@ module SearchAndBrowseColumnConfig
       "processing_hours_total" => {:field => "processing_hours_total", :sortable => true},
       "processing_funding_source" => {:field => "processing_funding_source", :sortable => true},
       "processors" => {:field => "processors", :sortable => true},
-      "publish" => {:field => "publish", :sortable => true, :type => "boolean"},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]}
     },
     "container_profile" => {
@@ -184,6 +187,7 @@ module SearchAndBrowseColumnConfig
       "context" => {:field => "context"},
       "dates" => {:field => "dates"},
       "extents" => {:field => "extents"},
+      "langcode" => {:field => "langcode", :sortable => false},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]}
     },
     "event" => {

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -1921,6 +1921,7 @@ en:
     sort_direction: Default Sort Direction
     sort_direction_tooltip: Default direction to sort results.
     locale: Language Selection
+    search_browse_columns: Search and Browse Column Preferences
     accession_browse_section: Accession Browse Columns
     resource_browse_section: Resource Browse Columns
     archival_object_browse_section: Archival Object Browse Columns
@@ -1938,6 +1939,7 @@ en:
     location_profile_browse_section: Location Profile Browse Columns
     container_profile_browse_section: Container Profile Browse Columns
     multi_browse_section: Search Columns
+    job_browse_section: Background Jobs Columns
     note_order_section: Note Order
     accept_default_message: '> Accept Default:'
     no_value: '[no value]'

--- a/common/locales/es.yml
+++ b/common/locales/es.yml
@@ -1900,7 +1900,8 @@ es:
     sort_column_tooltip: El campo predeterminado para ordenar los resultados.
     sort_direction: Dirección de clasificación predeterminada
     sort_direction_tooltip: Dirección predeterminada para ordenar los resultados.
-    locale: Language Selection
+    locale: Selección de idioma
+    search_browse_columns: Preferencias de columna de búsqueda y exploración
     accession_browse_section: Navegar columnas de entrada
     resource_browse_section: Fondos ver columnas
     archival_object_browse_section: Objeto de archivo Examinar columnas
@@ -1918,6 +1919,7 @@ es:
     location_profile_browse_section: Perfil de ubicación Examinar columnas
     container_profile_browse_section: Perfil de contenedor Examinar columnas
     multi_browse_section: Buscar columnas
+    job_browse_section: Columnas de trabajos en segundo plano
     note_order_section: Orden de las notas
     accept_default_message: ' > Acepte por defecto:'
     no_value: '[ningún valor]'

--- a/common/locales/fr.yml
+++ b/common/locales/fr.yml
@@ -1920,7 +1920,8 @@ fr:
     sort_column_tooltip: Champ par défaut pour le tri des résultats.
     sort_direction: Direction de tri par défaut
     sort_direction_tooltip: Direction par défaut pour trier les résultats.
-    locale: Language Selection
+    locale: Sélection de la langue
+    search_browse_columns: Rechercher et parcourir les préférences de colonne
     accession_browse_section: Colonnes d'exploration des entrées
     resource_browse_section: Colonnes d'exploration ressource
     archival_object_browse_section: Colonnes de recherche d'objets d'archives
@@ -1938,6 +1939,7 @@ fr:
     location_profile_browse_section: Profil d'emplacement Parcourir les colonnes
     container_profile_browse_section: Colonnes de navigation du profil de conteneur
     multi_browse_section: Colonnes de recherche
+    job_browse_section: Colonnes des travaux d'arrière-plan
     note_order_section: Ordres des notes
     accept_default_message: '> Accepter défaut:'
     no_value: '[pas de valeur]'

--- a/common/locales/ja.yml
+++ b/common/locales/ja.yml
@@ -1445,7 +1445,8 @@ ja:
     sort_column_tooltip: 結果をソートするためのデフォルトのフィールド。
     sort_direction: デフォルトのソート方向
     sort_direction_tooltip: 結果をソートするデフォルトの方向。
-    locale: Language Selection
+    locale: 言語選択
+    search_browse_columns: 列設定の検索と参照
     accession_browse_section: アクセス列を参照
     resource_browse_section: リソース参照列
     archival_object_browse_section: アーカイブオブジェクトの参照列
@@ -1463,6 +1464,7 @@ ja:
     location_profile_browse_section: ロケーションプロファイルの参照列
     container_profile_browse_section: コンテナプロファイルの参照列
     multi_browse_section: 検索列
+    job_browse_section: バックグラウンドジョブの列
     note_order_section: 注文書
     accept_default_message: "&gt;デフォルトを受け入れる："
     no_value: "[値なし]"

--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -129,12 +129,10 @@ module SearchHelper
   def locales(model)
     case model
     when 'resource', 'archival_object'
-      {'level' => 'archival_record_level', 'language' => 'language_iso639_2',
+      {'level' => 'archival_record_level',
         'processing_priority' => 'collection_management_processing_priority'}
     when 'accession'
       {'processing_priority' => 'collection_management_processing_priority'}
-    when 'digital_object', 'digital_object_component'
-      {'language' => 'language_iso639_2'}
     when 'subject'
       {'source' => 'subject_source', 'first_term_type' => 'subject_term_type'}
     when 'agent'

--- a/frontend/app/views/defaults/_template.html.erb
+++ b/frontend/app/views/defaults/_template.html.erb
@@ -1,14 +1,30 @@
 <% def_msg = I18n.t("defaults.accept_default_message") %>
 <% define_template("defaults", jsonmodel_definition(:defaults)) do |form| %>
   <div class="subrecord-form-fields">
-      <h3><%= I18n.t "defaults.general_section" %></h3>
+      <h3 id="general"><%= I18n.t "defaults.general_section" %></h3>
       <%= form.label_and_boolean "show_suppressed", {}, form.default_for("show_suppressed") %>
       <%= form.label_and_boolean "publish", {}, form.default_for("publish") %>
       <%= form.label_and_boolean "default_values", {}, form.default_for("default_values") %>
       <%= form.label_and_select "locale", supported_locales_options, supported_locales_default %>
 
-      <% ['accession', 'resource', 'digital_object', 'multi'].each do |type| %>
-        <h3><%= I18n.t "defaults.#{type}_browse_section" %></h3>
+      <h3 id="noteorder"><%= I18n.t "defaults.note_order_section" %></h3>
+
+      <%=
+        out = "<ul id='note-order-preference-list' class='list-group'>"
+        order = @current_prefs['defaults']['note_order'] ||  []
+
+        order = order.empty? ? note_types_for(:resource).keys : order
+
+        order.each do |type|
+          out  += "<li data-id='#{type}' class='list-group-item'><span class='glyphicon glyphicon-menu-hamburger'></span> #{I18n.t('enumerations._note_types.'+type)}</li>"
+        end
+        out += "</ul>"
+        out.html_safe
+      %>
+
+      <h3 id="search_browse_columns"><%= I18n.t "defaults.search_browse_columns" %></h3>
+      <% @types.each do |type| %>
+        <h3 id="<%= type %>_browse_section"><%= I18n.t "defaults.#{type}_browse_section" %></h3>
         <% (1..AppConfig[:max_search_columns]).to_a.each do |n| %>
           <div class="form-group">
             <label for="<%= form.id_for("#{type}_browse_column_#{n}") %>" class="col-sm-2 control-label has-tooltip" data-placement="bottom" title="<%= I18n.t("defaults.browse_column_tooltip", :num => n) %>">
@@ -39,22 +55,6 @@
           </div>
         </div>
       <% end %>
-
-      <h3><%= I18n.t "defaults.note_order_section" %></h3>
-
-      <%=
-        out = "<ul id='note-order-preference-list' class='list-group'>"
-        order = @current_prefs['defaults']['note_order'] ||  []
-
-        order = order.empty? ? note_types_for(:resource).keys : order
-
-        order.each do |type|
-          out  += "<li data-id='#{type}' class='list-group-item'><span class='glyphicon glyphicon-menu-hamburger'></span> #{I18n.t('enumerations._note_types.'+type)}</li>"
-        end
-        out += "</ul>"
-        out.html_safe
-      %>
-
 
       <%= form.hidden_input "junk", "bin me please" %>
    </div>

--- a/frontend/app/views/preferences/_sidebar.html.erb
+++ b/frontend/app/views/preferences/_sidebar.html.erb
@@ -1,0 +1,16 @@
+<%= render(:layout => '/shared/sidebar',
+           :locals => {
+             :record_type => 'preference',
+             :record => @preference,
+             :suppress_basic_information => true,
+             :types => @types
+           }) do |sidebar| %>
+
+    <%= sidebar.render_for_view_and_edit(:title=> I18n.t('defaults.general_section'),:property => :none, :subrecord_type => :defaults, :anchor => 'general') %>
+    <%= sidebar.render_for_view_and_edit(:title=> I18n.t('defaults.note_order_section'),:property => :none, :subrecord_type => :defaults, :anchor => 'noteorder') %>
+    <%= sidebar.render_for_view_and_edit(:title=> I18n.t('defaults.search_browse_columns'), :property => :none,:subrecord_type => :defaults, :anchor => 'search_browse_columns') %>
+    <% @types.each do |type| %>
+        <%= sidebar.render_for_view_and_edit(:title=> I18n.t("defaults.#{type}_browse_section"),:property => :none, :subrecord_type => :defaults, :anchor => "#{type}_browse_section", :subentry => true) %>
+    <% end %>
+
+<% end %>

--- a/frontend/app/views/preferences/edit.html.erb
+++ b/frontend/app/views/preferences/edit.html.erb
@@ -32,9 +32,13 @@
   <% end %>
 
   <%= form_context :preference, @preference do |form| %>
+    <% @types = SearchAndBrowseColumnConfig.columns.keys.sort_by{|k| I18n.t "defaults.#{k}_browse_section"} %>
+    <% @types.delete('repositories') if !user_can?('create_repository') %>
 
     <div class="row">
-      <div class="col-md-3"></div>
+      <div class="col-md-3">
+        <%= render_aspace_partial :partial => "sidebar", :locals => {:form => form, :types => @types} %>
+      </div>
       <div class="col-md-9">
         <%= render_aspace_partial :partial => "toolbar" %>
         <div class="record-pane">
@@ -46,7 +50,7 @@
 
           <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:form => form} %>
 
-          <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "defaults", :cardinality => :zero_to_one, :template => "defaults", :hidden => true} %>
+          <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "defaults", :cardinality => :zero_to_one, :template => "defaults", :types => @types, :hidden => true} %>
 
         </div>
       </div>

--- a/frontend/app/views/search/_langcode_cell.html.erb
+++ b/frontend/app/views/search/_langcode_cell.html.erb
@@ -1,0 +1,11 @@
+<% if !record['langcode'].nil? && record['langcode'].length > 1 %>
+	<ul style="padding-left: 20px;">
+		<% record['langcode'].each do |langcode| %>
+			<li><%= "#{I18n.t("enumerations.language_iso639_2.#{langcode}", :default => langcode)}" %></li>
+		<% end %>
+	</ul>
+<% else %>
+	<% (record['langcode'] || []).each do |langcode| %>
+		<%= "#{I18n.t("enumerations.language_iso639_2.#{langcode}", :default => langcode)}" %>
+	<% end %>
+<% end %>

--- a/frontend/app/views/shared/_sidebar_entry.html.erb
+++ b/frontend/app/views/shared/_sidebar_entry.html.erb
@@ -6,6 +6,7 @@
       title = I18n.t("#{record_type}._frontend.section.#{subrecord_type}",
                      :default => I18n.t("#{subrecord_type}._plural"))
    end
+   subentry = nil if !defined?(subentry)
 %>
 
-<li class="sidebar-entry-<%= anchor %>"><a href="#<%= anchor %>"><%= title %> <span class="glyphicon glyphicon-chevron-right"></span></a></li>
+<li class="sidebar-entry-<%= anchor %>"><a href="#<%= anchor %>" style="<%= "padding-left: 25px !important;" if !subentry.nil? %>"><%= title %> <span class="glyphicon glyphicon-chevron-right"></span></a></li>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -335,6 +335,7 @@ en:
       title: Title
       publish: Published
       has_classification_terms: Has classification terms?
+      identifier: Identifier
       audit_info: Audit Information
       user_mtime: Modified
       create_time: Created
@@ -442,6 +443,7 @@ en:
       create_time: Created
       dates: Dates
       extents: Extent
+      langcode: Language of Materials
       asc: Ascending
       desc: Descending
     blank_facet_query_fields:
@@ -1098,6 +1100,8 @@ en:
     _frontend:
       messages:
         updated: "Preferences updated"
+      action:
+        save: Save Preferences
 
   rights_statement:
     _frontend:

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -337,6 +337,7 @@ es:
       title: Título
       publish: Publicado
       has_classification_terms: Tiene términos de clasificación?
+      identifier: Identificador
       audit_info: Datos de auditoría
       user_mtime: Modificado
       create_time: Creado
@@ -444,6 +445,7 @@ es:
       create_time: Creado
       dates: Fechas
       extents: Extensión
+      langcode: Lenguaje de materiales
       asc: Ascendente
       desc: Descendente
     blank_facet_query_fields:
@@ -1099,6 +1101,8 @@ es:
     _frontend:
       messages:
         updated: "Preferencias actualizadas"
+      action:
+        save: Guardar preferencias
 
   rights_statement:
     _frontend:

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -335,6 +335,7 @@ fr:
       title: Intitulé
       publish: Publié
       has_classification_terms: A des termes des classements?
+      identifier: Identifiant
       audit_info: Audit Information
       user_mtime: Modifié
       create_time: Créé
@@ -442,6 +443,7 @@ fr:
       create_time: Créé
       dates: Dates
       extents: Importance matérielle
+      langcode: Langue des matériaux
       asc: Ascendant
       desc: Descendant
     blank_facet_query_fields:
@@ -1098,6 +1100,8 @@ fr:
     _frontend:
       messages:
         updated: "Préférences actualisées"
+      action:
+        save: Enregistrer les préférences
 
   rights_statement:
     _frontend:

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -342,7 +342,8 @@ ja:
       score: 関連性
       title: タイトル
       publish: 発行済み
-      has_classification_terms: Has classification terms?
+      has_classification_terms: 分類用語はありますか？
+      identifier: 識別
       audit_info: 監査データ
       user_mtime: 更新しました
       create_time: 作成した
@@ -450,6 +451,7 @@ ja:
       create_time: 作成した
       dates: 日付
       extents: エクステント
+      langcode: 材料の言語
       asc: 上昇
       desc: 降順
     blank_facet_query_fields:
@@ -1109,6 +1111,8 @@ ja:
     _frontend:
       messages:
         updated: プリファレンスの更新
+      action:
+        save: 設定を保存
 
   rights_statement:
     _frontend:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Extends existing search/browse preference column behavior in the following ways:

- Browse/search columns preferences may be set in the UI for all 18 record types currently in `search_browse_column_config.rb`;
- Language of Materials columns may now be added for the following record types in the UI: resources, archival objects, digital objects, digital object components, and multi/search.;
- Given the addition of 14 new record types to the UI, a new sidebar has been added to the user/repo/global preferences page, with browse columns sorted alphabetically by translated key.  Also, note order has been moved nearer the top, a heading has been provided for the browse columns section, and a new `subentry` local has been added to `sidebar_entry` to make it somewhat easier to nest sub-subheadings under an existing heading (this should probably be refined in the future, but it's a start);
- Repository browse columns settings have been removed from the preferences of users who do not have `create_repository` permissions;
- Translations have been added/updated as necessary (including a few unrelated updates that just happened to be nearby to what I was working on);

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1099
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-776
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1008

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Preferences sidebar:
![image](https://user-images.githubusercontent.com/15144646/97232871-586ca780-17b4-11eb-9bbe-56b2e06a7fdd.png)

Adding option Language of Materials column to Resource browse:
![image](https://user-images.githubusercontent.com/15144646/97232967-894cdc80-17b4-11eb-9189-338d1f569f3d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
