### PR TITLE
Improve styling of event and classifications record linkers

### DIFF
--- a/frontend/app/views/classification_terms/_record_linker.html.erb
+++ b/frontend/app/views/classification_terms/_record_linker.html.erb
@@ -24,26 +24,27 @@
              aria-label="Link to record"
              />
 
-        <% if form.obj.has_key?('_resolved') %>
+      <% if form.obj.has_key?('_resolved') %>
 
-            <input type="text"
-              class='prelinker'
-              name="<%= form.path %>[_resolved]"
-              value="<%= selected_json %>" />
+        <input type="text"
+               class='prelinker'
+               name="<%= form.path %>[_resolved]"
+               value="<%= selected_json %>" />
 
-            <input type="text"
-              class='prelinker'
-              name="<%= form.path %>[ref]"
-              value="<%= form.obj["ref"] %>" />
+        <input type="text"
+               class='prelinker'
+               name="<%= form.path %>[ref]"
+               value="<%= form.obj["ref"] %>" />
 
       <% end %>
 
-      <div class="btn-group dropdown pull-right">
-        <a class="btn dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="Link to record"><span class="caret"></span></a>
+      <div class="input-group-btn">
+        <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="Link to record"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
         </ul>
       </div>
+      
     </div>
   </div>
 </div>

--- a/frontend/app/views/classifications/_record_linker.html.erb
+++ b/frontend/app/views/classifications/_record_linker.html.erb
@@ -24,26 +24,27 @@
              aria-label="Link to record"
              />
 
-        <% if form.obj.has_key?('_resolved') %>
+      <% if form.obj.has_key?('_resolved') %>
 
-            <input type="text"
-              class='prelinker'
-              name="<%= form.path %>[_resolved]"
-              value="<%= selected_json %>" />
+        <input type="text"
+               class='prelinker'
+               name="<%= form.path %>[_resolved]"
+               value="<%= selected_json %>" />
 
-            <input type="text"
-              class='prelinker'
-              name="<%= form.path %>[ref]"
-              value="<%= form.obj["ref"] %>" />
+        <input type="text"
+               class='prelinker'
+               name="<%= form.path %>[ref]"
+               value="<%= form.obj["ref"] %>" />
 
       <% end %>
 
-      <div class="btn-group dropdown pull-right">
-        <a class="btn dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="Link to record"><span class="caret"></span></a>
+      <div class="input-group-btn">
+        <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="Link to record"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
         </ul>
       </div>
+
     </div>
   </div>
 </div>

--- a/frontend/app/views/events/_record_linker.html.erb
+++ b/frontend/app/views/events/_record_linker.html.erb
@@ -24,25 +24,27 @@
              aria-label="Link to record"
              />
 
-        <% if form.obj.has_key?('_resolved') %>
+      <% if form.obj.has_key?('_resolved') %>
 
-            <input type="text"
-              class='prelinker'
-              name="<%= form.path %>[_resolved]"
-              value="<%= selected_json %>" />
+        <input type="text"
+               class='prelinker'
+               name="<%= form.path %>[_resolved]"
+               value="<%= selected_json %>" />
 
-            <input type="text"
-              class='prelinker'
-              name="<%= form.path %>[ref]"
-              value="<%= form.obj["ref"] %>" />
+        <input type="text"
+               class='prelinker'
+               name="<%= form.path %>[ref]"
+               value="<%= form.obj["ref"] %>" />
 
-        <% end %>
-      <div class="btn-group dropdown pull-right">
-        <a class="btn dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="Link to record"><span class="caret"></span></a>
+      <% end %>
+
+      <div class="input-group-btn">
+        <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="Link to record"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
         </ul>
       </div>
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Seems like this one has been around for a long while, but the Linked Records sections on Events, Classifications, and Classification Terms edit pages don't have the same styling applied to them as other instances of Linked Records sections elsewhere in the application (likely because these are less frequently used record types in general).  This change just mimics the classes/html used elsewhere in the application to fix the existing ugly/broken-looking styling.

I also did a little indentation/code style cleanup since I was already in there... 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Incidentally discovered during pre-v2.8.1-RC testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Looks good :-)

## Screenshots (if appropriate):
Before this PR:
![image](https://user-images.githubusercontent.com/15144646/97750107-945e8000-1ac6-11eb-9e39-e72c8c7482cf.png)

Proposed changes:
![image](https://user-images.githubusercontent.com/15144646/97750028-72fd9400-1ac6-11eb-855e-0312a2426cb8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
