### PR TITLE
ANW-1265 Improve linker box accessibility

### DIFF
--- a/frontend/app/assets/javascripts/jquery.tokeninput.js
+++ b/frontend/app/assets/javascripts/jquery.tokeninput.js
@@ -253,6 +253,7 @@ $.TokenList = function (input, url_or_data, settings) {
                 show_dropdown_hint();
             }
             token_list.addClass($(input).data("settings").classes.focused);
+            token_list.closest("div").attr("aria-expanded", true)
         })
         .blur(function () {
             hide_dropdown();
@@ -265,6 +266,7 @@ $.TokenList = function (input, url_or_data, settings) {
               $(this).val("");
             }
             token_list.removeClass($(input).data("settings").classes.focused);
+            token_list.closest("div").attr("aria-expanded", false)
         })
         .bind("keyup keydown blur update", resize_input)
         .keydown(function (event) {
@@ -836,7 +838,9 @@ $.TokenList = function (input, url_or_data, settings) {
     function populate_dropdown (query, results) {
         if(results && results.length) {
             dropdown.empty();
-            var dropdown_ul = $("<ul>")
+            var dropdown_label = dropdown_parent[0].nextSibling.id + "_label";
+            var ul_id = dropdown_parent[0].nextSibling.id + "_listbox";
+            var dropdown_ul = $("<ul  aria-labelledby=" + dropdown_label + " role='listbox' id=" + ul_id + ">")
                 .appendTo(dropdown)
                 .mouseover(function (event) {
                     select_dropdown_item($(event.target).closest("li"));
@@ -894,14 +898,14 @@ $.TokenList = function (input, url_or_data, settings) {
                 deselect_dropdown_item($(selected_dropdown_item));
             }
 
-            item.addClass($(input).data("settings").classes.selectedDropdownItem);
+            item.addClass($(input).data("settings").classes.selectedDropdownItem).attr("aria-selected", true);
             selected_dropdown_item = item.get(0);
         }
     }
 
     // Remove highlighting from an item in the results dropdown
     function deselect_dropdown_item (item) {
-        item.removeClass($(input).data("settings").classes.selectedDropdownItem);
+        item.removeClass($(input).data("settings").classes.selectedDropdownItem).removeAttr("aria-selected");
         selected_dropdown_item = null;
     }
 

--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -429,11 +429,11 @@ $(function() {
           },
           resultsFormatter: function(item) {
             var string = item.name;
-            var $resultSpan = $("<span class='"+ item.json.jsonmodel_type + "'>");
+            var $resultSpan = $("<span class='"+ item.json.jsonmodel_type + "' aria-label='"+ string + "'>");
             var extra_class = tag_subjects_by_term_type(item);
             $resultSpan.text(string);
             $resultSpan.prepend("<span class='icon-token " + extra_class + "'></span>");
-            var $resultLi = $("<li>");
+            var $resultLi = $("<li role='option'>");
             $resultLi.append($resultSpan);
             return $resultLi[0].outerHTML;
           },

--- a/frontend/app/views/accessions/_linker.html.erb
+++ b/frontend/app/views/accessions/_linker.html.erb
@@ -22,11 +22,22 @@
         value="<%= form.obj["ref"] %>" />
 
     <% end %>
-   <label class="control-label col-sm-2"><%= I18n.t "accession._singular" %></label>
+   <label class="control-label col-sm-2"
+          id="<%= form.id_for("ref") %>_label"
+          for="<%= form.id_for("ref") %>">
+     <%= I18n.t "accession._singular" %>
+   </label>
    <div class="controls col-sm-8">
-       <div class="input-group linker-wrapper">
-          <input type="text" class="linker"
+       <div class="input-group linker-wrapper"
+            role="combobox"
+            aria-owns="<%= form.id_for("ref") %>_listbox"
+            id="<%= form.id_for("ref") %>_combobox">
+          <input type="text" 
+            class="linker"
             id="<%= form.id_for("ref") %>"
+            aria-autocomplete="both"
+            aria-controls="<%= form.id_for("ref") %>_listbox"
+            aria-labelledby="<%= form.id_for("ref") %>_label"
             data-label="<%= I18n.t "accession._singular" %>"
             data-label_plural="<%= I18n.t "accession._plural" %>"
             data-path="<%= form.path %>"

--- a/frontend/app/views/agents/_linker.html.erb
+++ b/frontend/app/views/agents/_linker.html.erb
@@ -22,13 +22,22 @@
   end
 %>
 <div class="form-group <% if required %> required <% end %>">
-  <label class="control-label col-sm-2">
+  <label class="control-label col-sm-2"
+         id="<%= form.id_for("ref") %>_label"
+         for="<%= form.id_for("ref") %>">
     <%= wrap_with_tooltip(linker_label, "related_agent.related_agent_tooltip", "control-label initialised") %>
   </label>
   <div class="controls col-sm-8">
-    <div class="input-group linker-wrapper">
-      <input type="text" class="linker"
+    <div class="input-group linker-wrapper"
+         role="combobox"
+         aria-owns="<%= form.id_for("ref") %>_listbox"
+         id="<%= form.id_for("ref") %>_combobox">
+      <input type="text" 
+             class="linker"
              id="<%= form.id_for("ref") %>"
+             aria-autocomplete="both"
+             aria-controls="<%= form.id_for("ref") %>_listbox"
+             aria-labelledby="<%= form.id_for("ref") %>_label"
              data-label="<%= I18n.t("agent._singular") %>"
              data-label_plural="<%= I18n.t("agent._plural") %>"
              data-name="ref"

--- a/frontend/app/views/classification_terms/_linker.html.erb
+++ b/frontend/app/views/classification_terms/_linker.html.erb
@@ -21,11 +21,22 @@
 
 %>
 <div class="form-group required">
-   <label class="control-label col-sm-2"><%= linker_label %></label>
+   <label class="control-label col-sm-2"
+          id="<%= form.id_for("ref") %>_label"
+          for="<%= form.id_for("ref") %>">
+     <%= linker_label %>
+   </label>
    <div class="controls col-sm-8">
-       <div class="input-group linker-wrapper">
-          <input type="text" class="linker"
+       <div class="input-group linker-wrapper"
+            role="combobox"
+            aria-owns="<%= form.id_for("ref") %>_listbox"
+            id="<%= form.id_for("ref") %>_combobox">
+          <input type="text" 
+            class="linker"
             id="<%= form.id_for("ref") %>"
+            aria-autocomplete="both"
+            aria-controls="<%= form.id_for("ref") %>_listbox"
+            aria-labelledby="<%= form.id_for("ref") %>_label"
             data-label="<%= I18n.t("classification_term._singular") %>"
             data-label_plural="<%= I18n.t("classification_term._plural") %>"
             data-path="<%= form.path %>"

--- a/frontend/app/views/classification_terms/_record_linker.html.erb
+++ b/frontend/app/views/classification_terms/_record_linker.html.erb
@@ -6,11 +6,21 @@
    end
 %>
 <div class="form-group required">
-  <label class="control-label col-sm-2"><%= I18n.t("linked_record.ref") %></label>
+  <label class="control-label col-sm-2"
+         id="<%= form.id_for("ref") %>_label"
+         for="<%= form.id_for("ref") %>">
+    <%= I18n.t("linked_record.ref") %>
+  </label>
   <div class="controls col-sm-8">
-    <div class="input-group linker-wrapper">
+    <div class="input-group linker-wrapper"
+         role="combobox"
+         aria-owns="<%= form.id_for("ref") %>_listbox"
+         id="<%= form.id_for("ref") %>_combobox">
       <input type="text" class="linker"
              id="<%= form.id_for("ref") %>"
+             aria-autocomplete="both"
+             aria-controls="<%= form.id_for("ref") %>_listbox"
+             aria-labelledby="<%= form.id_for("ref") %>_label"
              data-label="<%= I18n.t("linked_record.ref") %>"
              data-label_plural="<%= I18n.t("linked_record.ref_plural") %>"
              data-name="ref"
@@ -21,7 +31,6 @@
              data-multiplicity="one"
              data-format_template="title"
              data-types='["accession", "resource"]'
-             aria-label="Link to record"
              />
 
       <% if form.obj.has_key?('_resolved') %>

--- a/frontend/app/views/classifications/_linker.html.erb
+++ b/frontend/app/views/classifications/_linker.html.erb
@@ -21,11 +21,21 @@
   
 %>
 <div class="form-group required">
-   <label class="control-label col-sm-2"><%= linker_label %></label>
+   <label class="control-label col-sm-2"
+          id="<%= form.id_for("ref") %>_label"
+          for="<%= form.id_for("ref") %>">
+     <%= linker_label %>
+   </label>
    <div class="controls col-sm-8">
-       <div class="input-group linker-wrapper">
+       <div class="input-group linker-wrapper"
+            role="combobox"
+            aria-owns="<%= form.id_for("ref") %>_listbox"
+            id="<%= form.id_for("ref") %>_combobox">
           <input type="text" class="linker"
             id="<%= form.id_for("ref") %>"
+            aria-autocomplete="both"
+            aria-controls="<%= form.id_for("ref") %>_listbox"
+            aria-labelledby="<%= form.id_for("ref") %>_label"
             data-label="<%= I18n.t("classification._singular") %>"
             data-label_plural="<%= I18n.t("classification._plural") %>"
             data-path="<%= form.path %>"

--- a/frontend/app/views/classifications/_record_linker.html.erb
+++ b/frontend/app/views/classifications/_record_linker.html.erb
@@ -6,11 +6,21 @@
    end
 %>
 <div class="form-group required">
-  <label class="control-label col-sm-2"><%= I18n.t("linked_record.ref") %></label>
+  <label class="control-label col-sm-2"
+         id="<%= form.id_for("ref") %>_label"
+         for="<%= form.id_for("ref") %>">
+    <%= I18n.t("linked_record.ref") %>
+  </label>
   <div class="controls col-sm-8">
-    <div class="input-group linker-wrapper">
+    <div class="input-group linker-wrapper"
+         role="combobox"
+         aria-owns="<%= form.id_for("ref") %>_listbox"
+         id="<%= form.id_for("ref") %>_combobox">
       <input type="text" class="linker"
              id="<%= form.id_for("ref") %>"
+             aria-autocomplete="both"
+             aria-controls="<%= form.id_for("ref") %>_listbox"
+             aria-labelledby="<%= form.id_for("ref") %>_label"
              data-label="<%= I18n.t("linked_record.ref") %>"
              data-label_plural="<%= I18n.t("linked_record.ref_plural") %>"
              data-name="ref"
@@ -21,7 +31,6 @@
              data-multiplicity="one"
              data-format_template="title"
              data-types='["accession", "resource"]'
-             aria-label="Link to record"
              />
 
       <% if form.obj.has_key?('_resolved') %>

--- a/frontend/app/views/container_profiles/_linker.html.erb
+++ b/frontend/app/views/container_profiles/_linker.html.erb
@@ -14,11 +14,21 @@
   linkable_types = ["container_profile"]
 %>
 <div class="form-group <% if required %>required<% end %>">
-  <label class="control-label col-sm-2"><%= I18n.t("container_profile._singular") %></label>
+  <label class="control-label col-sm-2"
+         id="<%= form.id_for("ref") %>_label"
+         for="<%= form.id_for("ref") %>">
+    <%= I18n.t("container_profile._singular") %>
+  </label>
   <div class="controls col-sm-8">
-    <div class="input-group linker-wrapper">
+    <div class="input-group linker-wrapper"
+         role="combobox"
+         aria-owns="<%= form.id_for("ref") %>_listbox"
+         id="<%= form.id_for("ref") %>_combobox">
       <input type="text" class="linker"
              id="<%= form.id_for("ref") %>"
+             aria-autocomplete="both"
+             aria-controls="<%= form.id_for("ref") %>_listbox"
+             aria-labelledby="<%= form.id_for("ref") %>_label"
              data-label="<%= I18n.t("container_profile._singular") %>"
              data-label_plural="<%= I18n.t("container_profile._plural") %>"
              data-name="ref"

--- a/frontend/app/views/digital_objects/_linker.html.erb
+++ b/frontend/app/views/digital_objects/_linker.html.erb
@@ -8,11 +8,21 @@
    exclude_ids = [] if exclude_ids.blank?
 %>
 <div class="form-group required">
-  <label class="control-label col-sm-2"><%= I18n.t("digital_object._singular") %></label>
+  <label class="control-label col-sm-2"
+         id="<%= form.id_for("ref") %>_label"
+         for="<%= form.id_for("ref") %>">
+    <%= I18n.t("digital_object._singular") %>
+  </label>
   <div class="controls col-sm-8">
-    <div class="input-group linker-wrapper">
+    <div class="input-group linker-wrapper"
+         role="combobox"
+         aria-owns="<%= form.id_for("ref") %>_listbox"
+         id="<%= form.id_for("ref") %>_combobox">
       <input type="text" class="linker"
              id="<%= form.id_for("ref") %>"
+             aria-autocomplete="both"
+             aria-controls="<%= form.id_for("ref") %>_listbox"
+             aria-labelledby="<%= form.id_for("ref") %>_label"
              data-label="<%= I18n.t("digital_object._singular") %>"
              data-label_plural="<%= I18n.t("digital_object._plural") %>"
              data-path="<%= form.path %>"

--- a/frontend/app/views/events/_record_linker.html.erb
+++ b/frontend/app/views/events/_record_linker.html.erb
@@ -6,11 +6,21 @@
    end
 %>
 <div class="form-group required">
-  <label class="control-label col-sm-2"><%= I18n.t("linked_record.ref") %></label>
+  <label class="control-label col-sm-2"
+         id="<%= form.id_for("ref") %>_label"
+         for="<%= form.id_for("ref") %>">
+    <%= I18n.t("linked_record.ref") %>
+  </label>
   <div class="controls col-sm-8">
-    <div class="input-group linker-wrapper">
+    <div class="input-group linker-wrapper"
+         role="combobox"
+         aria-owns="<%= form.id_for("ref") %>_listbox"
+         id="<%= form.id_for("ref") %>_combobox">
       <input type="text" class="linker"
              id="<%= form.id_for("ref") %>"
+             aria-autocomplete="both"
+             aria-controls="<%= form.id_for("ref") %>_listbox"
+             aria-labelledby="<%= form.id_for("ref") %>_label"
              data-label="<%= I18n.t("linked_record.ref") %>"
              data-label_plural="<%= I18n.t("linked_record.ref_plural") %>"
              data-name="ref"

--- a/frontend/app/views/location_profiles/_linker.html.erb
+++ b/frontend/app/views/location_profiles/_linker.html.erb
@@ -14,11 +14,21 @@
   linkable_types = ["location_profile"]
 %>
 <div class="form-group <% if required %>required<% end %>">
-  <label class="control-label col-sm-2"><%= I18n.t("location_profile._singular") %></label>
+  <label class="control-label col-sm-2"
+         id="<%= form.id_for("ref") %>_label"
+         for="<%= form.id_for("ref") %>">
+    <%= I18n.t("location_profile._singular") %>
+  </label>
   <div class="controls col-sm-8">
-    <div class="input-group linker-wrapper">
+    <div class="input-group linker-wrapper"
+         role="combobox"
+         aria-owns="<%= form.id_for("ref") %>_listbox"
+         id="<%= form.id_for("ref") %>_combobox">
       <input type="text" class="linker"
              id="<%= form.id_for("ref") %>"
+             aria-autocomplete="both"
+             aria-controls="<%= form.id_for("ref") %>_listbox"
+             aria-labelledby="<%= form.id_for("ref") %>_label"
              data-label="<%= I18n.t("location_profile._singular") %>"
              data-label_plural="<%= I18n.t("location_profile._plural") %>"
              data-name="ref"
@@ -29,7 +39,6 @@
              data-multiplicity="one"
              data-types='<%= linkable_types.to_json %>'
              data-exclude='<%= exclude_ids.to_json %>'
-             aria-label="Link to location profile"
       />
       <div class="input-group-btn">
         <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="Link to location profile"><span class="caret"></span></a>

--- a/frontend/app/views/locations/_linker.html.erb
+++ b/frontend/app/views/locations/_linker.html.erb
@@ -10,11 +10,22 @@
 %>
 <hr/>
 <div class="form-group required">
-   <label class="control-label col-sm-2"><%= I18n.t("location._singular") %></label>
+   <label class="control-label col-sm-2"
+          id="<%= form.id_for("ref") %>_label"
+          for="<%= form.id_for("ref") %>">
+     <%= I18n.t("location._singular") %>
+   </label>
    <div class="controls col-sm-8">
-       <div class="input-group linker-wrapper">
-          <input type="text" class="linker"
+       <div class="input-group linker-wrapper"
+            role="combobox"
+            aria-owns="<%= form.id_for("ref") %>_listbox"
+            id="<%= form.id_for("ref") %>_combobox">
+          <input type="text"
+            class="linker"
             id="<%= form.id_for("ref") %>"
+            aria-autocomplete="both"
+            aria-controls="<%= form.id_for("ref") %>_listbox"
+            aria-labelledby="<%= form.id_for("ref") %>_label"
             data-label="<%= I18n.t("location._singular") %>"
             data-label_plural="<%= I18n.t("location._plural") %>"
             data-name="ref"

--- a/frontend/app/views/repositories/_linker.html.erb
+++ b/frontend/app/views/repositories/_linker.html.erb
@@ -14,11 +14,22 @@
   linkable_types = ["repository"]
 %>
 <div class="form-group <% if required %>required<% end %>">
-  <label class="control-label col-sm-2"><%= I18n.t("repository._singular") %></label>
+  <label class="control-label col-sm-2"
+         id="<%= form.id_for("ref") %>_label"
+         for="<%= form.id_for("ref") %>">
+    <%= I18n.t("repository._singular") %>
+  </label>
   <div class="controls col-sm-8">
-    <div class="input-group linker-wrapper">
-      <input type="text" class="linker"
+    <div class="input-group linker-wrapper"
+         role="combobox"
+         aria-owns="<%= form.id_for("ref") %>_listbox"
+         id="<%= form.id_for("ref") %>_combobox">
+      <input type="text" 
+             class="linker"
              id="<%= form.id_for("ref") %>"
+             aria-autocomplete="both"
+             aria-controls="<%= form.id_for("ref") %>_listbox"
+             aria-labelledby="<%= form.id_for("ref") %>_label"
              data-label="<%= I18n.t("repository._singular") %>"
              data-label_plural="<%= I18n.t("repository._plural") %>"
              data-name="ref"
@@ -29,7 +40,6 @@
              data-multiplicity="one"
              data-types='<%= linkable_types.to_json %>'
              data-exclude='<%= exclude_ids.to_json %>'
-             aria-label="Link to repository"
       />
       <div class="input-group-btn">
         <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="Link to repository"><span class="caret"></span></a>

--- a/frontend/app/views/resources/_linker.html.erb
+++ b/frontend/app/views/resources/_linker.html.erb
@@ -11,11 +11,22 @@
 
 %>
 <div class="form-group required">
-   <label class="control-label <%= layout != 'stacked' ? 'col-sm-2' : '' %>"><%= field_label %></label>
-   <div class="controls <%= layout != 'stacked' ? 'col-sm-8' : ''%>">
+   <label class="control-label <%= layout != 'stacked' ? 'col-sm-2' : '' %>"
+          id="<%= form.id_for("ref") %>_label"
+          for="<%= form.id_for("ref") %>">
+     <%= field_label %>
+   </label>
+   <div class="controls <%= layout != 'stacked' ? 'col-sm-8' : ''%>"
+        role="combobox"
+        aria-owns="<%= form.id_for("ref") %>_listbox"
+        id="<%= form.id_for("ref") %>_combobox">
        <div class="input-group linker-wrapper">
-          <input type="text" class="linker"
+          <input type="text" 
+            class="linker"
             id="<%= form.id_for("ref") %>"
+            aria-autocomplete="both"
+            aria-controls="<%= form.id_for("ref") %>_listbox"
+            aria-labelledby="<%= form.id_for("ref") %>_label"
             data-label="<%= I18n.t("resource._singular") %>"
             data-label_plural="<%= I18n.t("resource._plural") %>"
             data-path="<%= form.path %>"

--- a/frontend/app/views/shared/_linker.html.erb
+++ b/frontend/app/views/shared/_linker.html.erb
@@ -38,11 +38,21 @@
 
 
 <div class="form-group <% if required %> required <% end %>">
-  <label class="control-label col-sm-2"><%= linker_label %></label>
+  <label class="control-label col-sm-2"
+         id="<%= form.id_for("ref") %>_label"
+         for="<%= form.id_for("ref") %>">
+    <%= linker_label %>
+  </label>
   <div class="controls col-sm-8">
-    <div class="input-group linker-wrapper">
+    <div class="input-group linker-wrapper"
+         role="combobox"
+         aria-owns="<%= form.id_for("ref") %>_listbox"
+         id="<%= form.id_for("ref") %>_combobox">
       <input type="text" class="linker"
              id="<%= form.id_for("ref") %>"
+             aria-autocomplete="both"
+             aria-controls="<%= form.id_for("ref") %>_listbox"
+             aria-labelledby="<%= form.id_for("ref") %>_label"
              data-label="<%= I18n.t("agent._singular") %>"
              data-label_plural="<%= I18n.t("agent._plural") %>"
              data-name="ref"

--- a/frontend/app/views/subjects/_linker.html.erb
+++ b/frontend/app/views/subjects/_linker.html.erb
@@ -42,13 +42,28 @@
 <div class="form-group required">
    <% if !name.blank? %>
      <%= wrap_with_tooltip(linker_label, "#{form.i18n_for(name)}_tooltip", "subrecord-form-heading-label control-label col-sm-2") %>
+     <label class="sr-only"
+            id="<%= form.id_for(data_name) %>_label"
+            for="<%= form.id_for(data_name) %>">
+        <%= linker_label %>
+      </label>
    <% else %>
-     <label class="control-label col-sm-2"><%= linker_label %></label>
+     <label class="control-label col-sm-2"
+            id="<%= form.id_for(data_name) %>_label"
+            for="<%= form.id_for(data_name) %>">
+        <%= linker_label %>
+      </label>
    <% end %>
    <div class="controls col-sm-8">
-       <div class="input-group linker-wrapper">
+       <div class="input-group linker-wrapper"
+            role="combobox"
+            aria-owns="<%= form.id_for(data_name) %>_listbox"
+            id="<%= form.id_for(data_name) %>_combobox">
           <input type="text" class="linker"
             id="<%= form.id_for(data_name) %>"
+            aria-autocomplete="both"
+            aria-controls="<%= form.id_for(data_name) %>_listbox"
+            aria-labelledby="<%= form.id_for(data_name) %>_label"
             data-label="<%= I18n.t("subject._singular") %>"
             data-label_plural="<%= I18n.t("subject._plural") %>"
             data-path="<%= data_path %>"

--- a/frontend/app/views/top_containers/_linker.html.erb
+++ b/frontend/app/views/top_containers/_linker.html.erb
@@ -37,11 +37,22 @@
 %>
 
 <div class="form-group <% if required %>required<% end %>">
-  <label class="control-label col-sm-2"><%= I18n.t("top_container._singular") %></label>
+  <label class="control-label col-sm-2"
+         id="<%= form.id_for("ref") %>_label"
+         for="<%= form.id_for("ref") %>">
+    <%= I18n.t("top_container._singular") %>
+  </label>
   <div class="controls col-sm-8">
-    <div class="input-group linker-wrapper">
-      <input type="text" class="linker"
+    <div class="input-group linker-wrapper"
+         role="combobox"
+         aria-owns="<%= form.id_for("ref") %>_listbox"
+         id="<%= form.id_for("ref") %>_combobox">
+      <input type="text" 
+             class="linker"
              id="<%= form.id_for("ref") %>"
+             aria-autocomplete="both"
+             aria-controls="<%= form.id_for("ref") %>_listbox"
+             aria-labelledby="<%= form.id_for("ref") %>_label"
              data-label="<%= I18n.t("top_container._singular") %>"
              data-label_plural="<%= I18n.t("top_container._plural") %>"
              data-name="ref"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Continuation of work started in #2182 to improve accessibility of staff side comboboxes, specifically linker boxes.  Includes small fixes to accomplish the following:
- identifying/labeling the comboboxes and component parts (listbox, combobox, options);
- ensuring the dropdown/autocomplete options are selectable by the keyboard;
- indicating when the combobox dropdown is expanded/collapsed; 
- indicating which dropdown option is currently selected; and,
- indicating which option is selected and, when selected, that screenreaders do not trip over the text highlighting (`<b>`) used in the option text.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1265

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Fully expanded empty accession record before:
![image](https://user-images.githubusercontent.com/15144646/114928278-695fb280-9e00-11eb-8b73-7e1084f987d4.png)

Fully expanded empty accession record after:
![image](https://user-images.githubusercontent.com/15144646/114928104-31586f80-9e00-11eb-9978-24c9a4061c98.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
