### PR TITLE
Fix for EAD import bug when top-level descriptive identification has container info but no langmaterial

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -756,7 +756,7 @@ class EADConverter < Converter
         return
       end
 
-      if !att('id') && (instance = context_obj.instances.last)
+      if !att('id') && defined?(context_obj.instances) && (instance = context_obj.instances.last)
         # this container doesn't have an @id
         # and has a container sibling before it
         # so even though it doesn't have a parent attribute


### PR DESCRIPTION
## Description
This bug was introduced in 2.7.0, when it became compulsory for resources to have at least one language code. To comply, [a new handler](https://github.com/archivesspace/archivesspace/blob/85965cead1451d1b1cddc3d8283c6035d2333c97/backend/app/converters/ead_converter.rb#L268-L282) was added to the EAD importer so that, if there are no _langmaterial_ elements inside the _archdesc/did_, the "und" code is set, to explicitly declare the language of materials to be "Undetermined". However, in doing so it means the `lang_material` object created is added to the `@batch.working_area` queue, in a different context than when they are created in the _langmaterial_ handler. Hence the `lang_material` object is subsequently returned by calls to the [context_obj method](https://github.com/archivesspace/archivesspace/blob/85965cead1451d1b1cddc3d8283c6035d2333c97/backend/app/converters/lib/xml_sax.rb#L331-L333) in handlers for child elements of the _did_.

The trouble is the handler for _container_ elements assumes that `context_obj` is the parent record (a resource or an archival object). So it expects it to have a property called `instances`, which is an array of linked containers. Therefore, when an EAD file contains no language information at the top level, but it does have a container at the top level, then the import job fails with:
```
Error: #&lt;NoMethodError: undefined method `instances&#39; for &lt;JSONModel(:lang_material):0x79b2accc&gt;
Did you mean?  instance_of?&gt;
```
So, I have implemented the simplest fix for this, which is to modify the _container_ handler to check whether `context_obj.instances` is defined. It cannot break anything that previously worked, because it does not change the logic of the handler. I am unclear what is supposed to happen when the if statement evaluates to true (when there are multiple containers) but that occurring in an _archdesc/did_ with no _langmaterial_ is an even rarer scenario, and creating more containers is better than the import failing completely.

Alternatively, it is arguable that the issue is the newer _archdesc/did_ handler changing the `context_obj`, but I cannot think of a way to default to the "Undetermined" language when no _langmaterial_ is present. Possibly if it were changed to an `and_in_closing` handler the issue would be avoided, but that part of the SAX parser doesn't seem to work.

## Related JIRA Ticket or GitHub Issue
No JIRA or GitHub issues, but it is possible this [mailing list thread](http://lyralists.lyrasis.org/pipermail/archivesspace_users_group/2020-March/007438.html) is the same bug, although maybe triggered by a different EAD elements, or in a different sequence.

## How Has This Been Tested?
The backend:test suite passes.

On a development system, running this branch, the [attached valid EAD 2002 file](https://github.com/archivesspace/archivesspace/files/5894215/test_ead.zip) imports successfully, whereas it fails on test.archivesspace.org running on master.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
