### PR TITLE
Anw 429 MARC import enhancements

### DIFF
--- a/backend/app/converters/lib/marcxml_auth_agent_base_map.rb
+++ b/backend/app/converters/lib/marcxml_auth_agent_base_map.rb
@@ -24,8 +24,9 @@ module MarcXMLAuthAgentBaseMap
 
   def agent_person_base(import_events, lcnaf_import)
     {
-      "self::datafield" => agent_person_name_with_parallel_map(:name_person, :names, lcnaf_import),
-      "//record/datafield[@tag='046']" => agent_person_dates_of_existence_map,
+      "self::datafield" => agent_person_name_map(:name_person, :names, lcnaf_import),
+      "//datafield[@tag='400' and (@ind1='1' or @ind1='0')]" => agent_person_name_map(:name_person, :names, lcnaf_import),
+      "//record/datafield[@tag='046']" =>  agent_person_dates_of_existence_map,
       "//record/datafield[@tag='372']/subfield[@code='a']" => agent_topic_map,
       "//record/datafield[@tag='375']/subfield[@code='a']" => agent_gender_map,
     }.merge(shared_subrecord_map(import_events))
@@ -33,7 +34,8 @@ module MarcXMLAuthAgentBaseMap
 
   def agent_corporate_entity_base(import_events, lcnaf_import)
     {
-      "self::datafield" => agent_corporate_entity_name_with_parallel_map(:name_corporate_entity, :names, lcnaf_import),
+      "self::datafield" => agent_corporate_entity_name_map(:name_corporate_entity, :names, lcnaf_import),
+      "//datafield[@tag='410' or @tag='411']" => agent_corporate_entity_name_map(:name_corporate_entity, :names, lcnaf_import),
       "//record/datafield[@tag='046']" => agent_corporate_entity_dates_of_existence_map,
       "//record/datafield[@tag='372']/subfield[@code='a']" => agent_function_map,
     }.merge(shared_subrecord_map(import_events))
@@ -41,7 +43,8 @@ module MarcXMLAuthAgentBaseMap
 
   def agent_family_base(import_events, lcnaf_import)
     {
-      "self::datafield" => agent_family_name_with_parallel_map(:name_family, :names, lcnaf_import),
+      "self::datafield" => agent_family_name_map(:name_family, :names, lcnaf_import),
+      "//datafield[@tag='400' and @ind1='3']" => agent_family_name_map(:name_family, :names, lcnaf_import),
       "//record/datafield[@tag='046']" => agent_family_dates_of_existence_map,
       "//record/datafield[@tag='372']/subfield[@code='a']" => agent_function_map,
     }.merge(shared_subrecord_map(import_events))
@@ -72,22 +75,6 @@ module MarcXMLAuthAgentBaseMap
     return h
   end
 
-  def agent_person_name_with_parallel_map(obj, rel, lcnaf_import)
-    {
-      :obj => obj,
-      :rel => rel,
-      :map => agent_person_name_components_map.merge({
-        "//datafield[@tag='400' and (@ind1='1' or @ind1='0')]" => agent_person_name_map(:parallel_name_person, :parallel_names, lcnaf_import)
-      }),
-      :defaults => {
-        :source => lcnaf_import ? 'naf' : 'local',
-        :rules => 'local',
-        :primary_name => 'primary name',
-        :name_order => 'direct',
-      }
-    }
-  end
-
   def agent_person_name_map(obj, rel, lcnaf_import)
     {
       :obj => obj,
@@ -102,43 +89,11 @@ module MarcXMLAuthAgentBaseMap
     }
   end
 
