### PR TITLE
Fixes 140 migration by checking for existing enum value before insert

### DIFF
--- a/common/db/migrations/utils.rb
+++ b/common/db/migrations/utils.rb
@@ -148,6 +148,8 @@ def add_values_to_enum(name, values)
     end
 
     values.each_with_index do |value, ind|
+      next if self[:enumeration_value].where(enumeration_id: enum_id, value: value).any?
+
       props = { :enumeration_id => enum_id,
                 :value => value,
                 :readonly => 0 }


### PR DESCRIPTION
Specifically: if the name_source enumeration already had the value snac then the migration would fail.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
