### PR TITLE
Fix local access restriction enum search

### DIFF
--- a/backend/app/model/rights_restriction_type.rb
+++ b/backend/app/model/rights_restriction_type.rb
@@ -2,6 +2,9 @@ class RightsRestrictionType < Sequel::Model(:rights_restriction_type)
 
   include DynamicEnums
 
-  uses_enums(:property => 'restriction_type', :uses_enum => ['restriction_type'])
+  uses_enums(
+    {:property => 'restriction_type', :uses_enum => ['restriction_type']},
+    {:property => 'local_access_restriction_type', :uses_enum => ['restriction_type']},
+  )
 
 end

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -370,7 +370,7 @@ class IndexerCommon
 
       # Turn our sets back into regular arrays so they serialize out to JSON correctly
       found_keys.each do |key|
-        doc[key] = doc[key].to_a
+        doc[key] = doc[key].to_a.flatten
       end
     }
 


### PR DESCRIPTION
1. Conversion of set to array in indexer when the field value was
an array led to a nested array with contents put into a string.
Fixed by ensuring the array is flattened.

2. Update to use correct schema prop: local_access_restriction_type

## Steps to reproduce

Create a record with a note type "Conditions Governing Access" and select one or more "Local Access Restriction Type" options. Go to controlled value lists "Local Access Restriction Type" and confirm that there are related items.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
