### PR TITLE
use an environment variable ARCHIVESSPACE_VERSION rather than editing…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ build/.cache
 backend/tests/ladle-server*
 webdriver-profile*
 common/ARCHIVESSPACE_VERSION
-common/asconstants.rb
 .yardoc
 API.md
 endpoint_examples*

--- a/_yard/templates/default/layout/html/footer.erb
+++ b/_yard/templates/default/layout/html/footer.erb
@@ -1,5 +1,5 @@
 <div id="footer">
-  ArchivesSpace Version <%= ASConstants.VERSION %> Documentation Generated on <%= Time.now.strftime("%c") %> by
+  ArchivesSpace Version <%= ENV['ARCHIVESSPACE_VERSION'] || ASConstants.VERSION %> Documentation Generated on <%= Time.now.strftime("%c") %> by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   <%= YARD::VERSION %>.
 </div>


### PR DESCRIPTION
… asconstants when generating yard docs outside a distribution context

## Description
The yard docs include the ARCHIVESSPACE_VERSION property in the footer, but the file is only present in a distribution package, so there was a workaround that involved putting a version number in the `asconstants.rb` file, and adding that file to `.gitignore`. This removes the need for that by allowing the user to provide a version to yard via an environment variable.

## Related JIRA Ticket or GitHub Issue
None that I am aware of.

## How Has This Been Tested?
I ran:
`ARCHIVESSPACE_VERSION=FOO ./build/run doc:build`
and 
`./build/run doc:build` and both work as expected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
