### PR TITLE
ANW-251 Provide error for invalid restriction date

### DIFF
--- a/backend/app/model/mixins/rights_restriction_notes.rb
+++ b/backend/app/model/mixins/rights_restriction_notes.rb
@@ -1,12 +1,6 @@
-# FIXME: custom validation for dates, etc.?
-
-
 module RightsRestrictionNotes
 
   RESTRICTION_NOTE_TYPES = ['accessrestrict', 'userestrict']
-
-     # [java] D, [2015-03-17T13:22:45.092000 #26783] DEBUG -- : Thread-3540: POST /repositories/2/resources/3 [session: #<Session:0x67d6b87e @store={:user=>"admin", :login_time=>2015-03-17 13:05:09 +1100, :expirable=>true}, @id="7417bad2ee8e2e27b26a12707817334b99d69b50e604e507ce3bee560d354d37">]
-     # [java] D, [2015-03-17T13:22:45.149000 #26783] DEBUG -- : Thread-3540: Post-processed params: {:id=>3, :resource=>#<JSONModel(:resource) {"lock_version"=>"0", "title"=>"moo", "id_0"=>"123", "id_1"=>"f", "level"=>"file", "language"=>"eng", "dates"=>[{"lock_version"=>"0", "label"=>"creation", "expression"=>"moooo", "date_type"=>"single", "begin"=>"2015-03-04"}], "extents"=>[{"lock_version"=>"0", "portion"=>"whole", "number"=>"10", "extent_type"=>"leaves"}], "notes"=>[{"jsonmodel_type"=>"note_multipart", "persistent_id"=>"56de90dad4c61995a2cb65b9e8439f92", "type"=>"accessrestrict", "rights_restriction"=>{"begin"=>"2000-01-01", "end"=>"2005-01-01", "local_access_restriction_type"=>["RestrictedCurApprSpecColl"]}, "subnotes"=>[{"jsonmodel_type"=>"note_text", "content"=>"moo", "publish"=>false}], "publish"=>false}], "publish"=>false, "restrictions"=>false, "jsonmodel_type"=>"resource", "external_ids"=>[], "subjects"=>[], "external_documents"=>[], "rights_statements"=>[], "linked_agents"=>[], "instances"=>[], "deaccessions"=>[], "related_accessions"=>[], "linked_events"=>[]}>, :repo_id=>2}
 
 
   def self.included(base)
@@ -50,11 +44,8 @@ module RightsRestrictionNotes
         next unless note['jsonmodel_type'] == 'note_multipart' && RESTRICTION_NOTE_TYPES.include?(note['type'])
         next unless note.has_key?('rights_restriction')
 
