### PR TITLE
Confirm all notes, dates, etc. appear in view only display of subrecords

### DIFF
--- a/frontend/app/views/agent_contact_details/_show.html.erb
+++ b/frontend/app/views/agent_contact_details/_show.html.erb
@@ -6,7 +6,7 @@
 <section id="<%= section_id %>">
   <h3><%= I18n.t("agent_contact._plural") %></h3>
   <div class="accordion details" id="agent_contact_accordion">
-    <% agent_contacts.each_with_index do | contact, index | %>
+    <%= context.list_for(context["agent_contacts"], "agent_contacts[]") do |contact, index| %>
       <div class="panel panel-default">
         <div class="panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#agent_contact_accordion" href="#agent_contact_<%= index %>">
@@ -19,13 +19,15 @@
           </div>
         </div>
         <div id="agent_contact_<%= index %>" class="accordion-body collapse">
-            <%= read_only_view(contact) %>
-            <% if contact["notes"].length > 0 %>
-            <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => contact["notes"], :section_id => "contact_notes", :context => context, :heading_size => "h4" } %>
+          <%= read_only_view(contact) %>
+          <% if contact["telephones"].length > 0 %>
+            <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => { :form => context, :telephones => contact["telephones"], :template_erb => "telephones/template", :template => "telephone", :name => "telephones", :heading_size => "h4" } %>
+          <% end %>
+          <% if contact["notes"].length > 0 %>
+            <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => contact["notes"], :section_id => "#{@agent.agent_type}_agent_contacts__#{index}__notes_", :context => context, :heading_size => "h4" } %>
           <% end %>
         </div>
       </div>
     <% end %>
   </div>
 </section>
-

--- a/frontend/app/views/agent_functions/_show.html.erb
+++ b/frontend/app/views/agent_functions/_show.html.erb
@@ -7,7 +7,7 @@
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
   <div class="panel-group details" id="<%= section_id %>_accordion">
-    <% agent_functions.each_with_index do | agent_function, index | %>
+    <%= context.list_for(context["agent_functions"], "agent_functions[]") do |agent_function, index| %>
       <div class="panel panel-default">
         <div class="panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_function_<%= index %>">
@@ -35,8 +35,8 @@
           <% end %>
 
           <% if agent_function["notes"].length > 0 %>
-          <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => @agent.notes, :section_id => "agent_function_notes", :context => context, :heading_size => "h4" } %>
-        <% end %>
+            <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => agent_function["notes"], :section_id => "#{@agent.agent_type}_agent_function__#{index}__notes_", :context => context, :heading_size => "h4" } %>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/frontend/app/views/agent_genders/_show.html.erb
+++ b/frontend/app/views/agent_genders/_show.html.erb
@@ -6,7 +6,7 @@
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
   <div class="panel-group details" id="<%= section_id %>_accordion">
-    <% agent_genders.each_with_index do | agent_gender, index | %>
+    <%= context.list_for(context["agent_genders"], "agent_genders[]") do |agent_gender, index| %>
       <div class="panel panel-default">
         <div class="panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_gender_<%= index %>">
@@ -24,6 +24,12 @@
         </div>
         <div id="<%= section_id %>_agent_gender_<%= index %>" class="panel-collapse collapse">
           <%= read_only_view(agent_gender) %>
+          <% if agent_gender['dates'].length > 0 %>
+            <%= render_aspace_partial :partial => "structured_dates/show", :locals => { :dates => agent_gender['dates'], :section_id => "agent_gender_dates_#{index}", :section_title => I18n.t("agent_gender.dates"), :heading_size => "h4"} %>
+          <% end %>
+          <% if agent_gender["notes"].length > 0 %>
+            <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => agent_gender["notes"], :section_id => "#{@agent.agent_type}_agent_gender__#{index}__notes_", :context => context, :heading_size => "h4" } %>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/frontend/app/views/agent_occupations/_show.html.erb
+++ b/frontend/app/views/agent_occupations/_show.html.erb
@@ -7,7 +7,7 @@
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
   <div class="panel-group details" id="<%= section_id %>_accordion">
