### PR TITLE
Missing enumeration translations should default to the value

### DIFF
--- a/common/locales/enums/en.yml
+++ b/common/locales/enums/en.yml
@@ -1,9 +1,7 @@
 en:
   enumerations:
     gender:
-      male: Male
-      female: Female
-      not_known: Not Known
+      not_specified: Not Specified
     place_role:
       assoc_country: Associated Country
       residence: Residence

--- a/frontend/app/views/agent_alternate_sets/_show_fields.html.erb
+++ b/frontend/app/views/agent_alternate_sets/_show_fields.html.erb
@@ -12,8 +12,8 @@
     <%= I18n.t("agent_alternate_set.descriptive_note") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_alternate_set["descriptive_note"] %>
-      <%= agent_alternate_set["descriptive_note"] %>
+    <% if agent_alternate_set['descriptive_note'] %>
+      <%= agent_alternate_set['descriptive_note'] %>
       <% end %>
   </div>
 </div>
@@ -23,8 +23,8 @@
     <%= I18n.t("agent_alternate_set.file_uri") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_alternate_set["file_uri"] %>
-      <%= agent_alternate_set["file_uri"] %>
+    <% if agent_alternate_set['file_uri'] %>
+      <%= agent_alternate_set['file_uri'] %>
       <% end %>
   </div>
 </div>
