### PR TITLE
ANW-1215: Show specific relator if present in PUI

### DIFF
--- a/public/app/views/agents/_related_agents.html.erb
+++ b/public/app/views/agents/_related_agents.html.erb
@@ -12,8 +12,11 @@
       <% agent = relationship['_resolved'] %>
       <li>
         <%= link_to agent['display_name']['sort_name'], app_prefix(agent['uri']) %>
-        (<%= I18n.t("enumerations.#{type}_relator.#{relationship['relator']}", :default => relationship['relator']) %>,
-         <%= I18n.t("#{agent['jsonmodel_type']}._singular") %>)
+        <% if relationship['specific_relator'] %>
+          (<%= I18n.t("enumerations.specific_relator.#{relationship['specific_relator']}", :default => relationship['specific_relator']) %>)
+        <% else %>
+          (<%= I18n.t("enumerations.#{type}_relator.#{relationship['relator']}", :default => relationship['relator']) %>)
+        <% end %>
          <% if relationship['description'] || ASUtils.wrap(relationship['dates']).length > 0 %>
            <dl>
              <% if relationship['description'] %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Small tweak to the sidebar display of related agents in the PUI.  If an (optional) `specific_relator` is present, show that, else use the (required) `relator` term.  Also, remove the agent type from the parens.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1215

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15144646/111525513-1678d980-8734-11eb-9ce4-b3fcea68678f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
