### PR TITLE
Issue 2094 Don't provide clickable context links in embedded search

### DIFF
--- a/frontend/app/views/search/_context_cell.html.erb
+++ b/frontend/app/views/search/_context_cell.html.erb
@@ -2,7 +2,11 @@
 <% if ancestors != nil && ancestors != [''] %>
   <% ancestors.reverse.each_with_index do |ancestor, i| %>
     <% unless get_ancestor_title(ancestor) == nil %>
-      <%= resolve_readonly_link_to((get_ancestor_title(ancestor).html_safe), ancestor) %>
+      <% if params['listing_only'] %>
+        <%= get_ancestor_title(ancestor) %>
+      <% else %>
+        <%= resolve_readonly_link_to((get_ancestor_title(ancestor).html_safe), ancestor) %>
+      <% end %>
       <% if i < ancestors.length - 1 %>
         <%= context_separator(record) %>
       <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We can talk about this one further, but this is a first pass/quick fix for the issue described in #2094 .  This bug stemmed from the relatively recent refactor of search/browse that shipped with v2.8.0, and renders context links in embedded searches pretty useless/frustrating.  Since I'm not sure when we'll be able to investigate a more satisfactory fix, this just removes the links (but retains the text) from the context column (they don't cause anything but trouble at the time being anyway). 

As noted in the issue, a more satisfactory UI experience would be to open these links in a new browser tab, but since these links are generated with a `redirect_to` from the resolver controller that will likely involve some javascript finagling.  

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
#2094 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Removes found in links in embedded search forms:
![image](https://user-images.githubusercontent.com/15144646/117508304-5c913300-af56-11eb-90b8-6590819fa306.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
