### PR TITLE
ANW-695 top container csv links

### DIFF
--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -42,8 +42,9 @@ class TopContainersController < ApplicationController
                                        params_for_backend_search.merge('facet[]' => SearchResultData.TOP_CONTAINER_FACETS))
       }
       format.csv {
-        params[:fields] -= %w[context type indicator barcode]
+        params[:fields] -= %w[title context type indicator barcode]
         params[:fields] += %w[type_enum_s indicator_u_icusort barcode_u_sstr]
+        params[:fields].prepend('collection_display_string_u_sstr', 'series_title_u_sstr')
         csv_response(
           "/repositories/#{session[:repo_id]}/search",
           prepare_search.merge('facet[]' => SearchResultData.TOP_CONTAINER_FACETS),


### PR DESCRIPTION
Prepends columns for resource / accession & series links && removes
the title field which packs all the column data into a single field..

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
