### PR TITLE
ANW-429 related agents enhancements

### DIFF
--- a/backend/app/model/agent_relationship_associative.rb
+++ b/backend/app/model/agent_relationship_associative.rb
@@ -1,4 +1,4 @@
-class AgentRelationshipAssociative < Sequel::Model(:agent_relationship_associative)
+class AgentRelationshipAssociative < Sequel::Model(:related_agents_rlshp)
 
   include ASModel
   corresponds_to JSONModel(:agent_relationship_associative)

--- a/backend/app/model/agent_relationship_earlierlater.rb
+++ b/backend/app/model/agent_relationship_earlierlater.rb
@@ -1,4 +1,4 @@
-class AgentRelationshipEarlierlater < Sequel::Model(:agent_relationship_earlierlater)
+class AgentRelationshipEarlierlater < Sequel::Model(:related_agents_rlshp)
 
   include ASModel
   corresponds_to JSONModel(:agent_relationship_earlierlater)

--- a/backend/app/model/agent_relationship_family.rb
+++ b/backend/app/model/agent_relationship_family.rb
@@ -1,4 +1,4 @@
-class AgentRelationshipFamily < Sequel::Model(:agent_relationship_family)
+class AgentRelationshipFamily < Sequel::Model(:related_agents_rlshp)
 
   include ASModel
   corresponds_to JSONModel(:agent_relationship_family)

--- a/backend/app/model/agent_relationship_hierarchical.rb
+++ b/backend/app/model/agent_relationship_hierarchical.rb
@@ -1,4 +1,4 @@
-class AgentRelationshipHierarchical < Sequel::Model(:agent_relationship_hierarchical)
+class AgentRelationshipHierarchical < Sequel::Model(:related_agents_rlshp)
 
   include ASModel
   corresponds_to JSONModel(:agent_relationship_hierarchical)

--- a/backend/app/model/agent_relationship_identity.rb
+++ b/backend/app/model/agent_relationship_identity.rb
@@ -1,4 +1,4 @@
-class AgentRelationshipIdentity < Sequel::Model(:agent_relationship_identity)
+class AgentRelationshipIdentity < Sequel::Model(:related_agents_rlshp)
 
   include ASModel
   corresponds_to JSONModel(:agent_relationship_identity)

--- a/backend/app/model/agent_relationship_parentchild.rb
+++ b/backend/app/model/agent_relationship_parentchild.rb
@@ -1,4 +1,4 @@
-class AgentRelationshipParentchild < Sequel::Model(:agent_relationship_parentchild)
+class AgentRelationshipParentchild < Sequel::Model(:related_agents_rlshp)
 
   include ASModel
   corresponds_to JSONModel(:agent_relationship_parentchild)

--- a/backend/app/model/agent_relationship_subordinatesuperior.rb
+++ b/backend/app/model/agent_relationship_subordinatesuperior.rb
@@ -1,4 +1,4 @@
-class AgentRelationshipSubordinatesuperior < Sequel::Model(:agent_relationship_subordinatesuperior)
+class AgentRelationshipSubordinatesuperior < Sequel::Model(:related_agents_rlshp)
 
   include ASModel
   corresponds_to JSONModel(:agent_relationship_subordinatesuperior)

--- a/backend/app/model/agent_relationship_temporal.rb
+++ b/backend/app/model/agent_relationship_temporal.rb
@@ -1,4 +1,4 @@
-class AgentRelationshipTemporal < Sequel::Model(:agent_relationship_temporal)
+class AgentRelationshipTemporal < Sequel::Model(:related_agents_rlshp)
 
   include ASModel
   corresponds_to JSONModel(:agent_relationship_temporal)

--- a/backend/app/model/mixins/related_agents.rb
+++ b/backend/app/model/mixins/related_agents.rb
@@ -4,8 +4,6 @@ module RelatedAgents
   extend JSONModel
 
   def self.included(base)
