### PR TITLE
Bump Docker to java 11 and include java 11 in tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -13,9 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
+    strategy:
+      matrix:
+        java: [ 8, 11 ]
+
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: archivesspace
@@ -29,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: ${{ matrix.java }}
 
     - name: Bootstrap ArchivesSpace
       run: |
@@ -37,7 +41,7 @@ jobs:
 
     - name: Run Backend tests
       env:
-        ASPACE_TEST_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false
+        ASPACE_TEST_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false&allowPublicKeyRetrieval=true
       run: |
-        wget -P ./common/lib https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar
+        wget -P ./common/lib https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.23/mysql-connector-java-8.0.23.jar
         ./build/run backend:test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
 
     - name: Get the version
       id: get_version
@@ -30,7 +30,7 @@ jobs:
         ./build/run bootstrap
 
     - name: Build ArchivesSpace release package
-      env: 
+      env:
         VERSION: ${{ steps.get_version.outputs.VERSION }}
       run: ./scripts/build_release $VERSION
 

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Run rubocop
         run: |

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
+    strategy:
+      matrix:
+        java: [ 8, 11 ]
+
     services:
       mysql:
         image: mysql:5.7
@@ -29,22 +33,22 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: ${{ matrix.java }}
 
     - name: Bootstrap ArchivesSpace
       run: |
         ./build/run bootstrap
-        wget -P ./common/lib https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar
+        wget -P ./common/lib https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.23/mysql-connector-java-8.0.23.jar
 
     - name: Migrate ArchivesSpace DB
       env:
-        APPCONFIG_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false
+        APPCONFIG_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false&allowPublicKeyRetrieval=true
       run: |
         ./build/run db:migrate
 
     - name: Run Frontend tests
       env:
-        ASPACE_TEST_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false
+        ASPACE_TEST_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false&allowPublicKeyRetrieval=true
       run: |
         ./build/run frontend:selenium
         ./build/run frontend:test

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -11,11 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
+    strategy:
+      matrix:
+        java: [ 8, 11 ]
+
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: ${{ matrix.java }}
 
     - name: Bootstrap ArchivesSpace
       run: |

--- a/.github/workflows/public.yml
+++ b/.github/workflows/public.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
+    strategy:
+      matrix:
+        java: [ 8, 11 ]
+
     services:
       mysql:
         image: mysql:5.7
@@ -29,21 +33,21 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: ${{ matrix.java }}
 
     - name: Bootstrap ArchivesSpace
       run: |
         ./build/run bootstrap
-        wget -P ./common/lib https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar
+        wget -P ./common/lib https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.23/mysql-connector-java-8.0.23.jar
 
     - name: Migrate ArchivesSpace DB
       env:
-        APPCONFIG_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false
+        APPCONFIG_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false&allowPublicKeyRetrieval=true
       run: |
         ./build/run db:migrate
 
     - name: Run Public tests
       env:
-        ASPACE_TEST_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false
+        ASPACE_TEST_DB_URL: jdbc:mysql://127.0.0.1:${{ job.services.mysql.ports[3306] }}/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false&allowPublicKeyRetrieval=true
       run: |
         ./build/run public:test

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
     apt-get -y install --no-install-recommends \
       build-essential \
       git \
-      openjdk-8-jre-headless \
+      openjdk-11-jre-headless \
       shared-mime-info \
       wget \
       unzip
@@ -48,7 +48,7 @@ COPY --from=build_release /archivesspace /archivesspace
 RUN apt-get update && \
     apt-get -y install --no-install-recommends \
       ca-certificates \
-      openjdk-8-jre-headless \
+      openjdk-11-jre-headless \
       netbase \
       shared-mime-info \
       wget \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - db
       - solr
     environment:
-      APPCONFIG_DB_URL: 'jdbc:mysql://db:3306/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123'
+      APPCONFIG_DB_URL: 'jdbc:mysql://db:3306/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false&allowPublicKeyRetrieval=true'
       # solr config
       APPCONFIG_ENABLE_SOLR: 'false'
       APPCONFIG_SOLR_URL: 'http://solr:8983/solr/archivesspace'


### PR DESCRIPTION
Extend test workflows to include Java 11 and update Docker image to 11.

## How Has This Been Tested?
Have been using Java 11 with ArchivesSpace for at least a couple of months, without problems, so seems like a good next step is to incorporate it into the test workflows and Docker for the test server deployments. Can build and run ArchivesSpace (`docker-compose build && docker-compose up`).

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
