### PR TITLE
ANW-143 MARCXML 008 position 6 should be 's' when date type is single

### DIFF
--- a/backend/app/exporters/models/marc21.rb
+++ b/backend/app/exporters/models/marc21.rb
@@ -115,7 +115,7 @@ class MARCModel < ASpaceExport::ExportModel
   def self.assemble_controlfield_string(obj)
     date = obj.dates[0] || {}
     string = obj['system_mtime'].scan(/\d{2}/)[1..3].join('')
-    string += obj.level == 'item' && date['date_type'] == 'single' ? 's' : 'i'
+    string += date['date_type'] == 'single' ? 's' : 'i'
     string += date['begin'] ? date['begin'][0..3] : "    "
     string += date['end'] ? date['end'][0..3] : "    "
 

--- a/backend/spec/export_marc_spec.rb
+++ b/backend/spec/export_marc_spec.rb
@@ -666,11 +666,20 @@ describe 'MARC Export' do
                                            build(:json_lang_material_with_note)
                                           ]
                             )
+        @resource5 = create(:json_resource,
+                            :level => 'collection',
+                            :dates => [
+                                       build(:json_date,
+                                             :date_type => 'single',
+                                             :begin => '1900')
+                                      ]
+                            )
 
         @marc1 = get_marc(@resource1)
         @marc2 = get_marc(@resource2)
         @marc3 = get_marc(@resource3)
         @marc4 = get_marc(@resource4)
+        @marc5 = get_marc(@resource5)
       end
     end
 
@@ -698,10 +707,11 @@ describe 'MARC Export' do
       expect(@marc1.at("record/controlfield[@tag='008']")).to have_inner_text(/^\d{6}/)
     end
 
-    it "sets record/controlfield[@tag='008']/text()[6] according to resource.level" do
+    it "sets record/controlfield[@tag='008']/text()[6] according date type" do
       expect(@marc1.at("record/controlfield[@tag='008']")).to have_inner_text(/^.{6}i/)
       expect(@marc2.at("record/controlfield[@tag='008']")).to have_inner_text(/^.{6}s/)
       expect(@marc3.at("record/controlfield[@tag='008']")).to have_inner_text(/^.{6}i/)
+      expect(@marc5.at("record/controlfield[@tag='008']")).to have_inner_text(/^.{6}s/)
     end
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Previously, the MARC exporter would only set position 6 of 008 to `s` if the resource had a level of "item" AND a date type of single.  This change updates it so that `s` is set based only on the date type of single, and removes the resource level check, per the JIRA ticket.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-143

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
