### PR TITLE
Fix collection management title sorting

### DIFF
--- a/common/config/search_browse_column_config.rb
+++ b/common/config/search_browse_column_config.rb
@@ -164,7 +164,7 @@ module SearchAndBrowseColumnConfig
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]}
     },
     "collection_management" => {
-      "parent_title" => {:field => "parent_title", :sortable => true},
+      "parent_title" => {:field => "parent_title", :sortable => true, :sort_by => "title_sort"},
       "parent_type" => {:field => "parent_type", :sortable => true},
       "processing_priority" => {:field => "processing_priority", :sortable => true},
       "processing_status" => {:field => "processing_status", :sortable => true},

--- a/common/db/migrations/138_reindex_collection_management.rb
+++ b/common/db/migrations/138_reindex_collection_management.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative 'utils'
+
+Sequel.migration do
+  up do
+    self[:collection_management].update(system_mtime: Time.now)
+  end
+
+  down do
+  end
+end

--- a/frontend/app/models/search.rb
+++ b/frontend/app/models/search.rb
@@ -83,12 +83,9 @@ class Search
     end
 
     sort_col = prefs["#{type}_sort_column"] || 'score'
-    if sort_col
-      sort_col = 'title_sort' if sort_col == 'title'
-      "#{sort_col} #{(prefs["#{type}_sort_direction"] || "desc")}"
-    else
-      nil
-    end
+    derived_sort_col = SearchAndBrowseColumnConfig.columns.dig(type, sort_col, :sort_by)
+    sort_col = derived_sort_col if derived_sort_col
+    "#{sort_col} #{(prefs["#{type}_sort_direction"] || "desc")}"
   end
 
   def self.build_filters(criteria)

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -772,13 +772,15 @@ class IndexerCommon
       cm = record['record']['collection_management']
       if cm
         parent_type = JSONModel.parse_reference(record['uri'])[:type]
+        title = record['record']['title'] || record['record']['display_string']
         docs << {
           'id' => cm['uri'],
           'uri' => cm['uri'],
           'parent_id' => record['uri'],
-          'parent_title' => record['record']['title'] || record['record']['display_string'],
+          'parent_title' => title,
           'parent_type' => parent_type,
-          'title' => record['record']['title'] || record['record']['display_string'],
+          'title' => title,
+          'title_sort' => clean_for_sort(title),
           'types' => ['collection_management'],
           'primary_type' => 'collection_management',
           'json' => cm.to_json(:max_nesting => false),


### PR DESCRIPTION
Add title_sort to CM record, it was missing because CM records
are indexed as extra documents (reindex of CM records required).

Update parent_title to use title_sort. Don't need to change use
of parent_title as CM record titles are all the same anyway.

Update frontend search to find sort_by when available in config.
This will work for all instances of sort_by not just the
(previously) hard-coded title -> title_sort.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