-    <% agent_occupations.each_with_index do | agent_occupation, index | %>
+    <%= context.list_for(context["agent_occupations"], "agent_occupations[]") do |agent_occupation, index| %>
       <div class="panel panel-default">
         <div class="panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_occupation_<%= index %>">
@@ -35,7 +35,7 @@
           <% end %>
 
           <% if agent_occupation["notes"].length > 0 %>
-          <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => @agent.notes, :section_id => "agent_occupation_notes", :context => context, :heading_size => "h4" } %>
+            <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => agent_occupation["notes"], :section_id => "#{@agent.agent_type}_agent_occupation__#{index}__notes_", :context => context, :heading_size => "h4" } %>
         <% end %>
         </div>
       </div>

--- a/frontend/app/views/agent_places/_show.html.erb
+++ b/frontend/app/views/agent_places/_show.html.erb
@@ -7,7 +7,7 @@
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
   <div class="panel-group details" id="<%= section_id %>_accordion">
-    <% agent_places.each_with_index do | agent_place, index | %>
+    <%= context.list_for(context["agent_places"], "agent_places[]") do |agent_place, index| %>
       <div class="panel panel-default">
         <div class="panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_place_<%= index %>">
@@ -20,18 +20,16 @@
           </div>
         </div>
         <div id="<%= section_id %>_agent_place_<%= index %>" class="panel-collapse collapse">
-          <% if agent_place["subjects"].length > 0 %>
-            <%= render_aspace_partial :partial => "subjects/show_inline", :locals => {:subjects => agent_place['subjects'], :section_id => "agent_place_subjects_", :section_title => I18n.t("agent_place.subjects"), :heading_size => "h4"} %>
-          <% end %>
+          <%= read_only_view(agent_place) %>
+
+          <%= render_aspace_partial :partial => "subjects/show_inline", :locals => {:subjects => agent_place['subjects'], :role => agent_place['place_role_enum'], :section_id => "agent_place_subjects_", :section_title => I18n.t("agent_place.subjects"), :heading_size => "h4"} %>
 
           <% if agent_place["dates"].length > 0 %>
             <%= render_aspace_partial :partial => "structured_dates/show", :locals => { :dates => agent_place['dates'], :section_id => "agent_place_dates", :section_title => I18n.t("agent_place.dates"), :heading_size => "h4"} %>
           <% end %>
 
           <% if agent_place["notes"].length > 0 %>
-          <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => @agent.notes, :section_id => "agent_place_notes", :context => context, :heading_size => "h4" } %>
-
-          <%= read_only_view(agent_place) %>
+            <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => agent_place["notes"], :section_id => "#{@agent.agent_type}_agent_place__#{index}__notes_", :context => context, :heading_size => "h4" } %>
         <% end %>
         </div>
       </div>

--- a/frontend/app/views/agent_topics/_show.html.erb
+++ b/frontend/app/views/agent_topics/_show.html.erb
@@ -7,7 +7,7 @@
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
   <div class="panel-group details" id="<%= section_id %>_accordion">
-    <% agent_topics.each_with_index do | agent_topic, index | %>
+    <%= context.list_for(context["agent_topics"], "agent_topics[]") do |agent_topic, index| %>
       <div class="panel panel-default">
         <div class="panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_topic_<%= index %>">
@@ -35,8 +35,8 @@
           <% end %>
 
           <% if agent_topic["notes"].length > 0 %>
-          <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => @agent.notes, :section_id => "agent_topic_notes", :context => context, :heading_size => "h4" } %>
-        <% end %>
+            <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => agent_topic["notes"], :section_id => "#{@agent.agent_type}_agent_topic__#{index}__notes_", :context => context, :heading_size => "h4" } %>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/frontend/app/views/agents/show.html.erb
+++ b/frontend/app/views/agents/show.html.erb
@@ -66,7 +66,7 @@
         <% end %>
 
         <% if @agent_type == :agent_person && @agent.agent_genders.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_genders/show", :locals => { :agent_genders => @agent.agent_genders, :section_id => "#{@agent.agent_type}_agent_gender" } %>
