### PR TITLE
ANW-1248: Improve combobox accessibility

### DIFF
--- a/frontend/app/helpers/aspace_form_helper.rb
+++ b/frontend/app/helpers/aspace_form_helper.rb
@@ -401,7 +401,8 @@ module AspaceFormHelper
     end
 
     def combobox(name, options, opts = {})
-      select(name, options, opts.merge({:"data-combobox" => true}))
+      select(name, options, opts.merge({ :"data-combobox" => true,
+                                         :id => id_for(name) }))
     end
 
 
@@ -410,6 +411,10 @@ module AspaceFormHelper
         opts[:class] << " form-control"
       else
         opts[:class] = "form-control"
+      end
+      if opts.has_key? :"data-combobox"
+        opts[:role] = "listbox"
+        opts[:"aria-label"] = I18n.t(i18n_for(name))
       end
       selection = obj[name]
       selection = selection[0...-4] if selection.is_a? String and selection.end_with?("_REQ")

--- a/frontend/spec/selenium/spec/accessions_spec.rb
+++ b/frontend/spec/selenium/spec/accessions_spec.rb
@@ -54,7 +54,7 @@ describe 'Accessions' do
     @driver.find_element(id: 'accession_rights_statements__0__rights_type_').select_option('copyright')
     @driver.find_element(id: 'accession_rights_statements__0__status_').select_option('copyrighted')
     @driver.clear_and_send_keys([:id, 'accession_rights_statements__0__start_date_'], '2012-01-01')
-    combo = @driver.find_element(xpath: '//div[@class="combobox-container"][following-sibling::select/@id="accession_rights_statements__0__jurisdiction_"]//input[@type="text"]')
+    combo = @driver.find_element(xpath: '//*[@id="accession_rights_statements__0__jurisdiction_"]')
     combo.clear
     combo.click
     combo.send_keys('AU')
@@ -64,7 +64,7 @@ describe 'Accessions' do
     @driver.find_element(css: '#accession_rights_statements__0__external_documents_ .subrecord-form-heading .btn:not(.show-all)').click
     @driver.clear_and_send_keys([:id, 'accession_rights_statements__0__external_documents__0__title_'], 'Agreement')
     @driver.clear_and_send_keys([:id, 'accession_rights_statements__0__external_documents__0__location_'], 'http://locationof.agreement.com')
-    combo = @driver.find_element(xpath: '//div[@class="combobox-container"][following-sibling::select/@id="accession_rights_statements__0__external_documents__0__identifier_type_"]//input[@type="text"]')
+    combo = @driver.find_element(xpath: '//*[@id="accession_rights_statements__0__external_documents__0__identifier_type_"]')
     combo.clear
     combo.click
     combo.send_keys('Trove')
@@ -390,7 +390,7 @@ describe 'Accessions' do
     @driver.find_element(id: 'accession_rights_statements__0__rights_type_').select_option('copyright')
     @driver.find_element(id: 'accession_rights_statements__0__status_').select_option('copyrighted')
     @driver.clear_and_send_keys([:id, 'accession_rights_statements__0__start_date_'], '2012-01-01')
-    combo = @driver.find_element(xpath: '//div[@class="combobox-container"][following-sibling::select/@id="accession_rights_statements__0__jurisdiction_"]//input[@type="text"]')
+    combo = @driver.find_element(xpath: '//*[@id="accession_rights_statements__0__jurisdiction_"]')
     combo.clear
     combo.click
     combo.send_keys('AU')
@@ -400,7 +400,7 @@ describe 'Accessions' do
     @driver.find_element(css: '#accession_rights_statements__0__external_documents_ .subrecord-form-heading .btn:not(.show-all)').click
     @driver.clear_and_send_keys([:id, 'accession_rights_statements__0__external_documents__0__title_'], 'Agreement')
     @driver.clear_and_send_keys([:id, 'accession_rights_statements__0__external_documents__0__location_'], 'http://locationof.agreement.com')
-    combo = @driver.find_element(xpath: '//div[@class="combobox-container"][following-sibling::select/@id="accession_rights_statements__0__external_documents__0__identifier_type_"]//input[@type="text"]')
+    combo = @driver.find_element(xpath: '//*[@id="accession_rights_statements__0__external_documents__0__identifier_type_"]')
     combo.clear
     combo.click
     combo.send_keys('Trove')

