### PR TITLE
Hm qsa 110620

### DIFF
--- a/backend/app/lib/background_job_queue.rb
+++ b/backend/app/lib/background_job_queue.rb
@@ -132,7 +132,7 @@ class BackgroundJobQueue
         # Mark the job as permanently canceled
         job.finish!(:canceled)
       else
-        unless job.success?
+        if job.running?
           # If the job didn't record success, mark it as finished ourselves.
           # This isn't really a problem, but it does mean that the job status
           # update is now happening in a separate DB transaction than the one

--- a/backend/app/lib/job_runners/batch_import_runner.rb
+++ b/backend/app/lib/job_runners/batch_import_runner.rb
@@ -87,7 +87,28 @@ class BatchImportRunner < JobRunner
         end
       end
     rescue
-      last_error = $!
+      # If we get to here, last_error will generally not have been set yet.  The
+      # conditional set is here to deal with code that does something like this:
+      #
+      #  DB.open do                 # Start a transaction (1)
+      #    BatchImportRunner#run    # Run this import process, which does another DB.open (2)
+      #    <run some other updates>
+      #  end
+      #
+      # The intention is to run the import and some related updates in a single
+      # transaction, but the result is surprising: if the BatchImportRunner
+      # fails for some reason, everything gets rolled back and the only error
+      # logged is a Sequel::Rollback.
+      #
+      # What's happening here is that DB.open (2) actually didn't establish a
+      # new transaction (since it was already running in a transaction) and, as
+      # a result, Sequel didn't set up the begin/rescue block needed to catch
+      # Sequel::Rollback.  So the rollback exception keeps bubbling up until
+      # it's caught by the block you're currently reading.  When this happens,
+      # last_error contains the real cause of the strife, and Sequel::Rollback
+      # should be ignored.
+
+      last_error ||= $!
     end
 
     if last_error

--- a/backend/app/lib/streaming_import.rb
+++ b/backend/app/lib/streaming_import.rb
@@ -308,7 +308,9 @@ class StreamingImport
       json = model.to_jsonmodel(obj)
 
       limbs.each do |k, v|
-        if json[k.to_s].is_a?(Array)
+        if json[k.to_s].is_a?(Array) || json[k.to_s].respond_to?(:to_array)
+          json[k.to_s] = json[k.to_s].to_a
+
           # It's possible that the record we're reattaching relationships to
           # actually had some relationships added between when we lopped them
           # off and now.

--- a/backend/app/model/ASModel_crud.rb
+++ b/backend/app/model/ASModel_crud.rb
@@ -578,7 +578,7 @@ module ASModel
 
       def update_mtime_for_ids(ids)
         now = Time.now
-        ids.each_slice(50) do |subset|
+        ids.each_slice(1000) do |subset|
           self.dataset.filter(:id => subset).update(:system_mtime => now)
         end
       end

--- a/backend/app/model/backend_enum_source.rb
+++ b/backend/app/model/backend_enum_source.rb
@@ -66,6 +66,7 @@ class BackendEnumSource
           editable = true 
           db[:enumeration].join(:enumeration_value, :enumeration_id => :id).
                            filter(:name => enum_name).
+                           order(:position).
                            select(:value, Sequel.qualify(:enumeration_value, :id), :editable).
                            all.each do |row|
             value_to_id_map[row[:value]] = row[:id]

--- a/backend/app/model/db.rb
+++ b/backend/app/model/db.rb
@@ -94,7 +94,39 @@ class DB
       Thread.current[:nesting_level] ||= 0
       Thread.current[:nesting_level] += 1
 
+      Thread.current[:in_transaction] ||= false
+
       begin
+        if Thread.current[:in_transaction] && ASpaceEnvironment.environment != :unit_test
+          # We are already inside another DB.open that will handle all
+          # exceptions and retries for us.  We want to avoid a situation like
+          # this:
+          #
+          # transaction scope / DB.open do |db|
+          #                   |   db[:sometable].insert(foo)
+          #                   |
+          #                   |   DB.open do |db|                                         \
+          #                   |     db[:sometable].insert(something_that_depends_on_foo)  | retry scope
+          #                   |   end                                                     /
+          #                   \ end
+          #
+          # Despite the nested DB.open calls, Sequel's default behavior is to
+          # merge the inner call to DB.transaction with the already active
+          # transaction.
+          #
+          # If the inner "retry scope" hits an exception, the whole transaction
+          # is rolled back (all of "transaction scope", including the insert of
+          # `foo`), but only the inner "retry scope" is retried.  If that
+          # succeeds on the retry, we end up losing first insert and keeping the
+          # second.
+          #
+          # So the fix here is to let the outermost DB.open take responsibility
+          # for everything: make the retry scope and the transaction scope line
+          # up with each other.
+
+          return yield @pool
+        end
+
         last_err = false
         retries = opts[:retries] || 10
 
