### PR TITLE
ANW-1047 Update 1xx, 6xx, and 7xx to export both $e and $4 if relator

### DIFF
--- a/backend/app/exporters/models/marc21.rb
+++ b/backend/app/exporters/models/marc21.rb
@@ -340,11 +340,11 @@ class MARCModel < ASpaceExport::ExportModel
 
     ind2 = ' '
 
+    relator_sfs = []
     if link['relator']
-      relator = I18n.t("enumerations.linked_agent_archival_record_relators.#{link['relator']}")
-      role_info = ['4', relator]
+      handle_relators(relator_sfs, link['relator'])
     else
-      role_info = ['e', 'creator']
+      relator_sfs << ['e', 'creator']
     end
 
     case creator['agent_type']
@@ -352,17 +352,17 @@ class MARCModel < ASpaceExport::ExportModel
     when 'agent_corporate_entity'
       code = '110'
       ind1 = '2'
-      sfs = gather_agent_corporate_subfield_mappings(name, role_info, creator)
+      sfs = gather_agent_corporate_subfield_mappings(name, relator_sfs, creator)
 
     when 'agent_person'
       ind1  = name['name_order'] == 'direct' ? '0' : '1'
       code = '100'
-      sfs = gather_agent_person_subfield_mappings(name, role_info, creator)
+      sfs = gather_agent_person_subfield_mappings(name, relator_sfs, creator)
 
     when 'agent_family'
       code = '100'
       ind1 = '3'
-      sfs = gather_agent_family_subfield_mappings(name, role_info, creator)
+      sfs = gather_agent_family_subfield_mappings(name, relator_sfs, creator)
 
     end
 
@@ -383,12 +383,13 @@ class MARCModel < ASpaceExport::ExportModel
       terms = link['terms']
       role = link['role']
 
+      relator_sfs = []
       if link['relator']
-        relator_sf = ['4', link['relator']]
+        handle_relators(relator_sfs, link['relator'])
       elsif role == 'source'
-        relator_sf = ['e', 'former owner']
+        relator_sfs << ['e', 'former owner']
       else
-        relator_sf = ['e', 'creator']
+        relator_sfs << ['e', 'creator']
       end
 
       ind2 = ' '
@@ -398,17 +399,17 @@ class MARCModel < ASpaceExport::ExportModel
       when 'agent_corporate_entity'
         code = '710'
         ind1 = '2'
-        sfs = gather_agent_corporate_subfield_mappings(name, relator_sf, creator)
+        sfs = gather_agent_corporate_subfield_mappings(name, relator_sfs, creator)
 
       when 'agent_person'
         ind1  = name['name_order'] == 'direct' ? '0' : '1'
         code = '700'
-        sfs = gather_agent_person_subfield_mappings(name, relator_sf, creator)
+        sfs = gather_agent_person_subfield_mappings(name, relator_sfs, creator)
 
       when 'agent_family'
         ind1 = '3'
         code = '700'
-        sfs = gather_agent_family_subfield_mappings(name, relator_sf, creator)
+        sfs = gather_agent_family_subfield_mappings(name, relator_sfs, creator)
 
       end
 
@@ -431,9 +432,9 @@ class MARCModel < ASpaceExport::ExportModel
       terms = link['terms']
       ind2 = source_to_code(name['source'])
 
+      relator_sfs = []
       if link['relator']
-        relator = I18n.t("enumerations.linked_agent_archival_record_relators.#{link['relator']}")
-        relator_sf = ['4', relator]
+        handle_relators(relator_sfs, link['relator'])
       end
 
       case subject['agent_type']
@@ -441,17 +442,17 @@ class MARCModel < ASpaceExport::ExportModel
       when 'agent_corporate_entity'
         code = '610'
         ind1 = '2'
-        sfs = gather_agent_corporate_subfield_mappings(name, relator_sf, subject)
+        sfs = gather_agent_corporate_subfield_mappings(name, relator_sfs, subject)
 
       when 'agent_person'
         ind1  = name['name_order'] == 'direct' ? '0' : '1'
         code = '600'
-        sfs = gather_agent_person_subfield_mappings(name, relator_sf, subject)
+        sfs = gather_agent_person_subfield_mappings(name, relator_sfs, subject)
 
       when 'agent_family'
         code = '600'
         ind1 = '3'
-        sfs = gather_agent_family_subfield_mappings(name, relator_sf, subject)
+        sfs = gather_agent_family_subfield_mappings(name, relator_sfs, subject)
 
       when 'agent_software'
         code = '653'
