### PR TITLE
Fix for PUI slowness caused by unnecessary counting of record types

### DIFF
--- a/public/app/controllers/repositories_controller.rb
+++ b/public/app/controllers/repositories_controller.rb
@@ -181,11 +181,15 @@ class RepositoriesController < ApplicationController
     else
       types = %w(pui_collection pui_record pui_record_group pui_accession pui_digital_object pui_agent  pui_subject)
     end
-    # for now, we've got to get the whole enchilada, until we figure out what's wrong
-    #  counts = archivesspace.get_types_counts(types, repo_id)
-    counts = archivesspace.get_types_counts(types)
+
+    counts = archivesspace.get_types_counts(types, repo_id)
+
     final_counts = {}
-    if counts[repo_id]
+    if !repo_id.nil?
+      counts.each do |k, v|
+        final_counts[k.sub("pui_",'')] = v
+      end
+    elsif counts[repo_id]
       counts[repo_id].each do |k, v|
         final_counts[k.sub("pui_",'')] = v
       end

--- a/public/app/controllers/repositories_controller.rb
+++ b/public/app/controllers/repositories_controller.rb
@@ -139,8 +139,6 @@ class RepositoriesController < ApplicationController
     resources = {}
     query = "(id:\"#{uri}\" AND publish:true)"
     @counts = get_counts("/repositories/#{params[:id]}")
-    @counts['resource'] = @counts['collection']
-    @counts['classification'] = @counts['record_group']
     #  Pry::ColorPrinter.pp(counts)
     @criteria = {}
     @criteria[:page_size] = 1
@@ -174,26 +172,17 @@ class RepositoriesController < ApplicationController
   end
 
   private
-  # get counts for repository
-  def get_counts(repo_id = nil, collection_only = false)
-    if collection_only
-      types = ['pui_collection']
-    else
-      types = %w(pui_collection pui_record pui_record_group pui_accession pui_digital_object pui_agent  pui_subject)
-    end
 
-    counts = archivesspace.get_types_counts(types, repo_id)
-
+  # get counts of various records belonging to a repository
+  def get_counts(repo_uri)
+    types = %w(pui_collection pui_record pui_record_group pui_accession pui_digital_object pui_agent pui_subject)
+    counts = archivesspace.get_types_counts(types, repo_uri)
     final_counts = {}
-    if !repo_id.nil?
-      counts.each do |k, v|
-        final_counts[k.sub("pui_",'')] = v
-      end
-    elsif counts[repo_id]
-      counts[repo_id].each do |k, v|
-        final_counts[k.sub("pui_",'')] = v
-      end
+    counts.each do |k, v|
+      final_counts[k.sub("pui_",'')] = v
     end
+    final_counts['resource'] = final_counts['collection']
+    final_counts['classification'] = final_counts['record_group']
     final_counts
   end
 

--- a/public/app/controllers/search_controller.rb
+++ b/public/app/controllers/search_controller.rb
@@ -41,7 +41,7 @@ class SearchController < ApplicationController
     Rails.logger.debug("query: #{@query}")
 
     @results = archivesspace.advanced_search(@base_search, page, @criteria)
-    @counts = archivesspace.get_types_counts(DEFAULT_TYPES)
+
     if @results['total_hits'].blank? ||  @results['total_hits'] == 0
       flash[:notice] = I18n.t('search_results.no_results')
       fallback_location = URI(fallback_location)

--- a/public/app/controllers/search_controller.rb
+++ b/public/app/controllers/search_controller.rb
@@ -58,8 +58,29 @@ class SearchController < ApplicationController
       all_sorts.keys.each do |type|
         @sort_opts.push(all_sorts[type])
       end
+      # If there are any repositories in the results, get counts of their collections
+      @counts = {}
+      @results.records.each do |result|
+        if result['primary_type'] == 'repository'
+          @counts[result.uri] = get_collection_counts(result.uri)
+        end
+      end
       render 'search/search_results'
     end
+  end
+
+  private
+
+  # get counts of collections belonging to a repository
+  def get_collection_counts(repo_uri)
+    types = ['pui_collection']
+    counts = archivesspace.get_types_counts(types, repo_uri)
+    final_counts = {}
+    counts.each do |k, v|
+      final_counts[k.sub("pui_",'')] = v
+    end
+    final_counts['resource'] = final_counts['collection']
+    final_counts
   end
 
 end

--- a/public/app/services/archives_space_client.rb
+++ b/public/app/services/archives_space_client.rb
@@ -118,7 +118,7 @@ class ArchivesSpaceClient
 
   def get_types_counts(record_type_list, repo_uri = nil)
     opts = {"record_types[]" => record_type_list}
-    opts["repo_uri"] = "\"#{repo_uri}\"" if repo_uri
+    opts["repo_uri"] = repo_uri if repo_uri
     url = build_url('/search/record_types_by_repository',  opts)
     results = do_search(url)
   end


### PR DESCRIPTION
## Description
Cambridge University Library asked me for help with slow performance in their PUI. They have a similar number of records in their ArchivesSpace system, but they have 32 public repositories, whereas in the Bodleian we only have one.

The parts of their PUI which are the slowest are the main keyword search and displaying repository pages. Looking for commonalities, I found the controllers which handle those routes both call `get_types_counts()` in the `ArchivesSpaceClient` class. They do so to populate a variable called `@counts` with a hash of the numbers of records for each record type. That instance variable is used when displaying repository pages, in the template for rendering badges for each record type in the repository. <strike>But I cannot find any other use of `@counts` in the PUI code. It seems to have no purpose when searching and displaying the results.</strike> _[Incorrect, see comment below.]_ No other controllers set `@counts`, so it is good candidate for explaining the slowness of these features in particular.

To obtain the counts, queries are send via the backend to Solr for each record type in each repository. So for a single-repository system that is 7 additional queries. But for a 32-repostory system, it is 7 x 32 = 224 extra roundtrips to Solr before rendering the page can begin. If each query were to take, say, 50 milliseconds, it'd only add an imperceptible 0.35 seconds to response times for one repository, but a very noticeable 11.2 seconds for 32 repositories. That is consistent with the level of the performance difference observed.

You can see this effect in other ArchivesSpace implementations which use the PUI and have more than a few repositories, by comparing the response times for the [resource list](https://archives.yale.edu/repositories/resources) (which doesn't lookup counts) and a [search for * filtered to only return the resources](https://archives.yale.edu/search?q[]=%2A&op[]=&field[]=keyword&from_year[]=&to_year[]=&filter_fields[]=primary_type&filter_values[]=resource). Despite returning the same results, the latter is always significantly slower.

So, in this pull request, I have removed the call to `get_types_counts()` in `SearchController`.

Displaying a repository page is slow because it looks up counts for every repository, when it only needs to do the one being shown. So I have fixed that. From [a comment](https://github.com/archivesspace/archivesspace/blob/f455cd13e95f389b70aed4f45f0e98d05733ee9d/public/app/controllers/repositories_controller.rb#L184) left in `RepositoriesController` it appears this was something the original developer meant to fix, but didn't get round to doing so.

## Related JIRA Ticket or GitHub Issue
None

## How Has This Been Tested?
The public:test suite passes. On a development system it reduces the number of additional queries, with no change that I can see to the functionality of the PUI. I cannot test the effect on performance as I do not have access to system with both large numbers of records and repositories.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
