### PR TITLE
ANW-1173 EAD import should support multiple <langmaterial> <language>s

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -214,60 +214,65 @@ class EADConverter < Converter
     end
 
 
-    with "langmaterial" do |*|
-      # if <langmaterial> contains encoded <language> tags create a matching language_and_script record
+    with 'langmaterial' do |*|
       langmaterial = Nokogiri::XML::DocumentFragment.parse(inner_xml)
-      if (language = langmaterial.xpath('.//language')).size != 0 && (langcode = langmaterial.xpath('.//language').attr('langcode'))
-        script = language.attr('scriptcode')
-        make :lang_material, {
-          :jsonmodel_type => 'lang_material',
-          :language_and_script => {
-            'jsonmodel_type' => 'language_and_script',
-            'language' => langcode.to_s,
-            'script' => script ? script.to_s : nil
-          }
-        } do |lang|
-        set ancestor(:resource, :archival_object), :lang_materials, lang
+      ancestor(:resource, :archival_object) do |obj|
+        # if <langmaterial> contains encoded <language> tags create a matching language_and_script record
+        if !(languages = langmaterial.xpath('.//language')).empty? && langmaterial.xpath('.//language').any? { |l| l.attr('langcode') }
+          languages.each do |language|
+            next unless (langcode = language.attr('langcode'))
+
+            script = language.attr('scriptcode')
+            make :lang_material, {
+              :jsonmodel_type => 'lang_material',
+              :language_and_script => {
+                'jsonmodel_type' => 'language_and_script',
+                'language' => langcode.to_s,
+                'script' => script ? script.to_s : nil
+              }
+            } do |lang|
+            set obj, :lang_materials, lang
+            end
+          end
+        # if a resource and no <language> set to undetermined
+        elsif obj.class.record_type == 'resource'
+          make :lang_material, {
+            :jsonmodel_type => 'lang_material',
+            :language_and_script => {
+              'jsonmodel_type' => 'language_and_script',
+              'language' => 'und'
+            }
+          } do |lang|
+          set obj, :lang_materials, lang
+          end
         end
-      # if we don't have an encoded language inside the <langmaterial> set it to undetermined.
-      else
-        make :lang_material, {
-          :jsonmodel_type => 'lang_material',
-          :language_and_script => {
-            'jsonmodel_type' => 'language_and_script',
-            'language' => 'und'
-          }
-        } do |lang|
-        set ancestor(:resource, :archival_object), :lang_materials, lang
+
+        # write full <langmaterial> content to a note, subbing out the language tags (if present)
+        langmaterial.search('.//language').each do |node|
+          node.replace Nokogiri::XML::Text.new(node.inner_html, node.document)
+        end
+        content = langmaterial.to_s
+
+        unless content.nil? || content == ''
+          make :lang_material, {
+            :jsonmodel_type => 'lang_material',
+            :notes => {
+              'jsonmodel_type' => 'note_langmaterial',
+              'type' => 'langmaterial',
+              'persistent_id' => att('id'),
+              'publish' => att('audience') != 'internal',
+              'content' => [format_content( content.sub(/<head>.*?<\/head>/, '') )]
+            }
+          } do |note|
+            set obj, :lang_materials, note
+          end
         end
       end
-
-      # write full <langmaterial> content to a note, subbing out the language tags (if present)
-      content = inner_xml
-      if inner_xml.match(/(<language langcode="[a-z]+" scriptcode="[A-z]+">(.*)<\/language>)|(<language langcode="[a-z]+">(.*)<\/language>)|(<language langcode="[a-z]+"\/>)/)
-        content = inner_xml.sub(/(<language langcode="[a-z]+" scriptcode="[A-z]+">(.*)<\/language>)|(<language langcode="[a-z]+">(.*)<\/language>)|(<language langcode="[a-z]+"\/>)/, '\\2\\4')
-      end
-
-      unless content.nil? || content == ''
-        make :lang_material, {
-          :jsonmodel_type => 'lang_material',
-          :notes => {
-            'jsonmodel_type' => 'note_langmaterial',
-            'type' => 'langmaterial',
-            'persistent_id' => att('id'),
-            'publish' => att('audience') != 'internal',
-            'content' => [format_content( content.sub(/<head>.*?<\/head>/, '') )]
-          }
-        } do |note|
-          set ancestor(:resource, :archival_object), :lang_materials, note
-        end
-      end
-
     end
 
     # If we've gotten this far and still haven't hit a <langmaterial><language> we must assign an undetermined language value
     with "archdesc/did" do |e|
-      if context_obj['jsonmodel_type'] == 'resource' && inner_xml.include?('<langmaterial>') == false
+      if context_obj['jsonmodel_type'] == 'resource' && inner_xml.include?('<langmaterial') == false
         make :lang_material, {
           :jsonmodel_type => 'lang_material',
           :language_and_script => {
@@ -275,7 +280,7 @@ class EADConverter < Converter
             'language' => 'und'
           }
         } do |lang|
-        set ancestor(:resource, :archival_object), :lang_materials, lang
+        set ancestor(:resource), :lang_materials, lang
         break
         end
       end

--- a/backend/app/exporters/examples/ead/at-tracer.xml
+++ b/backend/app/exporters/examples/ead/at-tracer.xml
@@ -446,7 +446,7 @@
                                 <unittitle>Resource-C04-AT</unittitle>
                                 <unitid>Resource-C04-ID-AT</unitid>
                                 <langmaterial>
-                                    <language langcode="eng"/>
+                                    Materials in <language langcode="eng">English</language> and <language langcode="ger">German</language>.
                                 </langmaterial>
                                 <container id="cid4" type="Box" label="Text">4</container>
                                 <container parent="cid4" type="Folder">4</container>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Modifies EAD importer to support `<langmaterial>`s that include multiple `<language>` elements.  Previously, all but the first `<language>` was skipped on import.  This resolves an issue wherein numerous ASpace language_and_script records with a language value of 'undetermined' were improperly created.

Also modifies/adds backend tests.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1173

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests passing, new tests added.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
