### PR TITLE
ANW-1196: optional display of identifiers in record trees

### DIFF
--- a/backend/app/model/large_tree.rb
+++ b/backend/app/model/large_tree.rb
@@ -94,7 +94,6 @@ class LargeTree
                                                       "uri" => @root_record.uri,
                                                       "slugged_url" => SlugHelpers.get_slugged_url_for_largetree(@root_record.class.to_s, @root_record.repo_id, @root_record.slug),
                                                       "jsonmodel_type" => @root_table.to_s,
-                                                      "identifier" => (0...4).map {|i| @root_record["id_#{i}".to_sym]}.compact.join("-"),
                                                       "parsed_title" => MixedContentParser.parse(@root_record.title, '/'))
       @decorators.each do |decorator|
         response = decorator.root(response, @root_record)
@@ -125,7 +124,6 @@ class LargeTree
 
       response = waypoint_response(child_count).merge("title" => node_record.display_string,
                                                       "uri" => node_record.uri,
-                                                      "identifier" => node_record.component_id,
                                                       "position" => node_position,
                                                       "jsonmodel_type" => @node_table.to_s)
 
@@ -242,7 +240,7 @@ class LargeTree
                 :parent_id => parent_id)
         .filter(published_filter)
         .order(:position)
-        .select(:id, :repo_id, :title, :position, :slug, :component_id)
+        .select(:id, :repo_id, :title, :position, :slug)
         .offset(offset * WAYPOINT_SIZE)
         .limit(WAYPOINT_SIZE)
         .each do |row|
@@ -269,8 +267,7 @@ class LargeTree
                                              "uri" => JSONModel(@node_type).uri_for(row[:id], :repo_id => row[:repo_id]),
                                              "position" => (offset * WAYPOINT_SIZE) + idx,
                                              "parent_id" => parent_id,
-                                             "jsonmodel_type" => @node_type.to_s,
-                                             "identifier" => row[:component_id])
+                                             "jsonmodel_type" => @node_type.to_s)
 
       end
 

--- a/backend/app/model/large_tree.rb
+++ b/backend/app/model/large_tree.rb
@@ -94,6 +94,7 @@ class LargeTree
                                                       "uri" => @root_record.uri,
                                                       "slugged_url" => SlugHelpers.get_slugged_url_for_largetree(@root_record.class.to_s, @root_record.repo_id, @root_record.slug),
                                                       "jsonmodel_type" => @root_table.to_s,
+                                                      "identifier" => (0...4).map {|i| @root_record["id_#{i}".to_sym]}.compact.join("-"),
                                                       "parsed_title" => MixedContentParser.parse(@root_record.title, '/'))
       @decorators.each do |decorator|
         response = decorator.root(response, @root_record)
@@ -124,6 +125,7 @@ class LargeTree
 
       response = waypoint_response(child_count).merge("title" => node_record.display_string,
                                                       "uri" => node_record.uri,
+                                                      "identifier" => node_record.component_id,
                                                       "position" => node_position,
                                                       "jsonmodel_type" => @node_table.to_s)
 
@@ -240,7 +242,7 @@ class LargeTree
                 :parent_id => parent_id)
         .filter(published_filter)
         .order(:position)
-        .select(:id, :repo_id, :title, :position, :slug)
+        .select(:id, :repo_id, :title, :position, :slug, :component_id)
         .offset(offset * WAYPOINT_SIZE)
         .limit(WAYPOINT_SIZE)
         .each do |row|
@@ -267,7 +269,8 @@ class LargeTree
                                              "uri" => JSONModel(@node_type).uri_for(row[:id], :repo_id => row[:repo_id]),
                                              "position" => (offset * WAYPOINT_SIZE) + idx,
                                              "parent_id" => parent_id,
-                                             "jsonmodel_type" => @node_type.to_s)
+                                             "jsonmodel_type" => @node_type.to_s,
+                                             "identifier" => row[:component_id])
 
       end
 

--- a/backend/app/model/large_tree_resource.rb
+++ b/backend/app/model/large_tree_resource.rb
@@ -2,6 +2,7 @@ class LargeTreeResource
 
   def root(response, root_record)
     response['level'] = root_record.other_level || root_record.level
+    response['identifier'] = (0...4).map {|i| root_record["id_#{i}".to_sym]}.compact.join("-")
 
     # Collect all container data
     Instance
@@ -43,6 +44,7 @@ class LargeTreeResource
   end
 
   def node(response, node_record)
+    response['identifier'] = node_record.component_id
     response
   end
 
@@ -52,12 +54,14 @@ class LargeTreeResource
       .left_join(Sequel.as(:enumeration_value, :level_enum), :id => :archival_object__level_id)
       .filter(:archival_object__id => record_ids)
       .select(Sequel.as(:archival_object__id, :id),
+              Sequel.as(:archival_object__component_id, :component_id),
               Sequel.as(:level_enum__value, :level),
               Sequel.as(:archival_object__other_level, :other_level))
       .each do |row|
       id = row[:id]
       result_for_record = response.fetch(record_ids.index(id))
 
