### PR TITLE
ANW-913: Show warning when trying to merge 2 agents that have a relationship

### DIFF
--- a/frontend/app/controllers/agents_controller.rb
+++ b/frontend/app/controllers/agents_controller.rb
@@ -238,6 +238,13 @@ class AgentsController < ApplicationController
       return
     end
 
+    relationship_uris = @victim['related_agents'].map{|ra| ra['ref']}
+    if relationship_uris.include?(@agent['uri'])
+      flash[:error] = I18n.t('errors.merge_denied_relationship')
+      redirect_to({ action: :show, id: params[:id] })
+      return
+    end
+
     if !user_can?('view_agent_contact_record') && (@agent.agent_contacts.any? || @victim.agent_contacts.any?)
       flash[:error] = I18n.t('errors.merge_restricted_contact_details')
       redirect_to({ action: :show, id: params[:id] })

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -648,6 +648,7 @@ en:
     merge_too_many_victims: Only one agent may be selected for this merge.
     merge_different_types: Agents selected for this merge must be of the same type.
     merge_denied_for_system_user: One or more agents is a system user.
+    merge_denied_relationship: These agents have a relationship. Remove relationship before proceeding with merge.
     merge_restricted_contact_details: The merge cannot be completed because one or more of the agents has contact details you do not have permission to access.
     linked_to_assessment: Record cannot be deleted as it is linked to an assessment
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fix adds a check and cleanly fails with an error on screen if the user tries to merge agents that have a relationship.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-913

## How Has This Been Tested?
Manual testing and added selenium test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