-    callback = proc { |clz| RelatedAgents.set_up_date_record_handling(clz) }
-
     base.include(DirectionalRelationships)
 
     base.define_directional_relationship(:name => :related_agents,
@@ -13,7 +11,27 @@ module RelatedAgents
                                          :contains_references_to_types => proc {
                                            AgentManager.registered_agents.map {|a| a[:model]}
                                          },
-                                         :class_callback => callback)
+                                         :class_callback => proc {|clz|
+                                           clz.instance_eval do
+                                             include DynamicEnums
+                                             uses_enums({
+                                                          :property => 'relator',
+                                                          :uses_enum => %w[agent_relationship_associative_relator
+                                                                           agent_relationship_earlierlater_relator
+                                                                           agent_relationship_parentchild_relator
+                                                                           agent_relationship_subordinatesuperior_relator
+                                                                           agent_relationship_identity_relator
+                                                                           agent_relationship_hierarchical_relator
+                                                                           agent_relationship_temporal_relator
+                                                                           agent_relationship_family_relator]
+                                                        },
+                                                        {
+                                                          :property => 'specific_relator',
+                                                          :uses_enum => 'agent_relationship_specific_relator'
+                                                        })
+                                           end
+                                           RelatedAgents.set_up_date_record_handling(clz)
+                                         })
   end
 
 

--- a/backend/spec/controller_enumeration_spec.rb
+++ b/backend/spec/controller_enumeration_spec.rb
@@ -70,9 +70,7 @@ describe "Enumeration controller" do
   end
 
 
-  xit "can't remove values that are being used" do
-    pending "this test passes when run on it's own, failing when run with other tests"
-
+  it "can't remove values that are being used" do
     obj = JSONModel(:enumeration).find(@enum_id)
     obj.values += ["new_value"]
     obj.save
@@ -82,16 +80,13 @@ describe "Enumeration controller" do
 
     obj.values -= ['new_value']
 
-
     expect {
       obj.save
     }.to raise_error(ConflictException)
   end
 
 
-  xit "can migrate a value to get rid of it" do
-    pending "this test passes when run on it's own, failing when run with other tests"
-
+  it "can migrate a value to get rid of it" do
     obj = JSONModel(:enumeration).find(@enum_id)
     obj.values += ["new_value"]
     obj.save
@@ -100,15 +95,11 @@ describe "Enumeration controller" do
     record = @model.create(:my_enum_id => value.id)
 
     old_time = record[:system_mtime]
-
     request = JSONModel(:enumeration_migration).from_hash(:enum_uri => obj.uri,
                                                           :from => 'new_value',
                                                           :to => 'abc')
     request.save
-
     record.refresh
-
-    pending "this test passes when run on it's own, failing when run with other tests"
 
     expect(record[:system_mtime]).not_to eq(old_time)
     expect(record[:my_enum_id]).not_to eq(value.id)

--- a/backend/spec/model_related_agents_spec.rb
+++ b/backend/spec/model_related_agents_spec.rb
@@ -7,30 +7,58 @@ describe 'Related agents' do
     earlier_company = create(:json_agent_corporate_entity)
 
     relationship = JSONModel(:agent_relationship_earlierlater).new
-    relationship.relator = "is_later_form_of"
+    relationship.relator = 'is_later_form_of'
     relationship.ref = earlier_company.uri
 
     later_company = create(:json_agent_corporate_entity,
-                           "related_agents" => [relationship.to_hash])
+                           'related_agents' => [relationship.to_hash])
 
     earlier_company = JSONModel(:agent_corporate_entity).find(earlier_company.id)
     later_company = JSONModel(:agent_corporate_entity).find(later_company.id)
 
-    expect(earlier_company.related_agents[0]['relator']).to eq ('is_earlier_form_of')
-    expect(later_company.related_agents[0]['relator']).to eq ('is_later_form_of')
+    expect(earlier_company.related_agents[0]['relator']).to eq('is_earlier_form_of')
+    expect(later_company.related_agents[0]['relator']).to eq('is_later_form_of')
   end
 
+  it 'updates agent relationship specific relators when enumerations are merged' do
+    # Add some custom relators
+    enum = Enumeration.find(:name => 'agent_relationship_specific_relator')
+    enum.add_enumeration_value(:value => 'first')
+    enum.add_enumeration_value(:value => 'second')
 
-  it "Supports related agents with date records" do
+    person1 = create(:json_agent_person)
+    relationship = JSONModel(:agent_relationship_associative).new
+    relationship.relator = 'is_associative_with'
+    relationship.specific_relator = 'first'
+    relationship.ref = person1.uri
+    person2 = create(:json_agent_person,
+                     'related_agents' => [relationship.to_hash])
+
+    expect(person2.related_agents[0]['specific_relator']).to eq('first')
+
+    # Merge the enums
+    enum = Enumeration.find(:name => 'agent_relationship_specific_relator')
+    obj = JSONModel(:enumeration).find(enum.id)
+    request = JSONModel(:enumeration_migration).from_hash(:enum_uri => obj.uri,
+                                                          :from => 'first',
+                                                          :to => 'second')
+    request.save
+
+    person2 = JSONModel(:agent_person).find(person2.id)
+    expect(person2.related_agents[0]['specific_relator']).not_to eq('first')
+    expect(person2.related_agents[0]['specific_relator']).to eq('second')
+  end
+
+  it 'Supports related agents with date records' do
     parent = create(:json_agent_person)
     date = build(:json_structured_date_label).to_hash
 
     relationship = JSONModel(:agent_relationship_parentchild).new
