### PR TITLE
ANW-1156: Don't undo reordering when saving selected component

### DIFF
--- a/frontend/app/assets/javascripts/tree_toolbar.js.erb
+++ b/frontend/app/assets/javascripts/tree_toolbar.js.erb
@@ -34,7 +34,7 @@ var SHARED_TOOLBAR_ACTIONS = [
                 $('.cut-selection,.move-node',toolbarRenderer.container).removeClass('disabled');
             } else {
                 $(btn).text('<%= I18n.t('actions.enable_reorder') %>');
-                tree.ajax_tree.show_form();
+                location.reload(true);
                 tree.resizer.reset();
                 $('.btn',toolbarRenderer.container).show();
                 $('.cut-selection,.paste-selection,.move-node', toolbarRenderer.container).hide();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In some situations reordered components don't remain reordered.  If the active component prior to the user enabling/using reorder mode is then saved after reorder mode is exited (either with or without active changes), then the json that is sent via the update posts an old/pre-reorder logical position value.  The form/page needs to be reloaded to update this position after exiting reorder mode so that the form does not contain stale data.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1156

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests passed, confirmed db and json values persist/change as expected when using the UI's reorder mode.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