@@ -480,6 +481,17 @@ class MARCModel < ASpaceExport::ExportModel
 
       df(code, ind1, ind2, i).with_sfs(*sfs)
     end
+  end
+
+
+  def handle_relators(relator_sfs, link)
+    relator = I18n.t("enumerations.linked_agent_archival_record_relators.#{link}")
+    relator_sfs << ['4', link]
+    unless relator.to_s.include?('translation missing')
+      relator_sfs << ['e', relator]
+    end
+
+    return relator_sfs
   end
 
 
@@ -662,8 +674,8 @@ class MARCModel < ASpaceExport::ExportModel
       subfield_e = nil
       subfield_4 = nil
     else
-      subfield_e = role_info[0] == "e" ? role_info : nil
-      subfield_4 = role_info[0] == "4" ? role_info : nil
+      subfield_e = role_info.select { |k| k[0]=="e" }.flatten
+      subfield_4 = role_info.select { |k| k[0]=="4" }.flatten
     end
 
     number      = name['number'] rescue nil
@@ -727,8 +739,8 @@ class MARCModel < ASpaceExport::ExportModel
       subfield_e = nil
       subfield_4 = nil
     else
-      subfield_e = role_info[0] == "e" ? role_info : nil
-      subfield_4 = role_info[0] == "4" ? role_info : nil
+      subfield_e = role_info.select { |k| k[0]=="e" }.flatten
+      subfield_4 = role_info.select { |k| k[0]=="4" }.flatten
     end
 
     family_name = name['family_name'] rescue nil
@@ -816,8 +828,8 @@ class MARCModel < ASpaceExport::ExportModel
       subfield_e = nil
       subfield_4 = nil
     else
-      subfield_e = role_info[0] == "e" ? role_info : nil
-      subfield_4 = role_info[0] == "4" ? role_info : nil
+      subfield_e = role_info.select { |k| k[0]=="e" }.flatten
+      subfield_4 = role_info.select { |k| k[0]=="4" }.flatten
     end
 
     primary_name = name['primary_name'] rescue nil

--- a/backend/spec/export_marc_spec.rb
+++ b/backend/spec/export_marc_spec.rb
@@ -893,12 +893,16 @@ describe 'MARC Export' do
       name_string = %w(primary_ rest_of_).map {|p| name["#{p}name"]}.reject {|n| n.nil? || n.empty?}.join(name['name_order'] == 'direct' ? ' ' : ', ')
 
       df = @marcs[0].at("datafield[@tag='100'][@ind1='#{inverted}'][@ind2=' ']")
