### PR TITLE
ANW-1217 Only show same type agents in merge dropdown

### DIFF
--- a/frontend/app/views/agents/_linker.html.erb
+++ b/frontend/app/views/agents/_linker.html.erb
@@ -64,12 +64,12 @@
             <li class="dropdown-submenu pull-left">
               <% if !hide_create && user_can?('update_agent_record') %>
               <a href="javascript:void(0);"><%= I18n.t("actions.create") %></a>
-              <% end %>
               <ul class="dropdown-menu">
                 <% creatable_types.each do |agent_type| %>
-                <li><a href="javascript:void(0);" data-target="<%= url_for :controller => :agents, :action => :new, :agent_type => agent_type.intern, :inline => true %>" class="linker-create-btn"><%= I18n.t("#{agent_type}._singular") %></a></li>
+                  <li><a href="javascript:void(0);" data-target="<%= url_for :controller => :agents, :action => :new, :agent_type => agent_type.intern, :inline => true %>" class="linker-create-btn"><%= I18n.t("#{agent_type}._singular") %></a></li>
                 <% end %>
               </ul>
+              <% end %>
             </li>
           <% end %>
         </ul>

--- a/frontend/app/views/agents/_merge_dropdown.html.erb
+++ b/frontend/app/views/agents/_merge_dropdown.html.erb
@@ -15,7 +15,14 @@
 
         <fieldset>
           <div class="alert alert-danger missing-ref-message" style="display: none;"><%= I18n.t "#{singular}._frontend.messages.please_select_a_#{singular}_to_merge" %></div>
-          <%= render_aspace_partial :partial => "#{controller}/linker", :locals => { :form => form,  :exclude_ids => [record.uri], :hide_create => true, :multiplicity => multiplicity, :layout => 'stacked' }%>
+          <%= render_aspace_partial :partial => "#{controller}/linker", 
+                                    :locals => { 
+                                      :form => form,  
+                                      :exclude_ids => [record.uri], 
+                                      :allowed_types => @agent_type,
+                                      :hide_create => true, 
+                                      :multiplicity => multiplicity, 
+                                      :layout => 'stacked' }%>
         </fieldset>
         <div class="form-actions">
           <%=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Agents of different types cannot be merged, so the typeahead should only show agents of the same type.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Also discovered that the `creatable_types` block was running even when `hide_create` was set due to the position of the `<%end%>`.  Moved the closure down so `creatable_types` doesn't choke when an single `allowable_types` is sent via the merge_dropdown.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1217

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15144646/111184773-adecf980-8587-11eb-8f26-223261fe727a.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
