### PR TITLE
Fix structured date templates to use type

### DIFF
--- a/frontend/app/views/agents/_form_required.html.erb
+++ b/frontend/app/views/agents/_form_required.html.erb
@@ -35,7 +35,7 @@
 
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "names", :section_id => "#{@agent.agent_type}_names", :template_erb => "agents/name_forms/#{@agent.agent_type}_required", :template => "name_#{@agent.agent_type.to_s.gsub("agent_","")}", :help_topic => "#{@agent.agent_type}_names"} %>
 
-  <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "dates_of_existence", :section_id => "#{@agent.agent_type}_dates_of_existence", :template_erb => "dates/template_required", :template => "structured_date_label", :heading_text => I18n.t("agent._frontend.section.dates_of_existence"), :help_topic => "#{@agent.agent_type}_dates_of_existence"} %>
+  <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "dates_of_existence", :section_id => "#{@agent.agent_type}_dates_of_existence", :template_erb => "dates/template_required", :template => "structured_date_label_existence", :heading_text => I18n.t("agent._frontend.section.dates_of_existence"), :help_topic => "#{@agent.agent_type}_dates_of_existence"} %>
 
   <% if @agent.agent_type == "person" %>
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "agent_genders", :section_id => "#{@agent.agent_type}_agent_gender_required", :template => "agent_gender_required", help_topic: "agent_genders", :action_button_override => "agent_gender_required" } %>

--- a/frontend/app/views/agents/_merge_selector.html.erb
+++ b/frontend/app/views/agents/_merge_selector.html.erb
@@ -109,7 +109,7 @@
            <h3><%= I18n.t("agent._frontend.section.dates_of_existence") %></h3>
             <section id="agent_dates_of_existence_left" class="merge-group merge-group-left">
                   <% if @agent.dates_of_existence.length > 0 %>
-                    <%= render_aspace_partial :partial => "shared/subrecord_form_merge", :locals => {:form => form, :name => "dates_of_existence", :section_id => "#{@agent.agent_type}_dates_of_existence", :template_erb => "dates/template_merge_target", :template => "structured_date_label", :heading_text => I18n.t("agent._frontend.section.dates_of_existence"), :heading_size => "h5", :help_topic => "#{@agent.agent_type}_dates_of_existence"} %>
+                    <%= render_aspace_partial :partial => "shared/subrecord_form_merge", :locals => {:form => form, :name => "dates_of_existence", :section_id => "#{@agent.agent_type}_dates_of_existence", :template_erb => "dates/template_merge_target", :template => "structured_date_label_existence", :heading_text => I18n.t("agent._frontend.section.dates_of_existence"), :heading_size => "h5", :help_topic => "#{@agent.agent_type}_dates_of_existence"} %>
                   <% end %>
             </section>
           <% end %>
@@ -330,7 +330,7 @@
             <h3><%= I18n.t("agent._frontend.section.dates_of_existence") %></h3>
             <section id="agent_dates_of_existence_right" class="merge-group merge-group-right">
                   <% if @victim.dates_of_existence.length > 0 %>
-                    <%= render_aspace_partial :partial => "shared/subrecord_form_merge", :locals => {:form => form, :name => "dates_of_existence", :section_id => "#{@victim.agent_type}_dates_of_existence", :template_erb => "dates/template_merge", :template => "structured_date_label", :heading_text => I18n.t("agent._frontend.section.dates_of_existence"), :heading_size => "h5", :help_topic => "#{@victim.agent_type}_dates_of_existence", :replace => (@agent.dates_of_existence.length > 0)} %>
+                    <%= render_aspace_partial :partial => "shared/subrecord_form_merge", :locals => {:form => form, :name => "dates_of_existence", :section_id => "#{@victim.agent_type}_dates_of_existence", :template_erb => "dates/template_merge", :template => "structured_date_label_existence", :heading_text => I18n.t("agent._frontend.section.dates_of_existence"), :heading_size => "h5", :help_topic => "#{@victim.agent_type}_dates_of_existence", :replace => (@agent.dates_of_existence.length > 0)} %>
                   <% end %>
             </section>
           <% end %>

--- a/frontend/app/views/related_agents/_template.html.erb
+++ b/frontend/app/views/related_agents/_template.html.erb
@@ -68,7 +68,7 @@
         <%= form.label_and_textarea("description") %>
 
         <% if !form.readonly? %>
-          <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "dates", :template_erb => "dates/template", :template => "structured_date_label", :cardinality => :zero_to_one, :heading_size => "h4"} %>
+          <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "dates", :template_erb => "dates/template", :template => "structured_date_label_usage", :cardinality => :zero_to_one, :heading_size => "h4"} %>
 
         <% elsif form.readonly? && !form['date'].blank? %>
           <%= render_aspace_partial :partial => "structured_dates/show", :locals => { :dates => [form['date']], :section_id => "rel_dates", :section_title => I18n.t("related_agent.dates") } %>


### PR DESCRIPTION
Resolves:

```
     [java] F, [2021-01-22T09:14:39.578161 #2738] FATAL -- : ActionView::Template::Error (No such template: "structured_date_label"):
     [java] F, [2021-01-22T09:14:39.578323 #2738] FATAL -- :     52:   <div class="subrecord-form-container">
     [java]     53:     <% if cardinality === :zero_to_one && list_limited_to_one == false %>
     [java]     54:       <%= form.list_for([form[name]].compact, name) do |item| %>
     [java]     55:         <% form.emit_template(template, item) %>
     [java]     56:       <% end %>
     [java]     57:     <% else %>
     [java]     58:       <%= form.list_for(form[name], "#{name}[]") do |item| %>
```