### PR TITLE
ANW-1253: Bugfix for merging linked top containers into unassociated top container

### DIFF
--- a/backend/app/model/mixins/relationships.rb
+++ b/backend/app/model/mixins/relationships.rb
@@ -137,7 +137,7 @@ AbstractRelationship = Class.new(Sequel::Model) do
                     raise "Transfer would create a circular relationship!"
                   end
 
-                elsif relationship.is_a?(Relationships::SubContainerTopContainerLink)
+                elsif relationship.is_a?(Relationships::SubContainerTopContainerLink) && !find_by_participant(target).empty?
                   identify_duplicate_containers(target, relationship, target_col, dups)
 
                 elsif relationship.is_a?(Relationships::ContainerProfileTopContainerProfile)

--- a/backend/spec/controller_merge_request_spec.rb
+++ b/backend/spec/controller_merge_request_spec.rb
@@ -802,5 +802,81 @@ describe 'Merge request controller' do
       expect(JSONModel(:"#{type}").find(parent2.id).instances.count).to eq(1)
       expect(JSONModel(:"#{type}").find(parent2.id).instances).not_to include(victim)
     end
+
+    it "can merge one linked, one unlinked top container without destroying victim parent record" do
+      target = create(:json_top_container)
+      victim = create(:json_top_container)
+
+      parent = create(:"json_#{type}",
+                       :instances => [build(:json_instance,
+                                         :sub_container => build(:json_sub_container,
+                                                              :indicator_2 => nil,
+                                                              :type_2 => nil,
+                                                              :indicator_3 => nil,
+                                                              :type_3 => nil,
+                                                              :top_container => { :ref => victim.uri }))])
+
+      request = JSONModel(:merge_request).new
+      request.target = { 'ref' => target.uri }
+      request.victims = [{ 'ref' => victim.uri }]
+
+      request.save(:record_type => 'top_container')
+
+      expect { JSONModel(:"#{type}").find(parent.id) }.not_to raise_error
+    end
+
+    it "can merge one linked, one unlinked top container without destroying target parent record" do
+      target = create(:json_top_container)
+      victim = create(:json_top_container)
+
+      parent = create(:"json_#{type}",
+                       :instances => [build(:json_instance,
+                                         :sub_container => build(:json_sub_container,
+                                                              :indicator_2 => nil,
+                                                              :type_2 => nil,
+                                                              :indicator_3 => nil,
+                                                              :type_3 => nil,
+                                                              :top_container => { :ref => target.uri }))])
+
+      request = JSONModel(:merge_request).new
+      request.target = { 'ref' => target.uri }
+      request.victims = [{ 'ref' => victim.uri }]
+
+      request.save(:record_type => 'top_container')
+
+      expect { JSONModel(:"#{type}").find(parent.id) }.not_to raise_error
+    end
+
+    it "can merge two linked top containers without destroying parent records" do
+      target = create(:json_top_container)
+      victim = create(:json_top_container)
+
+      parent2 = create(:"json_#{type}",
+                       :instances => [build(:json_instance,
+                                         :sub_container => build(:json_sub_container,
+                                                              :indicator_2 => nil,
+                                                              :type_2 => nil,
+                                                              :indicator_3 => nil,
+                                                              :type_3 => nil,
+                                                              :top_container => { :ref => target.uri }))])
+
+      parent1 = create(:"json_#{type}",
+                       :instances => [build(:json_instance,
+                                         :sub_container => build(:json_sub_container,
+                                                              :indicator_2 => nil,
+                                                              :type_2 => nil,
+                                                              :indicator_3 => nil,
+                                                              :type_3 => nil,
+                                                              :top_container => { :ref => victim.uri }))])
+
+      request = JSONModel(:merge_request).new
+      request.target = { 'ref' => target.uri }
+      request.victims = [{ 'ref' => victim.uri }]
+
+      request.save(:record_type => 'top_container')
+
+      expect { JSONModel(:"#{type}").find(parent1.id) }.not_to raise_error
+      expect { JSONModel(:"#{type}").find(parent2.id) }.not_to raise_error
+    end
   end
 end

--- a/common/db/migrations/146_tc_link_cleanup.rb
+++ b/common/db/migrations/146_tc_link_cleanup.rb
@@ -14,7 +14,7 @@ Sequel.migration do
         $stderr.puts("==========================================")
         $stderr.puts("\n")
         $stderr.puts("#{bad_rlshp.count} corrupted top container links found due " +
-                     "to a previous failed merge of linked containers into an " + 
+                     "to a previous failed merge of linked containers into an " +
                      "unlinked container.")
         $stderr.puts("\n")
       end
@@ -48,7 +48,7 @@ Sequel.migration do
       end
     end
     $stderr.puts("\n")
