### PR TITLE
ANW-1069-help-links

### DIFF
--- a/frontend/app/views/custom_report_templates/_form.html.erb
+++ b/frontend/app/views/custom_report_templates/_form.html.erb
@@ -10,8 +10,9 @@
 	<% record_types.delete('global') %>
 
 	<div id="template_information">
-		<h3><%= I18n.t "custom_report_template._frontend.section.template_information" %></h3>
-	
+		<h3><%= I18n.t "custom_report_template._frontend.section.template_information" %>
+		<%= link_to_help :topic => "accession_basic_information" %></h3>
+
 		<%= form.label_and_textfield "name", :required => true %>
 		<%= form.label_and_textarea "description" %>
 		<%= form.label_and_select "limit", custom_report_template_limit_options %>

--- a/frontend/app/views/custom_report_templates/index.html.erb
+++ b/frontend/app/views/custom_report_templates/index.html.erb
@@ -7,6 +7,7 @@
 		<div class="record-toolbar">
 			<div class="btn-group pull-right">
 				<%= link_to I18n.t("custom_report_template._frontend.action.create"), {:controller => :custom_report_templates, :action => :new}, :class => "btn btn-sm btn-default" %>
+				<%= link_to_help :topic => "accession_basic_information" %>
 			</div>
 			<br style="clear:both" /> <!-- So dirty! -->
 		</div>


### PR DESCRIPTION
Just placeholders for help links. 
**NOTE**: Had to use an existing link to make the question mark show up so I used `accession_basic_information`.
