### PR TITLE
ANW-90 Map telephone and fax to agent contact telephones subrecord

### DIFF
--- a/backend/app/converters/accession_converter.rb
+++ b/backend/app/converters/accession_converter.rb
@@ -128,14 +128,16 @@ class AccessionConverter < Converter
       'agent_contact_city' => 'agent_contact.city',
       'agent_contact_country' => 'agent_contact.country',
       'agent_contact_email' => 'agent_contact.email',
-      'agent_contact_fax' => 'agent_contact.fax',
       'agent_contact_name' => 'agent_contact.name',
 
       'agent_contact_post_code' => 'agent_contact.post_code',
       'agent_contact_region' => 'agent_contact.region',
       'agent_contact_salutation' => 'agent_contact.salutation',
-      'agent_contact_telephone' => 'agent_contact.telephone',
-      'agent_contact_telephone_ext' => 'agent_contact.telephone_ext',
+
+      'agent_contact_fax' => 'agent_fax.number',
+
+      'agent_contact_telephone' => 'agent_telephone.number',
+      'agent_contact_telephone_ext' => 'agent_telephone.ext',
 
       'agent_name_authority_id' => 'agent_name.authority_id',
       'agent_name_dates' => 'agent_name.dates',
@@ -194,6 +196,10 @@ class AccessionConverter < Converter
           agent.agent_contacts << this
         }
       },
+
+      :agent_fax => telephone_template('fax'),
+
+      :agent_telephone => telephone_template('home'),
 
       :agent_name => {
         :record_type => Proc.new {|data|
@@ -332,6 +338,20 @@ class AccessionConverter < Converter
         event.linked_agents << {'role' => 'executing_program', 'ref' => '/agents/software/1'}
         event.date = date
         event.linked_records << {'role' => 'source', 'ref' => accession.uri}
+      }
+    }
+  end
+
+
+  def self.telephone_template(type)
+    {
+      :record_type => :telephone,
+      :on_create => Proc.new {|data, obj|
+        obj.number_type = type
+      },
+      :on_row_complete => Proc.new {|cache, this|
+        agent = cache.find {|obj| obj.class.record_type =~ /^agent_(perso|corpo|famil)/}
+        agent.agent_contacts.first['telephones'] << this
       }
     }
   end

--- a/backend/spec/lib_accession_converter_spec.rb
+++ b/backend/spec/lib_accession_converter_spec.rb
@@ -30,6 +30,15 @@ describe 'Accession converter' do
     expect(@agents.count).to eq(5)
   end
 
+  it "creates an Agent contact subrecord with telephone and fax if in the row" do
+    telephones = @agents.first['agent_contacts'].map { |c| c['telephones'] }.flatten
+    expect(telephones.count).to eq(2)
+    expect(telephones[0]['number_type']).to eq('fax')
+    expect(telephones[0]['number']).to eq('999-444-4444')
+    expect(telephones[1]['number_type']).to eq('home')
+    expect(telephones[1]['ext']).to eq('247')
+  end
+
   it "created a Subject record if one is in the row" do
     expect(@subjects.count).to eq(8)
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update to the accessions CSV importer to map `agent_contact_fax`, `agent_contact_telephone`, and `agent_contact_telephone_ext` to repeating  agent contact telephone subrecords.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
When telephones were removed from the agent_contact subrecord into their own repeating subrecords the accessions CSV importer wasn't updated to reflect this change.  This PR remedies that.

Note: The existing import mapping will need to be updated to reflect this change.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-90

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass, new test added.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
