### PR TITLE
ANW-1240 Add a new `filter_query` search parameter and use it for "Search within results"

### DIFF
--- a/backend/app/controllers/search.rb
+++ b/backend/app/controllers/search.rb
@@ -25,6 +25,8 @@ class ArchivesSpaceService < Sinatra::Base
       :optional => true],
      ["filter", JSONModel(:advanced_query), "A json string containing the advanced query to filter by",
       :optional => true],
+     ["filter_query", [String], "Search queries to be applied as a filter to the results.",
+      :optional => true],
      ["exclude",
       [String],
       "A list of document IDs that should be excluded from results",

--- a/backend/app/model/search.rb
+++ b/backend/app/model/search.rb
@@ -24,6 +24,7 @@ class Search
       show_published_only(show_published_only).
       set_excluded_ids(params[:exclude]).
       set_filter(params[:filter]).
+      set_filter_queries(params[:filter_query]).
       set_facets(params[:facet], (params[:facet_mincount] || 0)).
       set_sort(params[:sort]).
       set_root_record(params[:root_record]).

--- a/backend/app/model/solr.rb
+++ b/backend/app/model/solr.rb
@@ -172,6 +172,14 @@ class Solr
       self
     end
 
+    def set_filter_queries(queries)
+      ASUtils.wrap(queries).each do |q|
+        add_solr_param(:fq, "{!type=edismax}#{q}")
+      end
+
+      self
+    end
+
 
     def show_suppressed(value)
       @show_suppressed = value


### PR DESCRIPTION
Hey there,

This is a shot at addressing https://archivesspace.atlassian.net/browse/ANW-1240, where a "Search within results" query would end up returning more hits than the original query.

As described in that ticket, the root cause seems to be that ANDing these extra restrictions onto the main query flips it back to the standard query parser, which behaves quite differently to the original one.  This patch extends the search API to let you provide additional queries to be used as filters (which are parsed with edismax in the usual way), then uses those to express the search within results restrictions.