### PR TITLE
ANW-147 Merging extent controlled values loses related items

### DIFF
--- a/backend/app/model/extent.rb
+++ b/backend/app/model/extent.rb
@@ -1,6 +1,13 @@
 class Extent < Sequel::Model(:extent)
   include ASModel
+  include ActiveAssociation
   corresponds_to JSONModel(:extent)
 
   set_model_scope :global
+  many_to_one :accession
+  many_to_one :archival_object
+  many_to_one :deaccession
+  many_to_one :digital_object
+  many_to_one :digital_object_component
+  many_to_one :resource
 end

--- a/backend/app/model/mixins/active_association.rb
+++ b/backend/app/model/mixins/active_association.rb
@@ -1,0 +1,16 @@
+module ActiveAssociation
+
+  def active_association
+    association_type = find_associated_type
+    association_type ? self.send(association_type) : nil
+  end
+
+  def broadcast_reindex
+    active_association.update(system_mtime: Time.now) if active_association
+  end
+
+  def find_associated_type
+    self.class.associations.find { |type| self.send(type) }
+  end
+
+end

--- a/backend/app/model/mixins/touch_records.rb
+++ b/backend/app/model/mixins/touch_records.rb
@@ -48,7 +48,7 @@ module TouchRecords
       records = obj.class.touch_records(obj)
       return unless records.any?
       records.each do |record_set|
-        record_set[:type].update_mtime_for_ids(record_set[:ids])
+        record_set[:type].update_mtime_for_ids(record_set[:ids].compact)
       end
     end
 

--- a/backend/spec/mixin_active_association_spec.rb
+++ b/backend/spec/mixin_active_association_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'Active Association mixin' do
+  it 'can find the associated accession related to an extent record' do
+    accession = Accession.create_from_json(
+      build(:json_accession, :extents => [build(:json_extent)])
+    )
+    extent = Extent.where(accession_id: accession.id).first
+    expect(extent.find_associated_type).to eq :accession
+    expect(extent.active_association.class).to eq accession.class
+    expect(extent.active_association.id).to eq accession.id
+  end
+
+  it 'can find the associated resource related to an extent record' do
+    resource = Resource.create_from_json(
+      build(:json_resource, :extents => [build(:json_extent)])
+    )
+    extent = Extent.where(resource_id: resource.id).first
+    expect(extent.find_associated_type).to eq :resource
+    expect(extent.active_association.class).to eq resource.class
+    expect(extent.active_association.id).to eq resource.id
+  end
+
+  it 'can find the associated record and nudge it for reindexing' do
+    digital_object = DigitalObject.create_from_json(
+      build(:json_digital_object, :extents => [build(:json_extent)])
+    )
+    digital_object_original_mtime = digital_object.system_mtime
+    ArchivesSpaceService.wait(2)
+    extent = Extent.where(digital_object_id: digital_object.id).first
+    extent.broadcast_reindex
+    digital_object.refresh
+    expect(digital_object.system_mtime).to be > digital_object_original_mtime
+  end
+end

--- a/backend/spec/mixin_touch_records_spec.rb
+++ b/backend/spec/mixin_touch_records_spec.rb
@@ -1,79 +1,56 @@
 require 'spec_helper'
 
 describe 'Touch Records mixin' do
-
-  let(:resource) { create_resource({title: generate(:generic_title)}) }
-  let(:digital_object) { create_digital_object({title: generate(:generic_title)}) }
-  let(:agent_person) { create(:json_agent_person_full_subrec) }
-
-
-  def gimme_ao(uri)
-    create_archival_object({
-      'resource' => {
-        'ref' => uri
-      }
-    })
-  end
-
-  def gimme_doc(uri)
-    create_digital_object_component({
-      'digital_object' => {
-        'ref' => uri
-      }
-    })
-  end
-
   it 'can update resource system_mtime value when related ao created' do
+    resource = create_resource({title: generate(:generic_title)})
     resource_mt = resource.system_mtime
     ArchivesSpaceService.wait(:long)
-    obj = gimme_ao(resource.uri)
-
+    obj = create_archival_object({'resource' => { 'ref' => resource.uri }})
     resource.refresh
 
-    expect(resource.system_mtime).not_to eq(resource_mt)
-    expect(resource.system_mtime.to_i).to be >= obj.system_mtime.to_i
+    expect(resource.system_mtime).to be > resource_mt
+    expect(resource.system_mtime).to be >= obj.system_mtime
   end
 
   it 'can update resource system_mtime value when related ao updated' do
-    ArchivesSpaceService.wait(:long)
-    obj = gimme_ao(resource.uri)
+    resource = create_resource({title: generate(:generic_title)})
+    obj = create_archival_object({'resource' => { 'ref' => resource.uri }})
     obj_mt = obj.system_mtime
