### PR TITLE
ANW-1219 Add resource title and identifier to ao citations

### DIFF
--- a/public/app/models/archival_object.rb
+++ b/public/app/models/archival_object.rb
@@ -57,16 +57,20 @@ class ArchivalObject < Record
 
   def cite_item
     cite = note('prefercite')
-    unless cite.blank?
+    if !cite.blank?
       cite = strip_mixed_content(cite['note_text'])
     else
       cite = strip_mixed_content(display_string)
       cite += identifier.blank? ? '' : ", #{identifier}"
       cite += if container_display.blank? || container_display.length > 5
-        '.'
-      else
-        @citation_container_display ||= parse_container_display(:citation => true).join('; ')
-        ", #{@citation_container_display}."
+                '.'
+              else
+                @citation_container_display ||= parse_container_display(:citation => true).join('; ')
+                ", #{@citation_container_display}."
+              end
+      if resolved_resource
+        ttl = resolved_resource.dig('title')
+        cite += " #{strip_mixed_content(ttl)}, #{resource_identifier}."
       end
       unless repository_information['top']['name'].blank?
         cite += " #{ repository_information['top']['name']}."
@@ -77,16 +81,20 @@ class ArchivalObject < Record
 
   def cite_item_description
     cite = note('prefercite')
-    unless cite.blank?
+    if !cite.blank?
       cite = strip_mixed_content(cite['note_text'])
     else
       cite = strip_mixed_content(display_string)
       cite += identifier.blank? ? '' : ", #{identifier}"
       cite += if container_display.blank? || container_display.length > 5
-        '.'
-      else
-        @citation_container_display ||= parse_container_display(:citation => true).join('; ')
-        ", #{@citation_container_display}."
+                '.'
+              else
+                @citation_container_display ||= parse_container_display(:citation => true).join('; ')
+                ", #{@citation_container_display}."
+              end
+      if resolved_resource
+        ttl = resolved_resource.dig('title')
+        cite += " #{strip_mixed_content(ttl)}, #{resource_identifier}."
       end
       unless repository_information['top']['name'].blank?
         cite += " #{ repository_information['top']['name']}."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds back resource title and identifier to PUI archival object citations (accidentally removed during #1830 ).

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1219

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15144646/113619040-78877900-9626-11eb-9bc4-c254ee8468ec.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
