### PR TITLE
Set publish on subnotes the same as parent multi-part note in EAD importer

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -309,6 +309,7 @@ class EADConverter < Converter
         :label => att('label'),
         :publish => att('audience') != 'internal',
         :subnotes => {
+          :publish => att('audience') != 'internal',
           'jsonmodel_type' => 'note_text',
           'content' => format_content( content )
         }


### PR DESCRIPTION
## Description
Fixes non-display in the public user interface of _dimensions_ elements when imported from EAD into a dimensions note. For example:
```
<physdesc>
   <dimensions>16 1/2 × 12 in.</dimensions>
</physdesc>
```
Because the _physdesc_ has no _extent_ child, the `make_nested_note()` method is called. There is no  `audience="internal"` attribute, so the multi-part note created will have its publish property set to true. But not the publish property of the subnote containing the actual content. This pull request sets the publish property on both, as is the case in the other instances in ead_converter.rb where multi-part notes are created.

The `make_nested_note()` method is only called when creating dimensions notes. Possibly it shouldn't be creating multi-part notes, because in EAD 2002 the _dimensions_ element cannot contain _p_, _list_, etc, only nested _dimensions_ and inline tags like _emph_ or _title_, but there probably isn't the demand for creating a new data structure just for dimensions notes. Maybe it would be better if dimensions were single notes, but that would require other changes and testing. This fix is only intended to avoid the need to manually edit hundreds of archival objects in order to make their dimensions visible in the PUI.

Any dimensions notes created by the EAD importer in the past will remain invisible in the PUI unless a data migration script is also created. But I don't know if that would be appropriate (I can't imagine the dimensions of items being confidential information, but you never know)?

## Related JIRA Ticket or GitHub Issue
None

## How Has This Been Tested?
Tested on a development system. It does not trigger new backend test suite failures. (I cannot currently get it to run successfully, but I think the failures are unrelated to this change.)

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
