### PR TITLE
ANW-1264: Implementing updated EAC export map for agent dates

### DIFF
--- a/backend/app/exporters/serializers/eac.rb
+++ b/backend/app/exporters/serializers/eac.rb
@@ -479,18 +479,18 @@ class EACSerializer < ASpaceExport::Serializer
   # if there is an expression, it will be used for the inner text. Otherwise, the standardized date will be used.
   def _build_date_single_std(date, xml)
     expression = date['structured_date_single']['date_expression']
-    standardized = date['structured_date_single']['date_standardized'] 
+    standardized = date['structured_date_single']['date_standardized']
 
     inner_text = expression ? expression : standardized
 
     std_attr = case date['structured_date_single']['date_standardized_type']
-    when 'standard'
-      :standardDate
-    when 'not_before'
-      :notBefore
-    when 'not_after'
-      :notAfter
-    end
+               when 'standard'
+                 :standardDate
+               when 'not_before'
+                 :notBefore
+               when 'not_after'
+                 :notAfter
+               end
 
     attrs = { localType: date['date_label'] }
     attrs[std_attr] = standardized
@@ -509,31 +509,31 @@ class EACSerializer < ASpaceExport::Serializer
 
   def _build_date_range_std(date, xml)
     begin_expression = date['structured_date_range']['begin_date_expression']
-    begin_standardized = date['structured_date_range']['begin_date_standardized'] 
+    begin_standardized = date['structured_date_range']['begin_date_standardized']
 
     end_expression = date['structured_date_range']['end_date_expression']
-    end_standardized = date['structured_date_range']['end_date_standardized'] 
+    end_standardized = date['structured_date_range']['end_date_standardized']
 
     begin_inner_text = begin_expression ? begin_expression : begin_standardized
     end_inner_text = end_expression ? end_expression : end_standardized
 
     begin_std_attr = case date['structured_date_range']['begin_date_standardized_type']
-    when 'standard'
-      :standardDate
-    when 'not_before'
-      :notBefore
-    when 'not_after'
-      :notAfter
-    end
+                     when 'standard'
+                       :standardDate
+                     when 'not_before'
+                       :notBefore
+                     when 'not_after'
+                       :notAfter
+                     end
 
     end_std_attr = case date['structured_date_range']['end_date_standardized_type']
-    when 'standard'
-      :standardDate
-    when 'not_before'
-      :notBefore
-    when 'not_after'
-      :notAfter
-    end
+                   when 'standard'
+                     :standardDate
+                   when 'not_before'
+                     :notBefore
+                   when 'not_after'
+                     :notAfter
+                   end
 
     begin_attrs = {}
     begin_attrs[begin_std_attr] = begin_standardized


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The existing agent date map for EAC exports doesn't include support for standardized dates. This updated map adds this.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1264

## How Has This Been Tested?
Manual and unit testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
