### PR TITLE
ANW-1210 hide related agent subrecords when there are more than 4

### DIFF
--- a/frontend/app/assets/javascripts/related_agents.crud.js
+++ b/frontend/app/assets/javascripts/related_agents.crud.js
@@ -1,5 +1,7 @@
 //= require dates.crud
 //= require linker
+//= require subrecord.too_many.js
+
 $(function() {
 
   $.fn.init_related_agents_form = function() {
@@ -7,7 +9,7 @@ $(function() {
 
       var $this = $(this);
       $(".linker", $this).linker();
-      if ($this.hasClass("initialised")) {
+      if ($this.hasClass("initialised") || $this.hasClass("too-many")) {
         return;
       }
 
@@ -73,7 +75,7 @@ $(function() {
 
         $subsubform = $("<li>").data("type", $subsubform.data("type")).append($subsubform);
         $subsubform.attr("data-index", index);
-        $subsubform.show(); 
+        $subsubform.show();
         $target_subrecord_list.append($subsubform);
 
         initRemoveActionForSubRecord($subsubform);
@@ -102,20 +104,27 @@ $(function() {
         });
       }
 
-      AS.initAddAsYouGoActions($this, $list);
-      AS.initSubRecordSorting($list);
+      $existingAgents = $(".subrecord-form-list:first > .subrecord-form-wrapper", $this);
+      tooManyAgents = AS.initTooManySubRecords($this, $existingAgents.length, (function (callback) {
+        AS.initSubRecordSorting($list);
+        AS.initAddAsYouGoActions($this, $list);
+
+        if (callback) {
+          callback();
+        }
+      }));
+
+      if (tooManyAgents === false ) {
+        $this.addClass("initialised")
+        AS.initSubRecordSorting($list);
+        AS.initAddAsYouGoActions($this, $list);
+      }
     });
   };
-
 
   $(document).ready(function() {
     $(document).bind("loadedrecordform.aspace", function(event, $container) {
       $("section.related-agents-form.subrecord-form:not(.initialised)", $container).init_related_agents_form();
     });
-
-    $("section.related-agents-form.subrecord-form:not(.initialised)").init_related_agents_form();
-     
   });
-
-
 });

--- a/frontend/spec/selenium/spec/agents_spec.rb
+++ b/frontend/spec/selenium/spec/agents_spec.rb
@@ -6,7 +6,7 @@ require 'net/http'
 describe "agents merge" do
   before(:all) do
     @repo = create(:repo, repo_code: "agents_test_#{Time.now.to_i}")
-  
+
     @driver = Driver.get
     @driver.login_to_repo($admin, @repo)
 
@@ -77,7 +77,7 @@ end
 describe "agents record CRUD" do
   before(:all) do
     @repo = create(:repo, repo_code: "agents_test_#{Time.now.to_i}")
-  
+
     @driver = Driver.get
     @driver.login_to_repo($admin, @repo)
 
@@ -242,7 +242,7 @@ describe "agents record CRUD" do
 
       @driver.find_element(id: 'agent_dates_of_existence__0__date_type_structured_').select_option('single')
       @driver.clear_and_send_keys([:id, 'agent_dates_of_existence__0_[structured_date_single]_date_expression_'], '1973')
-    
+
       @driver.click_and_wait_until_gone(css: "form .record-pane button[type='submit']")
 
       # will fail here if date of existence not added correctly.
@@ -261,7 +261,7 @@ describe "agents record CRUD" do
       @driver.clear_and_send_keys([:id, 'agent_agent_record_identifiers__0__record_identifier_'], rand(10000))
 
       @driver.find_element(id: 'agent_agent_record_identifiers__0__source_').select_option('local')
-    
+
       @driver.click_and_wait_until_gone(css: "form .record-pane button[type='submit']")
 
       # will fail here if subrecord not added correctly.
@@ -280,7 +280,7 @@ describe "agents record CRUD" do
       @driver.clear_and_send_keys([:id, 'agent_agent_record_identifiers__0__record_identifier_'], rand(10000))
 
       @driver.find_element(id: 'agent_agent_record_identifiers__0__source_').select_option('local')
-  
+
       @driver.click_and_wait_until_gone(css: "form .record-pane button[type='submit']")
 
       # will fail here if subrecord not added correctly.
@@ -317,7 +317,7 @@ describe "agents record CRUD" do
 
       # will fail here if subrecord not added correctly.
       @driver.find_element(id: 'agent_agent_other_agency_codes__0_')
-    end  
+    end
 
     it 'can add a conventions declaration to an Agent' do
       @driver.find_element(:link, 'Create').click
@@ -334,7 +334,7 @@ describe "agents record CRUD" do
 
       # will fail here if subrecord not added correctly.
       @driver.find_element(id: 'agent_agent_conventions_declarations__0_')
-    end  
+    end
 
     it 'can add maintenance history to an Agent' do
       @driver.find_element(:link, 'Create').click
@@ -357,7 +357,7 @@ describe "agents record CRUD" do
 
       # will fail here if subrecord not added correctly.
       @driver.find_element(id: 'agent_agent_maintenance_histories__0_')
-    end  
+    end
 
     it 'can add source entry to an Agent' do
       @driver.find_element(:link, 'Create').click
@@ -374,7 +374,7 @@ describe "agents record CRUD" do
 
       # will fail here if subrecord not added correctly.
       @driver.find_element(id: 'agent_agent_sources__0_')
-    end  
+    end
 
     it 'can add alternate set to an Agent' do
       @driver.find_element(:link, 'Create').click
@@ -391,7 +391,7 @@ describe "agents record CRUD" do
 
       # will fail here if subrecord not added correctly.
       @driver.find_element(id: 'agent_agent_alternate_sets__0_')
-    end  
+    end
 
     it 'can add entity ids to an Agent' do
       @driver.find_element(:link, 'Create').click
@@ -408,7 +408,7 @@ describe "agents record CRUD" do
 
       # will fail here if subrecord not added correctly.
       @driver.find_element(id: 'agent_agent_identifiers__0_')
-    end  
+    end
 
     it 'can add a name use date to an Agent' do
       @driver.find_element(:link, 'Create').click
@@ -421,12 +421,12 @@ describe "agents record CRUD" do
 
       @driver.find_element(id: 'agent_names__0__use_dates__0__date_type_structured_').select_option('single')
       @driver.clear_and_send_keys([:id, 'agent_names__0__use_dates__0_[structured_date_single]_date_expression_'], '1973')
- 
+
       @driver.click_and_wait_until_gone(css: "form .record-pane button[type='submit']")
 
       # will fail here if subrecord not added correctly.
       @driver.find_element(id: 'agent_names__0__use_dates__0_')
-    end  
+    end
 
     it 'can add a parallel name to an Agent' do
       @driver.find_element(:link, 'Create').click
@@ -438,12 +438,12 @@ describe "agents record CRUD" do
       @driver.find_element(css: '#agent_names__0__parallel_names_ .btn:not(.show-all)').click
 
       @driver.clear_and_send_keys([:id, 'agent_names__0__parallel_names__0__primary_name_'], rand(10000))
- 
+
       @driver.click_and_wait_until_gone(css: "form .record-pane button[type='submit']")
 
       # will fail here if subrecord not added correctly.
       @driver.find_element(id: 'agent_names__0__parallel_names__0_')
-    end  
+    end
 
     it 'can add a name use date to a parallel name' do
       @driver.find_element(:link, 'Create').click
@@ -460,12 +460,12 @@ describe "agents record CRUD" do
 
        @driver.find_element(id: 'agent_names__0__parallel_names__0__use_dates__0__date_type_structured_').select_option('single')
       @driver.clear_and_send_keys([:id, 'agent_names__0__parallel_names__0__use_dates__0_[structured_date_single]_date_expression_'], '1973')
- 
+
       @driver.click_and_wait_until_gone(css: "form .record-pane button[type='submit']")
 
       # will fail here if subrecord not added correctly.
       @driver.find_element(id: 'agent_names__0__parallel_names__0__use_dates__0_')
-    end  
+    end
 
     it 'can add gender to an Agent' do
       @driver.find_element(:link, 'Create').click
@@ -482,7 +482,7 @@ describe "agents record CRUD" do
 
       # will fail here if subrecord not added correctly.
       @driver.find_element(id: 'agent_agent_genders__0_')
-    end  
+    end
 
     it 'can add date to a gender' do
       @driver.find_element(:link, 'Create').click
@@ -505,7 +505,7 @@ describe "agents record CRUD" do
 
       # will fail here if subrecord not added correctly.
       @driver.find_element(id: 'agent_agent_genders__0__dates__0_')
-    end  
+    end
 
     it 'can add a note to a gender' do
       @driver.find_element(:link, 'Create').click
@@ -528,7 +528,7 @@ describe "agents record CRUD" do
 
       # will fail here if subrecord not added correctly.
       @driver.find_element(id: 'agent_agent_genders__0__notes__0_')
-    end  
+    end
 
     it 'can create an agent_place' do
       # create subject
@@ -599,7 +599,7 @@ describe "agents record CRUD" do
       @driver.find_element(css: '#agent_agent_places__0__subjects_ .btn:not(.show-all)').click
 
       token_input = @driver.find_element(:id, 'token-input-agent_agent_places__0__subjects__0__ref_')
-      
+
       @driver.typeahead_and_select(token_input, term)
 
 
@@ -645,7 +645,7 @@ describe "agents record CRUD" do
       @driver.find_element(css: '#agent_agent_places__0__subjects_ .btn:not(.show-all)').click
 
       token_input = @driver.find_element(:id, 'token-input-agent_agent_places__0__subjects__0__ref_')
-      
+
       @driver.typeahead_and_select(token_input, term)
 
       # note
@@ -653,7 +653,7 @@ describe "agents record CRUD" do
       @driver.find_element(css: '.top-level-note-type').select_option('note_text')
 
       @driver.execute_script("$('#agent_agent_places__0__notes__0__content_').data('CodeMirror').setValue('this is a note')")
-      @driver.execute_script("$('#agent_agent_places__0__notes__0__content_').data('CodeMirror').save()") 
+      @driver.execute_script("$('#agent_agent_places__0__notes__0__content_').data('CodeMirror').save()")
 
       @driver.click_and_wait_until_gone(css: "form .record-pane button[type='submit']")
 
@@ -724,7 +724,7 @@ describe "agents record CRUD" do
       @driver.find_element(css: '#agent_agent_occupations__0__subjects_ .btn:not(.show-all)').click
 
       token_input = @driver.find_element(:id, 'token-input-agent_agent_occupations__0__subjects__0__ref_')
-      
+
       @driver.typeahead_and_select(token_input, term)
 
 
@@ -767,7 +767,7 @@ describe "agents record CRUD" do
       @driver.find_element(css: '#agent_agent_occupations__0__subjects_ .btn:not(.show-all)').click
 
       token_input = @driver.find_element(:id, 'token-input-agent_agent_occupations__0__subjects__0__ref_')
-      
+
       @driver.typeahead_and_select(token_input, term)
 
       # note
@@ -775,7 +775,7 @@ describe "agents record CRUD" do
       @driver.find_element(css: '.top-level-note-type').select_option('note_text')
 
       @driver.execute_script("$('#agent_agent_occupations__0__notes__0__content_').data('CodeMirror').setValue('this is a note')")
-      @driver.execute_script("$('#agent_agent_occupations__0__notes__0__content_').data('CodeMirror').save()") 
+      @driver.execute_script("$('#agent_agent_occupations__0__notes__0__content_').data('CodeMirror').save()")
 
       @driver.click_and_wait_until_gone(css: "form .record-pane button[type='submit']")
 
@@ -846,7 +846,7 @@ describe "agents record CRUD" do
       @driver.find_element(css: '#agent_agent_functions__0__subjects_ .btn:not(.show-all)').click
 
       token_input = @driver.find_element(:id, 'token-input-agent_agent_functions__0__subjects__0__ref_')
-      
+
       @driver.typeahead_and_select(token_input, term)
 
       # date
@@ -888,7 +888,7 @@ describe "agents record CRUD" do
       @driver.find_element(css: '#agent_agent_functions__0__subjects_ .btn:not(.show-all)').click
 
       token_input = @driver.find_element(:id, 'token-input-agent_agent_functions__0__subjects__0__ref_')
-      
+
       @driver.typeahead_and_select(token_input, term)
 
       # note
@@ -896,7 +896,7 @@ describe "agents record CRUD" do
       @driver.find_element(css: '.top-level-note-type').select_option('note_text')
 
       @driver.execute_script("$('#agent_agent_functions__0__notes__0__content_').data('CodeMirror').setValue('this is a note')")
-      @driver.execute_script("$('#agent_agent_functions__0__notes__0__content_').data('CodeMirror').save()") 
+      @driver.execute_script("$('#agent_agent_functions__0__notes__0__content_').data('CodeMirror').save()")
 
       @driver.click_and_wait_until_gone(css: "form .record-pane button[type='submit']")
 
@@ -967,7 +967,7 @@ describe "agents record CRUD" do
       @driver.find_element(css: '#agent_agent_topics__0__subjects_ .btn:not(.show-all)').click
 
       token_input = @driver.find_element(:id, 'token-input-agent_agent_topics__0__subjects__0__ref_')
-      
+
       @driver.typeahead_and_select(token_input, term)
 
       # date
@@ -1009,7 +1009,7 @@ describe "agents record CRUD" do
       @driver.find_element(css: '#agent_agent_topics__0__subjects_ .btn:not(.show-all)').click
 
       token_input = @driver.find_element(:id, 'token-input-agent_agent_topics__0__subjects__0__ref_')
-      
+
       @driver.typeahead_and_select(token_input, term)
 
       # note
@@ -1017,7 +1017,7 @@ describe "agents record CRUD" do
       @driver.find_element(css: '.top-level-note-type').select_option('note_text')
 
       @driver.execute_script("$('#agent_agent_topics__0__notes__0__content_').data('CodeMirror').setValue('this is a note')")
-      @driver.execute_script("$('#agent_agent_topics__0__notes__0__content_').data('CodeMirror').save()") 
+      @driver.execute_script("$('#agent_agent_topics__0__notes__0__content_').data('CodeMirror').save()")
 
       @driver.click_and_wait_until_gone(css: "form .record-pane button[type='submit']")
 
@@ -1095,7 +1095,7 @@ describe "agents record CRUD" do
     it 'displays agent_record_identifiers in form' do
       expect(@driver.is_visible?(:css, "#agent_person_agent_record_identifier")).to eq(true)
     end
-  
+
     it 'hides agent_record_control from form' do
       expect(@driver.is_visible?(:css, "#agent_person_agent_record_control")).to eq(false)
     end
@@ -1179,6 +1179,45 @@ describe "agents record CRUD" do
 
     it 'displays related_agents in form' do
       expect(@driver.is_visible?(:css, "#related_agents")).to eq(true)
+    end
+  end
+end
+
+describe "agents record with too many related agents" do
+  before(:all) do
+    @repo = create(:repo, repo_code: "agents_test_#{Time.now.to_i}")
+
+    @driver = Driver.get
+    @driver.login_to_repo($admin, @repo)
+
+    @big_agent = create(:agent_person, :related_agents => (1..5).map {
+                      JSONModel(:agent_relationship_parentchild).new({ :ref => create(:agent_person).uri, :relator => 'is_child_of' }).to_hash
+                    })
+    @small_agent = create(:agent_person, :related_agents => (1..4).map {
+                             JSONModel(:agent_relationship_parentchild).new({ :ref => create(:agent_person).uri, :relator => 'is_child_of' }).to_hash
+                           })
+  end
+
+  after(:all) do
+    @driver ? @driver.quit : next
+  end
+
+  it "does not lazy load related agents when there are fewer than four" do
+    path = URI.encode("/agents/agent_person/#{@small_agent.id}/edit")
+    puts path
+    @driver.get(URI.join($frontend, path))
+    (0..3).each do |i|
+      expect(@driver.find_element(id: "agent_related_agents__#{i}_")).not_to be_nil
+    end
+  end
+
+  it "lazy loads related agents when there are more than four" do
+    path = URI.encode("/agents/agent_person/#{@big_agent.id}/edit")
+    @driver.get(URI.join($frontend, path))
+    expect(@driver.find_element(css: ".alert-too-many")).not_to be_nil
+    @driver.find_elements(css: '.alert-too-many').each { |c| c.click }
+    (0..4).each do |i|
+      expect(@driver.find_element(id: "agent_related_agents__#{i}_")).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Load related agents on demand when editing an agent record when there are more than four relationships.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Added the "tooMany" check to the agents.crud.js initializer following the pattern used in notes.crud.js

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1210


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added two tests to the agent selenium spec.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