-    relationship.relator = "is_child_of"
+    relationship.relator = 'is_child_of'
     relationship.ref = parent.uri
     relationship.dates = date
 
-    child = create(:json_agent_person, "related_agents" => [relationship.to_hash])
+    child = create(:json_agent_person, 'related_agents' => [relationship.to_hash])
 
     child = JSONModel(:agent_person).find(child.id)
     expect(child.related_agents.first['dates']['structured_date_single']['date_expression']).to eq(date['structured_date_single']['date_expression'])

--- a/common/db/migrations/145_update_agent_rlshps.rb
+++ b/common/db/migrations/145_update_agent_rlshps.rb
@@ -1,17 +1,79 @@
 require_relative 'utils'
 
 agent_relationships = %w[agent_relationship_associative_relator
-                         agent_relationship_earlierlater_relator agent_relationship_parentchild_relator agent_relationship_subordinatesuperior_relator
+                         agent_relationship_earlierlater_relator
+                         agent_relationship_parentchild_relator
+                         agent_relationship_subordinatesuperior_relator
                          agent_relationship_identity_relator
                          agent_relationship_hierarchical_relator
                          agent_relationship_temporal_relator
                          agent_relationship_family_relator]
 
+existing_relators = %w[is_associative_with
+                       is_earlier_form_of
+                       is_later_form_of
+                       is_parent_of
+                       is_child_of
+                       is_subordinate_to
+                       is_superior_of
+                       is_identified_with
+                       is_hierarchical_with
+                       is_temporal_with
+                       is_related_with]
+
 Sequel.migration do
   up do
-    $stderr.puts 'Updating agent relationship relator lists to be editable'
-    agent_relationships.each do |rel|
-      self[:enumeration].filter(:name => rel).update(:editable => 1)
+    # Add new enum for specific relationship
+    create_editable_enum('agent_relationship_specific_relator', [])
+
+    # Add the new columns
+    alter_table(:related_agents_rlshp) do
+      add_column(:relator_id, Integer, :null => true)
+      add_foreign_key([:relator_id], :enumeration_value, :key => :id)
+      add_column(:specific_relator_id, Integer, :null => true)
+      add_foreign_key([:specific_relator_id], :enumeration_value, :key => :id)
+      add_column(:relationship_uri, String, :null => true)
+      set_column_allow_null :relator
     end
+
+    # Migrate enumeration values to relator_id from relator string
+    agent_relationships.each do |rel|
+      enum = self[:enumeration].filter(:name => rel).select(:id)
+      enumeration_values = self[:enumeration_value].filter(:enumeration_id => enum).all
+
+      self.transaction do
+        enumeration_values.each do |value|
+          self[:related_agents_rlshp].filter(:relator => value[:value],
+                                             :relator_id => nil)
+                                     .update(:relator => nil,
+                                             :relator_id => value[:id])
+        end
+      end
+    end
+
+    alter_table(:related_agents_rlshp) do
+      set_column_not_null(:relator_id)
+    end
+
+    # Attempt to delete old relator string
+    if self[:related_agents_rlshp].filter(Sequel.~(:relator => nil)).count == 0
+      alter_table(:related_agents_rlshp) do
+        drop_column(:relator)
+      end
+    else
+      $stderr.puts("WARNING: we tried to drop the column " +
+                   "'related_agents_rlshp.relator' as a part of " +
+                   "migration 145_update_agent_rlshps.rb but " +
+                   "there's still data in it.  Please contact " +
+                   "support as your migration may be incomplete.")
+    end
+
+    # These probably shouldn't have been editable in the first place since
+    # the presence of 1 or 2 (and only 1 or 2) relators here conveys meaning
+    # in directional relationships.
+    existing_relators.each do |val|
+      self[:enumeration_value].filter(:value => val).update(:readonly => 1)
+    end
+
   end
 end

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -975,6 +975,14 @@ en:
 
   related_agent: &related_agent_attributes
     relationship_type: General Relationship Type