-    obj.system_mtime = Time.now + 120
-    obj.save
+    ArchivesSpaceService.wait(:long)
+    obj.update_from_json(ArchivalObject.to_jsonmodel(obj.id))
+    resource.refresh && obj.refresh
 
-    resource.refresh
-
-    expect(obj.system_mtime).not_to eq(obj_mt)
-    expect(resource.system_mtime.to_i).to be >= obj.system_mtime.to_i
+    expect(obj.system_mtime).to be > obj_mt
+    expect(resource.system_mtime).to be >= obj.system_mtime
   end
 
   it 'can update resource system_mtime value when related ao deleted' do
-    obj = gimme_ao(resource.uri)
-    resource.system_mtime = Time.now - 3600 # reset resource mtime after ao create
-    resource.save
-
+    resource = create_resource({title: generate(:generic_title)})
+    resource_mt = resource.system_mtime
+    ArchivesSpaceService.wait(:long)
+    obj = create_archival_object({'resource' => { 'ref' => resource.uri }})
     obj_mt = obj.system_mtime
     obj.delete
-
     resource.refresh
 
-    expect(resource.system_mtime.to_i).to be >= obj_mt.to_i
+    expect(resource.system_mtime).to be > resource_mt
+    expect(resource.system_mtime).to be >= obj_mt
   end
 
   it 'works the same for digital objects and components' do
-    ArchivesSpaceService.wait(:long)
-    doc = gimme_doc(digital_object.uri)
+    digital_object = create_digital_object({title: generate(:generic_title)})
+    doc = create_digital_object_component({ 'digital_object' => { 'ref' => digital_object.uri }})
     doc_mt = doc.system_mtime
-    doc.system_mtime = Time.now + 120
-    doc.save
+    ArchivesSpaceService.wait(:long)
+    doc.update_from_json(DigitalObjectComponent.to_jsonmodel(doc.id))
+    digital_object.refresh && doc.refresh
 
-    digital_object.refresh
-
-    expect(doc.system_mtime).not_to eq(doc_mt)
-    expect(digital_object.system_mtime.to_i).to be >= doc.system_mtime.to_i
+    expect(doc.system_mtime).to be > doc_mt
+    expect(digital_object.system_mtime).to be >= doc.system_mtime
   end
 
   it "updates the system_mtime for linked subjects when agents are updated" do
+    agent_person = create(:json_agent_person_full_subrec)
     [AgentFunction, AgentOccupation, AgentPlace, AgentTopic].each do |type|
       # Gotta get the subrecord to get the subject id
       subrecord = type.find(agent_person.id).first
@@ -81,15 +58,15 @@ describe 'Touch Records mixin' do
       original_mtime = Subject[subj_id].refresh.system_mtime
 
       ArchivesSpaceService.wait(:long)
-      agent_person.system_mtime = Time.now + 120
-      agent_person.save
+      AgentPerson[agent_person.id].update_from_json(AgentPerson.to_jsonmodel(agent_person.id))
 
-      expect(Subject[subj_id].refresh.system_mtime).not_to eq(original_mtime)
+      expect(Subject[subj_id].refresh.system_mtime).to be > original_mtime
       expect(Subject[subj_id].system_mtime.to_i).to be >= agent_person.system_mtime.to_i
     end
   end
 
   it "updates the system_mtime for linked subject places when agents are updated" do
+    agent_person = create(:json_agent_person_full_subrec)
     [AgentFunction, AgentOccupation, AgentResource, AgentTopic].each do |type|
       # Gotta get the subrecord to get the subject id
       subrecord = type.find(agent_person.id).first
@@ -97,10 +74,9 @@ describe 'Touch Records mixin' do
       original_mtime = Subject[subj_id].refresh.system_mtime
 
       ArchivesSpaceService.wait(:long)
-      agent_person.system_mtime = Time.now + 120
-      agent_person.save
+      AgentPerson[agent_person.id].update_from_json(AgentPerson.to_jsonmodel(agent_person.id))
 
-      expect(Subject[subj_id].refresh.system_mtime).not_to eq(original_mtime)
+      expect(Subject[subj_id].refresh.system_mtime).to be > original_mtime
       expect(Subject[subj_id].system_mtime.to_i).to be >= agent_person.system_mtime.to_i
     end
   end


### PR DESCRIPTION
Related items relies on search, however the indexer was not being
updated for records "related" to the referenced extents. An active
association mixin has been added to make it convenient to determine
the parent record of the extent and bump the mtime for re-indexing.

The mixin could also be applied to other records types and used for
refactoring in the future where if / case statements are being used
to find an associated record by non-null id.

There is more detail on use cases: ANW-1278
There is also some cleanup for the gnarly touch records mixin spec.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
