### PR TITLE
avoid passing nil elements to Hash

### DIFF
--- a/public/app/controllers/agents_controller.rb
+++ b/public/app/controllers/agents_controller.rb
@@ -101,7 +101,7 @@ class AgentsController <  ApplicationController
                               if params[f]
                                 [f, params[f]]
                               end
-                            }].compact.to_query
+                            }.compact].to_query
 
         @pager =  Pager.new("#{uri}?#{extra_params}", @results['this_page'],@results['last_page'])
       else


### PR DESCRIPTION
## Description
map will return `nil` for all values in `RETAINED_PARAMETERS` that are not keys in `params`, which makes `Hash` emit a warning:
```
webapp/WEB-INF/app/controllers/agents_controller.rb:100: warning: this causes ArgumentError in the next release
webapp/WEB-INF/app/controllers/agents_controller.rb:100: warning: wrong element type NilClass at 1 (expected array)
webapp/WEB-INF/app/controllers/agents_controller.rb:100: warning: ignoring wrong elements is deprecated, remove them explicitly
```
Using the array's `compact` method  before casting eliminates `nil` values and the warning.

## How Has This Been Tested?
Confirmed fix in irb and ran the public:test suite to completion.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