@@ -34,7 +34,7 @@
     <%= I18n.t("agent_alternate_set.file_version_xlink_actuate_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <%= I18n.t("enumerations.file_version_xlink_actuate_attribute." + agent_alternate_set["file_version_xlink_actuate_attribute"]) %>
+    <%= I18n.t("enumerations.file_version_xlink_actuate_attribute.#{agent_alternate_set['file_version_xlink_actuate_attribute']}", :default => agent_alternate_set['file_version_xlink_actuate_attribute']) %>
   </div>
 </div>
 
@@ -43,7 +43,7 @@
     <%= I18n.t("agent_alternate_set.file_version_xlink_show_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <%= I18n.t("enumerations.file_version_xlink_show_attribute." + agent_alternate_set["file_version_xlink_show_attribute"]) %>
+    <%= I18n.t("enumerations.file_version_xlink_show_attribute.#{agent_alternate_set['file_version_xlink_show_attribute']}", :default => agent_alternate_set['file_version_xlink_show_attribute']) %>
   </div>
 </div>
 
@@ -53,8 +53,8 @@
     <%= I18n.t("agent_alternate_set.xlink_title_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_alternate_set["xlink_title_attribute"] %>
-      <%= agent_alternate_set["xlink_title_attribute"] %>
+    <% if agent_alternate_set['xlink_title_attribute'] %>
+      <%= agent_alternate_set['xlink_title_attribute'] %>
       <% end %>
   </div>
 </div>
@@ -64,8 +64,8 @@
     <%= I18n.t("agent_alternate_set.xlink_role_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_alternate_set["xlink_role_attribute"] %>
-      <%= agent_alternate_set["xlink_role_attribute"] %>
+    <% if agent_alternate_set['xlink_role_attribute'] %>
+      <%= agent_alternate_set['xlink_role_attribute'] %>
       <% end %>
   </div>
 </div>
@@ -75,8 +75,8 @@
     <%= I18n.t("agent_alternate_set.xlink_arcrole_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_alternate_set["xlink_arcrole_attribute"] %>
-      <%= agent_alternate_set["xlink_arcrole_attribute"] %>
+    <% if agent_alternate_set['xlink_arcrole_attribute'] %>
+      <%= agent_alternate_set['xlink_arcrole_attribute'] %>
       <% end %>
   </div>
 </div>
@@ -86,8 +86,8 @@
     <%= I18n.t("agent_alternate_set.last_verified_date") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_alternate_set["last_verified_date"] %>
-      <%= agent_alternate_set["last_verified_date"] %>
+    <% if agent_alternate_set['last_verified_date'] %>
+      <%= agent_alternate_set['last_verified_date'] %>
       <% end %>
   </div>
 </div>

--- a/frontend/app/views/agent_conventions_declarations/_show.html.erb
+++ b/frontend/app/views/agent_conventions_declarations/_show.html.erb
@@ -14,7 +14,7 @@
               <span class="glyphicon"></span>
             </div>
             <div class="col-md-6">
-              <%= I18n.t("enumerations.name_rule." + agent_conventions_declaration["name_rule"]) %>
+              <%= I18n.t("enumerations.name_rule.#{agent_conventions_declaration['name_rule']}", :default => agent_conventions_declaration['name_rule']) %>
             </div>
           </div>
         </div>

--- a/frontend/app/views/agent_conventions_declarations/_show_fields.html.erb
+++ b/frontend/app/views/agent_conventions_declarations/_show_fields.html.erb
@@ -3,7 +3,7 @@
   	<%= I18n.t("agent_conventions_declaration.name_rule") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<%= I18n.t("enumerations.name_rule." + agent_conventions_declaration["name_rule"]) %>
+  	<%= I18n.t("enumerations.name_rule.#{agent_conventions_declaration['name_rule']}", :default => agent_conventions_declaration['name_rule']) %>
  	</div>
 </div>
 
@@ -12,8 +12,8 @@
   	<%= I18n.t("agent_conventions_declaration.citation") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<% if agent_conventions_declaration["citation"] %>
- 		 	<%= agent_conventions_declaration["citation"] %>
+  	<% if agent_conventions_declaration['citation'] %>
+ 		 	<%= agent_conventions_declaration['citation'] %>
   		<% end %>
  	</div>
 </div>
@@ -23,8 +23,8 @@
     <%= I18n.t("agent_conventions_declaration.descriptive_note") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_conventions_declaration["descriptive_note"] %>
-      <%= agent_conventions_declaration["descriptive_note"] %>
+    <% if agent_conventions_declaration['descriptive_note'] %>
+      <%= agent_conventions_declaration['descriptive_note'] %>
       <% end %>
   </div>
 </div>
@@ -34,8 +34,8 @@
     <%= I18n.t("agent_conventions_declaration.file_uri") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_conventions_declaration["file_uri"] %>
-      <%= agent_conventions_declaration["file_uri"] %>
+    <% if agent_conventions_declaration['file_uri'] %>
+      <%= agent_conventions_declaration['file_uri'] %>
       <% end %>
   </div>
 </div>
@@ -45,7 +45,7 @@
     <%= I18n.t("agent_conventions_declaration.file_version_xlink_actuate_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <%= I18n.t("enumerations.file_version_xlink_actuate_attribute." + agent_conventions_declaration["file_version_xlink_actuate_attribute"]) if agent_conventions_declaration["file_version_xlink_actuate_attribute"] %>
+    <%= I18n.t("enumerations.file_version_xlink_actuate_attribute.#{agent_conventions_declaration['file_version_xlink_actuate_attribute']}", :default => agent_conventions_declaration['file_version_xlink_actuate_attribute']) if agent_conventions_declaration['file_version_xlink_actuate_attribute'] %>
   </div>
 </div>
 
@@ -54,7 +54,7 @@
     <%= I18n.t("agent_conventions_declaration.file_version_xlink_show_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <%= I18n.t("enumerations.file_version_xlink_show_attribute." + agent_conventions_declaration["file_version_xlink_show_attribute"]) if agent_conventions_declaration["file_version_xlink_show_attribute"] %>
+    <%= I18n.t("enumerations.file_version_xlink_show_attribute.#{agent_conventions_declaration['file_version_xlink_show_attribute']}", :default => agent_conventions_declaration['file_version_xlink_show_attribute']) if agent_conventions_declaration['file_version_xlink_show_attribute'] %>
   </div>
 </div>
 
@@ -64,8 +64,8 @@
     <%= I18n.t("agent_conventions_declaration.xlink_title_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_conventions_declaration["xlink_title_attribute"] %>
-      <%= agent_conventions_declaration["xlink_title_attribute"] %>
+    <% if agent_conventions_declaration['xlink_title_attribute'] %>
+      <%= agent_conventions_declaration['xlink_title_attribute'] %>
       <% end %>
   </div>
 </div>
@@ -75,8 +75,8 @@
     <%= I18n.t("agent_conventions_declaration.xlink_role_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_conventions_declaration["xlink_role_attribute"] %>
-      <%= agent_conventions_declaration["xlink_role_attribute"] %>
+    <% if agent_conventions_declaration['xlink_role_attribute'] %>
+      <%= agent_conventions_declaration['xlink_role_attribute'] %>
       <% end %>
   </div>
 </div>
@@ -87,8 +87,8 @@
     <%= I18n.t("agent_conventions_declaration.xlink_arcrole_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_conventions_declaration["xlink_arcrole_attribute"] %>
-      <%= agent_conventions_declaration["xlink_arcrole_attribute"] %>
+    <% if agent_conventions_declaration['xlink_arcrole_attribute'] %>
+      <%= agent_conventions_declaration['xlink_arcrole_attribute'] %>
       <% end %>
   </div>
 </div>
@@ -99,8 +99,8 @@
     <%= I18n.t("agent_conventions_declaration.last_verified_date") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_conventions_declaration["last_verified_date"] %>
-      <%= agent_conventions_declaration["last_verified_date"] %>
+    <% if agent_conventions_declaration['last_verified_date'] %>
+      <%= agent_conventions_declaration['last_verified_date'] %>
       <% end %>
   </div>
 </div>

--- a/frontend/app/views/agent_genders/_show.html.erb
+++ b/frontend/app/views/agent_genders/_show.html.erb
@@ -14,8 +14,8 @@
               <span class="glyphicon"></span>
             </div>
             <div class="col-md-6">
-              <% if agent_gender["gender"] %>
-                <%= I18n.t("enumerations.gender." + agent_gender["gender"]) %>
+              <% if agent_gender['gender'] %>
+                <%= I18n.t("enumerations.gender.#{agent_gender['gender']}", :default => agent_gender['gender']) %>
               <% else %>
                 <%= I18n.t("agent_gender._singular") %>
               <% end %>
@@ -27,8 +27,8 @@
           <% if agent_gender['dates'].length > 0 %>
             <%= render_aspace_partial :partial => "structured_dates/show", :locals => { :dates => agent_gender['dates'], :section_id => "agent_gender_dates_#{index}", :section_title => I18n.t("agent_gender.dates"), :heading_size => "h4"} %>
           <% end %>
-          <% if agent_gender["notes"].length > 0 %>
-            <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => agent_gender["notes"], :section_id => "#{@agent.agent_type}_agent_gender__#{index}__notes_", :context => context, :heading_size => "h4" } %>
+          <% if agent_gender['notes'].length > 0 %>
+            <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => agent_gender['notes'], :section_id => "#{@agent.agent_type}_agent_gender__#{index}__notes_", :context => context, :heading_size => "h4" } %>
           <% end %>
         </div>
       </div>

--- a/frontend/app/views/agent_maintenance_histories/_show.html.erb
+++ b/frontend/app/views/agent_maintenance_histories/_show.html.erb
@@ -14,7 +14,7 @@
               <span class="glyphicon"></span>
             </div>
             <div class="col-md-6">
-              <%= I18n.t("enumerations.maintenance_event_type." + agent_maintenance_history["maintenance_event_type"]) %>
+              <%= I18n.t("enumerations.maintenance_event_type.#{agent_maintenance_history['maintenance_event_type']}", :default => agent_maintenance_history['maintenance_event_type']) %>
 
             </div>
           </div>

--- a/frontend/app/views/agent_maintenance_histories/_show_fields.html.erb
+++ b/frontend/app/views/agent_maintenance_histories/_show_fields.html.erb
@@ -3,7 +3,7 @@
     <%= I18n.t("agent_maintenance_history.maintenance_event_type") %>
   </div>
   <div class='label-only col-sm-8'>
-    <%= I18n.t("enumerations.maintenance_event_type." + agent_maintenance_history["maintenance_event_type"]) %>
+    <%= I18n.t("enumerations.maintenance_event_type.#{agent_maintenance_history['maintenance_event_type']}", :default => agent_maintenance_history['maintenance_event_type']) %>
   </div>
 </div>
 
@@ -12,8 +12,8 @@
     <%= I18n.t("agent_maintenance_history.event_date") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_maintenance_history["event_date"] %>
-      <%= agent_maintenance_history["event_date"] %>
+    <% if agent_maintenance_history['event_date'] %>
+      <%= agent_maintenance_history['event_date'] %>
       <% end %>
   </div>
 </div>
@@ -23,8 +23,8 @@
     <%= I18n.t("agent_maintenance_history.agent") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_maintenance_history["agent"] %>
-      <%= agent_maintenance_history["agent"] %>
+    <% if agent_maintenance_history['agent'] %>
+      <%= agent_maintenance_history['agent'] %>
       <% end %>
   </div>
 </div>
@@ -34,7 +34,7 @@
     <%= I18n.t("agent_maintenance_history.maintenance_agent_type") %>
   </div>
   <div class='label-only col-sm-8'>
-    <%= I18n.t("enumerations.maintenance_agent_type." + agent_maintenance_history["maintenance_agent_type"]) %>
+    <%= I18n.t("enumerations.maintenance_agent_type.#{agent_maintenance_history['maintenance_agent_type']}", :default => agent_maintenance_history['maintenance_agent_type']) %>
   </div>
 </div>
 
@@ -43,8 +43,8 @@
     <%= I18n.t("agent_maintenance_history.descriptive_note") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_maintenance_history["descriptive_note"] %>
-      <%= agent_maintenance_history["descriptive_note"] %>
+    <% if agent_maintenance_history['descriptive_note'] %>
+      <%= agent_maintenance_history['descriptive_note'] %>
       <% end %>
   </div>
 </div>

--- a/frontend/app/views/agent_record_controls/_show.html.erb
+++ b/frontend/app/views/agent_record_controls/_show.html.erb
@@ -14,7 +14,7 @@
               <span class="glyphicon"></span>
             </div>
             <div class="col-md-6">
-              <%= I18n.t("enumerations.maintenance_status." + agent_record_control["maintenance_status"]) %>
+              <%= I18n.t("enumerations.maintenance_status.#{agent_record_control['maintenance_status']}", :default => agent_record_control['maintenance_status']) %>
             </div>
           </div>
         </div>

--- a/frontend/app/views/agent_record_controls/_show_fields.html.erb
+++ b/frontend/app/views/agent_record_controls/_show_fields.html.erb
@@ -3,7 +3,7 @@
   	<%= I18n.t("agent_record_control.maintenance_status") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<%= I18n.t("enumerations.maintenance_status." + agent_record_control["maintenance_status"]) %>
+  	<%= I18n.t("enumerations.maintenance_status.#{agent_record_control['maintenance_status']}", :default => agent_record_control['maintenance_status']) %>
  	</div>
 </div>
 
@@ -12,8 +12,8 @@
   	<%= I18n.t("agent_record_control.publication_status") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<% if agent_record_control["publication_status"] %>
- 		 	<%= I18n.t("enumerations.publication_status." + agent_record_control["publication_status"]) %>
+  	<% if agent_record_control['publication_status'] %>
+ 		 	<%= I18n.t("enumerations.publication_status.#{agent_record_control['publication_status']}", :default => agent_record_control['publication_status']) %>
   		<% end %>
  	</div>
 </div>
@@ -34,8 +34,8 @@
   	<%= I18n.t("agent_record_control.agency_name") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<% if agent_record_control["maintenance_agency"] %>
-	  	<%= agent_record_control["agency_name"] %>
+  	<% if agent_record_control['maintenance_agency'] %>
+	  	<%= agent_record_control['agency_name'] %>
   		<% end %>
  	</div>
 </div>
@@ -45,8 +45,8 @@
   	<%= I18n.t("agent_record_control.maintenance_agency_note") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<% if agent_record_control["maintenance_agency"] %>
-	  	<%= agent_record_control["maintenance_agency_note"] %>
+  	<% if agent_record_control['maintenance_agency'] %>
+	  	<%= agent_record_control['maintenance_agency_note'] %>
   		<% end %>
  	</div>
 </div>
@@ -56,8 +56,8 @@
   	<%= I18n.t("agent_record_control.language") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<% if agent_record_control["language"] %>
-	  	<%= I18n.t("enumerations.language_iso639_2." + agent_record_control["language"]) %>
+  	<% if agent_record_control['language'] %>
+	  	<%= I18n.t("enumerations.language_iso639_2.#{agent_record_control['language']}", :default => agent_record_control['language']) %>
   		<% end %>
  	</div>
 </div>
@@ -67,8 +67,8 @@
   	<%= I18n.t("agent_record_control.script") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<% if agent_record_control["script"] %>
-	  	<%= I18n.t("enumerations.script_iso15924." + agent_record_control["script"]) %>
+  	<% if agent_record_control['script'] %>
+	  	<%= I18n.t("enumerations.script_iso15924.#{agent_record_control['script']}", :default => agent_record_control['script']) %>
   		<% end %>
  	</div>
 </div>
@@ -78,8 +78,8 @@
   	<%= I18n.t("agent_record_control.language_note") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<% if agent_record_control["language_note"] %>
-	  	<%= agent_record_control["language_note"] %>
+  	<% if agent_record_control['language_note'] %>
+	  	<%= agent_record_control['language_note'] %>
   		<% end %>
  	</div>
 </div>
@@ -89,8 +89,8 @@
   	<%= I18n.t("agent_record_control.romanization") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<% if agent_record_control["romanization"] %>
-	  	<%= I18n.t("enumerations.romanization." + agent_record_control["romanization"]) %>
+  	<% if agent_record_control['romanization'] %>
+	  	<%= I18n.t("enumerations.romanization.#{agent_record_control['romanization']}", :default => agent_record_control['romanization']) %>
   		<% end %>
  	</div>
 </div>
@@ -100,8 +100,8 @@
   	<%= I18n.t("agent_record_control.government_agency_type") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<% if agent_record_control["government_agency_type"] %>
-	  	<%= I18n.t("enumerations.government_agency_type." + agent_record_control["government_agency_type"]) %>
+  	<% if agent_record_control['government_agency_type'] %>
+	  	<%= I18n.t("enumerations.government_agency_type.#{agent_record_control['government_agency_type']}", :default => agent_record_control['government_agency_type']) %>
   		<% end %>
  	</div>
 </div>
@@ -111,8 +111,8 @@
   	<%= I18n.t("agent_record_control.reference_evaluation") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<% if agent_record_control["reference_evaluation"] %>
-	  	<%= I18n.t("enumerations.reference_evaluation." + agent_record_control["reference_evaluation"]) %>
+  	<% if agent_record_control['reference_evaluation'] %>
+	  	<%= I18n.t("enumerations.reference_evaluation.#{agent_record_control['reference_evaluation']}", :default => agent_record_control['reference_evaluation']) %>
   		<% end %>
  	</div>
 </div>
@@ -122,8 +122,8 @@
   	<%= I18n.t("agent_record_control.name_type") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<% if agent_record_control["name_type"] %>
-	  	<%= I18n.t("enumerations.name_type." + agent_record_control["name_type"]) %>
+  	<% if agent_record_control['name_type'] %>
+	  	<%= I18n.t("enumerations.name_type.#{agent_record_control['name_type']}", :default => agent_record_control['name_type']) %>
   		<% end %>
  	</div>
 </div>
@@ -133,8 +133,8 @@
   	<%= I18n.t("agent_record_control.level_of_detail") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<% if agent_record_control["level_of_detail"] %>
-	  	<%= I18n.t("enumerations.level_of_detail." + agent_record_control["level_of_detail"]) %>
+  	<% if agent_record_control['level_of_detail'] %>
+	  	<%= I18n.t("enumerations.level_of_detail.#{agent_record_control['level_of_detail']}", :default => agent_record_control['level_of_detail']) %>
   		<% end %>
  	</div>
 </div>
@@ -144,8 +144,8 @@
   	<%= I18n.t("agent_record_control.modified_record") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<% if agent_record_control["modified_record"] %>
-	  	<%= I18n.t("enumerations.modified_record." + agent_record_control["modified_record"]) %>
+  	<% if agent_record_control['modified_record'] %>
+	  	<%= I18n.t("enumerations.modified_record.#{agent_record_control['modified_record']}", :default => agent_record_control['modified_record']) %>
   		<% end %>
  	</div>
 </div>
@@ -155,8 +155,8 @@
   	<%= I18n.t("agent_record_control.cataloging_source") %>
   </div>
   <div class='label-only col-sm-8'>
-  	<% if agent_record_control["cataloging_source"] %>
-	  	<%= I18n.t("enumerations.cataloging_source." + agent_record_control["cataloging_source"]) %>
+  	<% if agent_record_control['cataloging_source'] %>
+	  	<%= I18n.t("enumerations.cataloging_source.#{agent_record_control['cataloging_source']}", :default => agent_record_control['cataloging_source']) %>
   		<% end %>
  	</div>
 </div>

--- a/frontend/app/views/agent_resources/_show.html.erb
+++ b/frontend/app/views/agent_resources/_show.html.erb
@@ -15,9 +15,9 @@
               <span class="glyphicon"></span>
             </div>
             <div class="col-md-6">
-              <%= I18n.t("enumerations.linked_agent_role." + agent_resource["linked_agent_role"]) %>
+              <%= I18n.t("enumerations.linked_agent_role.#{agent_resource['linked_agent_role']}", :default => agent_resource['linked_agent_role']) %>
               :&nbsp;
-              <%= agent_resource["linked_resource"] %>
+              <%= agent_resource['linked_resource'] %>
             </div>
           </div>
         </div>

--- a/frontend/app/views/agent_resources/_show_fields.html.erb
+++ b/frontend/app/views/agent_resources/_show_fields.html.erb
@@ -3,7 +3,7 @@
   	<%= I18n.t("agent_resources.linked_agent_role") %>
   </div>
   <div class='label-only col-sm-8'>
-    <%= I18n.t("enumerations.linked_agent_role." + agent_resource["linked_agent_role"]) %>
+    <%= I18n.t("enumerations.linked_agent_role.#{agent_resource['linked_agent_role']}", :default => agent_resource['linked_agent_role']) %>
  	</div>
 </div>
 
@@ -12,7 +12,7 @@
     <%= I18n.t("agent_resources.linked_resource") %>
   </div>
   <div class='label-only col-sm-8'>
-    <%= agent_resource["linked_resource"] %>
+    <%= agent_resource['linked_resource'] %>
   </div>
 </div>
 
@@ -21,7 +21,7 @@
     <%= I18n.t("agent_resources.linked_resource_description") %>
   </div>
   <div class='label-only col-sm-8'>
-    <%= agent_resource["linked_resource_description"] %>
+    <%= agent_resource['linked_resource_description'] %>
   </div>
 </div>
 
@@ -30,8 +30,8 @@
     <%= I18n.t("agent_resources.file_uri") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_resource["file_uri"] %>
-      <%= agent_resource["file_uri"] %>
+    <% if agent_resource['file_uri'] %>
+      <%= agent_resource['file_uri'] %>
       <% end %>
   </div>
 </div>
@@ -41,7 +41,7 @@
     <%= I18n.t("agent_resources.file_version_xlink_actuate_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <%= agent_resource["file_version_xlink_actuate_attribute"] %>
+    <%= agent_resource['file_version_xlink_actuate_attribute'] %>
   </div>
 </div>
 
@@ -50,7 +50,7 @@
     <%= I18n.t("agent_resources.file_version_xlink_show_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <%= agent_resource["file_version_xlink_show_attribute"] %>
+    <%= agent_resource['file_version_xlink_show_attribute'] %>
   </div>
 </div>
 
@@ -60,8 +60,8 @@
     <%= I18n.t("agent_resources.xlink_title_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_resource["xlink_title_attribute"] %>
-      <%= agent_resource["xlink_title_attribute"] %>
+    <% if agent_resource['xlink_title_attribute'] %>
+      <%= agent_resource['xlink_title_attribute'] %>
       <% end %>
   </div>
 </div>
@@ -71,8 +71,8 @@
     <%= I18n.t("agent_resources.xlink_role_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_resource["xlink_role_attribute"] %>
-      <%= agent_resource["xlink_role_attribute"] %>
+    <% if agent_resource['xlink_role_attribute'] %>
+      <%= agent_resource['xlink_role_attribute'] %>
       <% end %>
   </div>
 </div>
@@ -82,8 +82,8 @@
     <%= I18n.t("agent_resources.xlink_arcrole_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_resource["xlink_arcrole_attribute"] %>
-      <%= agent_resource["xlink_arcrole_attribute"] %>
+    <% if agent_resource['xlink_arcrole_attribute'] %>
+      <%= agent_resource['xlink_arcrole_attribute'] %>
       <% end %>
   </div>
 </div>
@@ -93,8 +93,8 @@
     <%= I18n.t("agent_resources.last_verified_date") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_resource["last_verified_date"] %>
-      <%= agent_resource["last_verified_date"] %>
+    <% if agent_resource['last_verified_date'] %>
+      <%= agent_resource['last_verified_date'] %>
       <% end %>
   </div>
 </div>

--- a/frontend/app/views/agent_sources/_show_fields.html.erb
+++ b/frontend/app/views/agent_sources/_show_fields.html.erb
@@ -12,8 +12,8 @@
     <%= I18n.t("agent_sources.descriptive_note") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_source["descriptive_note"] %>
-      <%= agent_source["descriptive_note"] %>
+    <% if agent_source['descriptive_note'] %>
+      <%= agent_source['descriptive_note'] %>
       <% end %>
   </div>
 </div>
@@ -23,8 +23,8 @@
     <%= I18n.t("agent_sources.file_uri") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_source["file_uri"] %>
-      <%= agent_source["file_uri"] %>
+    <% if agent_source['file_uri'] %>
+      <%= agent_source['file_uri'] %>
       <% end %>
   </div>
 </div>
@@ -34,7 +34,7 @@
     <%= I18n.t("agent_sources.file_version_xlink_actuate_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <%= I18n.t("enumerations.file_version_xlink_actuate_attribute." + agent_source["file_version_xlink_actuate_attribute"]) if agent_source["file_version_xlink_actuate_attribute"] %>
+    <%= I18n.t("enumerations.file_version_xlink_actuate_attribute.#{agent_source['file_version_xlink_actuate_attribute']}", :default => agent_source['file_version_xlink_actuate_attribute']) if agent_source['file_version_xlink_actuate_attribute'] %>
   </div>
 </div>
 
@@ -43,7 +43,7 @@
     <%= I18n.t("agent_sources.file_version_xlink_show_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <%= I18n.t("enumerations.file_version_xlink_show_attribute." + agent_source["file_version_xlink_show_attribute"]) if agent_source["file_version_xlink_show_attribute"] %>
+    <%= I18n.t("enumerations.file_version_xlink_show_attribute.#{agent_source['file_version_xlink_show_attribute']}", :default => agent_source['file_version_xlink_show_attribute']) if agent_source['file_version_xlink_show_attribute'] %>
   </div>
 </div>
 
@@ -53,8 +53,8 @@
     <%= I18n.t("agent_sources.xlink_title_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_source["xlink_title_attribute"] %>
-      <%= agent_source["xlink_title_attribute"] %>
+    <% if agent_source['xlink_title_attribute'] %>
+      <%= agent_source['xlink_title_attribute'] %>
       <% end %>
   </div>
 </div>
@@ -64,8 +64,8 @@
     <%= I18n.t("agent_sources.xlink_role_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_source["xlink_role_attribute"] %>
-      <%= agent_source["xlink_role_attribute"] %>
+    <% if agent_source['xlink_role_attribute'] %>
+      <%= agent_source['xlink_role_attribute'] %>
       <% end %>
   </div>
 </div>
@@ -75,8 +75,8 @@
     <%= I18n.t("agent_sources.xlink_arcrole_attribute") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_source["xlink_arcrole_attribute"] %>
-      <%= agent_source["xlink_arcrole_attribute"] %>
+    <% if agent_source['xlink_arcrole_attribute'] %>
+      <%= agent_source['xlink_arcrole_attribute'] %>
       <% end %>
   </div>
 </div>
@@ -86,8 +86,8 @@
     <%= I18n.t("agent_sources.last_verified_date") %>
   </div>
   <div class='label-only col-sm-8'>
-    <% if agent_source["last_verified_date"] %>
-      <%= agent_source["last_verified_date"] %>
+    <% if agent_source['last_verified_date'] %>
+      <%= agent_source['last_verified_date'] %>
       <% end %>
   </div>
 </div>

--- a/frontend/app/views/used_languages/_show.html.erb
+++ b/frontend/app/views/used_languages/_show.html.erb
@@ -15,7 +15,7 @@
             </div>
             <div class="col-md-6">
               <% if !used_language["language"].blank? %>
-                <%= I18n.t("enumerations.language_iso639_2." + used_language["language"]) %>
+                <%= I18n.t("enumerations.language_iso639_2.#{used_language['language']}", :default => used_language['language']) %>
               <% else %>
                 <%= I18n.t("used_language._singular") %>
               <% end %>
@@ -25,7 +25,7 @@
         <div id="<%= section_id %>_used_language_<%= index %>" class="panel-collapse collapse">
           <%= read_only_view(used_language) %>
           <% if used_language["notes"].length > 0 %>
-            <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => used_language["notes"], :section_id => "#{@agent.agent_type}_used_language__#{index}__notes_", :context => context, :heading_size => "h4" } %>
+            <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => used_language['notes'], :section_id => "#{@agent.agent_type}_used_language__#{index}__notes_", :context => context, :heading_size => "h4" } %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Accomplishes three primary items:

- Fixes "translation missing" errors for the default (only) gender option of `not_specified` by adding a translation for not_specified;
- Removes the other existing gender translations (male, female, not known); and,
- Ensures the new agents-related staff-side forms all default to raw values in cases where translations are missing for those values (as is done elsewhere in the application).

Also updates forms to only use `"` when doing string interpolation in keeping with general ArchivesSpace practice.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Frontend tests passing.  Visually confirmed.

## Screenshots (if appropriate):
Helps avoid these types of translation missing errors (whether items are added via "Manage Controlled Value Lists" or whether items are added via an import job):
![image](https://user-images.githubusercontent.com/15144646/104328715-19e4b000-54ba-11eb-8f85-c6f76b88f2ca.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
