### PR TITLE
Staff sidebar enhancements for agents

### DIFF
--- a/backend/spec/model_agent_corporate_entity_spec.rb
+++ b/backend/spec/model_agent_corporate_entity_spec.rb
@@ -154,7 +154,7 @@ describe 'Agent model' do
         )
 
         expect(agent_corporate_entity1[:slug]).to match("foo")
-        expect(agent_corporate_entity2[:slug]).to match("foo_2")
+        expect(agent_corporate_entity2[:slug]).to match("foo_1")
       end
 
 

--- a/backend/spec/model_agent_family_spec.rb
+++ b/backend/spec/model_agent_family_spec.rb
@@ -161,7 +161,7 @@ describe 'Agent Family model' do
           )
 
           expect(agent_family1[:slug]).to match("foo")
-          expect(agent_family2[:slug]).to match("foo_2")
+          expect(agent_family2[:slug]).to match("foo_1")
         end
 
 

--- a/backend/spec/model_agent_person_spec.rb
+++ b/backend/spec/model_agent_person_spec.rb
@@ -547,8 +547,8 @@ describe 'Agent model' do
                 :names => [agent_name_person2])
           )
 
-          expect(agent_person1[:slug]).to match("foo_1")
-          expect(agent_person2[:slug]).to match("foo_2")
+          expect(agent_person1[:slug]).to match("foo")
+          expect(agent_person2[:slug]).to match("foo_1")
         end
 
 

--- a/backend/spec/model_agent_software_spec.rb
+++ b/backend/spec/model_agent_software_spec.rb
@@ -156,8 +156,8 @@ describe 'Agent model' do
                 :names => [agent_name_software2])
           )
 
-          expect(agent_software1[:slug]).to eq("foo_1")
-          expect(agent_software2[:slug]).to eq("foo_2")
+          expect(agent_software1[:slug]).to eq("foo")
+          expect(agent_software2[:slug]).to eq("foo_1")
         end
 
 

--- a/common/db/migrations/002_missing_date_foreign_keys.rb
+++ b/common/db/migrations/002_missing_date_foreign_keys.rb
@@ -14,26 +14,7 @@ Sequel.migration do
   end
 
   down do
-    foreign_keys = ['agent_person_date_fk',
-                    'agent_family_date_fk',
-                    'agent_corporate_entity_date_fk',
-                    'agent_software_date_fk',
-                    'name_person_date_fk',
-                    'name_family_date_fk',
-                    'name_corporate_entity_date_fk',
-                    'name_software_date_fk']
-
-
-    foreign_keys.each do |fk|
-      alter_table(:date) do
-        drop_constraint(fk)
-      end
-
-      if $db_type == :mysql
-        self.run("alter table date drop foreign key #{fk}")
-      end
-    end
+    # Removed due to changes to foreign keys as part of ANW-429. You can't downgrade anyway.
   end
 
 end
-

--- a/common/locales/enums/en.yml
+++ b/common/locales/enums/en.yml
@@ -1987,6 +1987,6 @@ en:
     maintenance_agent_type: Maintenence Agent Type
     gender: Gender
     place_role: Place Role
-    date_type: Date Type
+    date_type_structured: Date Type
     date_standardized_type: Date Standardized Type
     date_role: Date Role