@@ -102,7 +134,12 @@ class DB
           begin
             if transaction
               self.transaction(:isolation => opts.fetch(:isolation_level, :repeatable)) do
-                return yield @pool
+                Thread.current[:in_transaction] = true
+                begin
+                  return yield @pool
+                ensure
+                  Thread.current[:in_transaction] = false
+                end
               end
 
               # Sometimes we'll make it to here.  That means we threw a

--- a/backend/app/model/db.rb
+++ b/backend/app/model/db.rb
@@ -18,12 +18,15 @@ class DB
                         ]
 
   class DBPool
+    DATABASE_READ_ONLY_REGEX = /is read only|server is running with the --read-only option/
 
     attr_reader :pool_size
 
     def initialize(pool_size = AppConfig[:db_max_connections], opts = {})
       @pool_size = pool_size
       @opts = opts
+  
+      @lock = Mutex.new
     end
 
     def connect
@@ -51,6 +54,7 @@ class DB
           @pool = pool
         rescue
           Log.error("DB connection failed: #{$!}")
+          raise
         end
       end
 
@@ -63,10 +67,68 @@ class DB
       not @pool.nil?
     end
 
-
     def transaction(*args)
-      @pool.transaction(*args) do
-        yield
+      retry_count = 0
+
+      begin
+        # @pool might be nil if we're in the middle of a reconnect.  Spin for a
+        # bit before giving up.
+        pool = nil
+
+        60.times do
+          pool = @pool
+          break if pool
+          sleep 1
+        end
+
+        if pool.nil?
+          Log.info("DB connection failed: unable to get a connection")
+          raise
+        end
+
+        pool.transaction(*args) do
+          yield(pool)
+        end
+      rescue Sequel::DatabaseError, java.sql.SQLException => e
+        if retry_count > 0
+          Log.warn("DB connection failure: #{e}.  Retry count is #{retry_count}")
+        end
+
+        if retry_count > 6
+          # We give up
+          raise e
+        end
+
+        if e.to_s =~ DATABASE_READ_ONLY_REGEX
+          sleep rand * 10
+
+          # Reset the pool...
+          old_pool = @pool
+
+          @lock.synchronize do
+            if @pool == old_pool
+              # If we got the lock and nobody has reset the pool yet, it's time to do our thing.
+              @pool = nil
+
+              # We retry the connection indefinitely here.  The system isn't
+              # going to function until the pool is restored, so either return
+              # successful or don't return at all.
+              begin
+                connect
+              rescue
+                Log.warn("DB connection failure on reconnect: #{$!}.  Retrying indefinitely...")
+                sleep 1
+                retry
+              end
+            end
+          end
+
+          retry_count += 1
+          retry
+        else
+          raise e
+        end
+
       end
     end
 

--- a/backend/app/model/job.rb
+++ b/backend/app/model/job.rb
@@ -197,6 +197,12 @@ class Job < Sequel::Model(:job)
   end
 
 
+  def running?
+    self.reload
+    self.status == 'running'
+  end
+
+
   def success?
     self.reload
     self.status == 'completed'

--- a/backend/app/model/mixins/relationships.rb
+++ b/backend/app/model/mixins/relationships.rb
@@ -418,10 +418,25 @@ AbstractRelationship = Class.new(Sequel::Model) do
 
   # A list of all DB columns that might contain a foreign key reference to a
   # record of type 'model'.
+  MODEL_COLUMNS_CACHE = java.util.concurrent.ConcurrentHashMap.new(128)
+
   def self.reference_columns_for(model)
