### PR TITLE
ANW-1227: MARC export related agents 'w' and 'i' subfs

### DIFF
--- a/backend/spec/agent_spec_helper.rb
+++ b/backend/spec/agent_spec_helper.rb
@@ -3,44 +3,59 @@
 # creates an agent via API call to the backend
 # returns created agent ID, or -1 if error
 def create_agent_via_api(agent_type, opts = {})
-	case agent_type
-	when :person
-		agent_json = opts[:create_subrecords] ? 
-			build(:json_agent_person_full_subrec) : 
-			build(:json_agent_person)
-		url = URI("#{JSONModel::HTTP.backend_url}/agents/people")
-	when :corporate_entity
-	  agent_json = opts[:create_subrecords] ? 
-			build(:json_agent_corporate_entity_full_subrec) : 
-			build(:json_agent_corporate_entity)
-		url = URI("#{JSONModel::HTTP.backend_url}/agents/corporate_entities")
-	when :family
-		agent_json = opts[:create_subrecords] ? 
-			build(:json_agent_family_full_subrec) : 
-			build(:json_agent_familly)
-		url = URI("#{JSONModel::HTTP.backend_url}/agents/families")
-	when :software
-    agent_json = opts[:create_subrecords] ? 
-			build(:json_agent_software_full_subrec) : 
-			build(:json_agent_software)
-		url = URI("#{JSONModel::HTTP.backend_url}/agents/software")
-	end
+  case agent_type
+  when :person
+    agent_json = if opts[:create_subrecords]
+                   build(:json_agent_person_full_subrec)
+                 else
+                   build(:json_agent_person)
+                 end
+    url = URI("#{JSONModel::HTTP.backend_url}/agents/people")
+  when :corporate_entity
+    agent_json = if opts[:create_subrecords]
+                   build(:json_agent_corporate_entity_full_subrec)
+                 else
+                   build(:json_agent_corporate_entity)
+                 end
+    url = URI("#{JSONModel::HTTP.backend_url}/agents/corporate_entities")
+  when :family
+    agent_json = if opts[:create_subrecords]
+                   build(:json_agent_family_full_subrec)
+                 else
+                   build(:json_agent_familly)
+                 end
+    url = URI("#{JSONModel::HTTP.backend_url}/agents/families")
+  when :software
+    agent_json = if opts[:create_subrecords]
+                   build(:json_agent_software_full_subrec)
+                 else
+                   build(:json_agent_software)
+                 end
+    url = URI("#{JSONModel::HTTP.backend_url}/agents/software")
+  end
 
   response = JSONModel::HTTP.post_json(url, agent_json.to_json)
   json_response = ASUtils.json_parse(response.body)
 
-  if json_response["status"] == "Created"
-    return json_response["id"]
+  if json_response['status'] == 'Created'
+    json_response['id']
   else
-    return -1
-	end
-rescue => e
-	return -1
+    -1
+  end
+rescue StandardError => e
+  -1
 end
 
 def add_gender_values
-	ge = Enumeration.find(:name => 'gender')
+  ge = Enumeration.find(:name => 'gender')
   ge.add_enumeration_value(:value => 'female')
   ge.add_enumeration_value(:value => 'male')
   ge.add_enumeration_value(:value => 'non-binary')
+end
+
+def add_specific_relator_values
+  spec_rel = Enumeration.find(:name => 'agent_relationship_specific_relator')
+  spec_rel.add_enumeration_value(:value => 'daughterOf')
+  spec_rel.add_enumeration_value(:value => 'correspondentOf')
+  spec_rel.add_enumeration_value(:value => 'Acronym')
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates MARC authority record exports to match the following:

For 500/510/511 subfield 'i':
- if specific_relator, value of specific relator;
-  if no specific_relator, but description, value of description;  otherwise, 
- value of relator

For 500/510/511 subfield 'w':
-   if relator = is_earlier_form_of, `a`;
-  if relator = is_later_form of, `b`;
-  if specific_relator = Acronym, `d`;
-  if specific_relator = Musical composition, `f`;
-  if specific_relator = Broader term , `g`;
-  if specific_relator = Narrower term, `h`;   otherwise, 
- `r`

Also, corrected bug wherein subfields 'w' and 'i' were being created for 100/110/111 and 400/410/411 tags. 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1227

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Several new tests added, including a helper method to setup some enumeration values for specific relator (which is, by default, empty).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
