### PR TITLE
ANW-90 don't attempt to import extension without telephone number

### DIFF
--- a/backend/app/converters/accession_converter.rb
+++ b/backend/app/converters/accession_converter.rb
@@ -340,7 +340,9 @@ class AccessionConverter < Converter
 
   def self.telephone_template(type)
     {
-      :record_type => :telephone,
+      :record_type => Proc.new {|data|
+        data['number'] ? :telephone : nil
+      },
       :on_create => Proc.new {|data, obj|
         obj.number_type = type
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --> 
Small addition to #2223 in response to testing feedback.  When using the Accession CSV importer, don't attempt to import a telephone subrecord when only a telephone extension, but no number, is provided.  Telephone number is a required element in the telephone subrecord.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
