### PR TITLE
ANW-814 Map EAD role attribute to linked agent relator

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -1034,7 +1034,7 @@ class EADConverter < Converter
       :agent_type => 'agent_corporate_entity',
       :publish => att('audience') == 'external' ? true : false
     } do |corp|
-      set ancestor(:resource, :archival_object), :linked_agents, {'ref' => corp.uri, 'role' => opts[:role]}
+      set ancestor(:resource, :archival_object), :linked_agents, {'ref' => corp.uri, 'role' => opts[:role], 'relator' => att('role')}
     end
 
     make :name_corporate_entity, {
@@ -1054,7 +1054,7 @@ class EADConverter < Converter
       :agent_type => 'agent_family',
       :publish => att('audience') == 'external' ? true : false
     } do |family|
-      set ancestor(:resource, :archival_object), :linked_agents, {'ref' => family.uri, 'role' => opts[:role]}
+      set ancestor(:resource, :archival_object), :linked_agents, {'ref' => family.uri, 'role' => opts[:role], 'relator' => att('role')}
     end
 
     make :name_family, {
@@ -1074,7 +1074,7 @@ class EADConverter < Converter
       :agent_type => 'agent_person',
       :publish => att('audience') == 'external' ? true : false
     } do |person|
-      set ancestor(:resource, :archival_object), :linked_agents, {'ref' => person.uri, 'role' => opts[:role]}
+      set ancestor(:resource, :archival_object), :linked_agents, {'ref' => person.uri, 'role' => opts[:role], 'relator' => att('role')}
     end
 
     make :name_person, {

--- a/backend/app/exporters/examples/ead/at-tracer.xml
+++ b/backend/app/exporters/examples/ead/at-tracer.xml
@@ -560,7 +560,7 @@
                                     <controlaccess>
                                         <corpname rules="dacs" source="naf">CNames-PrimaryName-AT. CNames-Subordinate1-AT. CNames-Subordiate2-AT. (CNames-Number-AT) (CNames-Qualifier-AT) -- Pictorial works</corpname>
                                         <famname rules="aacr" source="naf" audience="external">FNames-FamilyName-AT, FNames-Prefix-AT, FNames-Qualifier-AT -- Pictorial works</famname>
-                                        <persname rules="local" source="local">PNames-Primary-AT, PNames-RestOfName-AT, PNames-Prefix-AT, PName-Number-AT, PNames-Suffix-AT, PNames-Title-AT,  (PNames-FullerForm-AT), PNames-Dates-AT, PNames-Qualifier-AT -- Pictorial works</persname>
+                                        <persname rules="local" source="local" role="Donor (dnr)">PNames-Primary-AT, PNames-RestOfName-AT, PNames-Prefix-AT, PName-Number-AT, PNames-Suffix-AT, PNames-Title-AT,  (PNames-FullerForm-AT), PNames-Dates-AT, PNames-Qualifier-AT -- Pictorial works</persname>
                                         <function source="local">Subjects--Function-AT</function>
                                         <genreform source="local">Subjects--GenreForm--AT</genreform>
                                         <geogname source="local">Subjects--Geographic Name--AT</geogname>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates EAD importer to map <persname>, <famname>, or <corpname> role attribute to ArchivesSpace's linked agent relator field.

Also updates tests (including a little cleanup) and makes on minor tweak to EAD example file to support test changes.

Note: EAD import/export map will need to be updated to reflect this change.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-814

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests updated and passing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
