### PR TITLE
Lightmode updates

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -671,9 +671,6 @@ AppConfig[:ark_url_prefix] = proc { AppConfig[:public_proxy_url] }
 # Specifies if the fields that show up in csv should be limited to those in search results
 AppConfig[:limit_csv_fields] = true
 
-#Use Agents Full
-AppConfig[:agents_display_full] = false
-
 # Use to specify the maximum number of columns to display when searching or browsing
 AppConfig[:max_search_columns] = 7
 

--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -414,7 +414,7 @@ module ApplicationHelper
   end
 
   def full_mode?
-    AppConfig[:agents_display_full] == true && (user_can?("show_full_agents") || user_can?("administer_system"))
+    user_can?("show_full_agents") || user_can?("administer_system")
   end
 
   def has_agent_subrecords?(agent)

--- a/frontend/app/views/agents/_sidebar.html.erb
+++ b/frontend/app/views/agents/_sidebar.html.erb
@@ -30,37 +30,43 @@
         :subrecord_type => 'agent_record_control',
         :property => 'agent_record_controls',
         :anchor => "#{@agent.agent_type}_agent_record_control",
-        :subentry => true) %>
+        :subentry => true,
+        :lightmode_toggle => true) %>
 
         <%= sidebar.render_for_view_and_edit(
         :subrecord_type => 'agent_other_agency_code',
         :property => 'agent_other_agency_codes',
         :anchor => "#{@agent.agent_type}_agent_other_agency_codes",
-        :subentry => true) %>
+        :subentry => true,
+        :lightmode_toggle => true) %>
 
         <%= sidebar.render_for_view_and_edit(
         :subrecord_type => 'agent_conventions_declaration',
         :property => 'agent_conventions_declarations',
         :anchor => "#{@agent.agent_type}_agent_conventions_declaration",
-        :subentry => true) %>
+        :subentry => true,
+        :lightmode_toggle => true) %>
 
         <%= sidebar.render_for_view_and_edit(
         :subrecord_type => 'agent_maintenance_history',
         :property => 'agent_maintenance_histories',
         :anchor => "#{@agent.agent_type}_agent_maintenance_history",
-        :subentry => true) %>
+        :subentry => true,
+        :lightmode_toggle => true) %>
 
         <%= sidebar.render_for_view_and_edit(
         :subrecord_type => 'agent_source',
         :property => 'agent_sources',
         :anchor => "#{@agent.agent_type}_agent_sources",
-        :subentry => true) %>
+        :subentry => true,
+        :lightmode_toggle => true) %>
 
         <%= sidebar.render_for_view_and_edit(
         :subrecord_type => 'agent_alternate_set',
         :property => 'agent_alternate_sets',
         :anchor => "#{@agent.agent_type}_agent_alternate_set",
-        :subentry => true) %>
+        :subentry => true,
+        :lightmode_toggle => true) %>
       <% end %>
 
 
@@ -113,38 +119,44 @@
           :subrecord_type => 'agent_gender',
           :property => 'agent_genders',
           :anchor => "agent_person_agent_gender",
-          :subentry => true) %>
+          :subentry => true,
+          :lightmode_toggle => true) %>
         <% end %>
 
         <%= sidebar.render_for_view_and_edit(
           :subrecord_type => 'agent_place',
           :property => 'agent_places',
           :anchor => "#{@agent.agent_type}_agent_place",
-          :subentry => true) %>
+          :subentry => true,
+          :lightmode_toggle => true) %>
 
         <%= sidebar.render_for_view_and_edit(
           :subrecord_type => 'agent_occupation',
           :property => 'agent_occupations',
           :anchor => "#{@agent.agent_type}_agent_occupation",
-          :subentry => true) %>
+          :subentry => true,
+          :lightmode_toggle => true) %>
 
         <%= sidebar.render_for_view_and_edit(
           :subrecord_type => 'agent_function',
           :property => 'agent_functions',
           :anchor => "#{@agent.agent_type}_agent_function",
-          :subentry => true) %>
+          :subentry => true,
+          :lightmode_toggle => true) %>
 
         <%= sidebar.render_for_view_and_edit(
           :subrecord_type => 'agent_topic',
           :property => 'agent_topics',
           :anchor => "#{@agent.agent_type}_agent_topic",
-          :subentry => true) %>
+          :subentry => true,
+          :lightmode_toggle => true) %>
 
         <%= sidebar.render_for_view_and_edit(
           :subrecord_type => 'used_language',
           :property => 'used_languages',
           :anchor => "#{@agent.agent_type}_used_language",
-          :subentry => true) %>
+          :subentry => true,
+          :lightmode_toggle => true) %>
 
       <% end %>
 
