### PR TITLE
ANW-1232: JSON validations for software agents excised fields

### DIFF
--- a/backend/spec/controller_agent_software_spec.rb
+++ b/backend/spec/controller_agent_software_spec.rb
@@ -142,13 +142,6 @@ describe 'Software agent controller' do
       agent_id = create_agent_via_api(:software, {:create_subrecords => true})
       expect(agent_id).to_not eq(-1)
 
-      expect(AgentRecordControl.where(:agent_software_id => agent_id).count).to eq(1)
-      expect(AgentAlternateSet.where(:agent_software_id => agent_id).count).to eq(1)
-      expect(AgentConventionsDeclaration.where(:agent_software_id => agent_id).count).to eq(1)
-      expect(AgentSources.where(:agent_software_id => agent_id).count).to eq(1)
-      expect(AgentOtherAgencyCodes.where(:agent_software_id => agent_id).count).to eq(1)
-      expect(AgentMaintenanceHistory.where(:agent_software_id => agent_id).count).to eq(1)
-      expect(AgentRecordIdentifier.where(:agent_software_id => agent_id).count).to eq(1)
       expect(StructuredDateLabel.where(:agent_software_id => agent_id).count).to eq(1)
       expect(AgentPlace.where(:agent_software_id => agent_id).count).to eq(1)
       expect(AgentOccupation.where(:agent_software_id => agent_id).count).to eq(1)
@@ -156,7 +149,6 @@ describe 'Software agent controller' do
       expect(AgentTopic.where(:agent_software_id => agent_id).count).to eq(1)
       expect(AgentIdentifier.where(:agent_software_id => agent_id).count).to eq(1)
       expect(UsedLanguage.where(:agent_software_id => agent_id).count).to eq(1)
-      expect(AgentResource.where(:agent_software_id => agent_id).count).to eq(1)
     end
 
     it "deletes agent subrecords when parent agent is deleted" do
@@ -167,13 +159,6 @@ describe 'Software agent controller' do
       url = URI("#{JSONModel::HTTP.backend_url}/agents/software/#{agent_id}")
       response = JSONModel::HTTP.delete_request(url)
 
-      expect(AgentRecordControl.where(:agent_software_id => agent_id).count).to eq(0)
-      expect(AgentAlternateSet.where(:agent_software_id => agent_id).count).to eq(0)
-      expect(AgentConventionsDeclaration.where(:agent_software_id => agent_id).count).to eq(0)
-      expect(AgentSources.where(:agent_software_id => agent_id).count).to eq(0)
-      expect(AgentOtherAgencyCodes.where(:agent_software_id => agent_id).count).to eq(0)
-      expect(AgentMaintenanceHistory.where(:agent_software_id => agent_id).count).to eq(0)
-      expect(AgentRecordIdentifier.where(:agent_software_id => agent_id).count).to eq(0)
       expect(StructuredDateLabel.where(:agent_software_id => agent_id).count).to eq(0)
       expect(AgentPlace.where(:agent_software_id => agent_id).count).to eq(0)
       expect(AgentOccupation.where(:agent_software_id => agent_id).count).to eq(0)
@@ -181,7 +166,6 @@ describe 'Software agent controller' do
       expect(AgentTopic.where(:agent_software_id => agent_id).count).to eq(0)
       expect(AgentIdentifier.where(:agent_software_id => agent_id).count).to eq(0)
       expect(UsedLanguage.where(:agent_software_id => agent_id).count).to eq(0)
-      expect(AgentResource.where(:agent_software_id => agent_id).count).to eq(0)
     end
 
     it "gets subrecords along with agent" do
@@ -192,13 +176,6 @@ describe 'Software agent controller' do
       response = JSONModel::HTTP.get_response(url)
       json_response = ASUtils.json_parse(response.body)
 