--- a/frontend/spec/selenium/spec/classifications_spec.rb
+++ b/frontend/spec/selenium/spec/classifications_spec.rb
@@ -66,7 +66,7 @@ describe 'Classifications' do
     @driver.complete_4part_id('resource_id_%d_')
     @driver.find_element(:id, 'resource_level_').select_option('collection')
 
-    combo = @driver.find_element(xpath: '//*[@id="resource_lang_materials__0_"]/div[1]/div/div/div/div[1]/div/div/div/input[@type="text"]')
+    combo = @driver.find_element(xpath: '//*[@id="resource_lang_materials__0__language_and_script__language_"]')
     combo.clear
     combo.click
     combo.send_keys('eng')
@@ -80,13 +80,13 @@ describe 'Classifications' do
 
     sleep 2
 
-    combo = @driver.find_element(xpath: '//*[@id="finding_aid"]/div/div/fieldset/div[@class="form-group required"]/div[@class="col-sm-9"]/div[@class="combobox-container"][following-sibling::select/@id="resource_finding_aid_language_"]//input[@type="text"]')
+    combo = @driver.find_element(xpath: '//*[@id="resource_finding_aid_language_"]')
     combo.clear
     combo.click
     combo.send_keys('eng')
     combo.send_keys(:tab)
 
-    combo = @driver.find_element(xpath: '//*[@id="finding_aid"]/div/div/fieldset/div[@class="form-group required"]/div[@class="col-sm-9"]/div[@class="combobox-container"][following-sibling::select/@id="resource_finding_aid_script_"]//input[@type="text"]')
+    combo = @driver.find_element(xpath: '//*[@id="resource_finding_aid_script_"]')
     combo.clear
     combo.click
     combo.send_keys('Latn')

--- a/frontend/spec/selenium/spec/notes_spec.rb
+++ b/frontend/spec/selenium/spec/notes_spec.rb
@@ -323,7 +323,7 @@ describe 'Notes' do
     @driver.complete_4part_id('resource_id_%d_')
     @driver.find_element(:id, 'resource_level_').select_option('collection')
 
-    combo = @driver.find_element(xpath: '//*[@id="resource_lang_materials__0_"]/div[1]/div/div/div/div[1]/div/div/div/input[@type="text"]')
+    combo = @driver.find_element(xpath: '//*[@id="resource_lang_materials__0__language_and_script__language_"]')
     combo.clear
     combo.click
     combo.send_keys('eng')
@@ -335,13 +335,13 @@ describe 'Notes' do
     @driver.find_element(id: 'resource_dates__0__date_type_').select_option('single')
     @driver.clear_and_send_keys([:id, 'resource_dates__0__begin_'], '1978')
 
-    combo = @driver.find_element(xpath: '//*[@id="finding_aid"]/div/div/fieldset/div[@class="form-group required"]/div[@class="col-sm-9"]/div[@class="combobox-container"][following-sibling::select/@id="resource_finding_aid_language_"]//input[@type="text"]')
+    combo = @driver.find_element(xpath: '//*[@id="resource_finding_aid_language_"]')
     combo.clear
     combo.click
     combo.send_keys('eng')
     combo.send_keys(:tab)
 
-    combo = @driver.find_element(xpath: '//*[@id="finding_aid"]/div/div/fieldset/div[@class="form-group required"]/div[@class="col-sm-9"]/div[@class="combobox-container"][following-sibling::select/@id="resource_finding_aid_script_"]//input[@type="text"]')
+    combo = @driver.find_element(xpath: '//*[@id="resource_finding_aid_script_"]')
     combo.clear
     combo.click
     combo.send_keys('Latn')

--- a/frontend/spec/selenium/spec/resources_spec.rb
+++ b/frontend/spec/selenium/spec/resources_spec.rb
@@ -42,19 +42,19 @@ describe 'Resources and archival objects' do
 
     @driver.find_element(:id, 'resource_level_').select_option('collection')
 
-    res_lang_combo = @driver.find_element(xpath: '//*[@id="resource_lang_materials__0_"]/div[1]/div/div/div/div[1]/div/div/div/input[@type="text"]')
+    res_lang_combo = @driver.find_element(xpath: '//*[@id="resource_lang_materials__0__language_and_script__language_"]')
     res_lang_combo.clear
     res_lang_combo.click
     res_lang_combo.send_keys('eng')
     res_lang_combo.send_keys(:tab)
 