+      resource = @resources[0]['linked_agents'].select { |r| r['role'] == 'creator' }.first
+
       expect(df.at("subfield[@code='a']")).to have_inner_text(/#{name_string}/)
       expect(df.at("subfield[@code='b']")).to have_inner_text(/#{name['number']}/)
       expect(df.at("subfield[@code='c']")).to have_inner_text(/#{%w(prefix title suffix).map {|p| name[p]}.compact.join(', ')}/)
       expect(df.at("subfield[@code='d']")).to have_inner_text(/#{name['dates']}/)
       expect(df.at("subfield[@code='q']")).to have_inner_text(/#{name['fuller_form']}/)
       expect(df.at("subfield[@code='0']")).to have_inner_text(/#{name['authority_id']}/)
+      expect(df.at("subfield[@code='4']")).to have_inner_text(/#{resource['relator']}/)
+      expect(df.at("subfield[@code='e']")).to have_inner_text(/#{(I18n.t("enumerations.linked_agent_archival_record_relators.#{resource['relator']}"))}/)
     end
 
     it "agent has no authority_id, it should not create a subfield $0" do
@@ -957,6 +961,7 @@ describe 'MARC Export' do
       name = @agents[1]['names'][0]
 
       df = @marcs[1].at("datafield[@tag='110'][@ind1='2'][@ind2=' ']")
+      resource = @resources[1]['linked_agents'].select { |r| r['role'] == 'creator' }.first
 
       expect(df.at("subfield[@code='a']")).to have_inner_text(/#{name['primary_name']}/)
       subfield_b = df.at("subfield[@code='b']")
@@ -965,6 +970,8 @@ describe 'MARC Export' do
       end
       expect(df.at("subfield[@code='n']")).to have_inner_text(/#{name['number']}/)
       expect(df.at("subfield[@code='0']")).to have_inner_text(/#{name['authority_id']}/)
+      expect(df.at("subfield[@code='4']")).to have_inner_text(/#{resource['relator']}/)
+      expect(df.at("subfield[@code='e']")).to have_inner_text(/#{(I18n.t("enumerations.linked_agent_archival_record_relators.#{resource['relator']}"))}/)
     end
 
 
@@ -972,11 +979,14 @@ describe 'MARC Export' do
       name = @agents[2]['names'][0]
 
       df = @marcs[2].at("datafield[@tag='100'][@ind1='3'][@ind2=' ']")
+      resource = @resources[2]['linked_agents'].select { |r| r['role'] == 'creator' && r['ref'].include?('families')}.first
 
       expect(df.at("subfield[@code='a']")).to have_inner_text(/#{name['family_name']}/)
       expect(df.at("subfield[@code='c']")).to have_inner_text(/#{name['qualifier']}/)
       expect(df.at("subfield[@code='d']")).to have_inner_text(/#{name['dates']}/)
       expect(df.at("subfield[@code='0']")).to have_inner_text(/#{name['authority_id']}/)
+      expect(df.at("subfield[@code='4']")).to have_inner_text(/#{resource['relator']}/)
+      expect(df.at("subfield[@code='e']")).to have_inner_text(/#{(I18n.t("enumerations.linked_agent_archival_record_relators.#{resource['relator']}"))}/)
     end
 
 
@@ -988,6 +998,7 @@ describe 'MARC Export' do
       name_string = %w(primary_ rest_of_).map {|p| name["#{p}name"]}.reject {|n| n.nil? || n.empty?}.join(name['name_order'] == 'direct' ? ' ' : ', ')
 
       df = @marcs[1].at("datafield[@tag='600'][@ind1='#{inverted}'][@ind2='#{ind2}']")
+      resource = @resources[1]['linked_agents'].select { |r| r['role'] == 'subject' }.first
 
       sf_v = df.at("subfield[@code='v']")
       sf_x = df.at("subfield[@code='x']")
@@ -998,10 +1009,13 @@ describe 'MARC Export' do
       expect(df.at("subfield[@code='b']")).to have_inner_text(/#{name['number']}/)
       expect(df.at("subfield[@code='c']")).to have_inner_text(/#{%w(prefix title suffix).map {|p| name[p]}.compact.join(', ')}/)
       expect(df.at("subfield[@code='d']")).to have_inner_text(/#{name['dates']}/)
-      expect(df.at("subfield[@code='4']")).to have_inner_text(/#{name['relator']}/)
+
       if [sf_v, sf_x, sf_y, sf_z].all? { |sf| sf.nil? }
         expect(df.at("subfield[@code='0']")).to have_inner_text(/#{name['authority_id']}/)
       end
+
+      expect(df.at("subfield[@code='4']")).to have_inner_text(/#{resource['relator']}/)
+      expect(df.at("subfield[@code='e']")).to have_inner_text(/#{(I18n.t("enumerations.linked_agent_archival_record_relators.#{resource['relator']}"))}/)
 
       if ind2 == '7'
         expect(df.at("subfield[@code='2']")).to have_inner_text(/#{name['source']}/)
@@ -1042,6 +1056,7 @@ describe 'MARC Export' do
        ind2 = source_to_code(name['source'])
 
        df = @marcs[0].at("datafield[@tag='610'][@ind1='2'][@ind2='#{ind2}']")
+       resource = @resources[0]['linked_agents'].select { |r| r['role'] == 'subject' }.first
 
        sf_v = df.at("subfield[@code='v']")
        sf_x = df.at("subfield[@code='x']")
@@ -1054,10 +1069,13 @@ describe 'MARC Export' do
          expect(subfield_b).to have_inner_text(/#{name['subordinate_name_1']}/)
        end
        expect(df.at("subfield[@code='n']")).to have_inner_text(/#{name['number']}/)
-       expect(df.at("subfield[@code='4']")).to have_inner_text(/#{name['relator']}/)
+
        if [sf_v, sf_x, sf_y, sf_z].all? { |sf| sf.nil? }
          expect(df.at("subfield[@code='0']")).to have_inner_text(/#{name['authority_id']}/)
        end
+
+       expect(df.at("subfield[@code='4']")).to have_inner_text(/#{resource['relator']}/)
+       expect(df.at("subfield[@code='e']")).to have_inner_text(/#{(I18n.t("enumerations.linked_agent_archival_record_relators.#{resource['relator']}"))}/)
 
        if ind2 == '7'
          expect(df.at("subfield[@code='2']")).to have_inner_text(/#{name['source']}/)
@@ -1072,6 +1090,7 @@ describe 'MARC Export' do
 
       a_text = df.at("subfield[@code='a']").text
       b_text = df.at("subfield[@code='b']").text
+      e_text = df.at("subfield[@code='e']").text
       n_text = df.at("subfield[@code='n']").text
 
       if b_text.nil?
@@ -1080,6 +1099,7 @@ describe 'MARC Export' do
         expect(a_text[-1]).to eq(".")
       end
 
+      expect(e_text[-1]).to eq(",")
       expect(n_text[-1]).to eq(".")
       expect(n_text =~ /\(.*\)/).not_to be_nil
     end
@@ -1090,6 +1110,7 @@ describe 'MARC Export' do
       ind2 = source_to_code(name['source'])
 
       df = @marcs[0].at("datafield[@tag='600'][@ind1='3'][@ind2='#{ind2}']")
+      resource = @resources[0]['linked_agents'].select { |r| r['role'] == 'subject' && r['ref'].include?('families')}.first
 
       sf_v = df.at("subfield[@code='v']")
       sf_x = df.at("subfield[@code='x']")
@@ -1099,10 +1120,13 @@ describe 'MARC Export' do
       expect(df.at("subfield[@code='a']")).to have_inner_text(/#{name['family_name']}/)
       expect(df.at("subfield[@code='c']")).to have_inner_text(/#{name['qualifier']}/)
       expect(df.at("subfield[@code='d']")).to have_inner_text(/#{name['dates']}/)
-      expect(df.at("subfield[@code='4']")).to have_inner_text(/#{name['relator']}/)
+
       if [sf_v, sf_x, sf_y, sf_z].all? { |sf| sf.nil? }
         expect(df.at("subfield[@code='0']")).to have_inner_text(/#{name['authority_id']}/)
       end
+
+      expect(df.at("subfield[@code='4']")).to have_inner_text(/#{resource['relator']}/)
+      expect(df.at("subfield[@code='e']")).to have_inner_text(/#{(I18n.t("enumerations.linked_agent_archival_record_relators.#{resource['relator']}"))}/)
 
       if ind2 == '7'
         expect(df.at("subfield[@code='2']")).to have_inner_text(/#{name['source']}/)
@@ -1118,10 +1142,12 @@ describe 'MARC Export' do
       a_text = df.at("subfield[@code='a']").text
       d_text = df.at("subfield[@code='d']").text
       c_text = df.at("subfield[@code='c']").text
+      e_text = df.at("subfield[@code='e']").text
 
       expect(a_text[-1]).to eq(",")
       expect(d_text[-1]).to eq(",")
-      expect(c_text[-1]).to eq(".")
+      expect(c_text[-1]).to eq(",")
+      expect(e_text[-1]).to eq(".")
     end
 
 
@@ -1131,12 +1157,15 @@ describe 'MARC Export' do
       name_string = %w(primary_ rest_of_).map {|p| name["#{p}name"]}.reject {|n| n.nil? || n.empty?}.join(name['name_order'] == 'direct' ? ' ' : ', ')
 
       df = @marcs[1].at("datafield[@tag='700'][@ind1='#{inverted}'][@ind2=' ']")
+      resource = @resources[1]['linked_agents'].select { |r| r['role'] == 'creator' }[1]
 
       expect(df.at("subfield[@code='a']")).to have_inner_text(/#{name_string}/)
       expect(df.at("subfield[@code='b']")).to have_inner_text(/#{name['number']}/)
       expect(df.at("subfield[@code='c']")).to have_inner_text(/#{%w(prefix title suffix).map {|p| name[p]}.compact.join(', ')}/)
       expect(df.at("subfield[@code='d']")).to have_inner_text(/#{name['dates']}/)
       expect(df.at("subfield[@code='0']")).to have_inner_text(/#{name['authority_id']}/)
+      expect(df.at("subfield[@code='4']")).to have_inner_text(/#{resource['relator']}/)
+      expect(df.at("subfield[@code='e']")).to have_inner_text(/#{(I18n.t("enumerations.linked_agent_archival_record_relators.#{resource['relator']}"))}/)
     end
 
     it "should add required punctuation to 700 tag agent-person subfields" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates MARC XML export for 1xx, 6xx, and 7xx to do the following:
- $e --> translated value of `relator` if `relator` and a translation is available;
- $4 --> code/key value of `relator` if `relator`

Also includes some changes to tests to reflect the above changes.  Also, fixes the fact that existing tests were looking for `name['relator']` which is always going to be `nil` because a relator is not part of a name record, but instead the `linked_agents` record.

Note: MARC XML map will need to be updated to reflect this change.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1047

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New tests added, tests updated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
