### PR TITLE
ANW-1083: MARCXML import field 730

### DIFF
--- a/backend/app/converters/lib/marcxml_bib_base_map.rb
+++ b/backend/app/converters/lib/marcxml_bib_base_map.rb
@@ -1148,7 +1148,7 @@ module MarcXMLBibBaseMap
         "datafield[@tag='611']" => mix(corp_template, agent_as_subject, corp_variation),
 
         #SUBJECTS
-        "datafield[@tag='630' or @tag='130']" => subject_template(
+        "datafield[@tag='630' or @tag='130' or @tag='730']" => subject_template(
                                                                                 -> node {
                                                                                   terms = []
                                                                                   terms << make_term('uniform_title', concatenate_subfields(%w(a d e f g h k l m n o p r s t), node, ' ', true))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This change fixes an issue where MARC 730 field (Added Entry, Uniform Title) was being silently ignored during MARCXML bib record import. It implements field 730 import according to the same logic as 130 and 630, as specified in the JIRA ticket.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
* https://archivesspace.atlassian.net/browse/ANW-1083

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Backend unit tests passed on Ubuntu 20.04.2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - Ideally, the [MARCXML Import / Export Map](https://archivesspace.org/wp-content/uploads/2016/08/MARCXML-Import-Export-Mapping-20130715.xlsx) spreadsheet (linked from the [Migration Tools and Data Mapping](https://archivesspace.org/using-archivesspace/migration-tools-and-data-mapping) page) would be updated: it currently includes field 630, but is missing 130 and 730. I'm happy to make this change if anyone has guidance on the best means to update it!
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