@@ -181,7 +193,8 @@
           :subrecord_type => 'agent_resource',
           :property => 'agent_resources',
           :anchor => "#{@agent.agent_type}_agent_resource",
-          :subentry => true) %>
+          :subentry => true,
+          :lightmode_toggle => true) %>
       <% end %>
 
       <%= sidebar.render_for_view_and_edit(

--- a/frontend/app/views/shared/_sidebar_entry.html.erb
+++ b/frontend/app/views/shared/_sidebar_entry.html.erb
@@ -8,9 +8,10 @@
    end
    subentry = nil if !defined?(subentry)
    sidebar_heading = nil if !defined?(sidebar_heading)
+   lightmode_toggle = local_assigns.fetch(:lightmode_toggle, false)
 %>
 
-<li class="sidebar-entry-<%= anchor %> <%= "sidebar-heading" if sidebar_heading %>">
+<li class="sidebar-entry-<%= anchor %> <%= "sidebar-heading" if sidebar_heading %> <%= "lightmode_toggle" if lightmode_toggle %>">
   <a href="#<%= anchor %>" style="<%= "padding-left: 25px !important;" if !subentry.nil? %>">
     <%= title %>
     <% if !sidebar_heading %>

--- a/frontend/app/views/system_info/_info.html.erb
+++ b/frontend/app/views/system_info/_info.html.erb
@@ -9,12 +9,6 @@
     </div>
   </div>
   <div class='col-md-9'>
-    <form method="post" action="system_info/config">
-      <input type='hidden' value='<%= form_authenticity_token %>' name='authenticity_token' />
-      <button type="submit" class="btn btn-danger"/>Reload AppConfig</button>
-    </form>
-  </div>
-  <div class='col-md-9'>
     <h3 class="subrecord-form-heading">
       <%= I18n.t("system_info.#{@app_context}") %>   
     </h3>

--- a/frontend/spec/selenium/spec/agents_spec.rb
+++ b/frontend/spec/selenium/spec/agents_spec.rb
@@ -3,29 +3,7 @@
 require_relative '../spec_helper'
 require 'net/http'
 
-def enable_full_display_mode
-  $config_file.write "\n# Directive below added by agents_spec.rb selenium test\n"
-  $config_file.write "\nAppConfig[:agents_display_full] = true\n"
-  $config_file.flush
-
-  @driver.navigate.to($frontend + "/system_info")
-  @driver.find_element(css: "form button[type='submit']").click
-
-  sleep 1
-end
-
-def disable_full_display_mode
-  $config_file.write "\n# Directive below added by agents_spec.rb selenium test\n"
-  $config_file.write "\nAppConfig[:agents_display_full] = false\n"
-  $config_file.flush
-
-  @driver.navigate.to($frontend + "/system_info")
-  @driver.find_element(css: "form button[type='submit']").click
-
-  sleep 1
-end
-
-describe "Agents" do
+describe "Light Mode" do
   before(:all) do
     @repo = create(:repo, repo_code: "agents_test_#{Time.now.to_i}")
   
@@ -44,10 +22,6 @@ describe "Agents" do
   end
 
   describe 'Full Agent Record' do
-    before(:all) do
-      enable_full_display_mode
-    end
-
     it 'reports errors and warnings when creating an invalid Person Agent' do
       @driver.find_element(:link, 'Create').click
       @driver.find_element(:link, 'Agent').click
@@ -1041,8 +1015,9 @@ describe "Agents" do
 
   describe 'Light Agent Record' do
     before(:all) do
-      disable_full_display_mode
-
+      # user w/o full mode permissions
+      @data_entry_user = create_user(@repo => ['repository-advanced-data-entry'])
+      @driver.login_to_repo(@data_entry_user, @repo)
       @driver.navigate.to($frontend + "/agents/agent_person/new")
     end
 
@@ -1115,7 +1090,8 @@ describe "Agents" do
     end
 
     it 'displays agent_contacts in form' do
-      expect(@driver.is_visible?(:css, "#agent_person_contact_details")).to eq(true)
+      # not available to data entry user
+      expect(@driver.is_visible?(:css, "#agent_person_contact_details")).to eq(false)
     end
 
     it 'displays agent_notes in form' do


### PR DESCRIPTION
Remove AppConfig handbrake. Full agent view access determined
by permission only.

Update agent sidebar to add lightmode toggle class where needed.

Clean up tests to remove AppConfig specific handling.