### PR TITLE
anw-1200  : function became reserved word in MySQL 8.0.1

### DIFF
--- a/reports/accessions/accession_names_subreport/accession_names_subreport.rb
+++ b/reports/accessions/accession_names_subreport/accession_names_subreport.rb
@@ -9,7 +9,7 @@ class AccessionNamesSubreport < AbstractSubreport
     "select
       ifnull(ifnull(ifnull(name_person.sort_name, name_family.sort_name),
         name_corporate_entity.sort_name), 'Unknown') as name,
-      role_id as 'function',
+      role_id as `function`,
       relator_id as role
     from linked_agents_rlshp
       left outer join name_person

--- a/reports/accessions/accession_names_subreport/accession_names_subreport.rb
+++ b/reports/accessions/accession_names_subreport/accession_names_subreport.rb
@@ -9,7 +9,7 @@ class AccessionNamesSubreport < AbstractSubreport
     "select
       ifnull(ifnull(ifnull(name_person.sort_name, name_family.sort_name),
         name_corporate_entity.sort_name), 'Unknown') as name,
-      role_id as function,
+      role_id as 'function',
       relator_id as role
     from linked_agents_rlshp
       left outer join name_person


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1 line chang in accession_name_subreport to quote new reserved word 'function'  
simple syntactically valid change that should have no effect in environments that don't display the problem. 
<!--- Why is this change required? What problem does it solve? -->
accession reports fail running under MySQL 8.0 + 

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1200


## How Has This Been Tested?
Tested under MariaDB 10.x, which does not have that reserved word, but change is still proper SQL syntax so it works. Waiting for confirmation from users with MySQL 8.0 who reported the issue. But from the error message ( and experience with past SQL errors ) I'm certain this is the issue. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