-    fa_lang_combo = @driver.find_element(xpath: '//*[@id="finding_aid"]/div/div/fieldset/div[@class="form-group required"]/div[@class="col-sm-9"]/div[@class="combobox-container"][following-sibling::select/@id="resource_finding_aid_language_"]//input[@type="text"]')
+    fa_lang_combo = @driver.find_element(xpath: '//*[@id="resource_finding_aid_language_"]')
     fa_lang_combo.clear
     fa_lang_combo.click
     fa_lang_combo.send_keys('eng')
     fa_lang_combo.send_keys(:tab)
 
-    fa_script_combo = @driver.find_element(xpath: '//*[@id="finding_aid"]/div/div/fieldset/div[@class="form-group required"]/div[@class="col-sm-9"]/div[@class="combobox-container"][following-sibling::select/@id="resource_finding_aid_script_"]//input[@type="text"]')
+    fa_script_combo = @driver.find_element(xpath: '//*[@id="resource_finding_aid_script_"]')
     fa_script_combo.clear
     fa_script_combo.click
     fa_script_combo.send_keys('Latn')
@@ -196,13 +196,13 @@ describe 'Resources and archival objects' do
     @driver.clear_and_send_keys([:id, 'resource_title_'], resource_title)
     @driver.complete_4part_id('resource_id_%d_')
 
-    fa_lang_combo = @driver.find_element(xpath: '//*[@id="finding_aid"]/div/div/fieldset/div[@class="form-group required"]/div[@class="col-sm-9"]/div[@class="combobox-container"][following-sibling::select/@id="resource_finding_aid_language_"]//input[@type="text"]')
+    fa_lang_combo = @driver.find_element(xpath: '//*[@id="resource_finding_aid_language_"]')
     fa_lang_combo.clear
     fa_lang_combo.click
     fa_lang_combo.send_keys('eng')
     fa_lang_combo.send_keys(:tab)
 
-    fa_script_combo = @driver.find_element(xpath: '//*[@id="finding_aid"]/div/div/fieldset/div[@class="form-group required"]/div[@class="col-sm-9"]/div[@class="combobox-container"][following-sibling::select/@id="resource_finding_aid_script_"]//input[@type="text"]')
+    fa_script_combo = @driver.find_element(xpath: '//*[@id="resource_finding_aid_script_"]')
     fa_script_combo.clear
     fa_script_combo.click
     fa_script_combo.send_keys('Latn')
@@ -212,7 +212,7 @@ describe 'Resources and archival objects' do
     @driver.clear_and_send_keys([:id, 'resource_dates__0__begin_'], '1978')
     @driver.find_element(:id, 'resource_level_').select_option('collection')
 
-    combo = @driver.find_element(xpath: '//*[@id="resource_lang_materials__0_"]/div[1]/div/div/div/div[1]/div/div/div/input[@type="text"]')
+    combo = @driver.find_element(xpath: '//*[@id="resource_lang_materials__0__language_and_script__language_"]')
     combo.clear
     combo.click
     combo.send_keys('eng')

--- a/frontend/vendor/assets/javascripts/bootstrap-combobox.js
+++ b/frontend/vendor/assets/javascripts/bootstrap-combobox.js
@@ -105,6 +105,8 @@
     this.$element.attr('rel', this.$source.attr('rel'))
     this.$element.attr('title', this.$source.attr('title'))
     this.$element.attr('class', this.$source.attr('class'))
+    this.$element.attr('id', this.$source.attr('id'))
+    this.$source.attr('id', this.$source.attr('id') + '_list')  // Don't want duplicate ids.
     this.$element.attr('tabindex', this.$source.attr('tabindex'))
     this.$source.removeAttr('tabindex')
     if (this.$source.attr('disabled')!==undefined)
@@ -141,6 +143,7 @@
       $('.dropdown-menu').on('mousedown', $.proxy(this.scrollSafety, this));
 
       this.shown = true;
+      this.$element.attr('aria-expanded', true);
       return this;
     }
 
@@ -149,6 +152,7 @@
       $('.dropdown-menu').off('mousedown', $.proxy(this.scrollSafety, this));
       this.$element.on('blur', $.proxy(this.blur, this));
       this.shown = false;
