### PR TITLE
ANW-1225: Clean trailing characters from MARC auth import

### DIFF
--- a/backend/spec/lib_marcxml_auth_agent_converter_spec.rb
+++ b/backend/spec/lib_marcxml_auth_agent_converter_spec.rb
@@ -317,7 +317,7 @@ describe 'MARCXML Auth Agent converter' do
       expect(agent_corp_records.last['related_agents'].first['description']).to eq('Founder:')
       # related agent is there
       expect(agent_person_records.first['names'][0]['primary_name']).to eq('Flexner')
-      expect(agent_person_records.first['names'][0]['rest_of_name']).to eq('Abraham,')
+      expect(agent_person_records.first['names'][0]['rest_of_name']).to eq('Abraham')
     end
 
     it 'imports agent_sources subrecords' do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds additional cleaning of trailing characters to the new MARC auth import, including removing the unnecessary comma at the end of the $a when a $d is present.

In comparing the new auth imported to the old/shared bib importer, I noticed several other areas where trailing punctuation was previously being cleaned up.  I copied over these changes to keep the new importer as close as possible to the old/road tested importer, though more work will likely be necessary in the future.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1225

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
