### PR TITLE
Prevent loss of agent contact details, fixes #2110

### DIFF
--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -84,6 +84,16 @@ class ApplicationController < ActionController::Base
 
       obj.instance_data[:find_opts] = opts[:find_opts] if opts.has_key? :find_opts
 
+      # We need to retain any restricted properties from the existing object. i.e.
+      # properties that exist for the record but the user was not allowed to edit
+      if params[opts[:instance]].key?(:restricted_properties)
+        params[opts[:instance]][:restricted_properties].each do |restricted|
+          next unless obj.has_key? restricted
+
+          params[opts[:instance]][restricted] = obj[restricted].dup
+        end
+      end
+
       # Param validations that don't have to do with the JSON validator
       opts[:params_check].call(obj, params) if opts[:params_check]
 
@@ -571,7 +581,7 @@ class ApplicationController < ActionController::Base
           if not result.has_key?(property)
             result[property] = false
           else
-            result[property] = (result[property].to_i === 1)
+            result[property] = (result[property].respond_to?(:to_i) && result[property].to_i === 1)
           end
         end
       end

--- a/frontend/app/views/agents/_form.html.erb
+++ b/frontend/app/views/agents/_form.html.erb
@@ -92,6 +92,8 @@
 
   <% if user_can?('view_agent_contact_record') %>
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "agent_contacts", :section_id => "#{@agent.agent_type}_contact_details", :template_erb => "agents/contact_details", :template => "agent_contact", :help_topic => "#{@agent.agent_type}_contact_details", :invisible => false, :lightmode_toggle => false} %>
+  <% else %>
+    <%= form.hidden_input "restricted_properties[]", 'agent_contacts' %>
   <% end %>
 
   <%= render_aspace_partial :partial => "notes/form", :locals => {:form => form, :all_note_types => note_types_for(form['jsonmodel_type']), :section_id => "#{@agent.agent_type}_notes", :show_apply_note_order_action => false} %>

--- a/frontend/app/views/notes/_template.html.erb
+++ b/frontend/app/views/notes/_template.html.erb
@@ -444,9 +444,7 @@
       <%= form.hidden_input("ingest_problem") %>
       <%= form.label_and_textfield("persistent_id") %>
       <%= form.label_and_textfield("date_of_contact") %>
-
       <%= form.label_and_textarea('contact_notes', :field_opts => {:class => "mixed-content"}) %>
-
       <%# form.label_and_boolean("publish", {}, user_prefs["publish"]) %>
     </div>
   </div>

--- a/frontend/spec/selenium/factories.rb
+++ b/frontend/spec/selenium/factories.rb
@@ -204,10 +204,15 @@ module SeleniumFactories
         qualifier { generate(:alphanumstr) }
       end
 
+      factory :agent_contact, class: JSONModel(:agent_contact) do
+        name { generate(:generic_name) }
+      end
+
       factory :agent_person, class: JSONModel(:agent_person) do
         agent_type { 'agent_person' }
         names { [build(:name_person)] }
         dates_of_existence { [build(:json_structured_date_label)] }
+        agent_contacts { [build(:json_agent_contact)] }
       end
 
       factory :json_agent_person_full_subrec, class: JSONModel(:agent_person) do
@@ -250,13 +255,13 @@ module SeleniumFactories
         agent_identifiers { [build(:json_agent_identifier)] }
         used_languages { [build(:json_used_language)] }
         agent_resources { [build(:json_agent_resource)] }
-        notes { [build(:json_note_bioghist), 
+        notes { [build(:json_note_bioghist),
                  build(:json_note_legal_status),
                  build(:json_note_mandate),
                  build(:json_note_structure_or_genealogy),
                  build(:json_note_general_context)]}
       end
-      
+
       factory :json_structured_date_label, class: JSONModel(:structured_date_label) do
         date_type_structured { "single" }
         date_label { 'existence' }
@@ -290,7 +295,7 @@ module SeleniumFactories
         suffix { generate(:alphanumstr) }
         rest_of_name { generate(:alphanumstr) }
         authority_id { generate(:url) }
-      end      
+      end
 
       factory :json_name_corporate_entity, class: JSONModel(:name_corporate_entity) do
         rules { generate(:name_rule) }
@@ -427,7 +432,7 @@ module SeleniumFactories
       factory :json_agent_identifier, class: JSONModel(:agent_identifier) do
         entity_identifier { generate(:alphanumstr) }
         identifier_type { "loc"}
-      end  
+      end
 
       factory :json_used_language, class: JSONModel(:used_language) do
         language { generate(:language) }

--- a/frontend/spec/selenium/spec/restricted_properties_spec.rb
+++ b/frontend/spec/selenium/spec/restricted_properties_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+describe 'Restricted properties' do
+  before(:all) do
+    @repo = create(:repo, repo_code: "agents_test_#{Time.now.to_i}")
+    @user = create_user(@repo => ['repository-advanced-data-entry'])
+    @agent = create(:agent_person)
+    @restricted_property = 'agent_contacts'
+    @driver = Driver.get.login_to_repo(@user, @repo)
+  end
+
+  after(:all) do
+    @driver ? @driver.quit : next
+  end
+
+  it 'Updating a record with restricted properties retains the restricted data' do
+    expect(@agent[@restricted_property].count).to eq 1
+    @driver.navigate.to("#{$frontend}/agents/#{@agent['jsonmodel_type']}/#{@agent.id}/edit")
+    @driver.find_hidden_element(css: '#agent_restricted_properties___')
+    @driver.find_element(css: "form#agent_form button[type='submit']").click
+    @driver.find_element_with_text('//div[contains(@class, "alert-success")]', /Agent Saved/)
+
+    @driver.logout.login_to_repo($admin, @repo_to_manage)
+    @driver.navigate.to("#{$frontend}/agents/#{@agent['jsonmodel_type']}/#{@agent.id}/edit")
+    expect(@driver.find_element(id: 'agent_agent_contacts__0__name_')).not_to be_nil
+    expect(@driver.find_element(id: 'agent_agent_contacts__0__telephones__0__number_')).not_to be_nil
+    expect(@driver.find_element(id: 'agent_agent_contacts__0__notes__0__date_of_contact_')).not_to be_nil
+  end
+end


### PR DESCRIPTION
If a user without permission to view agent contact details updates
a record containing contact record/s then that data is lost.

This fix adds a generic restricted properties check to ensure
that sections of a record a user does not have access to are
preserved on update.
