### PR TITLE
Provide a direct method to deprecate a config property.

### DIFF
--- a/common/config/config-aliases.rb
+++ b/common/config/config-aliases.rb
@@ -5,3 +5,6 @@ AppConfig.add_alias(:option => :frontend_prefix,
 AppConfig.add_alias(:option => :public_prefix,
                     :maps_to => :public_proxy_prefix,
                     :deprecated => true)
+
+AppConfig.add_deprecated(:bulk_import_rows)
+AppConfig.add_deprecated(:bulk_import_size)

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -677,7 +677,3 @@ AppConfig[:max_search_columns] = 7
 # For Bulk Import:
 # specifies whether the "Load Digital Objects" button is available at the Resource Level
 AppConfig[:hide_do_load] = false
-# upper row limit for an excel spreadsheet
-AppConfig[:bulk_import_rows] = 1000
-# maximum size (in KiloBytes) for an excel spreadsheet
-AppConfig[:bulk_import_size] = 256

--- a/common/config/config-distribution.rb
+++ b/common/config/config-distribution.rb
@@ -31,16 +31,21 @@ class AppConfig
 
 
   def self.resolve_alias(parameter)
+    check_deprecated(parameter)
     if aliases[parameter]
-
-      if deprecated_parameters[parameter]
-        $stderr.puts("WARNING: The parameter '#{parameter}' is now deprecated.  Please use '#{aliases[parameter]}' instead.")
-      end
-
       aliases[parameter]
     else
       parameter
     end
+  end
+
+  def self.check_deprecated(parameter)
+    return unless deprecated_parameters[parameter]
+
+    message = "WARNING: The parameter '#{parameter}' is now deprecated."
+    message += " Please use '#{aliases[parameter]}' instead." if aliases[parameter]
+    deprecated_parameters.delete(parameter) # we don't need to repeat this message
+    $stderr.puts(message)
   end
 
 
@@ -199,6 +204,10 @@ class AppConfig
 
     aliases[alias_parameter] = target_parameter
     deprecated_parameters[alias_parameter] = options.fetch(:deprecated, false)
+  end
+
+  def self.add_deprecated(parameter)
+    deprecated_parameters[parameter] = true
   end
 
   def self.parse_value(value)


### PR DESCRIPTION
This is in addition to the existing alias option.

Deprecate bulk import frontend config settings for upload. They
are not used now that the bulk import runs as a background job.

## How Has This Been Tested?
Checked deprecated config settings are reported on startup.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
