### PR TITLE
Update marcxml_base_map.rb to account for 099

### DIFF
--- a/backend/app/converters/lib/marcxml_base_map.rb
+++ b/backend/app/converters/lib/marcxml_base_map.rb
@@ -737,7 +737,7 @@ module MarcXMLBaseMap
           resource.id_0 = id unless id.empty?
         },
 
-
+        # local LC-style identifer
         "datafield[@tag='090']" => -> resource, node {
           if resource.id_0.nil? or resource.id_0.empty?
             id = concatenate_subfields(('a'..'z'), node, '_')
@@ -745,6 +745,14 @@ module MarcXMLBaseMap
           end
         },
 
+        # local non-LC identifier
+        "datafield[@tag='099']" => -> resource, node {
+          if resource.id_0.nil? or resource.id_0.empty?
+            id = concatenate_subfields(('a'..'z'), node, '_')
+            resource.id_0 = id unless id.empty?
+          end
+        },
+        
         # description rules
         "datafield[@tag='040']/subfield[@code='e']" => :finding_aid_description_rules,
 


### PR DESCRIPTION
Account for call numbers/identifiers in the MARC 099 tag, as some collection/resource identifiers are stored there as compared to the 090, and export/import doesn't often include 852 tags from a separate holdings record.  The suggested change merely copies an existing subroutine that is focused on the 090, but the copied subroutine is focused on the 099.

## Related JIRA Ticket or GitHub Issue
None (Zendesk ticket was created)

## How Has This Been Tested?
We are a hosted instance, so I am unable to confirm the code change effect as I don't have a testing environment at my disposal.  The suggested change is merely a copy of an existing code block, but targeted toward a different MARC tag.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
