### PR TITLE
ANW-861: Include date certainty in display string for archival objects

### DIFF
--- a/backend/app/model/archival_object.rb
+++ b/backend/app/model/archival_object.rb
@@ -66,12 +66,20 @@ class ArchivalObject < Sequel::Model(:archival_object)
 
     date_label = json.has_key?('dates') && json['dates'].length > 0 ?
                    json['dates'].map do |date|
-                     if date['expression']
-                       date['date_type'] == 'bulk' ? "#{I18n.t("date_type_bulk.bulk")}: #{date['expression']}" : date['expression']
-                     elsif date['begin'] and date['end']
-                       date['date_type'] == 'bulk' ? "#{I18n.t("date_type_bulk.bulk")}: #{date['begin']} - #{date['end']}" : "#{date['begin']} - #{date['end']}"
+
+                     if date['certainty']
+                       translated = I18n.t("enumerations.date_certainty.#{date['certainty']}")
+                       certainty = " (#{translated})"
                      else
-                       date['date_type'] == 'bulk' ? "#{I18n.t("date_type_bulk.bulk")}: #{date['begin']}" : date['begin']
+                       certainty = ""
+                     end
+
+                     if date['expression']
+                       date['date_type'] == 'bulk' ? "#{I18n.t("date_type_bulk.bulk")}: #{date['expression'] + certainty}" : date['expression'] + certainty
+                     elsif date['begin'] and date['end']
+                       date['date_type'] == 'bulk' ? "#{I18n.t("date_type_bulk.bulk")}: #{date['begin']} - #{date['end'] + certainty}" : "#{date['begin']} - #{date['end'] + certainty}"
+                     else
+                       date['date_type'] == 'bulk' ? "#{I18n.t("date_type_bulk.bulk")}: #{date['begin'] + certainty}" : date['begin'] + certainty
                      end
                    end.join(', ') : false
 

--- a/backend/spec/model_archival_object_spec.rb
+++ b/backend/spec/model_archival_object_spec.rb
@@ -204,7 +204,7 @@ describe 'ArchivalObject model' do
     expect(ArchivalObject[ao[:id]].display_string).to eq("bulk: #{date['begin']} - #{date['end']} (Inferred)")
   end
 
-  
+
   it "includes date certainty in the generated display string" do
     opts = {
       :title => "",

--- a/backend/spec/model_archival_object_spec.rb
+++ b/backend/spec/model_archival_object_spec.rb
@@ -169,7 +169,7 @@ describe 'ArchivalObject model' do
       }),
       :repo_id => $repo_id)
 
-    expect(ArchivalObject[ao[:id]].display_string).to eq(date['expression'])
+    expect(ArchivalObject[ao[:id]].display_string).to eq(date['expression'] + " (Inferred)")
 
     # try with begin and end
     date = build(:json_date, :date_type => 'inclusive', :expression => nil)
@@ -180,7 +180,7 @@ describe 'ArchivalObject model' do
       }),
       :repo_id => $repo_id)
 
-    expect(ArchivalObject[ao[:id]].display_string).to eq("#{date['begin']} - #{date['end']}")
+    expect(ArchivalObject[ao[:id]].display_string).to eq("#{date['begin']} - #{date['end']} (Inferred)")
 
     date = build(:json_date, :date_type => 'bulk')
     ao = ArchivalObject.create_from_json(
@@ -190,7 +190,7 @@ describe 'ArchivalObject model' do
       }),
       :repo_id => $repo_id)
 
-    expect(ArchivalObject[ao[:id]].display_string).to eq("bulk: #{date['expression']}")
+    expect(ArchivalObject[ao[:id]].display_string).to eq("bulk: #{date['expression']} (Inferred)")
 
     # try with begin and end
     date = build(:json_date, :date_type => 'bulk', :expression => nil)
@@ -201,8 +201,27 @@ describe 'ArchivalObject model' do
       }),
       :repo_id => $repo_id)
 
-    expect(ArchivalObject[ao[:id]].display_string).to eq("bulk: #{date['begin']} - #{date['end']}")
+    expect(ArchivalObject[ao[:id]].display_string).to eq("bulk: #{date['begin']} - #{date['end']} (Inferred)")
   end
+
+  
+  it "includes date certainty in the generated display string" do
+    opts = {
+      :title => "",
+      :dates => [{
+                   "date_type" => "single",
+                   "label" => "creation",
+                   "certainty" => "approximate",
+                   "begin" => generate(:yyyy_mm_dd),
+                 }]
+    }
+
+    ao = ArchivalObject.create_from_json(build(:json_archival_object, opts),
+                                         :repo_id => $repo_id)
+
+    expect(ArchivalObject[ao[:id]].display_string).to match(/Approximate/)
+  end
+
 
   it "auto generates a 'label' based on the date and title when both are present" do
     title = "Just a title"
@@ -216,7 +235,7 @@ describe 'ArchivalObject model' do
       }),
       :repo_id => $repo_id)
 
-    expect(ArchivalObject[ao[:id]].display_string).to eq("#{title}, #{date1['expression']}, #{I18n.t("date_type_bulk.bulk")}: #{date2['expression']}")
+    expect(ArchivalObject[ao[:id]].display_string).to eq("#{title}, #{date1['expression']} (Inferred), #{I18n.t("date_type_bulk.bulk")}: #{date2['expression']} (Inferred)")
   end
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Include date certainty in display string for archival objects
 
## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-861

## How Has This Been Tested?
Manual and unit testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
