### PR TITLE
Prevent bulk import from creating date types

### DIFF
--- a/backend/app/lib/bulk_import/bulk_import_mixins.rb
+++ b/backend/app/lib/bulk_import/bulk_import_mixins.rb
@@ -154,6 +154,7 @@ module BulkImportMixins
       date_type = @date_types.value(date_type || "inclusive")
     rescue Exception => e
       @report.add_errors(I18n.t("bulk_import.error.date_type", :what => date_type, :date_str => date_str))
+      return nil
     end
     begin
       date = { "date_type" => date_type,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The bulk importer allows for creation of date_type enumeration values. This creates all sorts of havoc in the frontend. This is a quick patch to prevent that specific issue, but does not fix the validation problems in general. Nor does it prevent the importer from creating an object from a row with this issue. It will continue to discard that section of the row. IE if the date type is not in the list of enumeration values already present, that date section of the row will be discarded and no date subrecord will be created.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://github.com/archivesspace/archivesspace/issues/2035

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing, including manual import and backend tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