+      result_for_record['identifier'] = row[:component_id]
       result_for_record['level'] = row[:other_level] || row[:level]
     end
 

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -502,7 +502,7 @@ AppConfig[:pui_hide][:agents] = false
 AppConfig[:pui_hide][:classifications] = false
 AppConfig[:pui_hide][:search_tab] = false
 # The following determine globally whether the various "badges" appear on the Repository page
-# can be overriden at repository level below (e.g.:  AppConfig[:pui_repos][{repo_code}][:hide][:counts] = true
+# can be overridden at repository level below (e.g.:  AppConfig[:pui_repos][{repo_code}][:hide][:counts] = true
 AppConfig[:pui_hide][:resource_badge] = false
 AppConfig[:pui_hide][:record_badge] = true # hide by default
 AppConfig[:pui_hide][:digital_object_badge] = false
@@ -514,7 +514,7 @@ AppConfig[:pui_hide][:counts] = false
 # The following determines globally whether the 'container inventory' navigation tab/pill is hidden on resource/collection page
 AppConfig[:pui_hide][:container_inventory] = false
 
-# Whether to display linked decaccessions
+# Whether to display linked deaccessions
 AppConfig[:pui_display_deaccessions] = true
 
 # Whether to display archival record identifiers in the PUI collection organization tree

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -336,7 +336,9 @@ AppConfig[:demo_data_url] = ""
 # Expose external ids in the frontend
 AppConfig[:show_external_ids] = false
 
-#
+# Whether to display archival record identifiers in the frontend largetree container
+AppConfig[:display_identifiers_in_largetree_container] = false
+
 # This sets the allowed size of the request/response header that Jetty will accept (
 # anything bigger gets a 403 error ). Note if you want to jack this size up,
 # you will also have to configure your Nginx/Apache  as well if

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -517,6 +517,9 @@ AppConfig[:pui_hide][:container_inventory] = false
 # Whether to display linked decaccessions
 AppConfig[:pui_display_deaccessions] = true
 
+# Whether to display archival record identifiers in the PUI collection organization tree
+AppConfig[:pui_display_identifiers_in_resource_tree] = false
+
 #The number of characters to truncate before showing the 'Read More' link on notes
 AppConfig[:pui_readmore_max_characters] = 450
 

--- a/frontend/app/assets/javascripts/tree_renderers.js.erb
+++ b/frontend/app/assets/javascripts/tree_renderers.js.erb
@@ -39,6 +39,7 @@ function ResourceRenderer() {
                           '  <td class="resource-level"></td>' +
                           '  <td class="resource-type"></td>' +
                           '  <td class="resource-container"></td>' +
+                          '  <td class="resource-identifier"></td>' +
                           '</tr>');
 
     this.nodeTemplate = $('<tr> ' +
@@ -47,6 +48,7 @@ function ResourceRenderer() {
                           '  <td class="resource-level"></td>' +
                           '  <td class="resource-type"></td>' +
                           '  <td class="resource-container"></td>' +
+                          '  <td class="resource-identifier"></td>' +
                           '</tr>');
 }
 