-        begin_date = note['rights_restriction']['begin'] ? Date.parse(note['rights_restriction']['begin']) : nil
-        end_date = note['rights_restriction']['end'] ? Date.parse(note['rights_restriction']['end']) : nil
-
-        restriction = obj.add_rights_restriction(:begin => begin_date,
-                                                 :end => end_date,
+        restriction = obj.add_rights_restriction(:begin => note['rights_restriction']['begin'],
+                                                 :end => note['rights_restriction']['end'],
                                                  :restriction_note_type => note['type'])
 
         ASUtils.wrap(note['rights_restriction']['local_access_restriction_type']).each do |restriction_type|

--- a/backend/spec/model_restriction_spec.rb
+++ b/backend/spec/model_restriction_spec.rb
@@ -32,6 +32,17 @@ describe 'Managed Container restrictions' do
   let (:box_json) { create(:json_top_container, :indicator => "1", :barcode => "123") }
   let (:box_record) { TopContainer[box_json.id] }
 
+  it "can't create a restriction with an invalid date" do
+    (resource, grandparent, parent, child) = create_tree(box_json)
+
+    expect { add_restriction_to_record(child, '1990', '1995') }.to raise_error(JSONModel::ValidationException)
+  end
+
+  it "can't create a restriction with an end date before a begin date" do
+    (resource, grandparent, parent, child) = create_tree(box_json)
+
+    expect { add_restriction_to_record(child, '2014-06-01', '1983-10-01') }.to raise_error(JSONModel::ValidationException)
+  end
 
   it "can find all restrictions on a record linked directly to a top container" do
     (resource, grandparent, parent, child) = create_tree(box_json)

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -2364,6 +2364,7 @@ en:
     missing_property: Property was missing
     not_a_valid_date: Not a valid date
     must_not_be_before_begin: must not be before begin
+    must_be_in_yyyy-mm-dd_format: Date must be in a yyyy-mm-dd format
     is_required_unless_a_begin_or_end_date_is_given: is required unless a begin or end date is given
     is_required_unless_an_expression_or_an_end_date_is_given: is required unless an expression or an end date is given
     is_required_unless_an_expression_or_a_begin_date_is_given: is required unless an expression or a begin date is given

--- a/common/locales/es.yml
+++ b/common/locales/es.yml
@@ -1951,6 +1951,7 @@ es:
     missing_property: Faltaba propiedad
     not_a_valid_date: No es una fecha válida
     must_not_be_before_begin: No se debe comenzar antes
+    must_be_in_yyyy-mm-dd_format: La fecha debe estar en formato aaaa-mm-dd
     is_required_unless_a_begin_or_end_date_is_given: se requiere al menos que se da una fecha de inicio o final
     is_required_unless_an_expression_or_an_end_date_is_given: se requiere al menos que se da una expresión o una fecha de finalización
     is_required_unless_an_expression_or_a_begin_date_is_given: se requiere al menos que se da una expresión o una fecha de inicio

--- a/common/locales/fr.yml
+++ b/common/locales/fr.yml
@@ -1971,6 +1971,7 @@ fr:
     missing_property: Propriété manquante
     not_a_valid_date: N'est pas une date valide
     must_not_be_before_begin: ne doit pas précéder début
+    must_be_in_yyyy-mm-dd_format: La date doit être au format aaaa-mm-jj
     is_required_unless_a_begin_or_end_date_is_given: est requis à moins qu'une date de début ou de fin ne soit donnée
     is_required_unless_an_expression_or_an_end_date_is_given: est requis à moins qu'une expression ou date de fin ne soit donnée
     is_required_unless_an_expression_or_a_begin_date_is_given: est requis à moins qu'une expression ou date de début ne soit donnée

--- a/common/locales/ja.yml
+++ b/common/locales/ja.yml
@@ -1496,6 +1496,7 @@ ja:
     missing_property: プロパティが見つかりませんでした
     not_a_valid_date: 有効な日付ではありません
     must_not_be_before_begin: 始める前にしてはいけません
+    must_be_in_yyyy-mm-dd_format: 日付はyyyy-mm-dd形式である必要があります
     is_required_unless_a_begin_or_end_date_is_given: 開始日または終了日が指定されていない限り必須です
     is_required_unless_an_expression_or_an_end_date_is_given: 式または終了日が与えられていない限り必須です
     is_required_unless_an_expression_or_a_begin_date_is_given: 式または開始日が与えられていない限り必須です

--- a/common/validations.rb
+++ b/common/validations.rb
@@ -682,6 +682,35 @@ module JSONModel::Validations
     end
   end
 
+  def self.check_restriction_date(hash)
+    errors = []
+
+    if (rr = hash['rights_restriction'])
+      begin
+        begin_date = Date.strptime(rr['begin'], '%Y-%m-%d') if rr['begin']
+      rescue ArgumentError => e
+        errors << ["rights_restriction__begin", "must be in YYYY-MM-DD format"]
+      end
+
+      begin
+        end_date = Date.strptime(rr['end'], '%Y-%m-%d') if rr['end']
+      rescue ArgumentError => e
+        errors << ["rights_restriction__end", "must be in YYYY-MM-DD format"]
+      end
+
+      if begin_date && end_date && end_date < begin_date
+        errors << ["rights_restriction__end", "must not be before begin"]
+      end
+    end
+
+    errors
+  end
+
+  if JSONModel(:note_multipart)
+    JSONModel(:note_multipart).add_validation("check_restriction_date") do |hash|
+      check_restriction_date(hash)
+    end
+  end
 
   JSONModel(:find_and_replace_job).add_validation("only target properties on the target schemas") do |hash|
     target_model = JSONModel(hash['record_type'].intern)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently, if a user supplies a restriction start/end date that doesn't conform to yyyy-mm-dd pattern the staff interface throws an unhelpful Server Error.  To be machine actionable, these dates need to be entered in yyyy-mm-dd format, but there is no validation present to relay this to the user.  This adds such a validation to `validations.rb`.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Also includes error translations for all languages (google translate) and 2 new tests.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-251

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before fix:
![image](https://user-images.githubusercontent.com/15144646/113929066-96d3ad00-97bd-11eb-8322-d6a06fda05a7.png)

After fix:
![image](https://user-images.githubusercontent.com/15144646/113928865-5a07b600-97bd-11eb-9237-68295aad05e3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
