### PR TITLE
ANW-194 ANW-206 synchronize RDE templates and multiselect

### DIFF
--- a/frontend/app/assets/javascripts/rde.js
+++ b/frontend/app/assets/javascripts/rde.js
@@ -24,11 +24,13 @@ $(function() {
       var COOKIE_NAME_COLUMN_ORDER = "rde."+$rde_form.data("cookie-prefix")+".order";
 
       // Config from Cookies
-      var VISIBLE_COLUMN_IDS =  AS.prefixed_cookie(COOKIE_NAME_VISIBLE_COLUMN) ? JSON.parse(AS.prefixed_cookie(COOKIE_NAME_VISIBLE_COLUMN)) : null;
       var STICKY_COLUMN_IDS =  AS.prefixed_cookie(COOKIE_NAME_STICKY_COLUMN) ? JSON.parse(AS.prefixed_cookie(COOKIE_NAME_STICKY_COLUMN)) : null;
       var COLUMN_WIDTHS =  AS.prefixed_cookie(COOKIE_NAME_COLUMN_WIDTHS) ? JSON.parse(AS.prefixed_cookie(COOKIE_NAME_COLUMN_WIDTHS)) : null;
       var COLUMN_ORDER =  AS.prefixed_cookie(COOKIE_NAME_COLUMN_ORDER) ? JSON.parse(AS.prefixed_cookie(COOKIE_NAME_COLUMN_ORDER)) : null;
       var DEFAULT_VALUES = {};
+      // jquery.columnmanager gets wonky if the first pass through column
+      // order needs to unhide anything, so don't load visibility yet
+      var VISIBLE_COLUMN_IDS;
 
       // store section data
       var SECTION_DATA = {};
@@ -67,6 +69,7 @@ $(function() {
         AS.prefixed_cookie(COOKIE_NAME_COLUMN_WIDTHS, null);
         AS.prefixed_cookie(COOKIE_NAME_STICKY_COLUMN, null);
         AS.prefixed_cookie(COOKIE_NAME_COLUMN_ORDER, null);
+
         VISIBLE_COLUMN_IDS = null;
         STICKY_COLUMN_IDS = null;
         COLUMN_WIDTHS = null;
@@ -320,7 +323,10 @@ $(function() {
         });
 
         initAutoValidateFeature();
-        applyColumnOrder();
+        applyColumnOrder(function() {
+          VISIBLE_COLUMN_IDS =  AS.prefixed_cookie(COOKIE_NAME_VISIBLE_COLUMN) ? JSON.parse(AS.prefixed_cookie(COOKIE_NAME_VISIBLE_COLUMN)) : null;
+          applyPersistentVisibleColumns();
+        });
         initColumnReorderFeature();
         initRdeTemplates();
         applyPersistentStickyColumns();
@@ -595,7 +601,7 @@ $(function() {
         AS.prefixed_cookie(COOKIE_NAME_COLUMN_ORDER, JSON.stringify(COLUMN_ORDER));
       };
 
-      var applyColumnOrder = function() {
+      var applyColumnOrder = function(callback) {
         if (COLUMN_ORDER === null) {
           persistColumnOrder();
         } else {
@@ -636,7 +642,9 @@ $(function() {
             }
           });
 
-          applyPersistentVisibleColumns()
+          if (callback) {
+            callback();
+          }
         }
       };
 
@@ -843,22 +851,38 @@ $(function() {
 
 
       var applyTemplate = function(template) {
+        // we are relying on template.order to always
+        // contain all colIds
         COLUMN_ORDER = template.order;
-        VISIBLE_COLUMN_IDS = template.visible;
         DEFAULT_VALUES = template.defaults;
 
-        applyColumnOrder();
+        // sets the order, then
+        // calls applyPersistentVisibleColumns,
+        // which iterates over colums in DOM,
+        // and hides or shows
+        applyColumnOrder(function() {
+          VISIBLE_COLUMN_IDS = template.visible;
+          AS.prefixed_cookie(COOKIE_NAME_VISIBLE_COLUMN, JSON.stringify(VISIBLE_COLUMN_IDS));
+          applyPersistentVisibleColumns(function() {
+            var $firstRow = $("tbody tr:first", $rde_form);
 
-        var $firstRow = $("tbody tr:first", $rde_form);
+            _.each($("td", $firstRow), function(td) {
+              var $td = $( td );
+              var colId = $td.data('col');
+              var $$input = $(":input:first", $td)
+              if (DEFAULT_VALUES[colId] && ($$input.data('value-from-template') || $$input.val().length < 1)) {
+                $$input.val(DEFAULT_VALUES[colId]);
+                $$input.data('value-from-template', true);
+              }
+            });
 
-        _.each($("td", $firstRow), function(td) {
-          var $td = $( td );
-          var colId = $td.data('col');
-          var $$input = $(":input:first", $td)
-          if (DEFAULT_VALUES[colId] && ($$input.data('value-from-template') || $$input.val().length < 1)) {
-            $$input.val(DEFAULT_VALUES[colId]);
-            $$input.data('value-from-template', true);
-          }
+            // zap the multiselect widget
+            var $select = $("#rde_hidden_columns");
+            $select.data("multiselect").destroy();
+            $select.removeData("multiselect");
+            $select.empty();
+            initColumnShowHideWidget();
+          });
         });
       };
 
@@ -1007,7 +1031,7 @@ $(function() {
           buttonClass: 'btn btn-small btn-default',
           buttonWidth: 'auto',
           maxHeight: 300,
-          buttonContainer: '<div class="btn-group" />',
+          buttonContainer: '<div class="btn-group" id="multiselect_btn"/>',
           buttonText: function(options) {
             if (options.length == 0) {
               return $select.data("i18n-none") + ' <b class="caret"></b>';
@@ -1041,7 +1065,7 @@ $(function() {
             AS.prefixed_cookie(COOKIE_NAME_VISIBLE_COLUMN, JSON.stringify(VISIBLE_COLUMN_IDS));
           }
         });
-        
+
         function disableRequiredColumns() {
           // Don't allow omitting required fields in RDE templates
           // by disabling the bootstratp-multiselect.js generated
@@ -1059,7 +1083,6 @@ $(function() {
         }
 
         disableRequiredColumns();
-        applyPersistentVisibleColumns();
       };
 
       var persistColumnWidths = function() {
@@ -1135,7 +1158,7 @@ $(function() {
         }
       };
 
-      var applyPersistentVisibleColumns = function() {
+      var applyPersistentVisibleColumns = function(callback) {
         if ( VISIBLE_COLUMN_IDS ) {
           var total_width = 0;
 
@@ -1154,6 +1177,10 @@ $(function() {
             }
           });
           $table.width(total_width);
+
+          if (callback) {
+            callback();
+          }
         } else {
           applyPersistentColumnWidths();
         }

--- a/frontend/spec/selenium/spec/rde_templates_spec.rb
+++ b/frontend/spec/selenium/spec/rde_templates_spec.rb
@@ -8,6 +8,59 @@ describe 'RDE Templates' do
     set_repo(@repo)
 
     @r = create(:resource)
+
+    @template = create(:rde_template, defaults: { 'colTitle' => 'XX' },
+                       visible: [
+                         "colStatus",
+                         "colLevel",
+                         "colOtherLevel",
+                         "colPublish",
+                         "colTitle",
+                         "colCompId",
+                         "colLanguage",
+                         "colDType",
+                         "colDBegin",
+                         "colDEnd",
+                         "colActions"
+                       ],
+                       order: [
+                         "colStatus",
+                         "colLevel",
+                         "colOtherLevel",
+                         "colPublish",
+                         "colTitle",
+                         "colCompId",
+                         "colLanguage",
+                         "colScript",
+                         "colExpr",
+                         "colDType",
+                         "colDLabel",
+                         "colDBegin",
+                         "colDEnd",
+                         "colEPortion",
+                         "colENumber",
+                         "colEType",
+                         "colEContainer",
+                         "colEPhysical",
+                         "colEDimensions",
+                         "colIType",
+                         "colCTop",
+                         "colCType2",
+                         "colCInd2",
+                         "colCType3",
+                         "colCInd3",
+                         "colNType1",
+                         "colNLabel1",
+                         "colNCont1",
+                         "colNType2",
+                         "colNLabel2",
+                         "colNCont2",
+                         "colNType3",
+                         "colNLabel3",
+                         "colNCont3",
+                         "colActions"
+                       ])
+
     @driver = Driver.get.login_to_repo($admin, @repo)
   end
 
@@ -50,17 +103,20 @@ describe 'RDE Templates' do
   end
 
   it 'can load an RDE template' do
-    template = create(:rde_template, defaults: { 'colTitle' => 'XX' })
-
     @driver.find_element(link: 'Rapid Data Entry').click
     @driver.wait_for_ajax
 
+    multiselector_selected_cols = @driver.execute_script('return $("#rde_hidden_columns").data("multiselect").getSelected().length;')
+    expect(multiselector_selected_cols).to eq 33
+
     @driver.find_element(css: "button[data-id='rde_select_template']").click
     @driver.wait_for_ajax
-
-    @driver.find_element_with_text('//span', /#{template.name}/).click
+    @driver.find_element_with_text('//span', /#{@template.name}/).click
+    @driver.wait_for_ajax
 
     expect(@driver.find_element(id: 'archival_record_children_children__0__title_').attribute('value')).to eq('XX')
+    multiselector_selected_cols = @driver.execute_script('return $("#rde_hidden_columns").data("multiselect").getSelected().length;')
+    expect(multiselector_selected_cols).to eq 9
   end
 
   it 'can delete an RDE template' do


### PR DESCRIPTION
## Description
Changes the way RDE.JS applies column order and visibility, so that the first pass on order happens before any visibility state is loaded. Also appends destruction / reinit of the multiselect widget to the template loader, so the multiselect state matches the loaded template.

## Related JIRA Ticket or GitHub Issue
ANW-194 AND-206

## How Has This Been Tested?
Added explicit test for ANW-194. Tested the ANW-206 could not be reproduced.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