--- a/frontend/app/assets/javascripts/utils.js
+++ b/frontend/app/assets/javascripts/utils.js
@@ -85,7 +85,7 @@ $(function() {
       return;
     }
     $(".nav-list-record-count").remove();
-    $("#archivesSpaceSidebar .as-nav-list > li").each(function() {
+    $("#archivesSpaceSidebar .as-nav-list > li:not(.sidebar-heading)").each(function() {
       var $nav = $(this);
       var $link = $("a", $nav);
       var $section = $($link.attr("href"));

--- a/frontend/app/assets/stylesheets/archivesspace/sidebar.less
+++ b/frontend/app/assets/stylesheets/archivesspace/sidebar.less
@@ -6,8 +6,16 @@
   padding: 0;
   box-shadow: 0 1px 4px rgba(0,0,0,.065);
 
-  > li {
+  > li[class^="sidebar-heading"], li[class*=" sidebar-heading"] {
 
+    > a {
+      background-color: #F6F6F6;
+
+    }
+
+  }
+
+  > li{
 
     > a {
       display: block;
@@ -169,9 +177,9 @@
   }
 
 .as-nav-list.affix-bottom {
-  position: absolute !important;
+  position: fixed;
   top: auto;
-  bottom: 0px;
+  bottom: 75px;
 }
 
 /* Desktop large

--- a/frontend/app/helpers/sidebar_helper.rb
+++ b/frontend/app/helpers/sidebar_helper.rb
@@ -22,8 +22,10 @@ module SidebarHelper
 
       record = @opts[:record]
       property = opts[:property]
+      sidebar_heading = opts[:sidebar_heading]
+      sidebar_children = opts[:sidebar_children] || []
 
-      if @form.controller.action_name != "show" || property == :none || !record[property].blank?
+      if @form.controller.action_name != "show" || property == :none || !record[property].blank? || (sidebar_heading == true && !sidebar_children.map { |c| record[c]}.flatten.compact.blank?)
         render_entry(opts)
       end
     end
@@ -34,8 +36,9 @@ module SidebarHelper
 
       record = @opts[:record]
       property = opts[:property]
+      sidebar_heading = opts[:sidebar_heading]
 
-      if @form.controller.action_name == "show" && (!record[property].blank? || property == :none)
+      if @form.controller.action_name == "show" && (!record[property].blank? || property == :none || sidebar_heading == true)
         render_entry(opts)
       end
     end

--- a/frontend/app/views/agents/_sidebar.html.erb
+++ b/frontend/app/views/agents/_sidebar.html.erb
@@ -3,100 +3,210 @@
              :record_type => 'agent',
              :record => @agent,
              :plusone => :submit,
-             :suppress_basic_information => true,
              :save_button_text => I18n.t("#{@agent.agent_type}._frontend.action.save")
            }) do |sidebar| %>
 
-    <% if action_name != "show" %>
-      <%= render_aspace_partial :partial => "shared/sidebar_heading", :locals => {:anchor => "basic_information", :title => "Basic Information"} %>
+    <%= sidebar.render_for_view_and_edit(
+      :subrecord_type => 'record_control_information',
+      :property => 'record_control_information',
+      :anchor => "record_control_information",
+      :sidebar_heading => true,
+      :sidebar_children => [:agent_record_identifiers,
+                            :agent_record_controls,
+                            :agent_other_agency_codes,
+                            :agent_conventions_declarations,
+                            :agent_maintenance_histories,
+                            :agent_sources,
+                            :agent_alternate_sets]) %>
 
-      <%= render_aspace_partial :partial => "shared/sidebar_heading", :locals => {:anchor => "record_control_information", :title => "Record Control Information"} %>
-    <% end %>
+      <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => 'agent_record_identifier',
+        :property => 'agent_record_identifiers',
+        :anchor => "#{@agent.agent_type}_agent_record_identifier",
+        :subentry => true) %>
 
+      <% if full_mode? || action_name == "show" %>
+        <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => 'agent_record_control',
+        :property => 'agent_record_controls',
+        :anchor => "#{@agent.agent_type}_agent_record_control",
+        :subentry => true) %>
 
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_record_identifier', :property => 'agent_record_identifiers', :anchor => "#{@agent.agent_type}_agent_record_identifier") %>
+        <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => 'agent_other_agency_code',
+        :property => 'agent_other_agency_codes',
+        :anchor => "#{@agent.agent_type}_agent_other_agency_codes",
+        :subentry => true) %>
 
+        <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => 'agent_conventions_declaration',
+        :property => 'agent_conventions_declarations',
+        :anchor => "#{@agent.agent_type}_agent_conventions_declaration",
+        :subentry => true) %>
 
-   <% if full_mode? || action_name == "show" %>
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_record_control', :property => 'agent_record_controls', :anchor => "#{@agent.agent_type}_agent_record_control") %>
+        <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => 'agent_maintenance_history',
+        :property => 'agent_maintenance_histories',
+        :anchor => "#{@agent.agent_type}_agent_maintenance_history",
+        :subentry => true) %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_other_agency_code', :property => 'agent_other_agency_codes', :anchor => "#{@agent.agent_type}_agent_other_agency_codes") %>
+        <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => 'agent_source',
+        :property => 'agent_sources',
+        :anchor => "#{@agent.agent_type}_agent_sources",
+        :subentry => true) %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_conventions_declaration', :property => 'agent_conventions_declarations', :anchor => "#{@agent.agent_type}_agent_conventions_declaration") %>
-
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_maintenance_history', :property => 'agent_maintenance_histories', :anchor => "#{@agent.agent_type}_agent_maintenance_history") %>
-
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_source', :property => 'agent_sources', :anchor => "#{@agent.agent_type}_agent_sources") %>
-
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_alternate_set', :property => 'agent_alternate_sets', :anchor => "#{@agent.agent_type}_agent_alternate_set") %>
-   <% end %>
-
-    <% if action_name != "show" %>
-        <%= render_aspace_partial :partial => "shared/sidebar_heading", :locals => {:anchor => "identity_information", :title => "Identity Information"} %>
-    <% end %>
-
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_identifier', :property => 'agent_identifiers', :anchor => "#{@agent.agent_type}_agent_identifier") %>
-
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_name', :property => 'names', :anchor => "#{@agent.agent_type}_names") %>
-
-
-    <% if action_name != "show" %>
-        <%= render_aspace_partial :partial => "shared/sidebar_heading", :locals => {:anchor => "description_information", :title => "Description Information"} %>
-    <% end %>
-
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'dates_of_existence', :property => 'dates_of_existence',
-                                         :anchor => "#{@agent.agent_type}_dates_of_existence") %>
-
-
-   <% if full_mode? || action_name == "show" %>
-
-    <% if @agent.agent_type == "agent_person" %>
-        <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_gender', :property => 'agent_genders', :anchor => "agent_person_agent_gender") %>
-    <% end %>
-
-
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_place', :property => 'agent_places',
-                                         :anchor => "#{@agent.agent_type}_agent_place") %>
-
-      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_occupation', :property => 'agent_occupations',
-                                           :anchor => "#{@agent.agent_type}_agent_occupation") %>
- 
-      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_function', :property => 'agent_functions',
-                                           :anchor => "#{@agent.agent_type}_agent_function") %>
-
-      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_topic', :property => 'agent_topics',
-                                           :anchor => "#{@agent.agent_type}_agent_topic") %>
-
-      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'used_language', :property => 'used_languages',
-                                         :anchor => "#{@agent.agent_type}_used_language") %>
-
-    <% end %>
+        <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => 'agent_alternate_set',
+        :property => 'agent_alternate_sets',
+        :anchor => "#{@agent.agent_type}_agent_alternate_set",
+        :subentry => true) %>
+      <% end %>
 
 
-    <% if user_can?('view_agent_contact_record') %>
-      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_contact', :property => 'agent_contacts', :anchor => "#{@agent.agent_type}_contact_details") %>
-    <% end %>
+    <%= sidebar.render_for_view_and_edit(
+      :subrecord_type => "identity_information",
+      :property => "identity_information",
+      :anchor => "identity_information",
+      :sidebar_heading => true,
+      :sidebar_children => [:agent_identifiers,
+                            :names]) %>
 
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'note', :property => 'notes', :anchor => "#{@agent.agent_type}_notes") %>
+      <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => 'agent_identifier',
+        :property => 'agent_identifiers',
+        :anchor => "#{@agent.agent_type}_agent_identifier",
+        :subentry => true) %>
 
+      <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => 'agent_name',
+        :property => 'names',
+        :anchor => "#{@agent.agent_type}_names",
+        :subentry => true) %>
 
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_document', :property => "external_documents", :anchor => "#{@agent.agent_type}_external_documents") %>
+    <%= sidebar.render_for_view_and_edit(
+      :subrecord_type => "description_information",
+      :property => "description_information",
+      :anchor => "description_information",
+      :sidebar_heading => true,
+      :sidebar_children => [:dates_of_existence,
+                            :agent_genders,
+                            :agent_places,
+                            :agent_occupations,
+                            :agent_functions,
+                            :agent_topics,
+                            :used_languages,
+                            :agent_contacts,
+                            :notes,
+                            :external_documents]) %>
 
-    <% if action_name != "show" %>
-        <%= render_aspace_partial :partial => "shared/sidebar_heading", :locals => {:anchor => "relation_information", :title => "Relation Information"} %>
-    <% end %>
+      <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => 'dates_of_existence',
+        :property => 'dates_of_existence',
+        :anchor => "#{@agent.agent_type}_dates_of_existence",
+        :subentry => true) %>
 
-   <% if full_mode? || action_name == "show" %>
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_resource', :property => 'agent_resources',
-                                         :anchor => "#{@agent.agent_type}_agent_resource") %>
+      <% if full_mode? || action_name == "show" %>
 
-   <% end %>
+        <% if @agent.agent_type == "agent_person" %>
+          <%= sidebar.render_for_view_and_edit(
+          :subrecord_type => 'agent_gender',
+          :property => 'agent_genders',
+          :anchor => "agent_person_agent_gender",
+          :subentry => true) %>
+        <% end %>
 
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'related_agent', :property => 'related_agents', :anchor => "related_agents") %>
+        <%= sidebar.render_for_view_and_edit(
+          :subrecord_type => 'agent_place',
+          :property => 'agent_places',
+          :anchor => "#{@agent.agent_type}_agent_place",
+          :subentry => true) %>
 
-    <%= sidebar.render_for_view_only(:subrecord_type => 'search_embedded', :property => :none, :anchor => 'search_embedded') %>
+        <%= sidebar.render_for_view_and_edit(
+          :subrecord_type => 'agent_occupation',
+          :property => 'agent_occupations',
+          :anchor => "#{@agent.agent_type}_agent_occupation",
+          :subentry => true) %>
+
+        <%= sidebar.render_for_view_and_edit(
+          :subrecord_type => 'agent_function',
+          :property => 'agent_functions',
+          :anchor => "#{@agent.agent_type}_agent_function",
+          :subentry => true) %>
+
+        <%= sidebar.render_for_view_and_edit(
+          :subrecord_type => 'agent_topic',
+          :property => 'agent_topics',
+          :anchor => "#{@agent.agent_type}_agent_topic",
+          :subentry => true) %>
+
+        <%= sidebar.render_for_view_and_edit(
+          :subrecord_type => 'used_language',
+          :property => 'used_languages',
+          :anchor => "#{@agent.agent_type}_used_language",
+          :subentry => true) %>
+
+      <% end %>
+
+      <% if user_can?('view_agent_contact_record') %>
+        <%= sidebar.render_for_view_and_edit(
+          :subrecord_type => 'agent_contact',
+          :property => 'agent_contacts',
+          :anchor => "#{@agent.agent_type}_contact_details",
+          :subentry => true) %>
+      <% end %>
+
+      <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => 'note',
+        :property => 'notes',
+        :anchor => "#{@agent.agent_type}_notes",
+        :subentry => true) %>
+
+      <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => 'external_document',
+        :property => "external_documents",
+        :anchor => "#{@agent.agent_type}_external_documents",
+        :subentry => true) %>
+
+    <%= sidebar.render_for_view_and_edit(
+      :subrecord_type => "relation_information",
+      :property => "relation_information",
+      :anchor => "relation_information",
+      :sidebar_heading => true,
+      :sidebar_children => [:agent_resources,
+                            :related_agents]) %>
+
+      <% if full_mode? || action_name == "show" %>
+        <%= sidebar.render_for_view_and_edit(
+          :subrecord_type => 'agent_resource',
+          :property => 'agent_resources',
+          :anchor => "#{@agent.agent_type}_agent_resource",
+          :subentry => true) %>
+      <% end %>
+
+      <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => 'related_agent',
+        :property => 'related_agents',
+        :anchor => "related_agents",
+        :subentry => true) %>
+
+    <%= sidebar.render_for_view_only(
+      :subrecord_type => 'search_embedded',
+      :property => :none,
+      :anchor => 'search_embedded') %>
+
     <% if @agent.agent_type == 'agent_person' %>
-      <%= sidebar.render_for_view_only(:title => I18n.t('assessment._frontend.linked_records.linked_via_assessment_surveyed_by'), :subrecord_type => 'assessment', :property => :none, :anchor => 'linked_assessments_surveyed_by') %>
-      <%= sidebar.render_for_view_only(:title => I18n.t('assessment._frontend.linked_records.linked_via_assessment_reviewer'), :subrecord_type => 'assessment', :property => :none, :anchor => 'linked_assessments_reviewer') %>
+      <%= sidebar.render_for_view_only(
+        :title => I18n.t('assessment._frontend.linked_records.linked_via_assessment_surveyed_by'),
+        :subrecord_type => 'assessment',
+        :property => :none,
+        :anchor => 'linked_assessments_surveyed_by') %>
+
+      <%= sidebar.render_for_view_only(
+        :title => I18n.t('assessment._frontend.linked_records.linked_via_assessment_reviewer'),
+        :subrecord_type => 'assessment',
+        :property => :none,
+        :anchor => 'linked_assessments_reviewer') %>
     <% end %>
+
 <% end %>

--- a/frontend/app/views/agents/show.html.erb
+++ b/frontend/app/views/agents/show.html.erb
@@ -27,97 +27,142 @@
           <%= display_audit_info(@agent) %>
         </section>
 
-        <% if @agent.agent_record_identifiers.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_record_identifiers/show", :locals => { :agent_record_identifiers => @agent.agent_record_identifiers, :section_id => "#{@agent.agent_type}_agent_record_identifier" } %>
+        <% if ![:agent_record_identifiers, :agent_record_controls, :agent_other_agency_codes, :agent_conventions_declarations, :agent_maintenance_histories, :agent_sources, :agent_alternate_sets].map {|k| @agent[k]}.flatten.compact.blank? %>
+          <section id="record_control_information" class="agents-subsection">
+            <h3>
+              <%= I18n.t("agent._frontend.section.record_control_information") %>
+            </h3>
+
+            <% if @agent.agent_record_identifiers.length > 0 %>
+              <%= render_aspace_partial :partial => "agent_record_identifiers/show", :locals => { :agent_record_identifiers => @agent.agent_record_identifiers, :section_id => "#{@agent.agent_type}_agent_record_identifier" } %>
+            <% end %>
+
+            <% if @agent.agent_record_controls.length > 0 %>
+              <%= render_aspace_partial :partial => "agent_record_controls/show", :locals => { :agent_record_controls => @agent.agent_record_controls, :section_id => "#{@agent.agent_type}_agent_record_control" } %>
+            <% end %>
+
+            <% if @agent.agent_other_agency_codes.length > 0 %>
+              <%= render_aspace_partial :partial => "agent_other_agency_codes/show", :locals => { :agent_other_agency_codes => @agent.agent_other_agency_codes, :section_id => "#{@agent.agent_type}_agent_other_agency_codes" } %>
+            <% end %>
+
+            <% if @agent.agent_conventions_declarations.length > 0 %>
+              <%= render_aspace_partial :partial => "agent_conventions_declarations/show", :locals => { :agent_conventions_declarations => @agent.agent_conventions_declarations, :section_id => "#{@agent.agent_type}_agent_conventions_declaration" } %>
+            <% end %>
+
+            <% if @agent.agent_maintenance_histories.length > 0 %>
+              <%= render_aspace_partial :partial => "agent_maintenance_histories/show", :locals => { :agent_maintenance_histories => @agent.agent_maintenance_histories, :section_id => "#{@agent.agent_type}_agent_maintenance_history" } %>
+            <% end %>
+
+            <% if @agent.agent_sources.length > 0 %>
+              <%= render_aspace_partial :partial => "agent_sources/show", :locals => { :agent_sources => @agent.agent_sources, :section_id => "#{@agent.agent_type}_agent_sources" } %>
+            <% end %>
+
+            <% if @agent.agent_alternate_sets.length > 0 %>
+              <%= render_aspace_partial :partial => "agent_alternate_sets/show", :locals => { :agent_alternate_sets => @agent.agent_alternate_sets, :section_id => "#{@agent.agent_type}_agent_alternate_set" } %>
+            <% end %>
+
+          </section>
         <% end %>
 
-        <% if @agent.agent_record_controls.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_record_controls/show", :locals => { :agent_record_controls => @agent.agent_record_controls, :section_id => "#{@agent.agent_type}_agent_record_control" } %>
+        <section id="identity_information" class="agents-subsection">
+          <h3>
+            <%= I18n.t("agent._frontend.section.identity_information") %>
+          </h3>
+
+          <% if @agent.agent_identifiers.length > 0 %>
+            <%= render_aspace_partial :partial => "agent_identifiers/show", :locals => { :agent_identifiers => @agent.agent_identifiers, :section_id => "#{@agent.agent_type}_agent_identifier" } %>
+          <% end %>
+
+          <%= render_aspace_partial :partial => "agent_names/show", :locals => { :agent => @agent} %>
+
+        </section>
+
+        <% if ![:dates_of_existence, :agent_genders, :agent_places, :agent_occupations, :agent_functions, :agent_topics, :used_languages, :agent_contacts, :notes, :external_documents].map {|k| @agent[k]}.flatten.compact.blank? %>
+          <section id="description_information"  class="agents-subsection">
+            <h3>
+              <%= I18n.t("agent._frontend.section.description_information") %>
+            </h3>
+
+            <% if @agent.dates_of_existence.length > 0 %>
+              <%= render_aspace_partial :partial => "structured_dates/show", :locals => { :dates => @agent.dates_of_existence, :section_title => I18n.t("agent.dates_of_existence"), :section_id => "#{@agent.agent_type}_dates_of_existence"} %>
+            <% end %>
+
+            <% if @agent_type == :agent_person && @agent.agent_genders.length > 0 %>
+              <%= render_aspace_partial :partial => "agent_genders/show", :locals => { :agent_genders => @agent.agent_genders, :section_id => "#{@agent.agent_type}_agent_gender", :context => readonly } %>
+            <% end %>
+
+            <% if @agent.agent_places.length > 0 %>
+              <%= render_aspace_partial :partial => "agent_places/show", :locals => { :agent_places => @agent.agent_places, :section_id => "#{@agent.agent_type}_agent_place", :context => readonly } %>
+            <% end %>
+
+            <% if @agent.agent_occupations.length > 0 %>
+              <%= render_aspace_partial :partial => "agent_occupations/show", :locals => { :agent_occupations => @agent.agent_occupations, :section_id => "#{@agent.agent_type}_agent_occupation", :context => readonly } %>
+            <% end %>
+
+            <% if @agent.agent_functions.length > 0 %>
+              <%= render_aspace_partial :partial => "agent_functions/show", :locals => { :agent_functions => @agent.agent_functions, :section_id => "#{@agent.agent_type}_agent_function", :context => readonly } %>
+            <% end %>
+
+            <% if @agent.agent_topics.length > 0 %>
+              <%= render_aspace_partial :partial => "agent_topics/show", :locals => { :agent_topics => @agent.agent_topics, :section_id => "#{@agent.agent_type}_agent_topic", :context => readonly } %>
+            <% end %>
+
+            <% if @agent.used_languages.length > 0 %>
+              <%= render_aspace_partial :partial => "used_languages/show", :locals => { :used_languages => @agent.used_languages, :section_id => "#{@agent.agent_type}_used_language", :context => readonly } %>
+            <% end %>
+
+            <% if @agent.agent_contacts.length > 0 && user_can?('view_agent_contact_record') %>
+              <%= render_aspace_partial :partial => "agent_contact_details/show", :locals => { :agent_contacts => @agent.agent_contacts, :section_id => "#{@agent.agent_type}_contact_details", :context => readonly } %>
+            <% end %>
+
+            <% if @agent.notes.length > 0 %>
+              <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => @agent.notes, :context => readonly, :section_id => "#{@agent.agent_type}_notes" } %>
+            <% end %>
+
+            <% if @agent.external_documents.length > 0 %>
+              <%= render_aspace_partial :partial => "external_documents/show", :locals => { :external_documents => @agent.external_documents, :section_id => "#{@agent.agent_type}_external_documents" } %>
+            <% end %>
+
+          </section>
         <% end %>
 
-        <% if @agent.agent_other_agency_codes.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_other_agency_codes/show", :locals => { :agent_other_agency_codes => @agent.agent_other_agency_codes, :section_id => "#{@agent.agent_type}_agent_other_agency_codes" } %>
+        <% if ![:agent_resources, :related_agents].map {|k| @agent[k]}.flatten.compact.blank? %>
+          <section id="relation_information" class="agents-subsection">
+            <h3>
+              <%= I18n.t("agent._frontend.section.relation_information") %>
+            </h3>
+
+            <% if @agent.agent_resources.length > 0 %>
+              <%= render_aspace_partial :partial => "agent_resources/show", :locals => { :agent_resources => @agent.agent_resources, :section_id => "#{@agent.agent_type}_agent_resource", :context => readonly } %>
+            <% end %>
+
+
+            <% if !@agent['related_agents'].blank? %>
+              <%= render_aspace_partial :partial => "related_agents/show", :locals => { :related_agents => @agent.related_agents, :context => readonly, :section_id => "related_agents" } %>
+            <% end %>
+
+          </section>
         <% end %>
 
-        <% if @agent.agent_conventions_declarations.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_conventions_declarations/show", :locals => { :agent_conventions_declarations => @agent.agent_conventions_declarations, :section_id => "#{@agent.agent_type}_agent_conventions_declaration" } %>
-        <% end %>
+        <%= render_aspace_partial :partial => "search/embedded", :locals => {
+          :filter_term => {"agent_uris" => @agent.uri}.to_json,
+          :heading_text => I18n.t("agent._frontend.section.search_embedded")
+        } %>
 
-        <% if @agent.agent_maintenance_histories.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_maintenance_histories/show", :locals => { :agent_maintenance_histories => @agent.agent_maintenance_histories, :section_id => "#{@agent.agent_type}_agent_maintenance_history" } %>
-        <% end %>
+        <%= render_aspace_partial :partial => "search/embedded", :locals => {
+          :filter_term => {"rights_statement_agent_uris" => @agent.uri}.to_json,
+          :heading_text => I18n.t("agent._frontend.section.linked_via_rights_statement")
+        } %>
 
-        <% if @agent.agent_sources.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_sources/show", :locals => { :agent_sources => @agent.agent_sources, :section_id => "#{@agent.agent_type}_agent_sources" } %>
-        <% end %>
-
-        <% if @agent.agent_alternate_sets.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_alternate_sets/show", :locals => { :agent_alternate_sets => @agent.agent_alternate_sets, :section_id => "#{@agent.agent_type}_agent_alternate_set" } %>
-        <% end %>
-
-        <% if @agent.agent_identifiers.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_identifiers/show", :locals => { :agent_identifiers => @agent.agent_identifiers, :section_id => "#{@agent.agent_type}_agent_identifier" } %>
-        <% end %>
-
-        <%= render_aspace_partial :partial => "agent_names/show", :locals => { :agent => @agent} %>
-
-        <% if @agent.dates_of_existence.length > 0 %>
-          <%= render_aspace_partial :partial => "structured_dates/show", :locals => { :dates => @agent.dates_of_existence, :section_title => I18n.t("agent.dates_of_existence"), :section_id => "#{@agent.agent_type}_dates_of_existence"} %>
-        <% end %>
-
-        <% if @agent_type == :agent_person && @agent.agent_genders.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_genders/show", :locals => { :agent_genders => @agent.agent_genders, :section_id => "#{@agent.agent_type}_agent_gender", :context => readonly } %>
-        <% end %>
-
-        <% if @agent.agent_places.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_places/show", :locals => { :agent_places => @agent.agent_places, :section_id => "#{@agent.agent_type}_agent_place", :context => readonly } %>
-        <% end %>
-
-        <% if @agent.agent_occupations.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_occupations/show", :locals => { :agent_occupations => @agent.agent_occupations, :section_id => "#{@agent.agent_type}_agent_occupation", :context => readonly } %>
-        <% end %>
-
-        <% if @agent.agent_functions.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_functions/show", :locals => { :agent_functions => @agent.agent_functions, :section_id => "#{@agent.agent_type}_agent_function", :context => readonly } %>
-        <% end %>
-
-        <% if @agent.agent_topics.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_topics/show", :locals => { :agent_topics => @agent.agent_topics, :section_id => "#{@agent.agent_type}_agent_topic", :context => readonly } %>
-        <% end %>        
- 
-        <% if @agent.used_languages.length > 0 %>
-          <%= render_aspace_partial :partial => "used_languages/show", :locals => { :used_languages => @agent.used_languages, :section_id => "#{@agent.agent_type}_used_language", :context => readonly } %>
-        <% end %>
-
-        <% if @agent.agent_contacts.length > 0 && user_can?('view_agent_contact_record') %>
-          <%= render_aspace_partial :partial => "agent_contact_details/show", :locals => { :agent_contacts => @agent.agent_contacts, :section_id => "#{@agent.agent_type}_contact_details", :context => readonly } %>
-        <% end %>
-
-        <% if @agent.notes.length > 0 %>
-          <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => @agent.notes, :context => readonly, :section_id => "#{@agent.agent_type}_notes" } %>
-        <% end %>
-
-        <% if @agent.external_documents.length > 0 %>
-          <%= render_aspace_partial :partial => "external_documents/show", :locals => { :external_documents => @agent.external_documents, :section_id => "#{@agent.agent_type}_external_documents" } %>
-        <% end %>
-        
-        <% if @agent.agent_resources.length > 0 %>
-          <%= render_aspace_partial :partial => "agent_resources/show", :locals => { :agent_resources => @agent.agent_resources, :section_id => "#{@agent.agent_type}_agent_resource", :context => readonly } %>
-        <% end %>        
- 
-
-        <% if !@agent['related_agents'].blank? %>
-          <%= render_aspace_partial :partial => "related_agents/show", :locals => { :related_agents => @agent.related_agents, :context => readonly, :section_id => "related_agents" } %>
-        <% end %>
-
-        <%= render_aspace_partial :partial => "search/embedded", :locals => {:filter_term => {"agent_uris" => @agent.uri}.to_json, :heading_text => I18n.t("agent._frontend.section.search_embedded")} %>
-
-        <%= render_aspace_partial :partial => "search/embedded", :locals => {:filter_term => {"rights_statement_agent_uris" => @agent.uri}.to_json, :heading_text => I18n.t("agent._frontend.section.linked_via_rights_statement")} %>
-
-        <%= render_aspace_partial :partial => "search/embedded", :locals => { :record => @agent, :filter_term => {"linked_record_uris" => @agent.uri}.to_json, :heading_text => I18n.t("event._plural")} %>
+        <%= render_aspace_partial :partial => "search/embedded", :locals => {
+          :record => @agent,
+          :filter_term => {"linked_record_uris" => @agent.uri}.to_json,
+          :heading_text => I18n.t("event._plural")
+        } %>
 
         <% if @agent.agent_type == 'agent_person' %>
           <%= render_aspace_partial :partial => "assessments/embedded", :locals => { :record => @agent, :filter_term => {"assessment_surveyor_uris" => @agent.uri}.to_json, :heading_text => I18n.t("assessment._frontend.linked_records.linked_via_assessment_surveyed_by"), :section_id => 'linked_assessments_surveyed_by'} %>
+
           <%= render_aspace_partial :partial => "assessments/embedded", :locals => { :record => @agent, :filter_term => {"assessment_reviewer_uris" => @agent.uri}.to_json, :heading_text => I18n.t("assessment._frontend.linked_records.linked_via_assessment_reviewer"), :section_id => 'linked_assessments_reviewer'} %>
         <% end %>
 

--- a/frontend/app/views/shared/_sidebar_entry.html.erb
+++ b/frontend/app/views/shared/_sidebar_entry.html.erb
@@ -7,6 +7,14 @@
                      :default => I18n.t("#{subrecord_type}._plural"))
    end
    subentry = nil if !defined?(subentry)
+   sidebar_heading = nil if !defined?(sidebar_heading)
 %>
 
-<li class="sidebar-entry-<%= anchor %>"><a href="#<%= anchor %>" style="<%= "padding-left: 25px !important;" if !subentry.nil? %>"><%= title %> <span class="glyphicon glyphicon-chevron-right"></span></a></li>
+<li class="sidebar-entry-<%= anchor %> <%= "sidebar-heading" if sidebar_heading %>">
+  <a href="#<%= anchor %>" style="<%= "padding-left: 25px !important;" if !subentry.nil? %>">
+    <%= title %>
+    <% if !sidebar_heading %>
+      <span class="glyphicon glyphicon-chevron-right"></span>
+    <% end %>
+  </a>
+</li>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The sidebar for the new/full agents records can be quite long.  This adds the following:

- Indents subrecord sidebar entries under the proper sidebar heading;
- Shades headings in the sidebar in light gray and removes the `>` on the right side of the entry;
- Only adds the blue pill/record count in edit mode to subrecords (not to subrecord headings);
- Only displays sidebar entries/headings if there is record content for those entries/headings while in view mode;
- Only shows form headings/anchors in the view-only form if there are subrecords to display under that heading;
- Adds a bottom margin to the sidebar as a first pass/start of a fix for https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1152

Just a general note that there are a lot of whitespace changes in `frontend/app/views/agents/_sidebar.html.erb` that make this look like substantially more than it actually is.  

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Also includes the following (unrelated) updates:
- Fixes backend agent slug deduplication tests broken by https://github.com/archivesspace/archivesspace/commit/4c71c4a1a9f9a382fd4e68b2636654da8a9faee0
- Fixes frontend model enumerations test broken by missing translation for `date_type_structured` dynamic enum
- Fixes inability to `db:nuke` by commenting out the `down` in migration 002 (we can't downgrade anyway and it's broken by database changes made for ANW-429).

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Edit mode for full agent record:
![image](https://user-images.githubusercontent.com/15144646/102248310-0cde9c00-3ecf-11eb-85cd-da51c3fe914b.png)

View mode for nearly empty agent record:
![image](https://user-images.githubusercontent.com/15144646/102249078-f553e300-3ecf-11eb-800e-c31058a08a9e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