+      this.$element.attr('aria-expanded', false)
       return this;
     }
 
@@ -177,7 +181,7 @@
       if (this.options.bsVersion == '2') {
         return '<div class="combobox-container"><input type="hidden" /> <div class="input-append"> <input type="text" autocomplete="off" /> <span class="add-on dropdown-toggle" data-dropdown="dropdown"> <span class="caret"/> <i class="icon-remove"/> </span> </div> </div>'
       } else {
-        return '<div class="combobox-container"> <input type="hidden" /> <div class="input-group"> <input type="text" autocomplete="off" /> <span class="input-group-addon dropdown-toggle" data-dropdown="dropdown"> <span class="caret" /> <span class="glyphicon glyphicon-remove" /> </span> </div> </div>'
+        return '<div class="combobox-container"> <input type="hidden" /> <div class="input-group"> <input type="text" autocomplete="off" role="combobox" aria-autocomplete="both" aria-haspopup="true" aria-controls="' + this.$source.attr('id') + '_list' + '" /> <span class="input-group-addon dropdown-toggle" data-dropdown="dropdown" role="button"> <span class="caret" /> <span class="glyphicon glyphicon-remove" /> </span> </div> </div>'
       }
     }
 
@@ -216,31 +220,31 @@
         return i[0];
       })
 
-      items.first().addClass('active');
+      items.first().addClass('active').attr('aria-selected', true);
       this.$menu.html(items);
       return this;
     }
 
   , next: function (event) {
-      var active = this.$menu.find('.active').removeClass('active')
+      var active = this.$menu.find('.active').removeClass('active').removeAttr('aria-selected')
         , next = active.next();
 
       if (!next.length) {
         next = $(this.$menu.find('li')[0]);
       }
 
-      next.addClass('active');
+      next.addClass('active').attr('aria-selected', true);
     }
 
   , prev: function (event) {
-      var active = this.$menu.find('.active').removeClass('active')
+      var active = this.$menu.find('.active').removeClass('active').removeAttr('aria-selected')
         , prev = active.prev();
 
       if (!prev.length) {
         prev = this.$menu.find('li').last();
       }
 
-      prev.addClass('active');
+      prev.addClass('active').attr('aria-selected', true);
     }
 
   , toggle: function () {
@@ -406,8 +410,8 @@
 
   , mouseenter: function (e) {
       this.mousedover = true;
-      this.$menu.find('.active').removeClass('active');
-      $(e.currentTarget).addClass('active');
+      this.$menu.find('.active').removeClass('active').removeAttr('aria-selected');
+      $(e.currentTarget).addClass('active').attr('aria-selected', true);
     }
 
   , mouseleave: function (e) {
@@ -429,8 +433,8 @@
 
   $.fn.combobox.defaults = {
     bsVersion: '3'
-  , menu: '<ul class="typeahead typeahead-long dropdown-menu"></ul>'
-  , item: '<li><a href="#"></a></li>'
+  , menu: '<ul class="typeahead typeahead-long dropdown-menu" role="listbox" ></ul>'
+  , item: '<li role="option"><a href="#"></a></li>'
   };
 
   $.fn.combobox.Constructor = Combobox;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Minor changes to `aspace_form_helpers` and `bootstrap-combobox` to provide accessibility enhancements to staff side comboboxes (e.g. language and script subrecords).  Ultimately, this ensures a label is provided to both the typeahead text input as well as the dropdown, with some aria elements demonstrating the link between the input and dropdown  loosely modeled off of the recommendations at https://www.w3.org/TR/wai-aria-practices-1.1/examples/combobox/aria1.1pattern/listbox-combo.html 

While I generally wouldn't want to make changes to vendor assets like this, these additions merely add aria attributes and should be more or less noncontroversial/low risk.

Additional enhancements - most notably changing focus to the dropdown values/dropdown menu to enable screenreader use - are still needed, but this seemed the minimally viable amount to get in as we lookahead to a bootstrap update.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1248

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Prior to this PR: 
![image](https://user-images.githubusercontent.com/15144646/113358391-b24d3c80-9313-11eb-80d5-52e5559e9197.png)

After PR:
![image](https://user-images.githubusercontent.com/15144646/113356903-073b8380-9311-11eb-85d1-ed23086723c1.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
