### PR TITLE
ANW-1011, ANW-980: Updated fix to resolve ANW-980 and escape tags in request and citation

### DIFF
--- a/public/app/models/resource.rb
+++ b/public/app/models/resource.rb
@@ -273,6 +273,10 @@ class Resource < Record
         cite += " #{ repository_information['top']['name']}."
       end
     end
+
+    # escape any quotes/tags that may break the HTML on the page
+    cite = CGI::escapeHTML(cite)
+
     if cite_type == "description"
       HTMLEntities.new.decode("#{cite} #{cite_url_and_timestamp}.")
     else

--- a/public/app/views/shared/_request_hiddens.html.erb
+++ b/public/app/views/shared/_request_hiddens.html.erb
@@ -10,6 +10,10 @@
       <input type='hidden' name='<%= "#{attr.to_s}[]" %>' value='<%= sanitize v %>' />
     <% end %>
   <% else %>
-    <input type='hidden' name='<%= attr.to_s %>' value='<%= sanitize value %>' />
+	  <% val_str = sanitize(value) %>
+
+    <%# escape any quotes/tags that may break the HTML on the page %>
+	  <% val_str = CGI::escapeHTML(val_str) %>
+    <input type='hidden' name='<%= attr.to_s %>' value='<%= val_str %>' />
   <% end %>
 <% end %>


### PR DESCRIPTION
forms as well

<!--- Provide a general summary of your changes in the Title above -->

## Description
HTML entities are not being escaped properly in the PUI in the citation and request forms.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-980
https://archivesspace.atlassian.net/browse/ANW-1011

## How Has This Been Tested?
Manual in-browser testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