-      expect(json_response["agent_record_controls"].length).to eq(1)
-      expect(json_response["agent_alternate_sets"].length).to eq(1)
-      expect(json_response["agent_conventions_declarations"].length).to eq(1)
-      expect(json_response["agent_other_agency_codes"].length).to eq(1)
-      expect(json_response["agent_maintenance_histories"].length).to eq(1)
-      expect(json_response["agent_record_identifiers"].length).to eq(1)
-      expect(json_response["agent_sources"].length).to eq(1)
       expect(json_response["dates_of_existence"].length).to eq(1)
       expect(json_response["agent_places"].length).to eq(1)
       expect(json_response["agent_occupations"].length).to eq(1)
@@ -206,7 +183,6 @@ describe 'Software agent controller' do
       expect(json_response["agent_topics"].length).to eq(1)
       expect(json_response["agent_identifiers"].length).to eq(1)
       expect(json_response["used_languages"].length).to eq(1)
-      expect(json_response["agent_resources"].length).to eq(1)
     end
   end
 end

--- a/backend/spec/controller_exports_spec.rb
+++ b/backend/spec/controller_exports_spec.rb
@@ -10,20 +10,6 @@ describe 'Exports controller' do
     end
   end
 
-  it "lets you export an Agent as EAC, even when it is linked to records from another repo" do
-
-    accession = create(:json_accession)
-
-    create(:json_event,
-           'linked_agents' => [{'ref' => '/agents/software/1', 'role' => 'validator'}],
-           'linked_records' => [{'ref' => accession.uri, 'role' => 'source'}])
-
-
-    get "/repositories/#{$repo_id}/archival_contexts/softwares/1.xml"
-    expect(last_response).to be_ok
-    expect(last_response.body).to include("<eac-cpf")
-  end
-
 
   it "lets you export a person in EAC-CPF" do
     id = create(:json_agent_person_full_subrec).id
@@ -52,16 +38,6 @@ describe 'Exports controller' do
     expect(resp).to include("<eac-cpf")
     expect(resp).to include("<control>")
     expect(resp).to include("<entityType>corporateBody</entityType>")
-  end
-
-
-  it "lets you export a software in EAC-CPF" do
-    id = create(:json_agent_software_full_subrec).id
-    get "/repositories/#{$repo_id}/archival_contexts/softwares/#{id}.xml"
-    resp = last_response.body
-    expect(resp).to include("<eac-cpf")
-    expect(resp).to include("<control>")
-    expect(resp).to include("<entityType>software</entityType>")
   end
 
 
@@ -209,8 +185,6 @@ describe 'Exports controller' do
     check_metadata("archival_contexts/families/#{agent}.xml")
     agent = create(:json_agent_corporate_entity).id
     check_metadata("archival_contexts/corporate_entities/#{agent}.xml")
-    agent = create(:json_agent_software).id
-    check_metadata("archival_contexts/softwares/#{agent}.xml")
 
     # resource exports
     res = create(:json_resource, :publish => true).id

--- a/backend/spec/factories.rb
+++ b/backend/spec/factories.rb
@@ -398,20 +398,12 @@ FactoryBot.define do
     agent_type { 'agent_software' }
     names { [build(:json_name_software)] }
     dates_of_existence { [build(:json_structured_date_label)] }
-    agent_record_controls { [build(:agent_record_control)] }
-    agent_alternate_sets { [build(:agent_alternate_set)] }
-    agent_conventions_declarations { [build(:agent_conventions_declaration)] }
-    agent_sources { [build(:agent_sources)] }
-    agent_other_agency_codes { [build(:agent_other_agency_codes)] }
-    agent_maintenance_histories { [build(:agent_maintenance_history)] }
-    agent_record_identifiers { [build(:agent_record_identifier)] }
     agent_places { [build(:json_agent_place)] }
     agent_occupations { [build(:json_agent_occupation)] }
     agent_functions { [build(:json_agent_function)] }
     agent_topics { [build(:json_agent_topic)] }
     agent_identifiers { [build(:json_agent_identifier)] }
     used_languages { [build(:json_used_language)] }
-    agent_resources { [build(:json_agent_resource)] }
   end
 
   factory :json_agent_family_full_subrec, class: JSONModel(:agent_family) do

--- a/backend/spec/model_agent_software_spec.rb
+++ b/backend/spec/model_agent_software_spec.rb
@@ -20,6 +20,40 @@ describe 'Agent model' do
       }.to raise_error(JSONModel::ValidationException)
   end
 
