### PR TITLE
ANW-1228 Related agents rest of name whitespace fix

### DIFF
--- a/backend/app/converters/lib/eac_base_map.rb
+++ b/backend/app/converters/lib/eac_base_map.rb
@@ -1114,7 +1114,7 @@ module EACBaseMap
 
         case type
         when 'person'
-          nom_parts = val.split(', ', 2)
+          nom_parts = val.split(/,\s*/, 2)
           name['primary_name'] = nom_parts[0]
           name['rest_of_name'] = nom_parts[1]
         when 'family'

--- a/backend/app/converters/lib/eac_base_map.rb
+++ b/backend/app/converters/lib/eac_base_map.rb
@@ -1114,7 +1114,7 @@ module EACBaseMap
 
         case type
         when 'person'
-          nom_parts = val.split(',', 2)
+          nom_parts = val.split(', ', 2)
           name['primary_name'] = nom_parts[0]
           name['rest_of_name'] = nom_parts[1]
         when 'family'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When parsing a person related agent name, strip the space after a comma so there is (hopefully) no leading whitespace in 'rest_of_name'.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1228

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
