### PR TITLE
ANW-1232

### DIFF
--- a/backend/spec/factories.rb
+++ b/backend/spec/factories.rb
@@ -398,20 +398,12 @@ FactoryBot.define do
     agent_type { 'agent_software' }
     names { [build(:json_name_software)] }
     dates_of_existence { [build(:json_structured_date_label)] }
-    agent_record_controls { [build(:agent_record_control)] }
-    agent_alternate_sets { [build(:agent_alternate_set)] }
-    agent_conventions_declarations { [build(:agent_conventions_declaration)] }
-    agent_sources { [build(:agent_sources)] }
-    agent_other_agency_codes { [build(:agent_other_agency_codes)] }
-    agent_maintenance_histories { [build(:agent_maintenance_history)] }
-    agent_record_identifiers { [build(:agent_record_identifier)] }
     agent_places { [build(:json_agent_place)] }
     agent_occupations { [build(:json_agent_occupation)] }
     agent_functions { [build(:json_agent_function)] }
     agent_topics { [build(:json_agent_topic)] }
     agent_identifiers { [build(:json_agent_identifier)] }
     used_languages { [build(:json_used_language)] }
-    agent_resources { [build(:json_agent_resource)] }
   end
 
   factory :json_agent_family_full_subrec, class: JSONModel(:agent_family) do

--- a/backend/spec/model_agent_software_spec.rb
+++ b/backend/spec/model_agent_software_spec.rb
@@ -20,6 +20,40 @@ describe 'Agent model' do
       }.to raise_error(JSONModel::ValidationException)
   end
 
+  it "doesn't allow a software agent record to be created with any record control or relation subrecords" do
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_record_identifiers => [build(:agent_record_identifier)]))
+    }.to raise_error(JSONModel::ValidationException)
+
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_record_controls => [build(:agent_record_control)]))
+    }.to raise_error(JSONModel::ValidationException)
+
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_other_agency_codes => [build(:agent_other_agency_codes)]))
+    }.to raise_error(JSONModel::ValidationException)
+
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_conventions_declarations => [build(:agent_conventions_declaration)]))
+    }.to raise_error(JSONModel::ValidationException)
+
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_maintenance_histories => [build(:agent_maintenance_history)]))
+    }.to raise_error(JSONModel::ValidationException)
+
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_sources => [build(:agent_sources)]))
+    }.to raise_error(JSONModel::ValidationException)
+
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_alternate_sets => [build(:agent_alternate_set)]))
+    }.to raise_error(JSONModel::ValidationException)
+
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_resources => [build(:json_agent_resource)]))
+    }.to raise_error(JSONModel::ValidationException)
+  end
+
 
   it "allows a software agent record to be created with linked contact details" do
 

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -2427,6 +2427,7 @@ en:
     generic_validation_error: Validation Error
     requires_that_end_dates_are_after_begin_dates: End Dates must be after Begin Dates
     must_specify_a_primary_subject: "Description Information: Record is missing a primary subject"
+    subrecord_not_allowed_for_agent_software: "Software Agents cannot have record control or relation subrecords"
 
   job:
     _singular: Background Job

--- a/common/validations.rb
+++ b/common/validations.rb
@@ -27,6 +27,15 @@ module JSONModel::Validations
     end
   end
 
+  # ANW-1232: add validations to prevent software agents from having/saving record control or agent relation subrecords. 
+  # These records are hidden from the forms but allowed through the schema (as agent_software inherits from abstract_agent) so these validations serve to prevent these subrecords from being added via API calls.
+  if JSONModel(:agent_software)
+    JSONModel(:agent_software).add_validation("check_agent_software_subrecords") do |hash|
+        check_agent_software_subrecords(hash)
+    end
+
+  end
+
   [:agent_function, :agent_place, :agent_occupation, :agent_topic].each do |type|
     if JSONModel(type)
       JSONModel(type).add_validation("check_#{type}_subject_subrecord") do |hash|
@@ -330,6 +339,19 @@ module JSONModel::Validations
 
     if hash["subjects"].empty?
       errors << ["subjects", "Must specify a primary subject"]
+    end
+
+    return errors
+  end
+
+  def self.check_agent_software_subrecords(hash)
+    errors = []
+    subrecords_disallowed = ["agent_record_identifiers", "agent_record_controls", "agent_other_agency_codes", "agent_conventions_declarations", "agent_maintenance_histories", "agent_sources", "agent_alternate_sets", "agent_resources"]
+
+    subrecords_disallowed.each do |sd|
+      unless hash[sd] == [] || hash[sd].nil?
+        errors << [sd, "subrecord not allowed for agent software"]
+      end
     end
 
     return errors


### PR DESCRIPTION
Validations to prevent software agents from being created with disallowed subrecords

## Description
Software agents shouldn't have some of the subrecords the other agents have. These validation changes back up the removal of certain forms from the public interface.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1232

## How Has This Been Tested?
In browser and unit testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
