### PR TITLE
Update LCNAF import to process multiple selections of subjects

### DIFF
--- a/plugins/lcnaf/frontend/models/opensearcher.rb
+++ b/plugins/lcnaf/frontend/models/opensearcher.rb
@@ -30,9 +30,16 @@ class OpenSearcher
   end
 
 
+  # ANW-429: this method writes two tempfiles -- one for agents records and one for subject records so that the correct importer (MARC auth for agents, MARC bib for subjects is used.
   def results_to_marcxml_file(lccns)
-    tempfile = ASUtils.tempfile('lcnaf_import')
-    tempfile.write("<collection>\n")
+    agent_tempfile = ASUtils.tempfile('lcnaf_import_agent')
+    subject_tempfile = ASUtils.tempfile('lcnaf_import_subject')
+
+    agents_count = 0
+    subjects_count = 0
+
+    agent_tempfile.write("<collection>\n")
+    subject_tempfile.write("<collection>\n")
 
     lccns.each do |lccn|
       lccn.sub!( 'info:lc/authorities/subjects/', '')
@@ -48,16 +55,45 @@ class OpenSearcher
         doc.remove_namespaces!
         doc.encoding = 'utf-8'
 
-        tempfile.write(doc.root)
+        if is_subject_record?(doc)
+          subject_tempfile.write(doc.root)
+          subjects_count += 1
+        else
+          agent_tempfile.write(doc.root)
+          agents_count += 1
+        end
       end
     end
 
-    tempfile.write("\n</collection>")
+    agent_tempfile.write("\n</collection>")
+    subject_tempfile.write("\n</collection>")
 
-    tempfile.flush
-    tempfile.rewind
+    agent_tempfile.flush
+    subject_tempfile.flush
 
-    return tempfile
+    agent_tempfile.rewind
+    subject_tempfile.rewind
+
+    return {
+             :agents => {:count => agents_count, :file => agent_tempfile}, 
+             :subjects => {:count => subjects_count, :file => subject_tempfile}
+           }
+  end
+
+  def is_subject_record?(doc)
+    is_subject_record = false
+
+    subject_tags = ["630", "130", "650", "150", "651", "151", "655", "155", "656", "657", "690", "691", "692", "693", "694", "695", "696", "697", "698", "699"]
+
+
+    subject_tags.each do |tag|
+      if doc.search("//datafield[@tag='#{tag}']").length > 0
+        is_subject_record = true
+        break
+      end
+    end
+
+    is_subject_record
   end
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Modifies the LNCAF plugin to process agents and subjects separately, so that the correct importer can be used for each.

<!--- Why is this change required? What problem does it solve? -->
With the changes to the importer for ANW-429, there's a new MARC Auth agents importer that doesn't have subject support. This is necessary to use the best import function for whatever data is available.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
Multiple tests by hand with one and many agent and subject records together and separate from LCNAF and LCSH.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
