### PR TITLE
ANW-1277 Don't display skiplinks on classification terms pages

### DIFF
--- a/public/app/views/shared/_skipnav.html.erb
+++ b/public/app/views/shared/_skipnav.html.erb
@@ -1,6 +1,6 @@
 <div class="skipnav">
   <%= link_to I18n.t('skipnav.main_content'), '#maincontent', :class => 'sr-only sr-only-focusable' %>
-  <% unless action_name == 'inventory' || (action_name == 'show' && controller_name != 'repositories') %>
+  <% unless ['inventory', 'term'].include?(action_name) || (action_name == 'show' && controller_name != 'repositories') %>
     <% if defined?(@search) %>
       <% if defined?(@results) %>
         <% unless defined?(@no_statement) %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The shared skipnav partial was attempting to show skiplinks to search actions since the classifications terms show pages do have `@search` defined, however, like archival objects, no search actually appears on this page.  As such, the skipnav was linking to a broken link.  This had previously been handled for archival objects  by checking for `action_name == 'inventory'`, so I just extended this to include `action_name == term` as well.  (This is unambiguous as term isn't defined in any other controllers.) 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1277

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/15144646/116885893-6b928100-abf6-11eb-8540-b25d65413474.png)

After:
![image](https://user-images.githubusercontent.com/15144646/116885850-587fb100-abf6-11eb-89bf-4f3ff0ac01fe.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