+    relator: Directional Relationship Type
+    specific_relator: Specific Relationship Type
+    relationship_uri: Relationship URI
+    relator_tooltip: A specific qualifier that describes the relationship.
+    description: Description
+    date: Date
+    dates: Dates
+    ref: Related Agent
     _singular: Related Agent
     _plural: Related Agents
 
@@ -982,75 +990,35 @@ en:
     <<: *related_agent_attributes
 
   agent_relationship_parentchild:
-    relator: Specific Relationship Type
-    relator_tooltip: A specific qualifier that describes the relationship.
-    description: Description
-    ref: Related Agent
-    date: Date
-    dates: Dates
+    <<: *related_agent_attributes
     _singular: Parent/Child Relationship
 
   agent_relationship_earlierlater:
-    relator: Specific Relationship Type
-    relator_tooltip: A specific qualifier that describes the relationship.
-    description: Description
-    ref: Related Agent
-    date: Date
-    dates: Dates
+    <<: *related_agent_attributes
     _singular: Earlier/Later Relationship
 
   agent_relationship_subordinatesuperior:
-    relator: Specific Relationship Type
-    relator_tooltip: A specific qualifier that describes the relationship.
-    description: Description
-    ref: Related Agent
-    date: Date
-    dates: Dates
+    <<: *related_agent_attributes
     _singular: Subordinate/Superior Relationship
 
   agent_relationship_associative:
-    relator: Specific Relationship Type
-    relator_tooltip: A specific qualifier that describes the relationship.
-    description: Description
-    date: Date
-    dates: Dates
-    ref: Related Agent
+    <<: *related_agent_attributes
     _singular: Associative Relationship
 
   agent_relationship_identity:
-    relator: Specific Relationship Type
-    relator_tooltip: A specific qualifier that describes the relationship.
-    description: Description
-    date: Date
-    dates: Dates
-    ref: Related Agent
+    <<: *related_agent_attributes
     _singular: Agent Relationship Identified With Relator
 
   agent_relationship_hierarchical:
-    relator: Specific Relationship Type
-    relator_tooltip: A specific qualifier that describes the relationship.
-    description: Description
-    date: Date
-    dates: Dates
-    ref: Related Agent
+    <<: *related_agent_attributes
     _singular: Agent Relationship Hierarchical Relator
 
   agent_relationship_temporal:
-    relator: Specific Relationship Type
-    relator_tooltip: A specific qualifier that describes the relationship.
-    description: Description
-    date: Date
-    dates: Dates
-    ref: Related Agent
+    <<: *related_agent_attributes
     _singular: Agent Relationship Temporal Relator
 
   agent_relationship_family:
-    relator: Specific Relationship Type
-    relator_tooltip: A specific qualifier that describes the relationship.
-    description: Description
-    date: Date
-    dates: Dates
-    ref: Related Agent
+    <<: *related_agent_attributes
     _singular: Agent Relationship Related Relator
 
   note:

--- a/common/locales/enums/en.yml
+++ b/common/locales/enums/en.yml
@@ -1904,6 +1904,7 @@ en:
     agent_relationship_parentchild_relator: Agent Relationship Parentchild Relator
     agent_relationship_identity_relator: Agent Relationship Identity Relator
     agent_relationship_hierarchical_relator: Agent Relationship Hierarchical Relator
+    agent_relationship_specific_relator: Agent Relationship Specific Relator
     agent_relationship_temporal_relator: Agent Relationship Temporal Relator
     agent_relationship_family_relator: Agent Relationship Family Relator
     agent_relationship_subordinatesuperior_relator: Agent Relationship Subordinatesuperior Relator

--- a/common/schemas/abstract_agent_relationship.rb
+++ b/common/schemas/abstract_agent_relationship.rb
@@ -5,6 +5,11 @@
     "type" => "object",
     "subtype" => "ref",
     "properties" => {
+      "relationship_uri" => {"type" => "string", "required" => false},
+      "specific_relator" => {
+        "type" => "string",
+        "dynamic_enum" => "agent_relationship_specific_relator"
+      },
       "description" => {"type" => "string", "maxLength" => 65000},
       "dates" => {"type" => "JSONModel(:structured_date_label) object"}
     }

