### PR TITLE
ANW-853 Remove location info from PUI request form / emails

### DIFF
--- a/public/app/models/record.rb
+++ b/public/app/models/record.rb
@@ -375,16 +375,6 @@ class Record
     end
   end
 
-  def parse_top_container_location(top_container)
-    container_locations = top_container.dig('container_locations')
-
-    return if container_locations.blank?
-
-    current_location = container_locations.find {|c| c['status'] == 'current'}
-
-    current_location.dig('_resolved')
-  end
-
   def parse_sub_container_display_string(sub_container, inst, opts = {})
     summary = opts.fetch(:summary, false)
     citation = opts.fetch(:citation, false)
@@ -462,7 +452,7 @@ class Record
   def build_request_item_container_info
     container_info = {}
 
-    %i(top_container_url container location_title location_url machine barcode).each {|sym| container_info[sym] = [] }
+    %i(top_container_url container machine barcode).each {|sym| container_info[sym] = [] }
 
     unless json['instances'].blank?
       json['instances'].each do |instance|
@@ -484,16 +474,6 @@ class Record
           top_container_json = ASUtils.json_parse(top_container.fetch('json'))
           hsh[:barcode] = top_container_json.dig('barcode')
 
-          location = parse_top_container_location(top_container_json)
-
-          if (location)
-            hsh[:location_title] = location.dig('title')
-            hsh[:location_url] = location.dig('uri')
-          else
-            hsh[:location_title] = ''
-            hsh[:location_url] = ''
-          end
-
           restricts = top_container_json.dig('active_restrictions')
           if restricts
             restricts.each do |r|
@@ -503,8 +483,6 @@ class Record
           end
         else
           hsh[:barcode] = ''
-          hsh[:location_title] = ''
-          hsh[:location_url] = ''
         end
 
         hsh.keys.each {|sym| container_info[sym].push(hsh[sym] || '')}

--- a/public/app/models/request_item.rb
+++ b/public/app/models/request_item.rb
@@ -1,11 +1,11 @@
 require 'active_model'
 
 class RequestItem < Struct.new(:user_name, :user_email, :date, :note,
-                               :request_uri, :title, :resource_name, :identifier, :cite, :restrict,
-                               :hierarchy, :repo_name, :resource_id, :linked_record_uris,
-                               :machine,
-                               :top_container_url, :container, :barcode, :location_title,
-                               :location_url, :repo_uri, :repo_code, :repo_email)
+                               :request_uri, :title, :resource_name,
+                               :identifier, :cite, :restrict, :hierarchy,
+                               :repo_name, :resource_id, :linked_record_uris,
+                               :machine, :top_container_url, :container,
+                               :barcode, :repo_uri, :repo_code, :repo_email)
 
   def RequestItem.allow_for_type(repository_code, record_type)
     fallback = AppConfig[:pui_requests_permitted_for_types].include?(record_type)
@@ -58,12 +58,12 @@ class RequestItem < Struct.new(:user_name, :user_email, :date, :note,
     if !self[:container].blank? && !self[:container].empty?
       self[:container].each_with_index do |v, i|
 #        arr.push("#{:container.to_s}: #{v}")
-       %i(container top_container_url barcode location_title location_url).each do |sym|
+       %i(container top_container_url barcode).each do |sym|
          arr.push("#{sym.to_s}: #{defined?(self[sym][i]) ? self[sym][i] : ''}")
        end
      end
     elsif !skip_empty
-      %i(container top_container_url barcode location_title location_url).each {|sym| arr.push("#{sym.to_s}:") }
+      %i(container top_container_url barcode).each {|sym| arr.push("#{sym.to_s}:") }
     end
 
     arr


### PR DESCRIPTION
Location information may be sensitive and shouldn't appear in the
PUI request form or emails. The top container uris can be used to
find the location w/o exposing it outside of the ArchivesSpace SUI.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
