### PR TITLE
Avoid adding blank lines on each poll loop in job output display

### DIFF
--- a/frontend/app/assets/javascripts/jobs.show.js
+++ b/frontend/app/assets/javascripts/jobs.show.js
@@ -40,8 +40,11 @@ $(function() {
           var dataLength = data.length;
           $(".alert", $logSection).remove();
           $logSpool.slideDown();
-          $logSpool.append($("<div>").text(data));
-          offset +=dataLength;
+
+          if (dataLength > 0) {
+            $logSpool.append($("<div>").text(data));
+            offset +=dataLength;
+          }
 
           if (dataLength === 0) {
             // Hmm... we may have finished... or failed,


### PR DESCRIPTION
We really only need to append a new <div> when there's something to show.  Otherwise we keep adding blank lines and scroll away from the real action.

(This is a tiny bug that's been around for ever.  Finally annoyed me enough to fix...)
