### PR TITLE
mariadb fix for resource_list_report + extent_subreport

### DIFF
--- a/reports/custom/extent_subreport.rb
+++ b/reports/custom/extent_subreport.rb
@@ -12,9 +12,9 @@ class ExtentSubreport < AbstractSubreport
 	end
 
 
-	def query_string
+	def query_string  # keep portion keyword from blowing up on mariadb
 		"select
-			portion_id as portion,
+			portion_id as `portion`,
 			number as extent_number,
 			extent_type_id as extent_type,
 			container_summary,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
MariaDB adds 'portion' as a new keyword. This conflicts with is use in one (or more?) of the reports. 
Quoting 'portion' fixes the problem so the report doesn't blow up. 

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Without this fix, running resource_list_report using MariaDB blow up in extent_subreport.
After fix it works. It's just a more strict SQL syntax, so it should not affect anything else. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
