### PR TITLE
ANW-1226: EAC export related agents tags/attributes

### DIFF
--- a/backend/app/exporters/serializers/eac.rb
+++ b/backend/app/exporters/serializers/eac.rb
@@ -393,14 +393,37 @@ class EACSerializer < ASpaceExport::Serializer
 
           next unless filled_out?([name])
 
+          relation_type = case relator
+                          when 'is_identified_with'
+                            'identity'
+                          when 'is_hierarchical_with'
+                            'hierarchical'
+                          when 'is_parent_of', 'is_superior_of'
+                            'hierarchical-parent'
+                          when 'is_child_of', 'is_subordinate_to'
+                            'hierarchical-child'
+                          when 'is_temporal_with'
+                            'temporal'
+                          when 'is_earlier_form_of'
+                            'temporal-earlier'
+                          when 'is_later_form_of'
+                            'temporal-later'
+                          when 'is_related_with'
+                            'family'
+                          else
+                            'associative'
+                          end
+
           attrs = {
-            :cpfRelationType => I18n.t("enumerations.#{ra['jsonmodel_type']}_relator.#{relator}"),
+            :cpfRelationType => relation_type,
+            'xlink:arcrole' => ra['relationship_uri'],
             'xlink:type' => 'simple',
             'xlink:href' => AppConfig[:public_proxy_url] + resolved['uri']
           }
 
           xml.cpfRelation(clean_attrs(attrs)) do
             xml.relationEntry name
+            _descriptive_note(ra['description'], xml) if ra['description']
           end
         end
 

--- a/backend/spec/export_eac_spec.rb
+++ b/backend/spec/export_eac_spec.rb
@@ -619,6 +619,8 @@ describe 'EAC Export' do
 
         @relationship = JSONModel(:agent_relationship_parentchild).new
         @relationship.relator = 'is_child_of'
+        @relationship.description = 'A descriptive note.'
+        @relationship.relationship_uri = 'http://example.com'
         @relationship.ref = @rec.uri
 
         @linked_agent = create(:json_agent_person,
@@ -633,13 +635,26 @@ describe 'EAC Export' do
       expect(@eac).to have_tag(
         'relations/cpfRelation',
         {
-          'cpfRelationType' => I18n.t('enumerations.agent_relationship_parentchild_relator.is_parent_of'),
           'href' => uri
         }
       )
       expect(@eac).to have_tag(
         'relations/cpfRelation/relationEntry' => @linked_agent.names[0]['primary_name']
       )
+    end
+
+    it 'maps related agents relator to cpfRelationType attribute' do
+      expect(@eac).to have_tag("relations/cpfRelation[@cpfRelationType='hierarchical-parent']")
+    end
+
+    it 'maps related agents description to cpfRelation/descriptiveNote' do
+      expect(@eac).to have_tag(
+        'relations/cpfRelation/descriptiveNote/p' => 'A descriptive note.'
+      )
+    end
+
+    it 'maps related agents relationship uri to cpfRelation arcrole attribute' do
+      expect(@eac).to have_tag("relations/cpfRelation[@xlink:arcrole='http://example.com']")
     end
 
     it 'exports agent_resources' do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update EAC export to do the following:

- Map ArchivesSpace `relator` term to a valid `cpfRelationType` attribute;
- Export `relationship_uri` to `xlink:arcrole` attribute if available; and, 
- Export `description` to `descriptiveNote/p` if available.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1226

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New tests added, existing tests passing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
