### PR TITLE
ANW-1036: Adding dates field from name form to sort name string for software

### DIFF
--- a/backend/app/model/mixins/sort_name_processor.rb
+++ b/backend/app/model/mixins/sort_name_processor.rb
@@ -137,6 +137,7 @@ module SortNameProcessor
       result << "#{json["software_name"]}" if json["software_name"]
       result << " #{json["version"]}" if json["version"]
       result << " (#{json["qualifier"]})" if json["qualifier"]
+      result << ", #{json["dates"]}" if json["dates"]
 
       dates = json['dates'].nil? ? SortNameProcessor::Utils.first_date(extras, 'dates_of_existence') : nil
       result << " (#{dates})" if dates

--- a/backend/spec/model_agent_corporate_entity_spec.rb
+++ b/backend/spec/model_agent_corporate_entity_spec.rb
@@ -54,20 +54,25 @@ describe 'Agent model' do
      }.to raise_error(JSONModel::ValidationException)
   end
 
-  it "appends the date field from name form to the end of a agent corporate_entity display name" do
-    name_corporate_entity = build(:json_name_corporate_entity)
+  it "appends the name date to the agent software sort name" do
+    json = build(:json_agent_corporate_entity,
+                 :names => [build(:json_name_corporate_entity,
+                    'dates' => '1981'
+                )])
 
-    name_date = name_corporate_entity['dates']
+    AgentCorporateEntity.create_from_json(json)
 
-    expect(name_corporate_entity['sort_name'] =~ /#{name_date}/)
+    name_corporate_entity = json['names'][0]
+    expect(name_corporate_entity['sort_name']).to match(/1981/)
   end
+
 
   it "appends the location to the end of a agent corporate_entity display name" do
     name_corporate_entity = build(:json_name_corporate_entity)
 
     location = name_corporate_entity['use_dates'][0]['structured_date_single']['location']
 
-    expect(name_corporate_entity['sort_name'] =~ /#{location}/)
+    expect(name_corporate_entity['sort_name']).to match(/#{location}/)
   end
 
 

--- a/backend/spec/model_agent_family_spec.rb
+++ b/backend/spec/model_agent_family_spec.rb
@@ -60,11 +60,15 @@ describe 'Agent Family model' do
   end
 
   it "appends the use date to the end of a agent family display name" do
-    name_family = build(:json_name_family)
+    json = build(:json_agent_family,
+                 :names => [build(:json_name_family,
+                    'dates' => '1981'
+                )])
 
-    name_date = name_family['dates']
+    AgentFamily.create_from_json(json)
 
-    expect(name_family['sort_name'] =~ /#{name_date}/)
+    name_family = json['names'][0]
+    expect(name_family['sort_name']).to match(/1981/)
   end
 
 

--- a/backend/spec/model_agent_person_spec.rb
+++ b/backend/spec/model_agent_person_spec.rb
@@ -330,12 +330,16 @@ describe 'Agent model' do
     expect(AgentPerson.to_jsonmodel(agent.id).names[1]['is_display_name']).to be_truthy
   end
 
-  it "appends the use date to the end of a agent persons display name" do
-    name_person = build(:json_name_person)
+  it "appends the name date to the agent software sort name" do
+    json = build(:json_agent_person,
+                 :names => [build(:json_name_person,
+                    'dates' => '1981'
+                )])
 
-    name_date = name_person['use_dates'][0]['structured_date_single']['date_expression']
+    AgentPerson.create_from_json(json)
 
-    expect(name_person['sort_name'] =~ /#{name_date}/)
+    name_person = json['names'][0]
+    expect(name_person['sort_name']).to match(/1981/)
   end
 
   it "preserves the display name when combining the authorized name with an unauthorized name" do

--- a/backend/spec/model_agent_software_spec.rb
+++ b/backend/spec/model_agent_software_spec.rb
@@ -33,12 +33,17 @@ describe 'Agent model' do
     expect(AgentSoftware[agent[:id]].agent_contact[0][:name]).to eq(opts[:name])
   end
 
-  it "appends the use date to the end of a agent software display name" do
-    name_software = build(:json_name_software)
 
-    name_date = name_software['use_dates'][0]['structured_date_single']['date_expression']
+  it "appends the name date to the agent software sort name" do
+    json = build(:json_agent_software,
+                 :names => [build(:json_name_software,
+                    'dates' => '1981'
+                )])
 
-    expect(name_software['sort_name'] =~ /#{name_date}/)
+    AgentSoftware.create_from_json(json)
+
+    name_software = json['names'][0]
+    expect(name_software['sort_name']).to match(/1981/)
   end
 
 


### PR DESCRIPTION
agents

<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding dates field from name form to sort name string for software agents. This is the behavior for the other agent types so this brings.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1036

## How Has This Been Tested?
Manual testing, unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
