### PR TITLE
ANW-1174 Import MARC extents that include only numbers and commas

### DIFF
--- a/backend/app/converters/lib/marcxml_bib_base_map.rb
+++ b/backend/app/converters/lib/marcxml_bib_base_map.rb
@@ -868,9 +868,11 @@ module MarcXMLBibBaseMap
               ex = node.xpath('.//subfield[@code="a"]')
               if ex.length > 0
                 ext = ex.first.text
-                if ext =~ /^([0-9\.]+)+\s+(.*)$/
+                if ext =~ /^([0-9\.,]+)+\s+(.*)$/
                   extent.number = $1
                   extent.extent_type = $2
+                elsif ext =~ /^([0-9\.,]+)/
+                  extent.number = $1
                 end
               end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When importing MARCXML the current import map looks for a 300$a that looks something like `100 linear feet`.  It should also support $a's that only include numbers such as `100` or, even, `1,000`.  This minor change to the existing regex does that.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1174

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
