### PR TITLE
ANW-861: Show date certainty in parens next to date in PUI

### DIFF
--- a/public/app/models/record.rb
+++ b/public/app/models/record.rb
@@ -184,7 +184,15 @@ class Record
     #adding the date label & type below so that it'll be easy to figure out which dates to include in other mappings, such as the schema.org mappings
     (json['dates'] || json['dates_of_existence']).each do |date|
       label, exp = parse_date(date)
-      dates.push({'final_expression' => label + exp, '_inherited' => date.dig('_inherited'), 'label' => date['label'], 'date_type' => date['date_type']})
+
+      if date['certainty']
+        translated = I18n.t("enumerations.date_certainty.#{date['certainty']}")
+        certainty = " (#{translated})"
+      else
+        certainty = ""
+      end
+
+      dates.push({'final_expression' => label + exp + certainty, '_inherited' => date.dig('_inherited'), 'label' => date['label'], 'date_type' => date['date_type']})
     end
 
     dates

--- a/public/spec/factories.rb
+++ b/public/spec/factories.rb
@@ -265,6 +265,7 @@ module AspaceFactories
         self.begin { "1900-01-01" }
         self.end { "1999-12-31" }
         expression { "1900s" }
+        certainty { "approximate" }
       end
 
       factory :rde_template, class: JSONModel(:rde_template) do

--- a/public/spec/features/resources_spec.rb
+++ b/public/spec/features/resources_spec.rb
@@ -40,4 +40,12 @@ describe 'Resources', js: true do
     )
     expect(page).to have_content(first_title)
   end
+
+  it 'should show date certainty next to dates if defined' do
+    visit('/')
+    click_link 'Collections'
+    click_link 'Published Resource'
+    expect(page).to have_content("Approximate")
+    sleep 20
+  end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding date certainty to date display in PUI for clarity

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-861

## How Has This Been Tested?
In browser manual testing and integration testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