@@ -59,6 +61,10 @@ ResourceRenderer.prototype.add_root_columns = function (row, rootNode) {
 
     if (rootNode.parsed_title) {
         row.find('.title .record-title').html(rootNode.parsed_title);
+    }
+    
+    if (<%= AppConfig[:display_identifiers_in_largetree_container] %> && rootNode.identifier) {
+      row.find('.resource-identifier').text(rootNode.identifier).attr('title', rootNode.identifier);
     }
 
     row.find('.resource-level').text(level).attr('title', level);
@@ -74,6 +80,11 @@ ResourceRenderer.prototype.add_node_columns = function (row, node) {
     var container_summary = this.build_container_summary(node);
 
     row.find('.title .record-title').html(title).attr('title', title);
+
+    if (<%= AppConfig[:display_identifiers_in_largetree_container] %> && node.identifier) {
+      row.find('.resource-identifier').text(node.identifier).attr('title', node.identifier);
+    }
+
     row.find('.resource-level').text(level).attr('title', level);
     row.find('.resource-type').text(type).attr('title', type);
     row.find('.resource-container').text(container_summary).attr('title', container_summary);

--- a/frontend/spec/selenium/spec/resources_spec.rb
+++ b/frontend/spec/selenium/spec/resources_spec.rb
@@ -10,8 +10,7 @@ describe 'Resources and archival objects' do
     @accession = create(:accession,
                         collection_management: build(:collection_management))
 
-    @resource = create(:resource,
-                       id_0: 'resource-id')
+    @resource = create(:resource)
 
     @archival_object = create(:archival_object,
                               component_id: 'component-id',

--- a/frontend/spec/selenium/spec/resources_spec.rb
+++ b/frontend/spec/selenium/spec/resources_spec.rb
@@ -10,7 +10,8 @@ describe 'Resources and archival objects' do
     @accession = create(:accession,
                         collection_management: build(:collection_management))
 
-    @resource = create(:resource)
+    @resource = create(:resource,
+                       id_0: 'resource-id')
 
     @archival_object = create(:archival_object,
                               component_id: 'component-id',
@@ -598,7 +599,7 @@ describe 'Resources and archival objects' do
       @driver.find_element_with_text('//th', /Identifier/)
     end.not_to raise_error
     expect do
-      @driver.find_element_with_text('//th', /Componend ID/, false, true)
+      @driver.find_element_with_text('//th', /Component ID/, false, true)
     end.to raise_error(Selenium::WebDriver::Error::NoSuchElementError)
   end
 

--- a/public/app/assets/javascripts/tree_renderer.js.erb
+++ b/public/app/assets/javascripts/tree_renderer.js.erb
@@ -49,6 +49,8 @@
 
         if (rootNode.jsonmodel_type == 'classification') {
             $link.prepend(rootNode.identifier + '<%= I18n.t('classification.identifier_separator') %> ');
+        } else if (rootNode.jsonmodel_type == 'resource' && <%= AppConfig[:pui_display_identifiers_in_resource_tree] %> && rootNode.identifier) {
+            $link.prepend(rootNode.identifier + '<%= I18n.t('resource.identifier_separator') %> ');
         }
     }
 
@@ -62,6 +64,9 @@
         } else {
             var title = this.build_node_title(node);
             $link.html(title);
+            if (node.jsonmodel_type == 'archival_object' && <%= AppConfig[:pui_display_identifiers_in_resource_tree] %> && node.identifier) {
+                $link.prepend(node.identifier + '<%= I18n.t('resource.identifier_separator') %> ');
+            }
         }
 
         if (this.should_link_to_record) {

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -360,6 +360,7 @@ en:
   resource:
     _singular: Collection
     _plural: Collections
+    identifier_separator: ":"
     _public:
       identifier: Identifier
       extent: Extent

--- a/public/config/locales/es.yml
+++ b/public/config/locales/es.yml
@@ -341,6 +341,7 @@ es:
   resource:
     _singular: Colección
     _plural: Colecciones
+    identifier_separator: ":"
     _public:
       identifier: Identificador
       extent: Extensión

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -360,6 +360,7 @@ fr:
   resource:
     _singular: Collection
     _plural: Collections
+    identifier_separator: ":"
     _public:
       identifier: Identifiant
       extent: Volume

--- a/public/config/locales/ja.yml
+++ b/public/config/locales/ja.yml
@@ -315,6 +315,7 @@ ja:
   resource:
     _singular: コレクション
     _plural: コレクション
+    identifier_separator: ":"
     _public:
       identifier: 識別
       extent: エクステント

--- a/public/spec/rails_helper.rb
+++ b/public/spec/rails_helper.rb
@@ -5,7 +5,7 @@ CHROME_OPTS  = ENV.fetch('CHROME_OPTS', '--headless,--disable-gpu,--window-size=
 FIREFOX_OPTS = ENV.fetch('FIREFOX_OPTS', '-headless').split(',')
 # https://github.com/mozilla/geckodriver/issues/1354
 ENV['MOZ_HEADLESS_WIDTH'] = ENV.fetch('MOZ_HEADLESS_WIDTH', '1920')
-ENV['MOZ_HEADLESS_HEIGHT'] = ENV.fetch('MOZ_HEADLESS_WIDTH', '1080')
+ENV['MOZ_HEADLESS_HEIGHT'] = ENV.fetch('MOZ_HEADLESS_HEIGHT', '1080')
 
 # Chrome
 Capybara.register_driver(:chrome) do |app|

--- a/public/spec/spec_helper.rb
+++ b/public/spec/spec_helper.rb
@@ -81,7 +81,7 @@ def setup_test_data
                     :instances => [build(:instance_digital)])
   aos = (0..5).map do
     create(:archival_object,
-           resource: { 'ref' => resource.uri }, publish: true)
+           title: "Published Archival Object", resource: { 'ref' => resource.uri }, publish: true)
   end
 
   unpublished_resource = create(:resource, title: "Unpublished Resource", publish: false)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
These changes resolve the issue raised in JIRA issue ANW-1196 - a desire to be able to view resource and archival object identifiers in the PUI collection organisation tree. This allows for easier navigation within large collections, especially where runs of sibling archival objects have similar (or even identical) titles. The approach used was inspired by the University of Denver's tree_component_id plugin (https://github.com/duspeccoll/tree_component_id), so I have also added the option to put resource and archival object identifiers into the staff interface tree (in their own section, rather than being added to the container summary). This should mean that there is no need for this plugin in the future. As suggested by @cdibella in the JIRA issue, this identifier display in the PUI and SUI trees can be toggled on and off individually with options in the config file.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1196

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual verification and full test suites run locally on Ubuntu 20.04.

I have added tests for this new functionality (in "frontend/spec/selenium/spec/resources_spec.rb" and "public/spec/features/resources_spec.rb"), but they're pretty minimal and don't test both ways (i.e. checking the identifiers appear when told to as well as checking they don't appear when they're told not to). I couldn't see a way of dynamically adjusting these new config options for each test, or a way of idiomatically restarting the AS instance within the test to pick up a new config file setting, but I'm happy to make changes if you have any advice for this.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

