### PR TITLE
ANW-1266: For EAC agents export, use string "Revised" instead of "Revised/Corre…

### DIFF
--- a/backend/app/exporters/serializers/eac.rb
+++ b/backend/app/exporters/serializers/eac.rb
@@ -84,11 +84,15 @@ class EACSerializer < ASpaceExport::Serializer
       # AGENT_RECORD_CONTROLS
       with(xml, json['agent_record_controls']) do |arc|
         if arc['maintenance_status']
+          value = I18n.t("enumerations.maintenance_status.#{arc['maintenance_status']}")
+
+          value = value == "Revised/Corrected" ? "Revised" : value
+
           create_node(
             xml,
             'maintenanceStatus',
             {},
-            I18n.t("enumerations.maintenance_status.#{arc['maintenance_status']}")
+            value
           )
         end
         create_node(xml, 'publicationStatus', {}, arc['publication_status'])

--- a/backend/app/exporters/serializers/eac.rb
+++ b/backend/app/exporters/serializers/eac.rb
@@ -86,7 +86,7 @@ class EACSerializer < ASpaceExport::Serializer
         if arc['maintenance_status']
           value = I18n.t("enumerations.maintenance_status.#{arc['maintenance_status']}")
 
-          value = value == "Revised/Corrected" ? "Revised" : value
+          value = value == "Revised/Corrected" ? "revised" : value
 
           create_node(
             xml,

--- a/backend/spec/export_eac_spec.rb
+++ b/backend/spec/export_eac_spec.rb
@@ -16,6 +16,7 @@ describe 'EAC Export' do
       expect(eac).to have_tag('control/otherRecordId')
     end
 
+    #ANW-1266: for this test, the factory value for agent_record_control['maintenance_status'] is expected not to be 'revised_corrected', as that is a special case handled in the next test.
     it 'agent_record_control to control tags' do
       r = create(:json_agent_person_full_subrec)
       arc = r['agent_record_controls'].first
@@ -29,6 +30,20 @@ describe 'EAC Export' do
       expect(eac).to have_tag 'control/maintenanceAgency/descriptiveNote/p' => arc['maintenance_agency_note']
       expect(eac).to have_tag 'control/languageDeclaration/language' => I18n.t("enumerations.language_iso639_2.#{arc['language']}")
       expect(eac).to have_tag 'control/languageDeclaration/descriptiveNote/p' => arc['language_note']
+    end
+
+    it 'exports maintenanceStatus tag value as Revised instead of Revised/Corrected' do
+
+      r = create(:json_agent_person_full_subrec, 
+        :agent_record_controls => [ build(:agent_record_control, 
+          :maintenance_status => "revised_corrected")
+        ])
+
+      arc = r['agent_record_controls'].first
+      AppConfig[:export_eac_agency_code] = true
+      eac = get_eac(r)
+
+      expect(eac).to have_tag 'control/maintenanceStatus' => "Revised"
     end
 
     it 'does not export agency_code in agent_record_controls if config option not set' do

--- a/backend/spec/export_eac_spec.rb
+++ b/backend/spec/export_eac_spec.rb
@@ -34,8 +34,8 @@ describe 'EAC Export' do
 
     it 'exports maintenanceStatus tag value as Revised instead of Revised/Corrected' do
 
-      r = create(:json_agent_person_full_subrec, 
-        :agent_record_controls => [ build(:agent_record_control, 
+      r = create(:json_agent_person_full_subrec,
+        :agent_record_controls => [ build(:agent_record_control,
           :maintenance_status => "revised_corrected")
         ])
 
@@ -43,7 +43,7 @@ describe 'EAC Export' do
       AppConfig[:export_eac_agency_code] = true
       eac = get_eac(r)
 
-      expect(eac).to have_tag 'control/maintenanceStatus' => "Revised"
+      expect(eac).to have_tag 'control/maintenanceStatus' => "revised"
     end
 
     it 'does not export agency_code in agent_record_controls if config option not set' do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For EAC agents export, use string "Revised" instead of "Revised/Corrected in maintenanceStatus tag

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1266

## How Has This Been Tested?
Manual and unit testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
