### PR TITLE
ANW-1259 MARCXML Auth import 035 prepended with (DLC) source and type

### DIFF
--- a/backend/app/converters/lib/marcxml_auth_agent_base_map.rb
+++ b/backend/app/converters/lib/marcxml_auth_agent_base_map.rb
@@ -478,6 +478,11 @@ module MarcXMLAuthAgentBaseMap
             ari['source'] = 'lac' if node.parent.attr('ind1') == '#'
           end
 
+          if node.parent.attr('tag') == '035' && val.start_with?('(DLC)')
+            ari['source'] = 'naf'
+            ari['identifier_type'] = 'loc'
+          end
+
           if node.parent.attr('ind1') == '7'
             sf_2 = (node.parent).at_xpath("subfield[@code='2']")
             ari['source'] = sf_2.inner_text if sf_2

--- a/backend/app/exporters/examples/marc/authority_john_davis_2.xml
+++ b/backend/app/exporters/examples/marc/authority_john_davis_2.xml
@@ -8,9 +8,8 @@
 	    <marcxml:datafield tag="010" ind1=" " ind2=" ">
     <marcxml:subfield code="a">n  88218900 </marcxml:subfield>
   </marcxml:datafield>
-	    <marcxml:datafield tag="035" ind1="7" ind2=" ">
-    <marcxml:subfield code="a">n  88218900</marcxml:subfield>
-    <marcxml:subfield code="2">DLC</marcxml:subfield>
+	  <marcxml:datafield tag="035" ind2=" ">
+    <marcxml:subfield code="a">(DLC)n  88218900</marcxml:subfield>
   </marcxml:datafield>
 	    <marcxml:datafield tag="040" ind1=" " ind2=" ">
     <marcxml:subfield code="a">DLC</marcxml:subfield>

--- a/backend/spec/lib_marcxml_auth_agent_converter_spec.rb
+++ b/backend/spec/lib_marcxml_auth_agent_converter_spec.rb
@@ -206,6 +206,14 @@ describe 'MARCXML Auth Agent converter' do
       expect(record['agent_record_identifiers'][1]['primary_identifier']).to eq(false)
     end
 
+    it 'imports agent_record_identifier from 035 prepended with (DLC) with proper source and type' do
+      record = convert(person_agent_2).select { |r| r['jsonmodel_type'] == 'agent_person' }.first
+
+      expect(record['agent_record_identifiers'][1]['record_identifier']).to eq('(DLC)n  88218900')
+      expect(record['agent_record_identifiers'][1]['identifier_type']).to eq('loc')
+      expect(record['agent_record_identifiers'][1]['source']).to eq('naf')
+    end
+
     it 'does not import record_identifier from 001 when 003 is DLC and 010 is present' do
       record = convert(person_agent_1).select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
If the 035 starts with `(DLC)` then the MARCXML Auth importer should set the source to `naf` and type to `loc`.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1259

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