-  def agent_corporate_entity_name_with_parallel_map(obj, rel, lcnaf_import)
-    {
-      :obj => obj,
-      :rel => rel,
-      :map => agent_corporate_entity_name_components_map.merge({
-        "//datafield[@tag='410' or @tag='411']" => agent_corporate_entity_name_map(:parallel_name_corporate_entity, :parallel_names, lcnaf_import)
-      }),
-      :defaults => {
-        :source => lcnaf_import ? 'naf' : 'local',
-        :rules => 'local',
-        :primary_name => 'primary name',
-        :name_order => 'direct',
-      }
-    }
-  end
-
   def agent_corporate_entity_name_map(obj, rel, lcnaf_import)
     {
       :obj => obj,
       :rel => rel,
       :map => agent_corporate_entity_name_components_map,
-      :defaults => {
-        :source => lcnaf_import ? 'naf' : 'local',
-        :rules => 'local',
-        :primary_name => 'primary name',
-        :name_order => 'direct',
-      }
-    }
-  end
-
-  def agent_family_name_with_parallel_map(obj, rel, lcnaf_import)
-    {
-      :obj => obj,
-      :rel => rel,
-      :map => agent_family_name_components_map.merge({
-        "//datafield[@tag='400' and @ind1='3']" => agent_family_name_map(:parallel_name_family, :parallel_names, lcnaf_import)
-      }),
       :defaults => {
         :source => lcnaf_import ? 'naf' : 'local',
         :rules => 'local',

--- a/backend/app/converters/lib/marcxml_auth_agent_base_map.rb
+++ b/backend/app/converters/lib/marcxml_auth_agent_base_map.rb
@@ -834,16 +834,16 @@ module MarcXMLAuthAgentBaseMap
       "descendant::subfield[@code='a']" => Proc.new {|note, node|
         val = node.inner_text
 
-        sn = ASpaceImport::JSONModel(:note_text).new({
-          :content => val
+        sn = ASpaceImport::JSONModel(:note_abstract).new({
+          :content => [val]
         })
         note['subnotes'] << sn
       },
       "descendant::subfield[@code='b']" => Proc.new {|note, node|
         val = node.inner_text
 
-        sn = ASpaceImport::JSONModel(:note_abstract).new({
-          :content => [val]
+        sn = ASpaceImport::JSONModel(:note_text).new({
+          :content => val
         })
         note['subnotes'] << sn
       },

--- a/backend/app/converters/lib/marcxml_auth_agent_base_map.rb
+++ b/backend/app/converters/lib/marcxml_auth_agent_base_map.rb
@@ -199,9 +199,14 @@ module MarcXMLAuthAgentBaseMap
 
           name[:primary_name] = val
        },
-       "descendant::subfield[@code='b']" => Proc.new {|name, node|
-          val = node.inner_text
-          name[:subordinate_name_1] = val
+       "self::datafield[@tag='110' or @tag='410']" => Proc.new {|name, node|
+          subordinate_names = []
+          sf_bs = node.search("./subfield[@code='b']")
+          sf_bs.each do |b|
+            subordinate_names << b.inner_text
+          end
+          name[:subordinate_name_1] = subordinate_names.shift
+          name[:subordinate_name_2] = subordinate_names.join('. ')
        },
        "descendant::subfield[@code='c']" => Proc.new {|name, node|
           val = node.inner_text

--- a/backend/app/converters/lib/marcxml_auth_agent_base_map.rb
+++ b/backend/app/converters/lib/marcxml_auth_agent_base_map.rb
@@ -56,7 +56,7 @@ module MarcXMLAuthAgentBaseMap
       "//record/datafield[@tag='024']" => agent_record_identifiers_base_map("//record/datafield[@tag='024']/subfield[@code='a']"),
       "//record/datafield[@tag='035']" => agent_record_identifiers_base_map("//record/datafield[@tag='035']/subfield[@code='a']"),
       "//record/datafield[@tag='040']/subfield[@code='e']" => convention_declaration_map,
-      "//record/datafield[@tag='046']" => dates_map('self'),
+      "//record/datafield[@tag='046']" => dates_map,
       "//record/datafield[@tag='370']/subfield[@code='a']" => place_of_birth_map,
       "//record/datafield[@tag='370']/subfield[@code='b']" => place_of_death_map,
       "//record/datafield[@tag='370']/subfield[@code='c']" => associated_country_map,
@@ -607,12 +607,12 @@ module MarcXMLAuthAgentBaseMap
     date
   end
 
-  def dates_map(base, rel = :dates_of_existence)
+  def dates_map(rel = :dates_of_existence)
   {
     :obj => :structured_date_label,
     :rel => rel,
     :map => {
-      "#{base}::datafield" => Proc.new {|sdl, node|
+      "self::datafield" => Proc.new {|sdl, node|
 
         date_begin = structured_date_for(node, ['f', 'q', 's'])
         date_end = structured_date_for(node, ['g', 'r', 't'])
@@ -657,9 +657,8 @@ module MarcXMLAuthAgentBaseMap
     :obj => :agent_place,
     :rel => :agent_places,
     :map => {
-      "self::subfield" => subject_map(subject_terms_map('geographic', 'a'),
-                                      sets_subject_source),
-      "parent::datafield/subfield[@code='s' or @code='t']" => dates_map('parent', :dates)
+      "self::subfield" => subject_map(subject_terms_map('geographic', 'a')),
+      "parent::datafield[descendant::subfield[@code='s' or @code='t']]" => dates_map(:dates)
     },
     :defaults => {
       :place_role => "place_of_birth"
@@ -672,9 +671,8 @@ module MarcXMLAuthAgentBaseMap
     :obj => :agent_place,
     :rel => :agent_places,
     :map => {
-      "self::subfield" => subject_map(subject_terms_map('geographic', 'b'),
-                                      sets_subject_source),
-      "parent::datafield/subfield[@code='s' or @code='t']" => dates_map('parent', :dates)
+      "self::subfield" => subject_map(subject_terms_map('geographic', 'b')),
+      "parent::datafield[descendant::subfield[@code='s' or @code='t']]" => dates_map(:dates)
     },
     :defaults => {
       :place_role => "place_of_death"
@@ -687,9 +685,8 @@ module MarcXMLAuthAgentBaseMap
     :obj => :agent_place,
     :rel => :agent_places,
     :map => {
-      "self::subfield" => subject_map(subject_terms_map('geographic', 'c'),
-                                      sets_subject_source),
-      "parent::datafield/subfield[@code='s' or @code='t']" => dates_map('parent', :dates)
+      "self::subfield" => subject_map(subject_terms_map('geographic', 'c')),
+      "parent::datafield[descendant::subfield[@code='s' or @code='t']]" => dates_map(:dates)
     },
     :defaults => {
       :place_role => "assoc_country"
@@ -702,9 +699,8 @@ module MarcXMLAuthAgentBaseMap
     :obj => :agent_place,
     :rel => :agent_places,
     :map => {
-      "self::subfield" => subject_map(subject_terms_map('geographic', 'e'),
-                                      sets_subject_source),
-      "parent::datafield/subfield[@code='s' or @code='t']" => dates_map('parent', :dates)
+      "self::subfield" => subject_map(subject_terms_map('geographic', 'e')),
+      "parent::datafield[descendant::subfield[@code='s' or @code='t']]" => dates_map(:dates)
     },
     :defaults => {
       :place_role => "residence"
@@ -717,9 +713,8 @@ module MarcXMLAuthAgentBaseMap
     :obj => :agent_place,
     :rel => :agent_places,
     :map => {
-      "self::subfield" => subject_map(subject_terms_map('geographic', 'f'),
-                                      sets_subject_source),
-      "parent::datafield/subfield[@code='s' or @code='t']" => dates_map('parent', :dates)
+      "self::subfield" => subject_map(subject_terms_map('geographic', 'f')),
+      "parent::datafield[descendant::subfield[@code='s' or @code='t']]" => dates_map(:dates)
     },
     :defaults => {
       :place_role => "other_assoc"
@@ -732,9 +727,8 @@ module MarcXMLAuthAgentBaseMap
     :obj => :agent_occupation,
     :rel => :agent_occupations,
     :map => {
-      "self::subfield" => subject_map(subject_terms_map('occupation', 'a'),
-                                      sets_subject_source),
-      "parent::datafield/subfield[@code='s' or @code='t']" => dates_map('parent', :dates)
+      "self::subfield" => subject_map(subject_terms_map('occupation', 'a')),
+      "parent::datafield[descendant::subfield[@code='s' or @code='t']]" => dates_map(:dates)
     }
   }
   end
@@ -744,9 +738,8 @@ module MarcXMLAuthAgentBaseMap
     :obj => :agent_topic,
     :rel => :agent_topics,
     :map => {
-      "self::subfield" => subject_map(subject_terms_map('topical', 'a'),
-                                      sets_subject_source),
-      "parent::datafield/subfield[@code='s' or @code='t']" => dates_map('parent', :dates)
+      "self::subfield" => subject_map(subject_terms_map('topical', 'a')),
+      "parent::datafield[descendant::subfield[@code='s' or @code='t']]" => dates_map(:dates)
     }
   }
   end
@@ -756,9 +749,8 @@ module MarcXMLAuthAgentBaseMap
     :obj => :agent_function,
     :rel => :agent_functions,
     :map => {
-      "self::subfield" => subject_map(subject_terms_map('function', 'a'),
-                                      sets_subject_source),
-      "parent::datafield/subfield[@code='s' or @code='t']" => dates_map('parent', :dates)
+      "self::subfield" => subject_map(subject_terms_map('function', 'a')),
+      "parent::datafield[descendant::subfield[@code='s' or @code='t']]" => dates_map(:dates)
     }
   }
   end
@@ -772,8 +764,7 @@ module MarcXMLAuthAgentBaseMap
         val = node.inner_text
         gender['gender'] = val
       },
-
-      "parent::datafield/subfield[@code='s' or @code='t']" => dates_map('parent', :dates)
+      "parent::datafield[descendant::subfield[@code='s' or @code='t']]" => dates_map(:dates)
     }
   }
   end
@@ -852,30 +843,40 @@ module MarcXMLAuthAgentBaseMap
   def subject_terms_map(term_type, subfield)
     Proc.new {|node|
       [{:term_type => term_type,
-       :term => node.at_xpath("subfield[@code='#{subfield}']").inner_text,
+       :term => node.inner_text,
        :vocabulary => '/vocabularies/1'}]
     }
   end
-
-  def sets_subject_source
-    Proc.new{|node|
-      !node.at_xpath("subfield[@code='2']").nil? ? node.at_xpath("subfield[@code='2']").inner_text : 'Source not specified'
-    }
-  end
+  
+  # Sometimes we need to create more than one subject from a MARC field with a
+  # subfield 0, but the subject creation will fail if you try to create
+  # subjects with duplicate authority ids. Only create an authority id for the
+  # first subject created, and leaves authority id blank
+  def set_auth_id(node)
+    siblings = node.search("./preceding-sibling::*[not(@code='0' or @code='2')]")
+    
+    if siblings.empty?
+      auth_id = node.parent.at_xpath("subfield[@code='0']").inner_text
+    end
+    
+    auth_id
+  end 
 
   # usually, rel will be :subjects, but in some cases it will be :places
-  def subject_map(terms, getsrc, rel = :subjects)
+  def subject_map(terms, rel = :subjects)
     {
       :obj => :subject,
       :rel => rel,
       :map => {
-        "parent::datafield" => Proc.new{|subject, node|
+        "self::subfield" => Proc.new{|subject, node|
           subject.publish = true
           subject.terms = terms.call(node)
-          subject.source = getsrc.call(node)
+          if !node.parent.at_xpath("subfield[@code='2']").nil?
+            subject.source = node.parent.at_xpath("subfield[@code='2']").inner_text
+          end
           subject.vocabulary = '/vocabularies/1'
-          if !node.at_xpath("subfield[@code='0']").nil?
-            subject.authority_id = node.at_xpath("subfield[@code='0']").inner_text
+          if !node.parent.at_xpath("subfield[@code='0']").nil?
+            subject.authority_id = set_auth_id(node)
           end
         }
       },

--- a/backend/spec/lib_marcxml_auth_agent_converter_spec.rb
+++ b/backend/spec/lib_marcxml_auth_agent_converter_spec.rb
@@ -4,321 +4,325 @@ require 'converter_spec_helper'
 require_relative '../app/converters/marcxml_auth_agent_converter'
 
 describe 'MARCXML Auth Agent converter' do
-
   def my_converter
     MarcXMLAuthAgentConverter
   end
 
-  let(:person_agent_1) {
-    File.expand_path("../app/exporters/examples/marc/authority_john_davis.xml",
+  let(:person_agent_1) do
+    File.expand_path('../app/exporters/examples/marc/authority_john_davis.xml',
                      File.dirname(__FILE__))
-  }
+  end
 
-  let(:person_agent_2) {
-    File.expand_path("../app/exporters/examples/marc/authority_john_davis_2.xml",
+  let(:person_agent_2) do
+    File.expand_path('../app/exporters/examples/marc/authority_john_davis_2.xml',
                      File.dirname(__FILE__))
-  }
+  end
 
-  let(:corporate_agent_1) {
-    File.expand_path("../app/exporters/examples/marc/IAS.xml",
+  let(:corporate_agent_1) do
+    File.expand_path('../app/exporters/examples/marc/IAS.xml',
                      File.dirname(__FILE__))
-  }
+  end
 
-  let(:corporate_agent_2) {
-    File.expand_path("../app/exporters/examples/marc/IAS_2.xml",
+  let(:corporate_agent_2) do
+    File.expand_path('../app/exporters/examples/marc/IAS_2.xml',
                      File.dirname(__FILE__))
-  }
+  end
 
-  let(:family_agent_1) {
-    File.expand_path("../app/exporters/examples/marc/Wood.xml",
+  let(:family_agent_1) do
+    File.expand_path('../app/exporters/examples/marc/Wood.xml',
                      File.dirname(__FILE__))
-  }
+  end
 
-
-  describe "agent person" do
+  describe 'agent person' do
     before(:all) do
     end
 
-    it "converts agent name from marc auth (indirect)" do
-      record = convert(person_agent_1).select {|r| r['jsonmodel_type'] == "agent_person"}.first
+    it 'converts agent name from marc auth (indirect)' do
+      record = convert(person_agent_1).select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      expect(record['names'][0]['primary_name']).to eq("Davis")
-      expect(record['names'][0]['number']).to eq("IV")
-      expect(record['names'][0]['title']).to eq("Dr.")
-      expect(record['names'][0]['qualifier']).to eq("qualifier")
-      expect(record['names'][0]['fuller_form']).to eq("fuller_form")
-      expect(record['names'][0]['dates']).to eq("1873-1955")
+      expect(record['names'][0]['primary_name']).to eq('Davis')
+      expect(record['names'][0]['number']).to eq('IV')
+      expect(record['names'][0]['title']).to eq('Dr.')
+      expect(record['names'][0]['qualifier']).to eq('qualifier')
+      expect(record['names'][0]['fuller_form']).to eq('fuller_form')
+      expect(record['names'][0]['dates']).to eq('1873-1955')
       expect(record['names'][0]['authorized']).to eq(true)
     end
 
-    it "converts agent name from marc auth (direct)" do
-      record = convert(person_agent_2).select {|r| r['jsonmodel_type'] == "agent_person"}.first
+    it 'converts agent name from marc auth (direct)' do
+      record = convert(person_agent_2).select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      expect(record['names'][0]['primary_name']).to eq("Davis")
-      expect(record['names'][0]['number']).to eq("IV")
-      expect(record['names'][0]['title']).to eq("Dr.")
-      expect(record['names'][0]['qualifier']).to eq("qualifier")
-      expect(record['names'][0]['fuller_form']).to eq("378 fuller")
-      expect(record['names'][0]['dates']).to eq("1873-1955")
+      expect(record['names'][0]['primary_name']).to eq('Davis')
+      expect(record['names'][0]['number']).to eq('IV')
+      expect(record['names'][0]['title']).to eq('Dr.')
+      expect(record['names'][0]['qualifier']).to eq('qualifier')
+      expect(record['names'][0]['fuller_form']).to eq('378 fuller')
+      expect(record['names'][0]['dates']).to eq('1873-1955')
       expect(record['names'][0]['authorized']).to eq(true)
     end
 
-    it "imports parallel names" do
-      record = convert(person_agent_1).select {|r| r['jsonmodel_type'] == "agent_person"}.first
+    it 'imports parallel names' do
+      record = convert(person_agent_1).select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      expect(record['names'][0]['parallel_names'].length).to eq(1)
-      expect(record['names'][0]['parallel_names'][0]['primary_name']).to eq("Davis")
+      expect(record['names'].length).to eq(2)
+      expect(record['names'][1]['primary_name']).to eq('Davis')
     end
 
-    it "imports dates of existence" do
-      record = convert(person_agent_1).select {|r| r['jsonmodel_type'] == "agent_person"}.first
+    it 'imports dates of existence' do
+      record = convert(person_agent_1).select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      expect(record['dates_of_existence'][0]['structured_date_range']['begin_date_expression']).to eq("18990101")
-      expect(record['dates_of_existence'][0]['structured_date_range']['end_date_expression']).to eq("19611201")
+      expect(record['dates_of_existence'][0]['structured_date_range']['begin_date_expression']).to eq('18990101')
+      expect(record['dates_of_existence'][0]['structured_date_range']['end_date_expression']).to eq('19611201')
     end
 
-    it "imports agent gender" do
+    it 'imports agent gender' do
+      record = convert(person_agent_1).select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      record = convert(person_agent_1).select {|r| r['jsonmodel_type'] == "agent_person"}.first
-
-      expect(record['agent_genders'][0]['gender']).to eq("Male")
+      expect(record['agent_genders'][0]['gender']).to eq('Male')
     end
 
-    it "imports topics" do
-      record = convert(person_agent_1).select {|r| r['jsonmodel_type'] == "agent_person"}.first
+    it 'imports topics' do
+      record = convert(person_agent_1).select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
       expect(record['agent_topics'].length).to eq(1)
     end
   end
 
-  describe "agent family" do
-    it "imports name" do
-      record = convert(family_agent_1).select {|r| r['jsonmodel_type'] == "agent_family"}.first
+  describe 'agent family' do
+    it 'imports name' do
+      record = convert(family_agent_1).select { |r| r['jsonmodel_type'] == 'agent_family' }.first
 
-      expect(record['names'][0]['family_name']).to eq("Wood, Natalie")
-      expect(record['names'][0]['qualifier']).to eq("qualifier")
-      expect(record['names'][0]['dates']).to eq("1873-1955")
+      expect(record['names'][0]['family_name']).to eq('Wood, Natalie')
+      expect(record['names'][0]['qualifier']).to eq('qualifier')
+      expect(record['names'][0]['dates']).to eq('1873-1955')
       expect(record['names'][0]['authorized']).to eq(true)
     end
 
-    it "imports parallel names" do
-      record = convert(family_agent_1).select {|r| r['jsonmodel_type'] == "agent_family"}.first
+    it 'imports parallel names' do
+      record = convert(family_agent_1).select { |r| r['jsonmodel_type'] == 'agent_family' }.first
 
-      expect(record['names'][0]['parallel_names'].length).to eq(8)
-      expect(record['names'][0]['parallel_names'][0]['family_name']).to eq("Gurdin, Natasha,")
-      expect(record['names'][0]['parallel_names'][0]['authorized']).to eq(false)
+      expect(record['names'].length).to eq(9)
+      expect(record['names'][1]['family_name']).to eq('Gurdin, Natasha,')
+      expect(record['names'][1]['authorized']).to eq(false)
     end
 
-    it "imports dates of existence" do
-      record = convert(family_agent_1).select {|r| r['jsonmodel_type'] == "agent_family"}.first
+    it 'imports dates of existence' do
+      record = convert(family_agent_1).select { |r| r['jsonmodel_type'] == 'agent_family' }.first
 
-      expect(record['dates_of_existence'][0]['structured_date_range']['begin_date_expression']).to eq("1938-07-20")
-      expect(record['dates_of_existence'][0]['structured_date_range']['end_date_expression']).to eq("1981-11-29")
+      expect(record['dates_of_existence'][0]['structured_date_range']['begin_date_expression']).to eq('1938-07-20')
+      expect(record['dates_of_existence'][0]['structured_date_range']['end_date_expression']).to eq('1981-11-29')
     end
 
-    it "imports functions" do
-      record = convert(family_agent_1).select {|r| r['jsonmodel_type'] == "agent_family"}.first
+    it 'imports functions' do
+      record = convert(family_agent_1).select { |r| r['jsonmodel_type'] == 'agent_family' }.first
 
       expect(record['agent_functions'].length).to eq(1)
     end
   end
 
-  describe "agent_corporate_entity" do
-    it "imports name" do
-      record = convert(corporate_agent_1).select {|r| r['jsonmodel_type'] == "agent_corporate_entity"}.first
+  describe 'agent_corporate_entity' do
+    it 'imports name' do
+      record = convert(corporate_agent_1).select { |r| r['jsonmodel_type'] == 'agent_corporate_entity' }.first
 
-      expect(record['names'][0]['primary_name']).to eq("Institute for Advanced Study (Princeton, N.J.)")
+      expect(record['names'][0]['primary_name']).to eq('Institute for Advanced Study (Princeton, N.J.)')
       expect(record['names'][0]['authorized']).to eq(true)
       expect(record['names'][0]['conference_meeting']).to eq(false)
-      expect(record['names'][0]['subordinate_name_1']).to eq("sub name 1")
-      expect(record['names'][0]['location']).to eq("Miami")
-      expect(record['names'][0]['dates']).to eq("1999")
-      expect(record['names'][0]['number']).to eq("3")
-      expect(record['names'][0]['qualifier']).to eq("qualifier")
+      expect(record['names'][0]['subordinate_name_1']).to eq('sub name 1')
+      expect(record['names'][0]['location']).to eq('Miami')
+      expect(record['names'][0]['dates']).to eq('1999')
+      expect(record['names'][0]['number']).to eq('3')
+      expect(record['names'][0]['qualifier']).to eq('qualifier')
     end
 
-    it "imports name (conference)" do
-      record = convert(corporate_agent_2).select {|r| r['jsonmodel_type'] == "agent_corporate_entity"}.first
+    it 'imports name (conference)' do
+      record = convert(corporate_agent_2).select { |r| r['jsonmodel_type'] == 'agent_corporate_entity' }.first
 
-      expect(record['names'][0]['primary_name']).to eq("Institute for Advanced Study (Princeton, N.J.)")
+      expect(record['names'][0]['primary_name']).to eq('Institute for Advanced Study (Princeton, N.J.)')
       expect(record['names'][0]['authorized']).to eq(true)
       expect(record['names'][0]['conference_meeting']).to eq(true)
-      expect(record['names'][0]['subordinate_name_1']).to eq("sub name 1")
-      expect(record['names'][0]['location']).to eq("Miami")
-      expect(record['names'][0]['dates']).to eq("1999")
-      expect(record['names'][0]['number']).to eq("3")
-      expect(record['names'][0]['subordinate_name_2']).to eq("sub name 2")
+      expect(record['names'][0]['subordinate_name_1']).to eq('sub name 1')
+      expect(record['names'][0]['location']).to eq('Miami')
+      expect(record['names'][0]['dates']).to eq('1999')
+      expect(record['names'][0]['number']).to eq('3')
+      expect(record['names'][0]['subordinate_name_2']).to eq('sub name 2')
     end
 
-    it "imports parallel names" do
-      record = convert(corporate_agent_1).select {|r| r['jsonmodel_type'] == "agent_corporate_entity"}.first
+    it 'imports parallel names' do
+      record = convert(corporate_agent_1).select { |r| r['jsonmodel_type'] == 'agent_corporate_entity' }.first
 
-      expect(record['names'][0]['parallel_names'].length).to eq(3)
-      expect(record['names'][0]['parallel_names'][0]['primary_name']).to eq("Louis Bamberger and Mrs. Felix Fuld Foundation")
-      expect(record['names'][0]['parallel_names'][0]['authorized']).to eq(false)
-    end    
-
-    it "imports dates of existence" do
-      record = convert(corporate_agent_1).select {|r| r['jsonmodel_type'] == "agent_corporate_entity"}.first
-
-      expect(record['dates_of_existence'][0]['structured_date_range']['begin_date_expression']).to eq("1930-05-20")
+      expect(record['names'].length).to eq(4)
+      expect(record['names'][1]['primary_name']).to eq('Louis Bamberger and Mrs. Felix Fuld Foundation')
+      expect(record['names'][1]['authorized']).to eq(false)
     end
 
-    it "imports functions" do
-      record = convert(corporate_agent_1).select {|r| r['jsonmodel_type'] == "agent_corporate_entity"}.first
+    it 'imports dates of existence' do
+      record = convert(corporate_agent_1).select { |r| r['jsonmodel_type'] == 'agent_corporate_entity' }.first
+
+      expect(record['dates_of_existence'][0]['structured_date_single']['date_expression']).to eq('1930-05-20')
+      expect(record['dates_of_existence'][0]['structured_date_single']['date_role']).to eq('begin')
+    end
+
+    it 'imports functions' do
+      record = convert(corporate_agent_1).select { |r| r['jsonmodel_type'] == 'agent_corporate_entity' }.first
 
       expect(record['agent_functions'].length).to eq(1)
     end
   end
 
-  describe "common subrecords" do
-    it "imports agent_record_control" do
-      record = convert(person_agent_1).select {|r| r['jsonmodel_type'] == "agent_person"}.first
+  describe 'common subrecords' do
+    it 'imports agent_record_control' do
+      record = convert(person_agent_1).select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      expect(record['agent_record_controls'][0]['maintenance_status']).to eq("revised_corrected")
-      expect(record['agent_record_controls'][0]['maintenance_agency']).to eq("DLC")
-      expect(record['agent_record_controls'][0]['romanization']).to eq("not_applicable")
-      expect(record['agent_record_controls'][0]['language']).to eq("eng")
-      expect(record['agent_record_controls'][0]['government_agency_type']).to eq("unknown")
-      expect(record['agent_record_controls'][0]['reference_evaluation']).to eq("tr_consistent")
-      expect(record['agent_record_controls'][0]['name_type']).to eq("differentiated")
-      expect(record['agent_record_controls'][0]['level_of_detail']).to eq("fully_established")
-      expect(record['agent_record_controls'][0]['modified_record']).to eq("not_modified")
-      expect(record['agent_record_controls'][0]['cataloging_source']).to eq("nat_bib_agency")
+      expect(record['agent_record_controls'][0]['maintenance_status']).to eq('revised_corrected')
+      expect(record['agent_record_controls'][0]['maintenance_agency']).to eq('DLC')
+      expect(record['agent_record_controls'][0]['romanization']).to eq('not_applicable')
+      expect(record['agent_record_controls'][0]['language']).to eq('mul')
+      expect(record['agent_record_controls'][0]['government_agency_type']).to eq('unknown')
+      expect(record['agent_record_controls'][0]['reference_evaluation']).to eq('tr_consistent')
+      expect(record['agent_record_controls'][0]['name_type']).to eq('differentiated')
+      expect(record['agent_record_controls'][0]['level_of_detail']).to eq('fully_established')
+      expect(record['agent_record_controls'][0]['modified_record']).to eq('not_modified')
+      expect(record['agent_record_controls'][0]['cataloging_source']).to eq('nat_bib_agency')
     end
 
-    it "imports agent_record_identifier" do
-      record = convert(person_agent_1).select {|r| r['jsonmodel_type'] == "agent_person"}.first
+    it 'imports agent_record_identifier' do
+      record = convert(person_agent_1).select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      expect(record['agent_record_identifiers'][0]['record_identifier']).to eq("n  88218900")
-      expect(record['agent_record_identifiers'][0]['identifier_type']).to eq("local")
-      expect(record['agent_record_identifiers'][0]['source']).to eq("DLC")
+      # From 001
+      expect(record['agent_record_identifiers'][0]['record_identifier']).to eq('n88218900')
+      expect(record['agent_record_identifiers'][0]['source']).to eq('local')
       expect(record['agent_record_identifiers'][0]['primary_identifier']).to eq(true)
+
+      # From 010
+      expect(record['agent_record_identifiers'][1]['record_identifier']).to eq('n  88218900 ')
+      expect(record['agent_record_identifiers'][1]['identifier_type']).to eq('loc')
+      expect(record['agent_record_identifiers'][1]['source']).to eq('naf')
+      expect(record['agent_record_identifiers'][1]['primary_identifier']).to eq(false)
+
+      # From 035
+      expect(record['agent_record_identifiers'][2]['record_identifier']).to eq('n  88218900')
+      expect(record['agent_record_identifiers'][2]['identifier_type']).to eq('local')
+      expect(record['agent_record_identifiers'][2]['source']).to eq('DLC')
+      expect(record['agent_record_identifiers'][2]['primary_identifier']).to eq(false)
     end
 
-    it "imports agent_maintenance_histories" do
-      record = convert(person_agent_1, true).select {|r| r['jsonmodel_type'] == "agent_person"}.first
+    it 'imports agent_maintenance_histories' do
+      record = convert(person_agent_1, true).select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      expect(record['agent_maintenance_histories'][0]['event_date']).to eq("19890119")
-      expect(record['agent_maintenance_histories'][0]['maintenance_event_type']).to eq("created")
-      expect(record['agent_maintenance_histories'][0]['maintenance_agent_type']).to eq("machine")
-      expect(record['agent_maintenance_histories'][0]['agent']).to eq("DLC")
+      expect(record['agent_maintenance_histories'][0]['event_date']).to eq('19890119')
+      expect(record['agent_maintenance_histories'][0]['maintenance_event_type']).to eq('created')
+      expect(record['agent_maintenance_histories'][0]['maintenance_agent_type']).to eq('machine')
+      expect(record['agent_maintenance_histories'][0]['agent']).to eq('DLC')
     end
 
-    it "does not import agent_maintenance_histories if option not set" do
-      record = convert(person_agent_1, false).select {|r| r['jsonmodel_type'] == "agent_person"}.first
+    it 'does not import agent_maintenance_histories if option not set' do
+      record = convert(person_agent_1, false).select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      expect(record['agent_maintenance_histories'].count == 0).to eq(true)
+      expect(record['agent_maintenance_histories'].count.zero?).to eq(true)
     end
 
-    it "imports agent_conventions_declarations" do
-      record = convert(person_agent_1).select {|r| r['jsonmodel_type'] == "agent_person"}.first
+    it 'imports agent_conventions_declarations' do
+      record = convert(person_agent_1).select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      expect(record['agent_conventions_declarations'][0]['name_rule']).to eq("AACR2")
+      expect(record['agent_conventions_declarations'][0]['name_rule']).to eq('AACR2')
     end
 
-    it "imports places of birth" do
+    it 'imports places of birth' do
       raw = convert(person_agent_1)
 
-      record = raw.select {|r| r['jsonmodel_type'] == "agent_person"}.first
-      subjects = raw.select {|r| r['jsonmodel_type'] == "subject"}
+      record = raw.select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      place = record['agent_places'].select{|ap| ap['place_role'] == "place_of_birth"}
+      place = record['agent_places'].select { |ap| ap['place_role'] == 'place_of_birth' }
 
       expect(place.length).to eq(1)
     end
 
-    it "imports places of death" do
+    it 'imports places of death' do
       raw = convert(person_agent_1)
 
-      record = raw.select {|r| r['jsonmodel_type'] == "agent_person"}.first
-      subjects = raw.select {|r| r['jsonmodel_type'] == "subject"}
+      record = raw.select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      place = record['agent_places'].select{|ap| ap['place_role'] == "place_of_death"}
+      place = record['agent_places'].select { |ap| ap['place_role'] == 'place_of_death' }
 
       expect(place.length).to eq(1)
     end
 
-    it "imports places of associated country" do
+    it 'imports places of associated country' do
       raw = convert(person_agent_1)
 
-      record = raw.select {|r| r['jsonmodel_type'] == "agent_person"}.first
-      subjects = raw.select {|r| r['jsonmodel_type'] == "subject"}
+      record = raw.select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      place = record['agent_places'].select{|ap| ap['place_role'] == "assoc_country"}
+      place = record['agent_places'].select { |ap| ap['place_role'] == 'assoc_country' }
 
       expect(place.length).to eq(1)
     end
 
-    it "imports places of residence" do
+    it 'imports places of residence' do
       raw = convert(person_agent_1)
 
-      record = raw.select {|r| r['jsonmodel_type'] == "agent_person"}.first
-      subjects = raw.select {|r| r['jsonmodel_type'] == "subject"}
+      record = raw.select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      place = record['agent_places'].select{|ap| ap['place_role'] == "residence"}
+      place = record['agent_places'].select { |ap| ap['place_role'] == 'residence' }
 
       expect(place.length).to eq(1)
     end
 
-    it "imports places of other associated" do
+    it 'imports places of other associated' do
       raw = convert(person_agent_1)
 
-      record = raw.select {|r| r['jsonmodel_type'] == "agent_person"}.first
-      subjects = raw.select {|r| r['jsonmodel_type'] == "subject"}
+      record = raw.select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
-      place = record['agent_places'].select{|ap| ap['place_role'] == "other_assoc"}
+      place = record['agent_places'].select { |ap| ap['place_role'] == 'other_assoc' }
 
       expect(place.length).to eq(1)
     end
 
-    it "imports occupation" do
+    it 'imports occupation' do
       raw = convert(person_agent_1)
 
-      record = raw.select {|r| r['jsonmodel_type'] == "agent_person"}.first
-      subjects = raw.select {|r| r['jsonmodel_type'] == "subject"}
+      record = raw.select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
       expect(record['agent_occupations'].length).to eq(1)
     end
 
-    it "imports used language from $a" do
+    it 'imports used language from $a' do
       raw = convert(person_agent_1)
 
-      record = raw.select {|r| r['jsonmodel_type'] == "agent_person"}.first
+      record = raw.select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
       expect(record['used_languages'][0]['language']).to eq('eng')
     end
 
-    it "imports used language from value in $l if $a is not defined" do
+    it 'imports used language from value in $l if $a is not defined' do
       raw = convert(person_agent_2)
 
-      record = raw.select {|r| r['jsonmodel_type'] == "agent_person"}.first
+      record = raw.select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
       expect(record['used_languages'][0]['language']).to eq('fre')
     end
 
-    it "imports agent_sources subrecords" do
+    it 'imports agent_sources subrecords' do
       raw = convert(person_agent_1)
 
-      record = raw.select {|r| r['jsonmodel_type'] == "agent_person"}.first
+      record = raw.select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
       expect(record['agent_sources'][0]['source_entry']).to eq('NUCMC data from Washington and Lee University Lib. for Gaines, F. Papers, 1903-1982')
       expect(record['agent_sources'][0]['descriptive_note']).to eq('(Davis, John W.)')
       expect(record['agent_sources'][0]['file_uri']).to eq('http://www.google.com')
     end
 
-    it "imports bioghist notes" do
+    it 'imports bioghist notes' do
       raw = convert(person_agent_1)
 
-      record = raw.select {|r| r['jsonmodel_type'] == "agent_person"}.first
+      record = raw.select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 
       expect(record['notes'][0]['label']).to eq('Biographical note')
       expect(record['notes'][1]['label']).to eq('Administrative history')
 
-      expect(record['notes'][0]['subnotes'][0]['jsonmodel_type']).to eq('note_text')
-      expect(record['notes'][0]['subnotes'][0]['content']).to eq('Biographical or historical data.')
-      expect(record['notes'][0]['subnotes'][1]['jsonmodel_type']).to eq('note_abstract')
-      expect(record['notes'][0]['subnotes'][1]['content']).to eq(['Expansion ...'])
+      expect(record['notes'][0]['subnotes'][0]['jsonmodel_type']).to eq('note_abstract')
+      expect(record['notes'][0]['subnotes'][0]['content']).to eq(['Biographical or historical data.'])
+      expect(record['notes'][0]['subnotes'][1]['jsonmodel_type']).to eq('note_text')
+      expect(record['notes'][0]['subnotes'][1]['content']).to eq('Expansion ...')
 
       expect(record['notes'][1]['label']).to eq('Administrative history')
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Addressing a number of issues with MARC imports discovered during initial ANW-429 user testing, including: 

- MARCXML 008/040 importing content to single Record Info and/or repeating Other Agency Codes as needed
- MARCXML 001/010/016/024/035 fields importing into repeating Record IDs with appropriate types/sources/authorized flags as necessary
- MARCXML 040 field subfield e no longer generates citation field
- MARCXML 046 field subfields s, t, q, and r importing both standardized (if parseable) and expression dates
- MARCXML 100/110 field @ind1 value correctly setting Direct/Indirect name order
- MARCXML 100/110 repeating subfields all now import
- MARCXML 110 field @ind1 value not importing correctly
- MARCXML 37x fields no longer always generating date records
- MARCXML 37x subfields s, t, q, and r importing both standardized (if parseable) and expression dates
- MARCXML 37x sources and authority id's importing when provided in proper subfields
- MARCXML 400/410/411 imported as additional name records and not as as parallel names
Also include required test updates, though there are fewer changes than it might appear as I ran a linter to standardize some code style stuff (e.g. single quotes when not doing interpolation).
- MARC 678 notes mapping to note_text or note_abtract note types depending on subfields provided.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
