### PR TITLE
No escape on note exception message

### DIFF
--- a/backend/app/lib/bulk_import/bulk_import_mixins.rb
+++ b/backend/app/lib/bulk_import/bulk_import_mixins.rb
@@ -151,6 +151,7 @@ module BulkImportMixins
   def create_date(dates_label, date_begin, date_end, date_type, expression, date_certainty)
     date_str = "(Date: type:#{date_type}, label: #{dates_label}, begin: #{date_begin}, end: #{date_end}, expression: #{expression})"
     begin
+      @report.add_info(I18n.t('bulk_import.date_type_default')) unless date_type
       date_type = @date_types.value(date_type || "inclusive")
     rescue Exception => e
       @report.add_errors(I18n.t("bulk_import.error.date_type", :what => date_type, :date_str => date_str))

--- a/backend/app/lib/bulk_import/lang_handler.rb
+++ b/backend/app/lib/bulk_import/lang_handler.rb
@@ -58,7 +58,7 @@ class LangHandler < Handler
           lang.notes.push note
           langs.push lang
         rescue Exception => e
-          report.add_errors(I18n.t("bulk_import.error.bad_note", :type => "langmaterial", :msg => CGI::escapeHTML(e.message)))
+          report.add_errors(I18n.t("bulk_import.error.bad_note", :type => "langmaterial", :msg => e.message))
         end
       end
     end

--- a/backend/app/lib/bulk_import/notes_handler.rb
+++ b/backend/app/lib/bulk_import/notes_handler.rb
@@ -55,7 +55,7 @@ class NotesHandler < Handler
     begin
       wellformed(content)
     rescue Exception => e
-      raise BulkImportException.new(I18n.t("bulk_import.error.bad_note", :type => note_type[:value], :msg => CGI::escapeHTML(e.message)))
+      raise BulkImportException.new(I18n.t("bulk_import.error.bad_note", :type => note_type[:value], :msg => e.message))
     end
     # if the target is multipart, then the data goes in a JSONMODEL(:note_text).content;, which is pushed to the note.subnote array; otherwise it's just pushed to the note.content array
     if note_type[:target] == :note_multipart

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -2382,13 +2382,14 @@ en:
     object_created: "%{what} created"
     object_created_be: "%{what} would be created"
     object_not_created_be: "%{what} would not be created"
+    date_type_default: No date type was specified. Defaulting to 'inclusive'.
     warn:
       dup: "Managed Controlled Value List %{which} has multiple instances for the translation '%{trans}'. '%{used}' will be used as the value."
       disam: "Multiple match(es) found for '%{which}'. Creating '%{name}' for disabiguation."
       disamuse: "Multiple match(es) found for '%{which}'. Using already-created '%{name}' for disabiguation."
       single_date_end: "Single date %{date_str} has end date that will be ignored."
     error:
-      date_type: "Date type [%{what}] invalid for %{date_str}. Defaulting to 'inclusive'"
+      date_type: "Date type [%{what}] invalid for %{date_str}. The date will not be processed."
       date_label: "Date label [%{what}] invalid for %{date_str}. The date will not be processed."
       certainty: "Invalid 'date certainty' ignored for %{date_str}: (%{what})"
       below_bad_ao: Cannot process because it is a child of the bad archival object


### PR DESCRIPTION
Update date type messaging. Date will not be processed if type
is not recognized.

Makes error messaging consistent with: https://github.com/archivesspace/archivesspace/pull/2037

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