+          <%= render_aspace_partial :partial => "agent_genders/show", :locals => { :agent_genders => @agent.agent_genders, :section_id => "#{@agent.agent_type}_agent_gender", :context => readonly } %>
         <% end %>
 
         <% if @agent.agent_places.length > 0 %>

--- a/frontend/app/views/notes/_show.html.erb
+++ b/frontend/app/views/notes/_show.html.erb
@@ -29,12 +29,13 @@
    all_note_types["Bibliography"] = :note_bibliography
 
    section_id = "notes" if section_id.blank?
+   heading_size = "h3" if heading_size.blank?
 %>
 
 <%= render_aspace_partial :partial => "notes/template" %>
 
 <section id="<%= section_id %>" class="subrecord-form">
-  <h3 class="subrecord-form-heading"><%= I18n.t("note._plural") %></h3>
+  <<%= heading_size %> class="subrecord-form-heading"><%= I18n.t("note._plural") %></<%= heading_size %>>
   <div class="subrecord-form-container">
     <%= context.list_for(context["notes"], "notes[]") do |note| %>
       <% context.emit_template(note["jsonmodel_type"]) %>

--- a/frontend/app/views/related_agents/_show.html.erb
+++ b/frontend/app/views/related_agents/_show.html.erb
@@ -5,7 +5,11 @@
   <div class="subrecord-form-container">
     <%= context.list_for(context["related_agents"], "related_agents[]") do |related_agent| %>
       <% context.emit_template(related_agent["jsonmodel_type"], :readonly => true) %>
+      <% if !related_agent["dates"].blank? %>
+        <% dates = [] %>
+        <% dates << related_agent["dates"] %>
+        <%= render_aspace_partial :partial => "structured_dates/show", :locals => { :dates => dates, :section_id => "related_agent_dates", :section_title => I18n.t("related_agent.dates"), :heading_size => "h4"} %>
+      <% end %>
     <% end %>
   </div>
 </section>
-

--- a/frontend/app/views/used_languages/_show.html.erb
+++ b/frontend/app/views/used_languages/_show.html.erb
@@ -6,7 +6,7 @@
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
   <div class="panel-group details" id="<%= section_id %>_accordion">
-    <% used_languages.each_with_index do | used_language, index | %>
+    <%= context.list_for(context["used_languages"], "used_languages[]") do |used_language, index| %>
       <div class="panel panel-default">
         <div class="panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_used_language_<%= index %>">
@@ -25,7 +25,7 @@
         <div id="<%= section_id %>_used_language_<%= index %>" class="panel-collapse collapse">
           <%= read_only_view(used_language) %>
           <% if used_language["notes"].length > 0 %>
-            <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => used_language["notes"], :section_id => "used_language_notes", :context => context, :heading_size => "h4" } %>
+            <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => used_language["notes"], :section_id => "#{@agent.agent_type}_used_language__#{index}__notes_", :context => context, :heading_size => "h4" } %>
           <% end %>
         </div>
       </div>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1912,6 +1912,7 @@ en:
     text_note: Note
     dates: Dates
     subjects: Places
+    publish: Published
 
   agent_place_required:
     <<: *agent_place_attributes
@@ -1937,6 +1938,7 @@ en:
     dates: Dates
     subjects: Occupations
     places: Places
+    publish: Published
 
   agent_occupation_required:
     <<: *agent_occupation_attributes
@@ -1962,6 +1964,7 @@ en:
     dates: Dates
     subjects: Functions
     places: Places
+    publish: Published
 
   agent_function_required:
     <<: *agent_function_attributes
@@ -1987,6 +1990,7 @@ en:
     dates: Dates
     subjects: Topics
     places: Places
+    publish: Published
 
   agent_topic_required:
     <<: *agent_topic_attributes
@@ -2178,6 +2182,7 @@ en:
     _singular: Related External Resource
     dates: Dates
     places: Places
+    publish: Published
     linked_agent_role: Resource Relation Type
     linked_resource: Related External Resource
     linked_resource_description: Description


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Ensures that all subrecords' subrecords (e.g. notes, dates, telephones, etc.) display in the view-only views of a new/full agent record.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