-    self.db_schema.keys.select { |column_name|
-      column_name.to_s.downcase =~ /\A#{model.table_name.downcase}_id(_[0-9]+)?\z/
-    }
+    key = [self, model]
+
+    if columns = MODEL_COLUMNS_CACHE.get(key)
+      columns
+    else
+      MODEL_COLUMNS_CACHE.put(key,
+                              self.db_schema.keys.select { |column_name|
+                                [
+                                  model.table_name.downcase.to_s + "_id",
+                                  model.table_name.downcase.to_s + "_id_0",
+                                  model.table_name.downcase.to_s + "_id_1",
+                                ].include?(column_name.to_s.downcase)
+                              })
+
+      MODEL_COLUMNS_CACHE.get(key)
+    end
   end
 
 
@@ -475,6 +490,8 @@ AbstractRelationship = Class.new(Sequel::Model) do
         end
       }
     }
+
+    raise "Failed to find a URI for other referent in #{self}: #{obj.id}"
   end
 
 

--- a/common/aspace-rails/compressor.rb
+++ b/common/aspace-rails/compressor.rb
@@ -15,9 +15,9 @@ class ASpaceCompressor
     yui = Dir.glob(File.join(File.absolute_path(File.dirname(__FILE__)), "yui-compressor*jar")).first
     begin
       classloader = java.net.URLClassLoader.new([java.net.URL.new("file:#{yui}")].to_java(java.net.URL))
-      @js_compressor = classloader.find_class("com.yahoo.platform.yui.compressor.JavaScriptCompressor")
-      @css_compressor = classloader.find_class("com.yahoo.platform.yui.compressor.CssCompressor")
-      @error_reporter = classloader.find_class("org.mozilla.javascript.ErrorReporter")
+      @js_compressor = classloader.load_class("com.yahoo.platform.yui.compressor.JavaScriptCompressor")
+      @css_compressor = classloader.load_class("com.yahoo.platform.yui.compressor.CssCompressor")
+      @error_reporter = classloader.load_class("org.mozilla.javascript.ErrorReporter")
       @initialized = true
     rescue ClassNotFoundException
       @disabled = true

--- a/common/jsonmodel.rb
+++ b/common/jsonmodel.rb
@@ -12,8 +12,9 @@ require_relative 'validator_cache'
 
 module JSONModel
 
-  @@models = {}
-  @@custom_validations = {}
+  @@models = java.util.concurrent.ConcurrentHashMap.new
+  @@custom_validations = java.util.concurrent.ConcurrentHashMap.new
+
   @@strict_mode = false
 
 

--- a/common/jsonmodel_i18n_mixin.rb
+++ b/common/jsonmodel_i18n_mixin.rb
@@ -16,11 +16,7 @@ module JSONModelI18nMixin
       [:errors, :warnings].each do |level|
         next unless exceptions[level]
         exceptions[level].clone.each do |path, msgs|
-          if path == 'conflicting_record'
-            exceptions[level][path] = msgs
-          else
-            exceptions[level][path] = msgs.map{|m| translate_exception_message(m)}
-          end
+          exceptions[level][path] = msgs.map{|m| translate_exception_message(m, path)}
         end
       end
 
@@ -31,7 +27,11 @@ module JSONModelI18nMixin
   end
 
 
-  def translate_exception_message(msg)
+  def translate_exception_message(msg, path = nil)
+    if path == 'conflicting_record'
+      return t("validation_errors.conflicting_record", {:record_uri => msg})
+    end
+
     msg_data = case msg
       when "Can't be empty"
         [:cant_be_empty]