--- a/common/schemas/agent_family.rb
+++ b/common/schemas/agent_family.rb
@@ -22,7 +22,8 @@
 
       "related_agents" => {
         "type" => "array",
-        "items" => {"type" => [{"type" => "JSONModel(:agent_relationship_earlierlater) object"},
+        "items" => {"type" => [{"type" => "JSONModel(:agent_relationship_parentchild) object"},
+                               {"type" => "JSONModel(:agent_relationship_earlierlater) object"},
                                {"type" => "JSONModel(:agent_relationship_identity) object"},
                                {"type" => "JSONModel(:agent_relationship_hierarchical) object"},
                                {"type" => "JSONModel(:agent_relationship_temporal) object"},

--- a/common/schemas/agent_relationship_parentchild.rb
+++ b/common/schemas/agent_relationship_parentchild.rb
@@ -13,7 +13,8 @@
       },
 
       "ref" => {
-        "type" => [{"type" => "JSONModel(:agent_person) uri"}],
+        "type" => [{"type" => "JSONModel(:agent_person) uri"},
+                   {"type" => "JSONModel(:agent_family) uri"}],
         "ifmissing" => "error"
       },
 

--- a/frontend/app/views/related_agents/_template.html.erb
+++ b/frontend/app/views/related_agents/_template.html.erb
@@ -45,6 +45,10 @@
         <% else %>
           <%= form.label_and_select("relator", form.possible_options_for("relator")) %>
         <% end %>
+        
+        <%= form.label_and_select("specific_relator", form.possible_options_for("specific_relator", true)) %>
+
+        <%= form.label_and_textfield("relationship_uri") %>
 
         <% if opts[:readonly] %>
           <div class="token-list <%= form['_resolved']['agent_type'] %>">

--- a/frontend/app/views/related_agents/_template_merge.html.erb
+++ b/frontend/app/views/related_agents/_template_merge.html.erb
@@ -39,6 +39,8 @@
       <div class="subrecord-form-container">
         <%= form.hidden_input(:jsonmodel_type, "#{relationship_type}") %>
         <%= form.label_and_readonly("relator") %>
+        <%= form.label_and_select("specific_relator", form.possible_options_for("specific_relator", true)) %>
+        <%= form.label_and_textfield("relationship_uri") %>
         <% if opts[:readonly] %>
           <div class="token-list <%= form['_resolved']['agent_type'] %>">
             <%= form.label_with_field(:ref, render_token(:object => form,

--- a/frontend/app/views/related_agents/_template_merge_target.html.erb
+++ b/frontend/app/views/related_agents/_template_merge_target.html.erb
@@ -35,6 +35,8 @@
       <div class="subrecord-form-container">
         <%= form.hidden_input(:jsonmodel_type, "#{relationship_type}") %>
         <%= form.label_and_readonly("relator") %>
+        <%= form.label_and_select("specific_relator", form.possible_options_for("specific_relator", true)) %>
+        <%= form.label_and_textfield("relationship_uri") %>
         <% if opts[:readonly] %>
           <div class="token-list <%= form['_resolved']['agent_type'] %>">
             <%= form.label_with_field(:ref, render_token(:object => form,

--- a/frontend/app/views/related_agents/_template_required.html.erb
+++ b/frontend/app/views/related_agents/_template_required.html.erb
@@ -35,6 +35,8 @@
       <div class="subrecord-form-container">
         <%= form.hidden_input(:jsonmodel_type, "#{relationship_type}") %>
         <%= form.label_and_select("relator", form.possible_options_for("relator")) %>
+        <%= form.label_and_select("specific_relator", form.possible_options_for("specific_relator", true)) %>
+        <%= form.label_and_textfield("relationship_uri") %>
         <% if opts[:readonly] %>
           <div class="token-list <%= form['_resolved']['agent_type'] %>">
             <%= form.label_with_field(:ref, render_token(:object => form,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
First pass of additional related agents enhancements, including the following:

- Add two new form fields for `specific_relator` (optional editable controlled value list with no default) and `relationship_uri` (optional text string);
- Update marc_auth import map and eac import map to send appropriate content to those new fields;
- Update staff form fields to incorporate new fields;
- Update relationships models to point to an existing db table;
- Update new db migration (145) to add new fields, migrate relator term from a string to an id (inline with prior refactoring work https://github.com/archivesspace/archivesspace/commit/e2f2cdb5d94cd79123d464f1d74ad2a8b95b5911), and make existing relator term values readonly;
- Update some tests and add new test to confirm specific relator controlled values can be merged and the associated records updated;
- Start translations work (will need to update non-English ymls); and,
- Extend `agent_relationship_parentchild` relationship to family agents (was previously reserved for just person agents).

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