-    $stderr.puts("To identify the records that need to be corrected, do a keyword " + 
+    $stderr.puts("To identify the records that need to be corrected, do a keyword " +
                  "search for the 'Lost and Found' top container in the Manage " +
                  "Top Containers area within the application.")
     $stderr.puts("\n")

--- a/common/db/migrations/146_tc_link_cleanup.rb
+++ b/common/db/migrations/146_tc_link_cleanup.rb
@@ -8,9 +8,15 @@ Sequel.migration do
 
       bad_rlshp = self[:top_container_link_rlshp].exclude(sub_container_id: nil).where(top_container_id: nil).all
       if bad_rlshp.count.zero?
-        $stderr.puts("Good news! No corrupt top container relationship records found in DB.")
+        $stderr.puts("Good news! No corrupt top container relationship records found.")
       else
-        $stderr.puts("#{bad_rlshp.count} corrupt records found in DB.")
+        $stderr.puts("\n")
+        $stderr.puts("==========================================")
+        $stderr.puts("\n")
+        $stderr.puts("#{bad_rlshp.count} corrupted top container links found due " +
+                     "to a previous failed merge of linked containers into an " + 
+                     "unlinked container.")
+        $stderr.puts("\n")
       end
 
       bad_rlshp.each do |r|
@@ -19,7 +25,7 @@ Sequel.migration do
           record = self[:instance].where(id: instance).get(:"#{type}_id")
           next if record.nil?
 
-          $stderr.puts("Bad #{type} record found: #{record.inspect}")
+          $stderr.puts("     Bad top container link found on #{type} #{record}")
           repo = self[:"#{type}"].where(id: record).get(:repo_id)
           new_tc = self[:top_container].where(indicator: 'Lost and found',
                                               repo_id: repo)
@@ -33,14 +39,21 @@ Sequel.migration do
                                                  system_mtime: Time.now,
                                                  user_mtime: Time.now)
 
-            $stderr.puts("Created new top container #{new_tc} for repository #{repo} corrupted records.")
+            $stderr.puts("     Creating top container #{new_tc} in repository #{repo}")
           end
 
           self[:top_container_link_rlshp].where(id: r[:id]).update(top_container_id: new_tc)
-          $stderr.puts("Updated top container releationship for #{type} record #{record} to point to top container #{new_tc} in repository #{repo}.")
+          $stderr.puts("     Linking #{type} #{record} to top container #{new_tc} in repository #{repo}")
         end
       end
     end
+    $stderr.puts("\n")
+    $stderr.puts("To identify the records that need to be corrected, do a keyword " + 
+                 "search for the 'Lost and Found' top container in the Manage " +
+                 "Top Containers area within the application.")
+    $stderr.puts("\n")
+    $stderr.puts("==========================================")
+    $stderr.puts("\n")
   end
 
 

--- a/common/db/migrations/146_tc_link_cleanup.rb
+++ b/common/db/migrations/146_tc_link_cleanup.rb
@@ -1,0 +1,50 @@
+require_relative 'utils'
+
+Sequel.migration do
+
+  up do
+    self.transaction do
+      $stderr.puts("Starting top container cleanup to fix ANW-1253")
+
+      bad_rlshp = self[:top_container_link_rlshp].exclude(sub_container_id: nil).where(top_container_id: nil).all
+      if bad_rlshp.count.zero?
+        $stderr.puts("Good news! No corrupt top container relationship records found in DB.")
+      else
+        $stderr.puts("#{bad_rlshp.count} corrupt records found in DB.")
+      end
+
+      bad_rlshp.each do |r|
+        instance = self[:sub_container].where(id: r[:sub_container_id]).get(:instance_id)
+        ['accession', 'archival_object', 'resource'].each do |type|
+          record = self[:instance].where(id: instance).get(:"#{type}_id")
+          next if record.nil?
+
+          $stderr.puts("Bad #{type} record found: #{record.inspect}")
+          repo = self[:"#{type}"].where(id: record).get(:repo_id)
+          new_tc = self[:top_container].where(indicator: 'Lost and found',
+                                              repo_id: repo)
+                                              .get(:id)
+
+          unless !new_tc.nil?
+            new_tc = self[:top_container].insert(indicator: 'Lost and found',
+                                                 repo_id: repo,
+                                                 json_schema_version: 1,
+                                                 create_time: Time.now,
+                                                 system_mtime: Time.now,
+                                                 user_mtime: Time.now)
+
+            $stderr.puts("Created new top container #{new_tc} for repository #{repo} corrupted records.")
+          end
+
+          self[:top_container_link_rlshp].where(id: r[:id]).update(top_container_id: new_tc)
+          $stderr.puts("Updated top container releationship for #{type} record #{record} to point to top container #{new_tc} in repository #{repo}.")
+        end
+      end
+    end
+  end
+
+
+  down do
+  end
+
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#1764 introduced a bug wherein a user that merged one or many top containers linked to archival records (accessions, resources, aos) into another top container that was unassociated/unlinked to any archival records, the archival record(s) that were linked to the now deleted top container(s) were left with `top_container_link_rlshp` records that were corrupt (no top container present in the db) making it impossible for users to view those previously linked records in the staff UI and/or API.  

This PR fixes the underlying code that created the corrupt relationship records (change to `mixins/relationships.rb`), adds tests to confirm the fix, and adds a db migration to attempt to resurrect the records that became un-viewable/editable as a result of these silently failing merges.  

The 146 migration takes all accessions, resources, or archival objects per impacted repository and replaces the bad relationship records (those that contain `sub_container_id` but no `top_container_id`) and points them all to a newly created "Lost and Found" top container record.  This will retain any information added to the instance/subcontainer records linked to those accessions, resources, and archival objects, while making discovery of these post-merge top container-less records easier to find and remediate in the interface by searching for "Lost and Found" in the keyword search of the "Manage Top Containers" screen.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1253

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Prior to fix: 
<img width="1504" alt="anw-1253-error" src="https://user-images.githubusercontent.com/15144646/114461730-1a234300-9bb0-11eb-8632-721f9ffacdfd.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
