### PR TITLE
Show line breaks in the read-only raw view for note text

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/form.less
+++ b/frontend/app/assets/stylesheets/archivesspace/form.less
@@ -845,3 +845,7 @@ ul.checkbox-list {
   visibility: hidden !important;
   position: absolute;
 }
+
+.note-content-raw {
+    white-space: pre-line;
+}

--- a/frontend/app/views/notes/_template.html.erb
+++ b/frontend/app/views/notes/_template.html.erb
@@ -106,9 +106,9 @@
     <div class="tabbable tabs-below">
       <div class="tab-content">
         <div class="tab-pane active" id="<%= form.id_for("item") %>_raw">
-          <%= form.textarea(nil, item, { :escape => false, :class => "mixed-content" }) %>
+          <span class="note-content-raw"><%= form.textarea(nil, item, { :escape => false, :class => "mixed-content" }) %></span>
         </div>
-        <div class="tab-pane" id="<%= form.id_for("item") %>_parsed">
+        <div class="tab-pane note-content-formatted" id="<%= form.id_for("item") %>_parsed">
           <%= clean_note(item).html_safe %>
         </div>
       </div>
@@ -893,9 +893,9 @@
           <div class="tabbable tabs-below">
             <div class="tab-content">
               <div class="tab-pane active" id="<%= form.id_for("content") %>_raw">
-                <%= form.textarea(nil, form["content"], :class => "mixed-content") %>
+                <span class="note-content-raw"><%= form.textarea(nil, form["content"], :class => "mixed-content") %></span>
               </div>
-              <div class="tab-pane" id="<%= form.id_for("content") %>_parsed">
+              <div class="tab-pane note-content-formatted" id="<%= form.id_for("content") %>_parsed">
                 <%= clean_note(form["content"]).html_safe %>
               </div>
             </div>


### PR DESCRIPTION
Hi there,

This is just a minor thing, but I notice the "Raw" view of notes text doesn't show blank lines, which has the effect of merging multi-paragraph text (like bioghist) into one giant block of text.  "Formatted" does look better, but since "Raw" is the default I thought it might be nice to improve it a little.

I've just added a CSS class to note text in the read-only view, and added a `white-space: pre-line` to get those line breaks back.  Here's the before shot:

![image](https://user-images.githubusercontent.com/149123/114826529-f3ad1400-9e0a-11eb-806f-3bcb072dfad9.png)

and the after:

![image](https://user-images.githubusercontent.com/149123/114826559-fb6cb880-9e0a-11eb-8f4f-0ebb3d046e61.png)

