### PR TITLE
Staff UI accessibility enhancements

### DIFF
--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -270,7 +270,7 @@ module SearchHelper
   end
 
   def add_actions_column
-    add_column(sr_only('Actions'), {:template => 'shared/actions',
+    add_column(sr_only(I18n.t('search_results.actions')), {:template => 'shared/actions',
       :class => 'actions table-record-actions'})
   end
 

--- a/frontend/app/views/assessment_attributes/edit.html.erb
+++ b/frontend/app/views/assessment_attributes/edit.html.erb
@@ -56,9 +56,12 @@
                           <span class="glyphicon glyphicon-search"></span>
                         </a>
                       </span>
-                      <%= text_field_tag 'ratings[][label]', rating.fetch('label'), :class => 'form-control' %>
+                      <%= text_field_tag 'ratings[][label]', rating.fetch('label'), :class => 'form-control', :"aria-label" =>  I18n.t('assessment_attribute_definitions._frontend.section.ratings') %>
                       <span class="input-group-btn">
-                        <button class="btn btn-danger remove-repo-attribute"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></button>
+                        <button class="btn btn-danger remove-repo-attribute">
+                          <span class="glyphicon glyphicon-remove"></span>
+                          <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_rating", :rating_type =>rating.fetch('label')) %></span>
+                        </button>
                       </span>
                     </div>
                     <%= hidden_field_tag 'ratings[][id]', rating.fetch('id', nil) %>
@@ -122,9 +125,12 @@
                           <span class="glyphicon glyphicon-search"></span>
                         </a>
                       </span>
-                      <%= text_field_tag 'formats[][label]', format.fetch('label'), :class => 'form-control' %>
+                      <%= text_field_tag 'formats[][label]', format.fetch('label'), :class => 'form-control', :"aria-label" =>  I18n.t('assessment_attribute_definitions._frontend.section.formats') %>
                       <span class="input-group-btn">
-                        <button class="btn btn-danger remove-repo-attribute"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></button>
+                        <button class="btn btn-danger remove-repo-attribute">
+                          <span class="glyphicon glyphicon-remove"></span>
+                          <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_format", :format_type =>format.fetch('label')) %></span>
+                        </button>
                       </span>
                     </div>
                     <%= hidden_field_tag 'formats[][id]', format.fetch('id', nil) %>
@@ -188,9 +194,12 @@
                           <span class="glyphicon glyphicon-search"></span>
                         </a>
                       </span>
-                      <%= text_field_tag 'conservation_issues[][label]', conservation_issue.fetch('label'), :class => 'form-control' %>
+                      <%= text_field_tag 'conservation_issues[][label]', conservation_issue.fetch('label'), :class => 'form-control', :"aria-label" =>  I18n.t('assessment_attribute_definitions._frontend.section.conservation_issues') %>
                       <span class="input-group-btn">
-                        <button class="btn btn-danger remove-repo-attribute"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></button>
+                        <button class="btn btn-danger remove-repo-attribute">
+                          <span class="glyphicon glyphicon-remove"></span>
+                          <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_issue", :issue_type =>conservation_issue.fetch('label')) %></span>
+                        </button>
                       </span>
                     </div>
                     <%= hidden_field_tag 'conservation_issues[][id]', conservation_issue.fetch('id', nil) %>
@@ -230,9 +239,12 @@
         <span class="input-group-addon repo-attribute-drag-handle">
           <span class="glyphicon glyphicon-menu-hamburger"></span>
         </span>
-        <%= text_field_tag 'formats[][label]', '', :class => 'form-control' %>
+        <%= text_field_tag 'formats[][label]', '', :class => 'form-control', :"aria-label" =>  I18n.t('assessment_attribute_definitions._frontend.section.formats') %>
         <span class="input-group-btn">
-          <button class="btn btn-danger remove-repo-attribute"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></button>
+          <button class="btn btn-danger remove-repo-attribute">
+            <span class="glyphicon glyphicon-remove"></span>
+            <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_rating", :rating_type =>'') %></span>
+          </button>
         </span>
       </div>
     </td>
@@ -245,9 +257,12 @@
         <span class="input-group-addon repo-attribute-drag-handle">
           <span class="glyphicon glyphicon-menu-hamburger"></span>
         </span>
-        <%= text_field_tag 'ratings[][label]', '', :class => 'form-control' %>
+        <%= text_field_tag 'ratings[][label]', '', :class => 'form-control', :"aria-label" =>  I18n.t('assessment_attribute_definitions._frontend.section.ratings') %>
         <span class="input-group-btn">
-          <button class="btn btn-danger remove-repo-attribute"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></button>
+          <button class="btn btn-danger remove-repo-attribute">
+            <span class="glyphicon glyphicon-remove"></span>
+            <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_format", :format_type =>'') %></span>
+          </button>
         </span>
       </div>
     </td>
@@ -260,9 +275,12 @@
         <span class="input-group-addon repo-attribute-drag-handle">
           <span class="glyphicon glyphicon-menu-hamburger"></span>
         </span>
-        <%= text_field_tag 'conservation_issues[][label]', '', :class => 'form-control' %>
+        <%= text_field_tag 'conservation_issues[][label]', '', :class => 'form-control', :"aria-label" =>  I18n.t('assessment_attribute_definitions._frontend.section.conservation_issues') %>
         <span class="input-group-btn">
-          <button class="btn btn-danger remove-repo-attribute"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></button>
+          <button class="btn btn-danger remove-repo-attribute">
+            <span class="glyphicon glyphicon-remove"></span>
+            <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_issue", :issue_type =>'') %></span>
+          </button>
         </span>
       </div>
     </td>

--- a/frontend/app/views/groups/index.html.erb
+++ b/frontend/app/views/groups/index.html.erb
@@ -20,8 +20,8 @@
      <table class="table table-striped table-bordered table-condensed">
        <thead>
          <tr>
-           <th>Group name</th>
-           <th width="1px"><!-- actions --></th>
+           <th><%= I18n.t('group.group_code') %></th>
+           <th width="1px"><span class="sr-only"><%= I18n.t('search_results.actions') %></span></th>
          </tr>
        </thead>
        <tbody>

--- a/frontend/app/views/locations/batch.html.erb
+++ b/frontend/app/views/locations/batch.html.erb
@@ -42,7 +42,7 @@
               <div class="alert alert-warning"><%= I18n.t("location_batch._frontend.messages.warning") %></div>
             <% end %>
             <button type="submit" class="btn btn-primary">
-              <%= image_tag "archivesspace/btn-busy.gif", :class=>"btn-busy-icon" %>
+              <%= image_tag "archivesspace/btn-busy.gif", :class=>"btn-busy-icon", :alt=>I18n.t("location_batch._frontend.action.creating") %>
               <span class="btn-label"><%= I18n.t("location_batch._frontend.action.#{@action}") %></span>
               <span class="btn-busy-label"><%= I18n.t("location_batch._frontend.action.creating") %></span>
             </button>

--- a/frontend/app/views/oai_config/edit.html.erb
+++ b/frontend/app/views/oai_config/edit.html.erb
@@ -84,7 +84,7 @@
           <table class="table table-striped table-bordered table-condensed">
             <thead>
               <th>Name</th>
-              <th>&nbsp;</th>
+              <th><span class="sr-only"><%= I18n.t('search_results.actions') %></span></th>
             </thead>
             <tbody>
               <% @repositories.each do |r| %>

--- a/frontend/app/views/users/index.html.erb
+++ b/frontend/app/views/users/index.html.erb
@@ -30,7 +30,7 @@
          <thead>
            <tr>
              <th><%= I18n.t("user._singular") %></th>
-             <th width="70px"><!-- actions --></th>
+             <th width="70px"><span class="sr-only"><%= I18n.t('search_results.actions') %></span></th>
            </tr>
          </thead>
          <tbody>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1697,6 +1697,9 @@ en:
         find_rating: Find records with a %{rating_type} rating
         find_format: Find records with a %{format_type} material type/format
         find_issue: Find records with a %{issue_type} conservation issue
+        remove_rating: Remove %{rating_type} rating
+        remove_format: Remove %{format_type} material type/format
+        remove_issue: Remove %{issue_type} conservation issue
       messages:
         updated: Assessment Attributes updated
         error: Error updating Assessment Attributes

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -1697,6 +1697,9 @@ es:
         find_rating: Buscar registros con una calificación %{rating_type}
         find_format: Buscar registros con un %{format_type} tipo / formato de material
         find_issue: Buscar registros con un problema de conservación %{issue_type}
+        remove_rating: Quitar calificación de %{rating_type}
+        remove_format: Quitar %{format_type} tipo / formato de material
+        remove_issue: Eliminar %{issue_type} problema de conservación
       messages:
         updated: Atributos de evaluación actualizados
         error: Error al actualizar los atributos de evaluación

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -1697,6 +1697,9 @@ fr:
         find_rating: Rechercher des enregistrements avec une note %{rating_type}
         find_format: Rechercher des enregistrements avec un type / format de matériau %{format_type}
         find_issue: Rechercher des enregistrements avec un problème de conservation %{issue_type}
+        remove_rating: Supprimer la note %{rating_type}
+        remove_format: Supprimer le type / format de matériau %{format_type}
+        remove_issue: Supprimer le problème de conservation de %{issue_type}
       messages:
         updated: Attribut actualisés
         error: Erreur lors de l'actualisation

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -1679,6 +1679,9 @@ ja:
         find_rating: ％{rating_type} 評価のレコードを検索
         find_format: ％{format_type} マテリアルタイプ/フォーマットのレコードを検索します
         find_issue: ％{issue_type} 保全問題のあるレコードを検索する
+        remove_rating: ％{rating_type} レーティングを削除
+        remove_format: ％{format_type} マテリアルタイプ/フォーマットを削除します
+        remove_issue: ％{issue_type} 保護の問題を削除します
       messages:
         updated: 評価アトリビュートが更新されました
         error: アセスメント属性の更新中にエラーが発生しました

--- a/frontend/vendor/assets/javascripts/bootstrap-tagsinput.js
+++ b/frontend/vendor/assets/javascripts/bootstrap-tagsinput.js
@@ -45,10 +45,11 @@
     this.multiple = (this.isSelect && element.hasAttribute('multiple'));
     this.objectItems = options && options.itemValue;
     this.placeholderText = element.hasAttribute('placeholder') ? this.$element.attr('placeholder') : '';
+    this.id = element.hasAttribute('id') ? this.$element.attr('id') : '';
     this.inputSize = Math.max(1, this.placeholderText.length);
 
     this.$container = $('<div class="bootstrap-tagsinput"></div>');
-    this.$input = $('<input type="text" placeholder="' + this.placeholderText + '"/>').appendTo(this.$container);
+    this.$input = $('<input type="text" placeholder="' + this.placeholderText + '" id="' + this.id + '"/>').appendTo(this.$container);
 
     this.$element.before(this.$container);
 

--- a/plugins/lcnaf/frontend/locales/en.yml
+++ b/plugins/lcnaf/frontend/locales/en.yml
@@ -2,6 +2,7 @@ en:
   plugins:
     lcnaf:
       label: LCNAF Import
+      authority: Authority Source
       search:
         family_name: Primary Name 
         given_name: Rest of Name

--- a/plugins/lcnaf/frontend/locales/fr.yml
+++ b/plugins/lcnaf/frontend/locales/fr.yml
@@ -2,6 +2,7 @@ fr:
   plugins:
     lcnaf:
       label: Import LCNAF
+      authority: Source d'autorité
       search:
         family_name: Partie principale
         given_name: Reste du nom

--- a/plugins/lcnaf/frontend/views/lcnaf/index.html.erb
+++ b/plugins/lcnaf/frontend/views/lcnaf/index.html.erb
@@ -9,18 +9,21 @@
     <%= form_tag({:controller => :lcnaf, :action => :search}, {:id => "lcnaf_search", :class => "form-search", :method => "GET"}) do |form| %>
 
     <div class='control-group form-group required'>
-      <div class="radio">
-        <label for="lcnaf_service_loc">
-          <input type="radio" name="lcnaf_service" value="lcnaf" id="lcnaf_service_loc" checked="true">
-          LCNAF - https://id.loc.gov/authorities/names
-        </label>
-      </div>
-      <div class="radio">
+      <fieldset>
+      <legend class="sr-only"><%= I18n.t("plugins.lcnaf.authority") %></legend>
+        <div class="radio">
+          <label for="lcnaf_service_loc">
+            <input type="radio" name="lcnaf_service" value="lcnaf" id="lcnaf_service_loc" checked="true">
+            LCNAF - https://id.loc.gov/authorities/names
+          </label>
+        </div>
+        <div class="radio">
           <label for="lcsh_service_loc">
               <input type="radio" name="lcnaf_service" value="lcsh" id="lcsh_service_loc">
            LCSH - https://id.loc.gov/authorities/subjects
           </label>
-      </div>
+        </div>
+      </fieldset>
     </div>
 
     <div class='control-group form-group required'> 
@@ -38,7 +41,7 @@
     
     <div class='control-group form-group'> 
       <button type="submit" class="btn btn-primary btn-default">
-        <%= image_tag "archivesspace/btn-busy.gif", :class=>"btn-busy-icon" %>
+        <%= image_tag "archivesspace/btn-busy.gif", :class=>"btn-busy-icon", :alt=>"Loading..." %>
         <%= I18n.t("plugins.lcnaf.actions.search") %>
       </button>
     </div>
@@ -54,7 +57,7 @@
       <div class="alert alert-info"><%= I18n.t("plugins.lcnaf.messages.none_selected") %></div>
       <div id="selected"></div>
       <button id="import-selected" class="btn btn-primary btn-default" disabled="disabled">
-        <%= image_tag "archivesspace/btn-busy.gif", :class=>"btn-busy-icon" %>
+        <%= image_tag "archivesspace/btn-busy.gif", :class=>"btn-busy-icon", :alt=>"Importing..." %>
         <%= I18n.t("plugins.lcnaf.actions.import") %>
       </button>
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Several small accessibility improvements to issues discovered during post-2.8.1 release scanning.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Fixes several instances of the following types of issues:

- Adds sr-only table headings to several "Action" columns;
- Ensures translation values are used instead of hardcoded English (incidentally discovered during other work);
- Ensures "Close" buttons have sr-only text (not just a conveying their purpose through a "close" gif);
- Adds appropriate alt-text to spinner/loading gif;
- Adds some aria-labels to complex form fields (assessment attributes); and,
- Adds a fieldset/legend to LCNAF plugin import source selection.

Also includes a small change to `frontend/vendor/assets/javascripts/bootstrap-tagsinput.js` to ensure the resulting `input` has an id available for label assignment.  (This will change/be greatly improved in Bootstrap 4.)

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually confirmed, including using WAVE plugin.  Existing Selenium tests passing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
