### PR TITLE
ANW-1151, ANW-1173 Don't try to create empty langmaterial note

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -253,7 +253,7 @@ class EADConverter < Converter
         end
         content = langmaterial.to_s
 
-        unless content.nil? || content == ''
+        unless content.nil? || content.strip.empty?
           make :lang_material, {
             :jsonmodel_type => 'lang_material',
             :notes => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Very minor addition to #2168 to ensure that markup such as:

`<langmaterial><language langcode="eng"/> <language langcode="ger"/></langmaterial>`

doesn't fail on import because it tries to create a note with whitespace-only content.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1151
https://archivesspace.atlassian.net/browse/ANW-1173

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Able to import EAD with the above snippet without receiving:

```ValidationException: {:errors=>{"lang_materials/2/notes/0/content"=>["At least 1 item(s) is required"]}, :import_context=>"<c class=\"cdata\" id=\"ref37\" level=\"file\"> ... </c>"}>```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