@@ -71,7 +71,7 @@ module JSONModelI18nMixin
         [:username_already_in_use, {:username => $1}]
       else
         [msg.downcase.gsub(/[\s,':]/, '_')]
-               end
+      end
 
     key, vars = *msg_data
     t("validation_errors.#{key.to_s}", vars)

--- a/common/jsonmodel_type.rb
+++ b/common/jsonmodel_type.rb
@@ -148,7 +148,7 @@ class JSONModelType
     end
 
     pattern = self.schema['uri']
-    pattern = pattern.gsub(/\/:[a-zA-Z_]+\//, '/[^/ ]+/')
+    pattern = pattern.gsub(/\/:[a-zA-Z_]+(\/|$)/, '/[^/ ]+\1')
 
     if uri =~ /#{pattern}\/#{ID_REGEXP}(\#.*)?$/
       return id_to_int($1)

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -2027,7 +2027,7 @@ en:
     sponsor_set_desc_required: Sponsor set description is required for creating an OAI sponsor set
     sponsor_set_name_required: Sponsor set name is required for creating an OAI sponsor set
     invalid_characters: Contains invalid characters
-
+    conflicting_record: "<a href='/resolve/readonly?uri=%{record_uri}' target='_blank'>View conflicting record</a>"
 
   job:
     _singular: Background Job

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -306,28 +306,28 @@ class IndexerCommon
 
 
   def enum_fields
-    if @enum_fields
-      @enum_fields
-    else
-      enum_fields = []
+    return @enum_fields if @enum_fields
 
-      queue = JSONModel.models.map {|_,model| model.schema['properties']}.flatten.uniq
+    enum_fields = []
+    queue = JSONModel.models.map {|_,model| model.schema['properties']}.flatten.uniq
 
-      while !queue.empty?
-        elt = queue.shift
+    while !queue.empty?
+      elt = queue.shift
 
-        if elt.is_a?(Hash)
-          elt.each do |k, v|
-            enum_fields.push(k) if v.is_a?(Hash) && v['dynamic_enum']
-            queue << v
+      if elt.is_a?(Hash)
+        elt.each do |k, v|
+          if v.is_a?(Hash)
+            enum_fields.push(k) if v['dynamic_enum'] || v.dig('items', 'dynamic_enum')
           end
-        elsif elt.is_a?(Array)
-          queue.concat(elt)
+          queue << v
         end
+      elsif elt.is_a?(Array)
+        queue.concat(elt)
       end
-
-      @enum_fields = enum_fields.uniq
     end
+
+    enum_fields.delete('items') # not an enum, creeps in through dynamic enum lists
+    @enum_fields = enum_fields.uniq
   end
 
 

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -1124,11 +1124,9 @@ class IndexerCommon
 
     if !batch.empty?
       # For any record we're updating, delete any child records first (where applicable)
-      records_with_children = batch.map {|e|
-        if self.records_with_children.include?(e['primary_type'].to_s)
-          "\"#{e['id']}\""
-        end
-      }.compact
+      records_with_children = self.records_with_children.map {|record_type|
+        batch.record_info_for_type(record_type).map {|info| '"%s"' % [info[:id]]}
+      }.flatten
 
       if !records_with_children.empty?
         req = Net::HTTP::Post.new("#{solr_url.path}/update")

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -76,6 +76,9 @@ class IndexerCommon
       end
     end
 
+    # Force load up front
+    self.enum_fields
+
     configure_doc_rules
 
     @@init_hooks.each do |hook|
@@ -280,6 +283,7 @@ class IndexerCommon
     end
   end
 
+
   def add_extents(doc, record)
     if record['record']['extents']
       extents = record['record']['extents']
@@ -292,15 +296,39 @@ class IndexerCommon
     end
   end
 
-  # TODO: We should fix this to read from the JSON schemas
-  HARDCODED_ENUM_FIELDS = ["relator", "type", "role", "source", "rules", "acquisition_type", "resource_type", "processing_priority", "processing_status", "era", "calendar", "digital_object_type", "level", "processing_total_extent_type", "extent_type", "language", "script", "event_type", "type_1", "type_2", "type_3", "salutation", "outcome", "finding_aid_description_rules", "finding_aid_status", "instance_type", "use_statement", "checksum_method", "date_type", "label", "certainty", "scope", "portion", "xlink_actuate_attribute", "xlink_show_attribute", "file_format_name", "temporary", "name_order", "country", "jurisdiction", "rights_type", "ip_status", "term_type", "enum_1", "enum_2", "enum_3", "enum_4", "relator_type", "job_type"]
+
+  def enum_fields
+    if @enum_fields
+      @enum_fields
+    else
+      enum_fields = []
+
+      queue = JSONModel.models.map {|_,model| model.schema['properties']}.flatten.uniq
+
+      while !queue.empty?
+        elt = queue.shift
+
+        if elt.is_a?(Hash)
+          elt.each do |k, v|
+            enum_fields.push(k) if v.is_a?(Hash) && v['dynamic_enum']
+            queue << v
+          end
+        elsif elt.is_a?(Array)
+          queue.concat(elt)
+        end
+      end
+
+      @enum_fields = enum_fields.uniq
+    end
+  end
+
 
   def configure_doc_rules
 
     add_document_prepare_hook {|doc, record|
       found_keys = Set.new
 
-      ASUtils.search_nested(record["record"], HARDCODED_ENUM_FIELDS, ['_resolved']) do |field, field_value|
+      ASUtils.search_nested(record["record"], enum_fields, ['_resolved']) do |field, field_value|
         key = "#{field}_enum_s"
 
         doc[key] ||= Set.new

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -1012,6 +1012,7 @@ class IndexerCommon
 
 
   def clean_for_sort(value)
+    return nil if value.nil?
     out = value.gsub(/<[^>]+>/, '')
     out.gsub!(/-/, ' ')
     out.gsub!(/[^\w\s]/, '')

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -149,7 +149,7 @@ class IndexerCommon
       end
     end
 
-    strings.join(' ')
+    strings.join(' ').strip
   end
 
 
@@ -166,7 +166,7 @@ class IndexerCommon
         IndexerCommon.extract_string_values(name)
       }.join(" ")
     end
-    fullrecord
+    fullrecord.strip
   end
 
   # There's a problem with how translation paths get loaded when selenium tests are run

--- a/indexer/spec/indexer_common_spec.rb
+++ b/indexer/spec/indexer_common_spec.rb
@@ -163,7 +163,7 @@ describe "indexer common" do
       doc['uri'] = "URI"
       doc['title'] =  "Test record 1"
       doc['arr'] = ['type 1', 'type 2']
-      expect(IndexerCommon.extract_string_values(doc)).to eq('ID URI Test record 1 type 1 type 2 ')
+      expect(IndexerCommon.extract_string_values(doc)).to eq('ID URI Test record 1 type 1 type 2')
     end
     it "extracts string values from hashes" do
       doc = {}
@@ -171,14 +171,14 @@ describe "indexer common" do
       doc['uri'] = "URI2"
       doc['title'] =  "Test record 2"
       doc['hsh'] = {'type1': '1', 'type2': '2'}
-      expect(IndexerCommon.extract_string_values(doc)).to eq('ID2 URI2 Test record 2 1 2 ')
+      expect(IndexerCommon.extract_string_values(doc)).to eq('ID2 URI2 Test record 2 1 2')
     end
     it "extracts string values from strings" do
       doc = {}
       doc['id'] = "ID3"
       doc['uri'] = "URI3"
       doc['title'] =  "Test record 3"
-      expect(IndexerCommon.extract_string_values(doc)).to eq('ID3 URI3 Test record 3 ')
+      expect(IndexerCommon.extract_string_values(doc)).to eq('ID3 URI3 Test record 3')
     end
   end
   describe "build_fullrecord" do
@@ -189,7 +189,7 @@ describe "indexer common" do
         rec['record']['id'] = "ID1"
         rec['record']['uri'] = "URI1"
         rec['record']['title'] =  "Test record 1"
-        expect(IndexerCommon.build_fullrecord(rec)).to eq('ID1 URI1 Test record 1 ')
+        expect(IndexerCommon.build_fullrecord(rec)).to eq('ID1 URI1 Test record 1')
       end
     end
     describe "record has finding_aid_subtitle" do
@@ -200,7 +200,7 @@ describe "indexer common" do
         rec['record']['uri'] = "URI3"
         rec['record']['title'] =  "Test record 3"
         rec['record']['finding_aid_subtitle'] = 'Finding Aid Subtitle 3'
-        expect(IndexerCommon.build_fullrecord(rec)).to eq('ID3 URI3 Test record 3 Finding Aid Subtitle 3 Finding Aid Subtitle 3 ')
+        expect(IndexerCommon.build_fullrecord(rec)).to eq('ID3 URI3 Test record 3 Finding Aid Subtitle 3 Finding Aid Subtitle 3')
       end
     end
     describe "record has finding_aid_author" do
@@ -211,7 +211,7 @@ describe "indexer common" do
         rec['record']['uri'] = "URI2"
         rec['record']['title'] =  "Test record 2"
         rec['record']['finding_aid_author'] = 'Finding Aid Author 2'
-        expect(IndexerCommon.build_fullrecord(rec)).to eq('ID2 URI2 Test record 2 Finding Aid Author 2 Finding Aid Author 2 ')
+        expect(IndexerCommon.build_fullrecord(rec)).to eq('ID2 URI2 Test record 2 Finding Aid Author 2 Finding Aid Author 2')
       end
     end
     describe "record has names" do
@@ -222,7 +222,7 @@ describe "indexer common" do
         rec['record']['uri'] = "URI2"
         rec['record']['title'] =  "Test record 2"
         rec['record']['names'] = {'name1': 'NAME1', 'name2': 'NAME2', 'name3': 'NAME3'}
-        expect(IndexerCommon.build_fullrecord(rec)).to eq('ID2 URI2 Test record 2 NAME1 NAME2 NAME3   ')
+        expect(IndexerCommon.build_fullrecord(rec)).to eq('ID2 URI2 Test record 2 NAME1 NAME2 NAME3')
       end
     end
     describe "record has finding_aid_subtitle, finding_aid_author, and names" do
@@ -235,7 +235,7 @@ describe "indexer common" do
         rec['record']['finding_aid_subtitle'] = 'Finding Aid Subtitle 1'
         rec['record']['finding_aid_author'] = 'Finding Aid Author 1'
         rec['record']['names'] = {'name1': 'NAME1', 'name2': 'NAME2', 'name3': 'NAME3'}
-        expect(IndexerCommon.build_fullrecord(rec)).to eq('ID1 URI1 Test record 1 Finding Aid Subtitle 1 Finding Aid Author 1 NAME1 NAME2 NAME3 Finding Aid Subtitle 1 Finding Aid Author 1   ')
+        expect(IndexerCommon.build_fullrecord(rec)).to eq('ID1 URI1 Test record 1 Finding Aid Subtitle 1 Finding Aid Author 1 NAME1 NAME2 NAME3 Finding Aid Subtitle 1 Finding Aid Author 1')
       end
     end
   end

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -269,6 +269,10 @@
    <!-- Field for searching top container typeahead -->
    <dynamicField name="*_u_typeahead_utext"  type="text_general"  indexed="true"  stored="true" multiValued="false"/>
 
+   <!-- Custom sortable solr fields for dates -->
+   <dynamicField name="*_u_sortdate"  type="date"  indexed="true"  stored="false" multiValued="false"/>
+   <dynamicField name="*_u_ssortdate"  type="date"  indexed="true"  stored="true" multiValued="false"/>
+
    <!-- ASpace Custom Dynamics -->
    <dynamicField name="*_relator_sort"  type="sort_string"  indexed="true"  stored="true" multiValued="false"/>
 


### PR DESCRIPTION
Includes 18 commits from the larger #1896 funded by Queensland State Archives and written by:

- @marktriggs
- @jambun
- @payten

## Commits

- acf37cdc79453a8f9643882481ada16b2a8f6fba: Reduce JSON parsing by storing extra data about records in a batch
- 1d330d6c84b9225075ab789ea67b4de729b45cbb: Ensure that realtime-indexing always sees up-to-date records
- 676120f5d49908cb3449fe422db42dc6d9dddb08: Don't require URI patterns with placeholders to end in a slash
- 05abccbd0606cc9b65d7f02bfe3425d551d41c95: Don't blow up when indexing an accession with no title or date
- 498b8ecee90f437e0582c19d9e7be6e9eecfbe0e: Bugfix: Don't mark failed jobs as "completed"
- eed06fc26e63a217bf363f02b98a005aeded1cc2: Document a strange sequence of events that caused imports to silently rollback.
- b9acaca97a116b1e89c14f0f2d06369c4558bbf7: Cope with ArrayList here too
- 0d02a7960bb6cf4cb090b7cb0b03835083906524: Shouldn't call a protected method here
- 40b5c24b2b6b4ba2a054f0f0c32311cb59f9aac2: Threading bug fix for relationships
- 9da6b9e981a5a5e0c569f5688a86a62fbd19671b: Fix handling of nested DB.open calls when retries are happening
- 29b5a2b815ce2b16e511e9f5db2b7efb85a3d680: When indexing enum values, don't hardcode the list of enums
- fd3e1c0d348b2f74bbae0ed9bf65da381d002af8: Bugfix: these variables can be accessed from multiple threads
- 1ef6a60cfb8841a3a9c1656e74d44123cec8c0b4: Add custom sortable solr fields for dates
- 939180ab4b136857efa673594e1b3c52df53178c: Respect position in backend enum source
- e7b1df24c583b5efd65aac51c85cd1c3521d755f: Show a link to the conflicting record when conflicting_record error is raised
- 95698a4ac364fd479fbd89565cf10d7a1a2366b6: It's 2019 now so we can probably have bigger batches than this
- 60aeef584b463ddc3d53401fe96c61da0f81a0b4: Faster version of extract_string_values
- 51ab23d24115824ea5125ef726ae790b3488782c: Detect when a connection becomes read-only and reconnect

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