+  it "doesn't allow a software agent record to be created with any record control or relation subrecords" do
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_record_identifiers => [build(:agent_record_identifier)]))
+    }.to raise_error(JSONModel::ValidationException)
+
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_record_controls => [build(:agent_record_control)]))
+    }.to raise_error(JSONModel::ValidationException)
+
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_other_agency_codes => [build(:agent_other_agency_codes)]))
+    }.to raise_error(JSONModel::ValidationException)
+
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_conventions_declarations => [build(:agent_conventions_declaration)]))
+    }.to raise_error(JSONModel::ValidationException)
+
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_maintenance_histories => [build(:agent_maintenance_history)]))
+    }.to raise_error(JSONModel::ValidationException)
+
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_sources => [build(:agent_sources)]))
+    }.to raise_error(JSONModel::ValidationException)
+
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_alternate_sets => [build(:agent_alternate_set)]))
+    }.to raise_error(JSONModel::ValidationException)
+
+    expect {
+      AgentSoftware.create_from_json(build(:json_agent_software, :agent_resources => [build(:json_agent_resource)]))
+    }.to raise_error(JSONModel::ValidationException)
+  end
+
 
   it "allows a software agent record to be created with linked contact details" do
 

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -2433,6 +2433,7 @@ en:
     generic_validation_error: Validation Error
     requires_that_end_dates_are_after_begin_dates: End Dates must be after Begin Dates
     must_specify_a_primary_subject: "Description Information: Record is missing a primary subject"
+    subrecord_not_allowed_for_agent_software: "Software Agents cannot have record control or relation subrecords"
 
   job:
     _singular: Background Job

--- a/common/validations.rb
+++ b/common/validations.rb
@@ -27,11 +27,11 @@ module JSONModel::Validations
     end
   end
 
-  # ANW-1232: add validations to prevent software agents from having/saving record control or agent relation subrecords. 
+  # ANW-1232: add validations to prevent software agents from having/saving record control or agent relation subrecords.
   # These records are hidden from the forms but allowed through the schema (as agent_software inherits from abstract_agent) so these validations serve to prevent these subrecords from being added via API calls.
   if JSONModel(:agent_software)
     JSONModel(:agent_software).add_validation("check_agent_software_subrecords") do |hash|
-        check_agent_software_subrecords(hash)
+      check_agent_software_subrecords(hash)
     end
 
   end

--- a/common/validations.rb
+++ b/common/validations.rb
@@ -27,6 +27,15 @@ module JSONModel::Validations
     end
   end
 
+  # ANW-1232: add validations to prevent software agents from having/saving record control or agent relation subrecords. 
+  # These records are hidden from the forms but allowed through the schema (as agent_software inherits from abstract_agent) so these validations serve to prevent these subrecords from being added via API calls.
+  if JSONModel(:agent_software)
+    JSONModel(:agent_software).add_validation("check_agent_software_subrecords") do |hash|
+        check_agent_software_subrecords(hash)
+    end
+
+  end
+
   [:agent_function, :agent_place, :agent_occupation, :agent_topic].each do |type|
     if JSONModel(type)
       JSONModel(type).add_validation("check_#{type}_subject_subrecord") do |hash|
@@ -330,6 +339,19 @@ module JSONModel::Validations
 
     if hash["subjects"].empty?
       errors << ["subjects", "Must specify a primary subject"]
+    end
+
+    return errors
+  end
+
+  def self.check_agent_software_subrecords(hash)
+    errors = []
+    subrecords_disallowed = ["agent_record_identifiers", "agent_record_controls", "agent_other_agency_codes", "agent_conventions_declarations", "agent_maintenance_histories", "agent_sources", "agent_alternate_sets", "agent_resources"]
+
+    subrecords_disallowed.each do |sd|
+      unless hash[sd] == [] || hash[sd].nil?
+        errors << [sd, "subrecord not allowed for agent software"]
+      end
     end
 
     return errors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Software agents shouldn't have some of the subrecords the other agents have. These validation changes back up the removal of certain forms from the public interface.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1232

## How Has This Been Tested?
Manual and unit testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
