### PR TITLE
Hm plugin enhancements from #1896

### DIFF
--- a/backend/app/lib/uri_resolver.rb
+++ b/backend/app/lib/uri_resolver.rb
@@ -50,10 +50,10 @@ module URIResolver
     end
 
     result = if properties_to_resolve
-      URIResolverImplementation.new(properties_to_resolve).resolve_references(records)
-    else
-      records
-    end
+               URIResolverImplementation.new(properties_to_resolve).resolve_references(records)
+             else
+               records
+             end
 
     URIResolver.resolve_wrappers.each do |resolve_wrapper|
       result = resolve_wrapper.resolve(result, records, properties_to_resolve)

--- a/backend/app/main.rb
+++ b/backend/app/main.rb
@@ -130,7 +130,8 @@ class ArchivesSpaceService < Sinatra::Base
 
       end
 
-      [File.dirname(__FILE__), *ASUtils.find_local_directories('backend')].each do |prefix|
+      ordered_plugin_backend_dirs = ASUtils.order_plugins(ASUtils.find_local_directories('backend'))
+      [File.dirname(__FILE__), *ordered_plugin_backend_dirs].each do |prefix|
         ['model/mixins', 'model', 'model/reports', 'lib/bulk_import', 'controllers'].each do |path|
           Dir.glob(File.join(prefix, path, "*.rb")).sort.each do |file|
             require File.absolute_path(file)
@@ -211,7 +212,7 @@ class ArchivesSpaceService < Sinatra::Base
         end
 
         # Load plugin init.rb files (if present)
-        ASUtils.find_local_directories('backend').each do |dir|
+        ASUtils.order_plugins(ASUtils.find_local_directories('backend')).each do |dir|
           init_file = File.join(dir, "plugin_init.rb")
           if File.exist?(init_file)
             load init_file

--- a/backend/app/main.rb
+++ b/backend/app/main.rb
@@ -58,6 +58,18 @@ class ArchivesSpaceService < Sinatra::Base
     end
   end
 
+  @plugins_loaded_hooks = []
+  @archivesspace_plugins_loaded = false
+
+  def self.plugins_loaded_hook(&block)
+    if @archivesspace_plugins_loaded
+      block.call
+    else
+      @plugins_loaded_hooks << block
+    end
+  end
+
+
 
   configure :development do |config|
     require 'sinatra/reloader'
@@ -220,6 +232,11 @@ class ArchivesSpaceService < Sinatra::Base
         end
 
         BackgroundJobQueue.init if ASpaceEnvironment.environment != :unit_test
+
+        @plugins_loaded_hooks.each do |hook|
+          hook.call
+        end
+        @archivesspace_plugins_loaded = true
 
         Notifications.notify("BACKEND_STARTED")
         Log.noisiness "Logger::#{AppConfig[:backend_log_level].upcase}".constantize

--- a/backend/app/model/permission.rb
+++ b/backend/app/model/permission.rb
@@ -55,6 +55,7 @@ class Permission < Sequel::Model(:permission)
       db[:permission].filter(:permission_code => code).update(:system => 1)
     end
   end
+
   def self.show(code)
     DB.open do |db|
       db[:permission].filter(:permission_code => code).update(:system => 0)

--- a/backend/app/model/permission.rb
+++ b/backend/app/model/permission.rb
@@ -40,4 +40,24 @@ class Permission < Sequel::Model(:permission)
     admins.grant(permission.permission_code)
   end
 
+
+  # These methods provide a mechanism for plugins to hide (or show)
+  # permissions that are not relevant due to customizations made by
+  # the plugin. This is done by setting the :system attribute to true.
+  # System permissions behave exactly like other permissions except
+  # they are hidden from the user.
+  # NOTE: the update is done via a direct database query rather than
+  #       via the model because the permission table does not have
+  #       a :lock_version column, so the optimistic_locking plugin
+  #       freaks out on Permission.update
+  def self.hide(code)
+    DB.open do |db|
+      db[:permission].filter(:permission_code => code).update(:system => 1)
+    end
+  end
+  def self.show(code)
+    DB.open do |db|
+      db[:permission].filter(:permission_code => code).update(:system => 0)
+    end
+  end
 end

--- a/backend/app/model/sequence.rb
+++ b/backend/app/model/sequence.rb
@@ -49,7 +49,6 @@ class Sequence
       Log.error("Gave up trying to generate a sequence number for: '#{sequence}'")
       request[:result].completeExceptionally(java.lang.RuntimeException.new("Gave up trying to generate a sequence number for: '#{sequence}'"))
     end
-
   end
 
   Thread.new do

--- a/backend/app/model/sequence.rb
+++ b/backend/app/model/sequence.rb
@@ -2,23 +2,28 @@ class Sequence
   # DEPRECATED: this is dead code since ArchivesSpace v2
 
   def self.init(sequence, value)
-    DB.open(true) do |db|
-      db[:sequence].insert(:sequence_name => sequence.to_s, :value => value)
-    end
+    result = java.util.concurrent.CompletableFuture.new
+    QUEUE.add({action: :init, sequence: sequence, value: value, result: result})
+    result.get
+    nil
   end
 
-
   def self.get(sequence)
+    result = java.util.concurrent.CompletableFuture.new
+    QUEUE.add({action: :get, sequence: sequence, result: result})
+    result.get
+  end
+
+  def self._handle_get(request, initialised_sequences)
+    sequence = request[:sequence]
     DB.open(true) do |db|
-
-      Thread.current[:initialised_sequences] ||= {}
-
-      if !Thread.current[:initialised_sequences][sequence]
-        Thread.current[:initialised_sequences][sequence] = true
+      if !initialised_sequences[sequence]
+        initialised_sequences[sequence] = true
 
         DB.attempt {
-          init(sequence, 0)
-          return 0
+          db[:sequence].insert(:sequence_name => sequence.to_s, :value => 0)
+          request[:result].complete(0)
+          return
         }.and_if_constraint_fails {
           # Sequence is already defined, which is fine
         }
@@ -28,16 +33,49 @@ class Sequence
       1000.times do
         old_value = db[:sequence].filter(:sequence_name => sequence.to_s).get(:value)
         updated_count = db[:sequence].filter(:sequence_name => sequence.to_s, :value => old_value).
-                                      update(:value => old_value + 1)
+                          update(:value => old_value + 1)
 
         if updated_count == 0
           # Need to retry
           sleep(0.01)
         elsif updated_count == 1
-          return old_value + 1
+          request[:result].complete(old_value + 1)
+          return
         else
-          raise SequenceError.new("Unrecognised response from SQL update when generating next element in sequence '#{sequence}': #{updated_count}")
+          Log.error("Unrecognised response from SQL update when generating next element in sequence '#{sequence}': #{updated_count}")
         end
+      end
+
+      Log.error("Gave up trying to generate a sequence number for: '#{sequence}'")
+      request[:result].completeExceptionally(java.lang.RuntimeException.new("Gave up trying to generate a sequence number for: '#{sequence}'"))
+    end
+
+  end
+
+  Thread.new do
+    initialised_sequences = {}
+
+    while request = QUEUE.take
+      begin
+        if request[:action] == :init
+          DB.open(true) do |db|
+            DB.attempt {
+              db[:sequence].insert(:sequence_name => request[:sequence].to_s, :value => request[:value])
+            }.and_if_constraint_fails {
+              # Sequence is already defined, which is fine
+            }
+
+            request[:result].complete(nil)
+          end
+        elsif request[:action] == :get
+          _handle_get(request, initialised_sequences)
+        else
+          request[:result].completeExceptionally(java.lang.RuntimeException.new("Unrecognised action"))
+        end
+      rescue
+        Log.error("Error while generating sequence: $!")
+        Log.exception($!)
+        request[:result].completeExceptionally(java.lang.RuntimeException.new("Unexpected error"))
       end
 
       raise SequenceError.new("Gave up trying to generate a sequence number for: '#{sequence}'")

--- a/common/aspace_i18n.rb
+++ b/common/aspace_i18n.rb
@@ -8,7 +8,8 @@ I18n.load_path += ASUtils.find_locales_directories("#{AppConfig[:locale]}.yml")
 I18n.load_path += ASUtils.find_locales_directories(File.join("enums", "#{AppConfig[:locale]}.yml"))
 
 # Allow overriding of the i18n locales via the 'local' folder(s)
-ASUtils.wrap(ASUtils.find_local_directories).map {|local_dir| File.join(local_dir, 'frontend', 'locales')}.reject { |dir| !Dir.exist?(dir) }.each do |locales_override_directory|
+plugin_locale_directories = ASUtils.wrap(ASUtils.find_local_directories).map{|local_dir| File.join(local_dir, 'frontend', 'locales')}.reject { |dir| !Dir.exist?(dir) }
+ASUtils.order_plugins(plugin_locale_directories).each do |locales_override_directory|
   I18n.load_path += Dir[File.join(locales_override_directory, '**' , '*.{rb,yml}')]
 end
 

--- a/common/aspace_i18n.rb
+++ b/common/aspace_i18n.rb
@@ -8,7 +8,7 @@ I18n.load_path += ASUtils.find_locales_directories("#{AppConfig[:locale]}.yml")
 I18n.load_path += ASUtils.find_locales_directories(File.join("enums", "#{AppConfig[:locale]}.yml"))
 
 # Allow overriding of the i18n locales via the 'local' folder(s)
-plugin_locale_directories = ASUtils.wrap(ASUtils.find_local_directories).map{|local_dir| File.join(local_dir, 'frontend', 'locales')}.reject { |dir| !Dir.exist?(dir) }
+plugin_locale_directories = ASUtils.wrap(ASUtils.find_local_directories).map {|local_dir| File.join(local_dir, 'frontend', 'locales')}.reject { |dir| !Dir.exist?(dir) }
 ASUtils.order_plugins(plugin_locale_directories).each do |locales_override_directory|
   I18n.load_path += Dir[File.join(locales_override_directory, '**' , '*.{rb,yml}')]
 end

--- a/common/asutils.rb
+++ b/common/asutils.rb
@@ -253,7 +253,7 @@ ERRMSG
       gemfile = File.join(plugin, 'Gemfile')
       if File.exist?(gemfile)
         # only load Gemfiles we find
-        context.instance_eval(File.read(gemfile))
+        context.instance_eval(File.read(gemfile), gemfile, 1)
       end
     end
   end

--- a/common/asutils.rb
+++ b/common/asutils.rb
@@ -1,4 +1,3 @@
-
 require 'java'
 require 'tmpdir'
 require 'tempfile'
@@ -106,17 +105,21 @@ module ASUtils
     res
   end
 
-  def self.find_local_directories(base = nil, *plugins)
-    plugins = AppConfig[:plugins] if plugins.empty?
+  def self.plugin_base_directory
     # if a specific plugins directory is set in config.rb,
     # we use that. Otherwise, find the 'plugins' dir in the
     # aspace base.
-    base_directory =
-      if AppConfig.changed?(:plugins_directory)
-        AppConfig[:plugins_directory]
-      else
-        File.join( *[ self.find_base_directory, 'plugins'])
-      end
+    if AppConfig.changed?(:plugins_directory)
+      AppConfig[:plugins_directory]
+    else
+      File.join( *[ self.find_base_directory, 'plugins'])
+    end
+  end
+
+  def self.find_local_directories(base = nil, *plugins)
+    plugins = AppConfig[:plugins] if plugins.empty?
+    base_directory = self.plugin_base_directory
+
     Array(plugins).map do |plugin|
       File.join(*[base_directory, plugin, base].compact)
     end
@@ -326,5 +329,100 @@ ERRMSG
 
   def self.present?(obj)
     !blank?(obj)
+  end
+
+
+  PluginDependency = Struct.new(:depends_on, :recommends)
+
+  def self.load_plugin_dependencies
+    # YAML will generally have already been loaded at this point so this is
+    # usually a no-op.  This is here for DB migrations, which now rely on this
+    # code to run in the correct order and won't otherwise have loaded YAML.
+    require 'yaml'
+
+    result = {}
+
+    ASUtils.find_local_directories('config.yml').each do |f|
+      next unless File.exist?(f)
+
+      config = YAML.load_file(f)
+      plugin_name = File.basename(File.dirname(f))
+
+      result[plugin_name] = PluginDependency.new(config.fetch('depends_on_plugins', []),
+                                                 config.fetch('recommends_plugins', []))
+    end
+
+    # All other plugins have no dependencies
+    all_plugins = ASUtils.wrap(AppConfig[:plugins])
+
+    all_plugins.each do |plugin|
+      result[plugin] ||= PluginDependency.new([], [])
+    end
+
+    # Check that hard dependencies are satisfied and warn about missing recommended plugins.
+    all_plugins.each do |plugin|
+      plugin_deps = result.fetch(plugin)
+
+      unless (plugin_deps.depends_on - all_plugins).empty?
+        raise "Plugin #{plugin} is missing dependency plugin(s): #{(plugin_deps.depends_on - all_plugins).join(', ')}"
+      end
+
+      unless (plugin_deps.recommends - all_plugins).empty?
+        # No standard logging mechanism between public/backend/frontend/indexer.
+        # Sorry for the puts!
+        $stderr.puts("INFO: Plugin #{plugin} recommends additional plugin(s): #{(plugin_deps.recommends - all_plugins).join(', ')}")
+      end
+    end
+
+    result
+  end
+
+
+  def self.order_plugins(plugin_dirs)
+    all_plugins = ASUtils.wrap(AppConfig[:plugins])
+    all_deps = self.load_plugin_dependencies
+
+    # Order our list of plugins by walking the dependency graph
+    to_process = all_plugins.clone
+    ordered_plugins = []
+    while !to_process.empty?
+      # Select plugins whose prerequisites are all satisfied.
+      next_plugins = to_process.select {|plugin|
+        plugin_deps = all_deps.fetch(plugin)
+        ((plugin_deps.depends_on + plugin_deps.recommends) - ordered_plugins).empty?
+      }
+
+      # If we didn't match, try selecting a plugin whose hard dependencies are
+      # satisfied (ignoring recommended plugins).
+      if next_plugins.empty?
+        next_plugins = to_process.select {|plugin|
+          plugin_deps = all_deps.fetch(plugin)
+          (plugin_deps.depends_on - ordered_plugins).empty?
+        }
+      end
+
+      # If we're still deadlocked then there must be a dependency cycle...
+      if next_plugins.empty?
+        raise "Plugin dependency cycle detected among the following plugins: #{to_process.join(', ')}"
+      end
+
+      ordered_plugins.concat(next_plugins)
+      to_process -= next_plugins
+    end
+
+    # Our plugin base dir complete with trailing path separator
+    plugin_base_dir = File.join(File.absolute_path(self.plugin_base_directory),
+                                "")
+
+    # Sort our input according to its position in our plugin ordering.  Entries
+    # that aren't explicitly ordered can load in any order.
+    plugin_dirs.map {|f| File.absolute_path(f)}.sort_by {|plugin_dir|
+      unless plugin_dir.start_with?(plugin_base_dir)
+        raise "Assertion failure: Unexpected plugin dir: '#{plugin_dir}' was expected to begin with '#{plugin_base_dir}'"
+      end
+
+      plugin_name = (plugin_dir.gsub(plugin_base_dir, "")).split(File::SEPARATOR).find {|segment| segment != '.'}
+      ordered_plugins.index(plugin_name) or raise "Expected to find #{plugin_name} but didn't!"
+    }
   end
 end

--- a/common/db/db_migrator.rb
+++ b/common/db/db_migrator.rb
@@ -173,10 +173,21 @@ end
 
 class DBMigrator
 
+  def self.order_plugins(plugins)
+    ordered_plugin_dirs = ASUtils.order_plugins(plugins.map {|p| File.join(ASUtils.plugin_base_directory, p)})
+
+    result = plugins.sort_by {|p|
+      ordered_plugin_dirs.index(File.absolute_path(File.join(ASUtils.plugin_base_directory, p)))
+    }
+
+    result
+  end
+
   MIGRATIONS_DIR = File.join(File.dirname(__FILE__), "migrations")
   PLUGIN_MIGRATIONS = []
   PLUGIN_MIGRATION_DIRS = {}
-  AppConfig[:plugins].each do |plugin|
+
+  order_plugins(AppConfig[:plugins]).each do |plugin|
     mig_dir = ASUtils.find_local_directories("migrations", plugin).shift
     if mig_dir && Dir.exist?(mig_dir)
       PLUGIN_MIGRATIONS << plugin

--- a/frontend/app/assets/javascripts/ajaxtree.js.erb
+++ b/frontend/app/assets/javascripts/ajaxtree.js.erb
@@ -253,7 +253,7 @@ AjaxTree.prototype.title_for_new_node = function() {
     }
 };
 
-AjaxTree.prototype.add_new_after = function(node, level) {
+AjaxTree.prototype.add_new_after = function(node, level, extra_params) {
     var self = this;
 
     // update the hash
@@ -328,9 +328,7 @@ AjaxTree.prototype.add_new_after = function(node, level) {
         position = node.data('position') + 1;
     }
 
-    var params = {
-        inline: true
-    };
+    var params = $.extend({}, { inline: true }, extra_params || {});
 
     params[root_uri_parts.type + '_id'] = root_uri_parts.id;
 

--- a/frontend/app/assets/javascripts/top_containers.show.js
+++ b/frontend/app/assets/javascripts/top_containers.show.js
@@ -1,7 +1,4 @@
-//= require space_calculator
-
 $(document).ready(function() {
-    $(".linker:not(.initialised)").linker();
     $(document).triggerHandler("loadedrecordform.aspace", [$("#new_top_container_form")]);
 });
 

--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -222,7 +222,7 @@ class ApplicationController < ActionController::Base
                       "linked_events", "linked_events::linked_records",
                       "linked_events::linked_agents",
                       "top_container", "container_profile", "location_profile",
-                      "owner_repo"] + Plugins.fields_to_resolve
+                      "owner_repo", "places"] + Plugins.fields_to_resolve
     }
   end
 

--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -222,7 +222,7 @@ class ApplicationController < ActionController::Base
                       "linked_events", "linked_events::linked_records",
                       "linked_events::linked_agents",
                       "top_container", "container_profile", "location_profile",
-                      "owner_repo", "places"]
+                      "owner_repo"] + Plugins.fields_to_resolve
     }
   end
 

--- a/frontend/app/controllers/jobs_controller.rb
+++ b/frontend/app/controllers/jobs_controller.rb
@@ -110,14 +110,6 @@ class JobsController < ApplicationController
   def download_file
     @job = JSONModel(:job).find(params[:job_id], "resolve[]" => "repository")
 
-    if params[:ext]
-      format = params[:ext].delete_prefix('.')
-    elsif @job.job.has_key?("format") && !@job.job["format"].blank?
-      format = @job.job["format"]
-    else
-      format = "pdf"
-    end
-
     # this is a hacky solution
     # there should be a better way for jobs to specify file names
     if @job['job_type'] == 'report_job'
@@ -127,7 +119,7 @@ class JobsController < ApplicationController
     end
 
     url = "/repositories/#{JSONModel::repository}/jobs/#{params[:job_id]}/output_files/#{params[:id]}"
-    stream_file(url, {:format => format, :filename => "job_#{params[:job_id].to_s}_#{filename_end}" } )
+    stream_file(url, {:format => download_file_format(@job), :filename => "job_#{params[:job_id].to_s}_#{filename_end}" } )
   end
 
 
@@ -137,6 +129,16 @@ class JobsController < ApplicationController
   end
 
   private
+
+  def download_file_format(job)
+    if params[:ext]
+      format = params[:ext].delete_prefix('.')
+    elsif @job.job.has_key?("format") && !@job.job["format"].blank?
+      format = @job.job["format"]
+    else
+      format = "pdf"
+    end
+  end
 
   def selected_page
     [Integer(params[:page] || 1), 1].max

--- a/frontend/app/helpers/aspace_form_helper.rb
+++ b/frontend/app/helpers/aspace_form_helper.rb
@@ -527,15 +527,8 @@ module AspaceFormHelper
 
       options = {:class => classes.join(' '), :for => id_for(name)}
 
-      tooltip = I18n.t_raw("#{prefix}#{i18n_for(name)}_tooltip", :default => '')
-      if not tooltip.empty?
-        options[:title] = tooltip
-        options["data-placement"] = "bottom"
-        options["data-html"] = true
-        options["data-delay"] = 500
-        options["data-trigger"] = "manual"
-        options["data-template"] = '<div class="tooltip archivesspace-help"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
-        options[:class] += " has-tooltip"
+      unless (tooltip = tooltip(name, prefix)).empty?
+        add_tooltip_options(tooltip, options)
       end
 
       attr_string = options.merge(opts || {})
@@ -544,6 +537,22 @@ module AspaceFormHelper
                       .join(' ')
       content = CGI::escapeHTML(I18n.t(prefix + i18n_for(name)))
       "<label #{attr_string}>#{content}</label>".html_safe
+    end
+
+    def add_tooltip_options(tooltip, options)
+      options[:title] = tooltip
+      options['data-placement'] = 'bottom'
+      options['data-html'] = true
+      options['data-delay'] = 500
+      options['data-trigger'] = 'manual'
+      options['data-template'] = '<div class="tooltip archivesspace-help"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
+      options[:class] ||= ''
+      options[:class] += ' has-tooltip'
+      options
+    end
+
+    def tooltip(name, prefix = '')
+      I18n.t_raw("#{prefix}#{i18n_for(name)}_tooltip", :default => '')
     end
 
     def checkbox(name, opts = {}, default = true, force_checked = false)

--- a/frontend/app/helpers/notes_helper.rb
+++ b/frontend/app/helpers/notes_helper.rb
@@ -180,6 +180,8 @@ module NotesHelper
       }
     end
 
+    note_types = Plugins.handle_note_types_for(jsonmodel_type, note_types, self)
+
     note_types
   end
 

--- a/frontend/app/helpers/plugin_helper.rb
+++ b/frontend/app/helpers/plugin_helper.rb
@@ -12,6 +12,12 @@ module PluginHelper
         result << '<span class="glyphicon glyphicon-chevron-right"></span></a></li>'
       end
     end
+
+    mode = controller.action_name === 'show' ? :readonly : :edit
+    Plugins.sections_for(record, mode).each do |plugin_section|
+      result << plugin_section.render_sidebar(self, record, mode)
+    end
+
     result.html_safe
   end
 
@@ -27,6 +33,11 @@ module PluginHelper
                            :context => context, :section_id => "#{jsonmodel_type}_#{name}_" })
       end
     end
+
+    Plugins.sections_for(record, :readonly).each do |sub_record|
+      result << sub_record.render_readonly(self, record, context)
+    end
+
     result.html_safe
   end
 
@@ -41,6 +52,11 @@ module PluginHelper
                          :cardinality => parent['cardinality'].intern, :plugin => true})
 
     end
+
+    Plugins.sections_for(context.obj, :edit).each do |sub_record|
+      result << sub_record.render_edit(self, context.obj, context)
+    end
+
     result.html_safe
   end
 

--- a/frontend/app/helpers/plugin_helper.rb
+++ b/frontend/app/helpers/plugin_helper.rb
@@ -42,7 +42,7 @@ module PluginHelper
   end
 
 
-  def form_plugins_for(jsonmodel_type, context)
+  def form_plugins_for(jsonmodel_type, context, object = nil)
     result = ''
     Plugins.plugins_for(jsonmodel_type).each do |plugin|
       parent = Plugins.parent_for(plugin, jsonmodel_type)
@@ -53,7 +53,7 @@ module PluginHelper
 
     end
 
-    Plugins.sections_for(context.obj, :edit).each do |sub_record|
+    Plugins.sections_for(object || context.obj, :edit).each do |sub_record|
       result << sub_record.render_edit(self, context.obj, context)
     end
 

--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -90,6 +90,10 @@ module SearchHelper
   end
 
   def can_edit_search_result?(record)
+    Plugins.edit_roles.each do |edit_role|
+      return user_can?(edit_role.role, record['id']) if record['primary_type'] === edit_role.jsonmodel_type
+    end
+
     return user_can?('update_container_record', record['id']) if record['primary_type'] === "top_container"
     return user_can?('update_container_profile_record') if record['primary_type'] === "container_profile"
     return user_can?('manage_repository', record['id']) if record['primary_type'] === "repository"

--- a/frontend/app/models/search_result_data.rb
+++ b/frontend/app/models/search_result_data.rb
@@ -321,6 +321,10 @@ class SearchResultData
     ["subjects", "publish", "level", "classification_path", "primary_type", "langcode"] + Plugins.search_facets_for_type(:resource)
   end
 
+  def self.ARCHIVAL_OBJECT_FACETS
+    ["subjects", "publish", "level", "classification_path", "primary_type"] + Plugins.search_facets_for_type(:archival_object)
+  end
+
   def self.DIGITAL_OBJECT_FACETS
     ["subjects", "publish", "digital_object_type", "level", "primary_type", "langcode"] + Plugins.search_facets_for_type(:digital_object)
   end

--- a/frontend/app/models/search_result_data.rb
+++ b/frontend/app/models/search_result_data.rb
@@ -112,6 +112,11 @@ class SearchResultData
   end
 
   def facet_label_string(facet_group, facet)
+    # Plugins can opt to tell us how facet values should be translated.
+    if plugin_key = Plugins.facet_i18n_key(facet_group, facet)
+      return I18n.t(plugin_key, :default => facet)
+    end
+    
     return I18n.t("search.location.none") if facet == "none"
     return facet.upcase if facet_group == "owner_repo_display_string_u_ssort"
     return I18n.t("#{facet}._singular", :default => I18n.t("plugins.#{facet}._singular", :default => facet)) if facet_group === "primary_type"
@@ -299,39 +304,41 @@ class SearchResultData
   end
 
   def self.BASE_FACETS
-    ["primary_type", "creators", "subjects", "langcode"]
+    ["primary_type", "creators", "subjects", "langcode"] + Plugins.search_facets_for_base
   end
 
   def self.AGENT_FACETS
-    ["primary_type", "source", "rules"]
+    extras = [:agent_person, :agent_family, :agent_corporate_entity, :agent_software]
+               .flat_map {|agent_type| Plugins.search_facets_for_type(agent_type)}
+    ["primary_type", "source", "rules"] + extras
   end
 
   def self.ACCESSION_FACETS
-    ["subjects", "accession_date_year", "creators"]
+    ["subjects", "accession_date_year", "creators"] + Plugins.search_facets_for_type(:accession)
   end
 
   def self.RESOURCE_FACETS
-    ["subjects", "publish", "level", "classification_path", "primary_type", "langcode"]
+    ["subjects", "publish", "level", "classification_path", "primary_type", "langcode"] + Plugins.search_facets_for_type(:resource)
   end
 
   def self.DIGITAL_OBJECT_FACETS
-    ["subjects", "publish", "digital_object_type", "level", "primary_type", "langcode"]
+    ["subjects", "publish", "digital_object_type", "level", "primary_type", "langcode"] + Plugins.search_facets_for_type(:digital_object)
   end
 
   def self.CONTAINER_PROFILE_FACETS
-    ["container_profile_width_u_sstr", "container_profile_height_u_sstr", "container_profile_depth_u_sstr", "container_profile_dimension_units_u_sstr"]
+    ["container_profile_width_u_sstr", "container_profile_height_u_sstr", "container_profile_depth_u_sstr", "container_profile_dimension_units_u_sstr"] + Plugins.search_facets_for_type(:container_profile)
   end
 
   def self.LOCATION_FACETS
-    ["temporary", "owner_repo_display_string_u_ssort", "building", "floor", "room", "area", "location_profile_display_string_u_ssort"]
+    ["temporary", "owner_repo_display_string_u_ssort", "building", "floor", "room", "area", "location_profile_display_string_u_ssort"] + Plugins.search_facets_for_type(:location)
   end
 
   def self.SUBJECT_FACETS
-    ["source", "first_term_type"]
+    ["source", "first_term_type"] + Plugins.search_facets_for_type(:subject)
   end
 
   def self.EVENT_FACETS
-    ["event_type", "outcome"]
+    ["event_type", "outcome"] + Plugins.search_facets_for_type(:event)
   end
 
   def self.UNTITLED_TYPES
@@ -339,7 +346,7 @@ class SearchResultData
   end
 
   def self.CLASSIFICATION_FACETS
-    []
+    [] + Plugins.search_facets_for_type(:classification)
   end
 
   def self.TOP_CONTAINER_FACETS
@@ -347,7 +354,7 @@ class SearchResultData
   end
 
   def self.ASSESSMENT_FACETS
-    ['assessment_record_types', 'assessment_surveyors', 'assessment_review_required', 'assessment_reviewers', 'assessment_completed', 'assessment_inactive', 'assessment_survey_year', 'assessment_sensitive_material']
+    ['assessment_record_types', 'assessment_surveyors', 'assessment_review_required', 'assessment_reviewers', 'assessment_completed', 'assessment_inactive', 'assessment_survey_year', 'assessment_sensitive_material'] + Plugins.search_facets_for_type(:assessment)
   end
 
   def self.JOB_FACETS

--- a/frontend/app/models/search_result_data.rb
+++ b/frontend/app/models/search_result_data.rb
@@ -116,7 +116,7 @@ class SearchResultData
     if plugin_key = Plugins.facet_i18n_key(facet_group, facet)
       return I18n.t(plugin_key, :default => facet)
     end
-    
+
     return I18n.t("search.location.none") if facet == "none"
     return facet.upcase if facet_group == "owner_repo_display_string_u_ssort"
     return I18n.t("#{facet}._singular", :default => I18n.t("plugins.#{facet}._singular", :default => facet)) if facet_group === "primary_type"

--- a/frontend/app/views/accessions/_form.html.erb
+++ b/frontend/app/views/accessions/_form.html.erb
@@ -7,6 +7,10 @@
       <%= link_to_help :topic => "accession_basic_information" %>
     </h3>
     <fieldset>
+      <%= render_plugin_partials("top_of_basic_information_accession",
+                                 :form => form,
+                                 :record => @accession) %>
+
        <%= form.label_and_textarea "title" %>
        <%= form.label_and_fourpartid %>
 
@@ -28,6 +32,10 @@
        <%= form.label_and_textarea "access_restrictions_note" %>
        <%= form.label_and_boolean "use_restrictions", {}, form.default_for("use_restrictions") %>
        <%= form.label_and_textarea "use_restrictions_note" %>
+
+       <%= render_plugin_partials("basic_information_accession",
+                                  :form => form,
+                                  :record => @accession) %>
     </fieldset>
   </section>
 <% end %>

--- a/frontend/app/views/accessions/show.html.erb
+++ b/frontend/app/views/accessions/show.html.erb
@@ -18,6 +18,10 @@
           <section id="basic_information">
             <h3><%= I18n.t "accession._frontend.section.basic_information" %></h3>
 
+            <%= render_plugin_partials("top_of_basic_information_accession",
+                                       :form => readonly,
+                                       :record => @accession) %>
+
             <%= readonly.label_and_textarea "title" %>
             <%= readonly.label_and_fourpartid %>
 
@@ -41,6 +45,10 @@
             <%= readonly.label_and_textarea "access_restrictions_note" %>
             <%= readonly.label_and_boolean "use_restrictions" %>
             <%= readonly.label_and_textarea "use_restrictions_note" %>
+
+            <%= render_plugin_partials("basic_information_accession",
+                                       :form => readonly,
+                                       :record => @accession) %>
 
             <%= display_audit_info(@accession) %>
           </section>

--- a/frontend/app/views/agents/_form.html.erb
+++ b/frontend/app/views/agents/_form.html.erb
@@ -14,6 +14,11 @@
       </span>
       <%= link_to_help :topic => "#{@agent.agent_type}_basic_information" %>
     </h3>
+
+    <%= render_plugin_partials("top_of_basic_information_#{@agent.agent_type}",
+                               :form => form,
+                               :record => @agent) %>
+
     <div class="form-group">
       <label class="col-sm-2 control-label"><%= I18n.t("agent.type") %></label>
       <div class="col-sm-9 label-only">
@@ -24,7 +29,11 @@
 
     <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @agent} if AppConfig[:use_human_readable_urls] %>
 
-    <%= form.label_and_boolean "publish" %>
+    <%= form.label_and_boolean "publish", {}, user_prefs["publish"] %>
+
+    <%= render_plugin_partials("basic_information_#{@agent.agent_type}",
+                               :form => form,
+                               :record => @agent) %>
 
   </section>
 
@@ -122,6 +131,6 @@
     </section>
   <% end %>
 
-<%= form_plugins_for("agent", form) %>
+  <%= form_plugins_for("agent", form) %>
 
 </fieldset>

--- a/frontend/app/views/agents/_merge_preview.html.erb
+++ b/frontend/app/views/agents/_merge_preview.html.erb
@@ -13,11 +13,20 @@
         <section id="basic_information">
           <h3><%= I18n.t("agent._frontend.section.basic_information") %></h3>
 
+          <%= render_plugin_partials("top_of_basic_information_#{@agent.agent_type}",
+                                     :form => readonly,
+                                     :record => @agent) %>
+
           <div class="form-group">
             <label class="col-sm-2 control-label"><%= I18n.t("agent.type") %></label>
             <div class="col-sm-9 label-only"><%= I18n.t("agent.agent_type.#{@agent.agent_type}") %></div>
           </div>
           <%= readonly.label_and_boolean "publish" %>
+
+          <%= render_plugin_partials("basic_information_#{@agent.agent_type}",
+                                     :form => readonly,
+                                     :record => @agent) %>
+
           <%= display_audit_info(@agent) %>
         </section>
 

--- a/frontend/app/views/agents/_sidebar.html.erb
+++ b/frontend/app/views/agents/_sidebar.html.erb
@@ -209,7 +209,7 @@
       <%= sidebar.render_for_view_only(
         :subrecord_type => 'search_embedded',
         :property => :none,
-        :anchor => 'search_embedded') %>
+        :anchor => 'linked_agents') %>
 
       <% if @agent.agent_type.to_s == "agent_person" %>
         <%= sidebar.render_for_view_only(

--- a/frontend/app/views/agents/show.html.erb
+++ b/frontend/app/views/agents/show.html.erb
@@ -155,17 +155,20 @@
 
         <%= render_aspace_partial :partial => "search/embedded", :locals => {
           :filter_term => {"agent_uris" => @agent.uri}.to_json,
+          :section_id => "linked_agents",
           :heading_text => I18n.t("agent._frontend.section.search_embedded")
         } %>
 
         <%= render_aspace_partial :partial => "search/embedded", :locals => {
           :filter_term => {"rights_statement_agent_uris" => @agent.uri}.to_json,
+          :section_id => "linked_via_rights_statements",
           :heading_text => I18n.t("agent._frontend.section.linked_via_rights_statement")
         } %>
 
         <%= render_aspace_partial :partial => "search/embedded", :locals => {
           :record => @agent,
           :filter_term => {"linked_record_uris" => @agent.uri}.to_json,
+          :section_id => "events",
           :heading_text => I18n.t("event._plural")
         } %>
 

--- a/frontend/app/views/agents/show.html.erb
+++ b/frontend/app/views/agents/show.html.erb
@@ -16,6 +16,10 @@
         <section id="basic_information">
           <h3><%= I18n.t("agent._frontend.section.basic_information") %></h3>
 
+          <%= render_plugin_partials("top_of_basic_information_#{@agent.agent_type}",
+                                     :form => readonly,
+                                     :record => @agent) %>
+
           <div class="form-group">
             <label class="col-sm-2 control-label"><%= I18n.t("agent.type") %></label>
             <div class="col-sm-9 label-only"><%= I18n.t("agent.agent_type.#{@agent.agent_type}") %></div>
@@ -24,6 +28,11 @@
           <%= render_aspace_partial :partial => "shared/public_url", :locals => {:form_object => readonly} if AppConfig[:use_human_readable_urls] %>
 
           <%= readonly.label_and_boolean "publish" %>
+
+          <%= render_plugin_partials("basic_information_#{@agent.agent_type}",
+                                     :form => readonly,
+                                     :record => @agent) %>
+
           <%= display_audit_info(@agent) %>
         </section>
 

--- a/frontend/app/views/archival_objects/_form_container.html.erb
+++ b/frontend/app/views/archival_objects/_form_container.html.erb
@@ -27,6 +27,10 @@
       </h3>
 
       <fieldset>
+        <%= render_plugin_partials("top_of_basic_information_archival_object",
+                                   :form => form,
+                                   :record => @archival_object) %>
+
         <%= form.label_and_textarea("title", :required => :conditionally)%>
 
         <% if form.obj["ref_id"].blank? %>
@@ -53,6 +57,10 @@
         </div>
         <%= form.label_and_boolean "restrictions_apply", {}, form.default_for("restrictions_apply") %>
         <%= form.label_and_textarea "repository_processing_note" %>
+
+        <%= render_plugin_partials("basic_information_archival_object",
+                                   :form => form,
+                                   :record => @archival_object) %>
       </fieldset>
     </section>
   <% end %>

--- a/frontend/app/views/archival_objects/_show_inline.html.erb
+++ b/frontend/app/views/archival_objects/_show_inline.html.erb
@@ -10,6 +10,11 @@
         <%= render_aspace_partial :partial => "shared/flash_messages" %>
         <section id="basic_information">
           <h3><%= I18n.t("archival_object._frontend.section.basic_information") %></h3>
+
+          <%= render_plugin_partials("top_of_basic_information_archival_object",
+                                     :form => readonly,
+                                     :record => @archival_object) %>
+
           <%= readonly.label_and_textarea "title" , :field_opts => { :clean => true, :escape => false } %>
           <%= readonly.label_with_field "ref_id", "<div class='identifier-display'><div class='identifier-display-part'>#{readonly["ref_id"]}</div></div>" %>
           <%= readonly.label_and_textfield "component_id" %>
@@ -21,6 +26,11 @@
           <%= readonly.label_and_boolean "has_unpublished_ancestor" %>
           <%= readonly.label_and_boolean "restrictions_apply" %>
           <%= readonly.label_and_textarea "repository_processing_note" %>
+
+          <%= render_plugin_partials("basic_information_archival_object",
+                                     :form => readonly,
+                                     :record => @archival_object) %>
+
           <%= display_audit_info(@archival_object) %>
         </section>
 

--- a/frontend/app/views/assessments/_form.html.erb
+++ b/frontend/app/views/assessments/_form.html.erb
@@ -687,4 +687,8 @@
 
 <% form.emit_template("assessment") %>
 
-<%= form_plugins_for("assessment", form) %>
+<% if form.readonly? %>
+  <%= show_plugins_for(@assessment, readonly) %>
+<% else %>
+  <%= form_plugins_for("assessment", form) %>
+<% end %>

--- a/frontend/app/views/assessments/_form.html.erb
+++ b/frontend/app/views/assessments/_form.html.erb
@@ -49,6 +49,11 @@
     </h3>
     <fieldset>
       <legend class='sr-only'><%= I18n.t "assessment._frontend.section.basic_information" %></legend>
+
+      <%= render_plugin_partials("top_of_basic_information_assessments",
+                                 :form => form,
+                                 :record => @assessment) %>
+
       <% if form.readonly? %>
         <div class="form-group">
           <div class="control-label col-sm-2"><%= I18n.t("assessment.records") %></div>
@@ -215,6 +220,11 @@
 
       <%= form.label_and_boolean 'inactive' %>
     </fieldset>
+
+    <%= render_plugin_partials("basic_information_assessments",
+                               :form => form,
+                               :record => @assessment) %>
+
   </section>
 
   <section id="rating_attributes" class="subrecord-form-dummy">

--- a/frontend/app/views/assessments/_form.html.erb
+++ b/frontend/app/views/assessments/_form.html.erb
@@ -688,7 +688,7 @@
 <% form.emit_template("assessment") %>
 
 <% if form.readonly? %>
-  <%= show_plugins_for(@assessment, readonly) %>
+  <%= show_plugins_for(@assessment, form) %>
 <% else %>
   <%= form_plugins_for("assessment", form) %>
 <% end %>

--- a/frontend/app/views/assessments/show.html.erb
+++ b/frontend/app/views/assessments/show.html.erb
@@ -12,8 +12,6 @@
 
         <%= render_aspace_partial :partial => "assessments/form", :locals => {:form => readonly} %>
 
-        <%= show_plugins_for(@assessment, readonly) %>
-
       <% end %>
     </div>
   </div>

--- a/frontend/app/views/classification_terms/_form_container.html.erb
+++ b/frontend/app/views/classification_terms/_form_container.html.erb
@@ -20,12 +20,20 @@
     <section id="basic_information">
       <h3><%= I18n.t("classification_term._frontend.section.basic_information") %></h3>
 
+      <%= render_plugin_partials("top_of_basic_information_classification_term",
+                                 :form => form,
+                                 :record => @classification_term) %>
+
       <%= form.label_and_textfield "identifier" %>
       <%= form.label_and_textfield "title" %>
 
       <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @classification_term} if AppConfig[:use_human_readable_urls] %>
 
       <%= form.label_and_textarea "description" %>
+
+      <%= render_plugin_partials("basic_information_classification_term",
+                                 :form => form,
+                                 :record => @classification_term) %>
 
       <% form.push("creator", form["creator"] || {}) do %>
         <%= render_aspace_partial :partial => "agents/linker", :locals => {:form => form, :linker_label => I18n.t("classification_term.creator"), :optional => true, :multiplicity => "one"} %>

--- a/frontend/app/views/classification_terms/_show_inline.html.erb
+++ b/frontend/app/views/classification_terms/_show_inline.html.erb
@@ -38,7 +38,7 @@
       <% end %>
 
       <% readonly.emit_template("classification_term", @classification_term) %>
-      <%= render_aspace_partial :partial => "search/embedded", :locals => {:filter_term => {"classification_uris" => @classification_term.uri}.to_json, :heading_text => I18n.t("classification_term._frontend.section.search_embedded")} %>
+      <%= render_aspace_partial :partial => "search/embedded", :locals => {:section_id => "classifications", :filter_term => {"classification_uris" => @classification_term.uri}.to_json, :heading_text => I18n.t("classification_term._frontend.section.search_embedded")} %>
 
       <% end %>
     </div>

--- a/frontend/app/views/classification_terms/_show_inline.html.erb
+++ b/frontend/app/views/classification_terms/_show_inline.html.erb
@@ -11,12 +11,20 @@
         <% define_template "classification_term", jsonmodel_definition(:classification_term) do |form, classification_term| %>
         <section id="basic_information">
           <h3><%= I18n.t("classification_term._frontend.section.basic_information") %></h3>
-            <%= form.label_and_textarea "identifier" %>
+            <%= render_plugin_partials("top_of_basic_information_classification_term",
+                                       :form => form,
+                                       :record => @classification_term) %>
 
+            <%= form.label_and_textarea "identifier" %>
             <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @classification_term} if AppConfig[:use_human_readable_urls] %>
 
             <%= form.label_and_textarea "title" %>
             <%= form.label_and_textarea "description" %>
+
+            <%= render_plugin_partials("basic_information_classification_term",
+                                       :form => form,
+                                       :record => @classification_term) %>
+
 
           <% if !readonly["creator"].blank? %>
             <div class="token-list">

--- a/frontend/app/views/classification_terms/_sidebar.html.erb
+++ b/frontend/app/views/classification_terms/_sidebar.html.erb
@@ -4,5 +4,5 @@
              :record => @classification_term,
              :plusone => :button
            }) do |sidebar| %>
-    <%= sidebar.render_for_view_only(:subrecord_type => 'search_embedded', :property => :none, :anchor => 'search_embedded') %>
+    <%= sidebar.render_for_view_only(:subrecord_type => 'search_embedded', :property => :none, :anchor => 'classifications') %>
 <% end %>

--- a/frontend/app/views/classifications/_form_container.html.erb
+++ b/frontend/app/views/classifications/_form_container.html.erb
@@ -14,12 +14,20 @@
     <section id="basic_information">
       <h3><%= I18n.t("classification._frontend.section.basic_information") %></h3>
 
+      <%= render_plugin_partials("top_of_basic_information_classification",
+                                 :form => form,
+                                 :record => @classification) %>
+
       <%= form.label_and_textfield "identifier" %>
       <%= form.label_and_textfield "title" %>
 
       <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @classification} if AppConfig[:use_human_readable_urls] %>
 
       <%= form.label_and_textarea "description" %>
+
+      <%= render_plugin_partials("basic_information_classification",
+                                 :form => form,
+                                 :record => @classification) %>
 
       <% form.push("creator", form["creator"] || {}) do %>
         <%= render_aspace_partial :partial => "agents/linker", :locals => {:form => form, :linker_label => I18n.t("classification.creator"), :optional => true, :multiplicity => "one"} %>

--- a/frontend/app/views/classifications/_show_inline.html.erb
+++ b/frontend/app/views/classifications/_show_inline.html.erb
@@ -12,12 +12,20 @@
           <section id="basic_information">
             <h3><%= I18n.t("classification._frontend.section.basic_information") %></h3>
 
+            <%= render_plugin_partials("top_of_basic_information_classification",
+                                       :form => form,
+                                       :record => @classification) %>
+
             <%= form.label_and_textarea "identifier" %>
             <%= form.label_and_textarea "title" %>
 
             <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @classification} if AppConfig[:use_human_readable_urls] %>
 
             <%= form.label_and_textarea "description" %>
+
+            <%= render_plugin_partials("basic_information_classification",
+                                       :form => form,
+                                       :record => @classification) %>
 
             <% if !readonly["creator"].blank? %>
               <div class="token-list">

--- a/frontend/app/views/classifications/_show_inline.html.erb
+++ b/frontend/app/views/classifications/_show_inline.html.erb
@@ -41,7 +41,7 @@
 
         <% readonly.emit_template("classification", @classification) %>
 
-        <%= render_aspace_partial :partial => "search/embedded", :locals => {:filter_term => {"classification_uris" => @classification.uri}.to_json, :heading_text => I18n.t("classification._frontend.section.search_embedded")} %>
+        <%= render_aspace_partial :partial => "search/embedded", :locals => {:section_id => "classifications", :filter_term => {"classification_uris" => @classification.uri}.to_json, :heading_text => I18n.t("classification._frontend.section.search_embedded")} %>
 
       <% end %>
     </div>

--- a/frontend/app/views/classifications/_sidebar.html.erb
+++ b/frontend/app/views/classifications/_sidebar.html.erb
@@ -3,5 +3,5 @@
              :record_type => 'classification',
              :record => @classification || @classification_term
            }) do |sidebar| %>
-    <%= sidebar.render_for_view_only(:subrecord_type => 'search_embedded', :property => :none, :anchor => 'search_embedded') %>
+    <%= sidebar.render_for_view_only(:subrecord_type => 'search_embedded', :property => :none, :anchor => 'classifications') %>
 <% end %>

--- a/frontend/app/views/collection_management/show.html.erb
+++ b/frontend/app/views/collection_management/show.html.erb
@@ -22,6 +22,10 @@
           <section id="basic_information">
             <h3><%= I18n.t("collection_management_record._frontend.section.basic_information") %></h3>
   
+            <%= render_plugin_partials("top_of_basic_information_collection_management",
+                                       :form => readonly,
+                                       :record => @collection_management) %>
+
             <div class="row label-and-value">
                <div class="col-md-3">Id</div>
                <div class="col-md-9"><%= @collection_management.id %></div>
@@ -72,6 +76,11 @@
                <div class="col-md-9"><%= @collection_management.rights_determined ? I18n.t("collection_management.rights_determined_true") : I18n.t("collection_management.rights_determined_false") %></div>
   
             </div>
+
+            <%= render_plugin_partials("basic_information_collection_management",
+                                       :form => readonly,
+                                       :record => @collection_management) %>
+
           </section>
   
           <section id="collection_management_linked_records_" class="subrecord-form-dummy">

--- a/frontend/app/views/container_profiles/_form.html.erb
+++ b/frontend/app/views/container_profiles/_form.html.erb
@@ -7,6 +7,10 @@
       <%= link_to_help :topic => "container_profile_basic_information" %>
     </h3>
     <fieldset>
+      <%= render_plugin_partials("top_of_basic_information_container_profile",
+                                 :form => form,
+                                 :record => @container_profile) %>
+
       <%= form.label_and_textfield "name" %>
       <%= form.label_and_textfield "url" %>
       <%= form.label_and_select "dimension_units", form.possible_options_for("dimension_units") %>
@@ -15,7 +19,11 @@
       <%= form.label_and_textfield "height" %>
       <%= form.label_and_textfield "width" %>
       <%= form.label_and_textfield "stacking_limit" %>
-    </fieldset>
+
+      <%= render_plugin_partials("basic_information_container_profile",
+                                 :form => form,
+                                 :record => @container_profile) %>
+  </fieldset>
   </section>
 <% end %>
 

--- a/frontend/app/views/dates/_template.html.erb
+++ b/frontend/app/views/dates/_template.html.erb
@@ -188,4 +188,7 @@
   <%= form.label_and_select("certainty", form.possible_options_for("certainty", true)) %>
   <%= form.label_and_select("era", form.possible_options_for("era", true)) %>
   <%= form.label_and_select("calendar", form.possible_options_for("calendar", true)) %>
+
+  <%= render_plugin_partials("date_fields_ext", :form => form)
+  %>
 <% end %>

--- a/frontend/app/views/digital_object_components/_form_container.html.erb
+++ b/frontend/app/views/digital_object_components/_form_container.html.erb
@@ -26,6 +26,11 @@
         <%= I18n.t("digital_object_component._frontend.section.basic_information") %>
         <%= link_to_help :topic => "digital_object_component_basic_information" %>
       </h3>
+
+      <%= render_plugin_partials("top_of_basic_information_digital_object_component",
+                                 :form => form,
+                                 :record => @digital_object_component) %>
+
       <%= form.label_and_textfield "label", :required => :conditionally %>
       <%= form.label_and_textarea "title", :required => :conditionally %>
       <%= form.label_and_textfield "component_id" %>
@@ -41,6 +46,10 @@
           <% end %>
         </div>
       </div>
+
+      <%= render_plugin_partials("basic_information_digital_object_component",
+                                 :form => form,
+                                 :record => @digital_object_component) %>
 
     </section>
   <% end %>

--- a/frontend/app/views/digital_object_components/_show_inline.html.erb
+++ b/frontend/app/views/digital_object_components/_show_inline.html.erb
@@ -13,6 +13,10 @@
         <section id="basic_information">
           <h3><%= I18n.t("digital_object_component._frontend.section.basic_information") %></h3>
 
+          <%= render_plugin_partials("top_of_basic_information_digital_object_component",
+                                     :form => readonly,
+                                     :record => @digital_object_component) %>
+
           <%= readonly.label_and_textfield "label" %>
           <%= readonly.label_and_textarea "title" %>
           <%= readonly.label_and_textfield "component_id" %>
@@ -21,6 +25,10 @@
 
           <%= readonly.label_and_boolean "publish" %>
           <%= readonly.label_and_boolean "has_unpublished_ancestor" %>
+
+          <%= render_plugin_partials("basic_information_digital_object_component",
+                                     :form => readonly,
+                                     :record => @digital_object_component) %>
 
         </section>
 
@@ -65,6 +73,7 @@
         <% if digital_object_component.external_ids.length > 0 && show_external_ids? %>
           <%= render_aspace_partial :partial => "external_ids/show", :locals => { :external_ids => digital_object_component.external_ids, :context => readonly, :section_id => "digital_object_component_external_ids_" } %>
         <% end %>
+
 
         <%= show_plugins_for(@digital_object_component, readonly) %>
 

--- a/frontend/app/views/digital_objects/_form_container.html.erb
+++ b/frontend/app/views/digital_objects/_form_container.html.erb
@@ -10,6 +10,11 @@
         <%= I18n.t("digital_object._frontend.section.basic_information") %>
         <%= link_to_help :topic => "digital_object_basic_information" %>
       </h3>
+
+      <%= render_plugin_partials("top_of_basic_information_digital_object",
+                                 :form => form,
+                                 :record => @digital_object) %>
+
       <%= form.label_and_textarea "title" %>
 
       <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @digital_object} if AppConfig[:use_human_readable_urls] %>
@@ -19,6 +24,11 @@
       <%= form.label_and_select "level", form.possible_options_for("level", true) %>
       <%= form.label_and_select "digital_object_type", form.possible_options_for("digital_object_type", true) %>
       <%= form.label_and_boolean "restrictions", {}, form.default_for("restrictions") %>
+
+      <%= render_plugin_partials("basic_information_digital_object",
+                                 :form => form,
+                                 :record => @digital_object) %>
+
     </section>
   <% end %>
 

--- a/frontend/app/views/digital_objects/_show_inline.html.erb
+++ b/frontend/app/views/digital_objects/_show_inline.html.erb
@@ -13,6 +13,10 @@
         <section id="basic_information">
           <h3><%= I18n.t("digital_object._frontend.section.basic_information") %></h3>
 
+          <%= render_plugin_partials("top_of_basic_information_digital_object",
+                                     :form => readonly,
+                                     :record => digital_object) %>
+
           <%= readonly.label_and_textarea "title" %>
           <%= readonly.label_and_textfield "digital_object_id" %>
 
@@ -22,6 +26,11 @@
           <%= readonly.label_and_select "level", readonly.possible_options_for("level") %>
           <%= readonly.label_and_select "digital_object_type", readonly.possible_options_for("digital_object_type") %>
           <%= readonly.label_and_boolean "restrictions" %>
+
+          <%= render_plugin_partials("basic_information_digital_object",
+                                     :form => readonly,
+                                     :record => digital_object) %>
+
           <%= display_audit_info(digital_object) %>
         </section>
 

--- a/frontend/app/views/events/_form.html.erb
+++ b/frontend/app/views/events/_form.html.erb
@@ -7,9 +7,17 @@
       <%= link_to_help :topic => "event_basic_information" %>
     </h3>
     <fieldset>
+      <%= render_plugin_partials("top_of_basic_information_event",
+                                 :form => form,
+                                 :record => @event) %>
+
       <%= form.label_and_select "event_type", form.possible_options_for("event_type") %>
       <%= form.label_and_select "outcome", form.possible_options_for('outcome', true) %>
       <%= form.label_and_textarea "outcome_note" %>
+
+      <%= render_plugin_partials("basic_information_event",
+                                 :form => form,
+                                 :record => @event) %>
     </fieldset>
   </section>
 <% end %>

--- a/frontend/app/views/jobs/_show_templates.html.erb
+++ b/frontend/app/views/jobs/_show_templates.html.erb
@@ -33,6 +33,10 @@
   <section id="basic_information">
     <h3><%= I18n.t("job._frontend.section.basic_information") %></h3>
 
+    <%= render_plugin_partials("top_of_basic_information_job",
+                               :form => form,
+                               :record => @job) %>
+
     <%= form.label_with_field "import_type", job['import_type'] %>
 
     <% if job["job_type"] != 'generate_slugs_job' && job["job_type"] != 'generate_arks_job' %>
@@ -48,6 +52,11 @@
     </div>
 
     <% form.emit_template job.job['jsonmodel_type'], job.job %>
+
+    <%= render_plugin_partials("basic_information_job",
+                               :form => form,
+                               :record => @job) %>
+
 
     <%= display_audit_info(@job) %>
   </section>

--- a/frontend/app/views/layouts/application.html.erb
+++ b/frontend/app/views/layouts/application.html.erb
@@ -34,7 +34,7 @@
   <%= javascript_include_tag "html5shiv" %>
   <![endif]-->
 
-  <% ASUtils.find_local_directories('frontend/views/layout_head.html.erb').each do |layout| %>
+  <% ASUtils.order_plugins(ASUtils.find_local_directories('frontend/views/layout_head.html.erb')).each do |layout| %>
     <% if File.exist?(layout) %>
       <!-- Begin plugin layout -->
       <%= render :file => layout %>

--- a/frontend/app/views/location_profiles/_form.html.erb
+++ b/frontend/app/views/location_profiles/_form.html.erb
@@ -11,12 +11,21 @@
       <%= link_to_help :topic => "location_profile_basic_information" %>
     </h3>
     <fieldset>
+      <%= render_plugin_partials("top_of_basic_information_location_profile",
+                                 :form => form,
+                                 :record => @location_profile) %>
+
       <%= form.label_and_textfield "name" %>
       <%= form.label_and_select "dimension_units", form.possible_options_for("dimension_units") %>
       <%= form.label_and_textfield "depth" %>
       <%= form.label_and_textfield "height" %>
       <%= form.label_and_textfield "width" %>
-    </fieldset>
+  
+      <%= render_plugin_partials("basic_information_location_profile",
+                                 :form => form,
+                                 :record => @location_profile) %>
+
+  </fieldset>
   </section>
 <% end %>
 

--- a/frontend/app/views/locations/_form.html.erb
+++ b/frontend/app/views/locations/_form.html.erb
@@ -1,6 +1,10 @@
 <% define_template("location", jsonmodel_definition(:location)) do |form| %>
   <fieldset>
     <section id="basic_information">
+      <%= render_plugin_partials("top_of_basic_information_location",
+                                 :form => form,
+                                 :record => @location) %>
+
     <%= form.label_and_boolean "temporary_question", {}, false %> 
     <%= form.label_and_select "temporary",
         form.possible_options_for("temporary", true),
@@ -25,6 +29,10 @@
       <%= form.label_and_textfield "coordinate_3_label" %>
       <%= form.label_and_textfield "coordinate_3_indicator" %>
       <hr/>
+      <%= render_plugin_partials("basic_information_location",
+                                 :form => form,
+                                 :record => @location) %>
+
       <% form.push("location_profile", form.obj["location_profile"] || {}) do %>
         <%= render_aspace_partial :partial => "location_profiles/linker", :locals => {:form => form, :label => I18n.t("location_profile._singular")} %>
       <% end %>

--- a/frontend/app/views/locations/_form_batch.html.erb
+++ b/frontend/app/views/locations/_form_batch.html.erb
@@ -1,6 +1,10 @@
 <% define_template("location_batch", jsonmodel_definition(:location)) do |form| %>
   <fieldset>
     <section id="basic_information">
+      <%= render_plugin_partials("top_of_basic_information_location",
+                                 :form => form,
+                                 :record => @location) %>
+
     <%= form.label_and_boolean "temporary_question", {}, false %> 
     <%= form.label_and_select "temporary", form.possible_options_for("temporary", true), :field_opts =>  { :disabled => true, :class => "location_temporary" } %>
       <hr/>
@@ -8,6 +12,11 @@
       <%= form.label_and_textfield "floor" %>
       <%= form.label_and_textfield "room" %>
       <%= form.label_and_textfield "area" %>
+
+      <%= render_plugin_partials("basic_information_location",
+                                 :form => form,
+                                 :record => @location) %>
+
       <% form.push("location_profile", form.obj["location_profile"] || {}) do %>
         <%= render_aspace_partial :partial => "location_profiles/linker", :locals => {:form => form, :label => I18n.t("location_profile._singular")} %>
       <% end %>

--- a/frontend/app/views/locations/_sidebar.html.erb
+++ b/frontend/app/views/locations/_sidebar.html.erb
@@ -6,5 +6,5 @@
            }) do |sidebar| %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_id', :property => 'external_ids') if show_external_ids? && sidebar.show_external_ids_sidebar_entry? %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'location_function', :property => 'functions') %>
-    <%= sidebar.render_for_view_only(:subrecord_type => 'search_embedded', :property => :none, :anchor => 'search_embedded') %>
+    <%= sidebar.render_for_view_only(:subrecord_type => 'search_embedded', :property => :none, :anchor => 'location_containers') %>
 <% end %>

--- a/frontend/app/views/locations/show.html.erb
+++ b/frontend/app/views/locations/show.html.erb
@@ -52,7 +52,11 @@
         <%= render_aspace_partial :partial => "location_functions/show", :locals => { :functions => @location.functions, :section_id => "location_functions_" } %>
       <% end %>
 
-      <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @location, :filter_term => {"location_uris" => @location.uri, 'primary_type' => 'top_container'}.to_json, :heading_text => I18n.t("location._frontend.section.search_embedded")} %>
+      <%= render_aspace_partial :partial => "search/embedded", :locals => {
+        :record => @location,
+        :filter_term => {"location_uris" => @location.uri, 'primary_type' => 'top_container'}.to_json,
+        :heading_text => I18n.t("location._frontend.section.search_embedded"),
+        :section_id => 'location_containers'} %>
 
       <%= readonly_context :location, @location do |readonly| %>
         <%= show_plugins_for(@location, readonly) %>

--- a/frontend/app/views/notes/_template.html.erb
+++ b/frontend/app/views/notes/_template.html.erb
@@ -146,7 +146,7 @@
   <div class="subrecord-form-fields" data-type="note_singlepart">
     <h3 class="subrecord-form-heading">
       <% if form.readonly? %>
-        <%= I18n.t("enumerations.note_singlepart_type.#{form.obj["type"]}", :default => form.obj["type"]) %>
+        <%= I18n.t("enumerations.#{JSONModel(:note_singlepart).schema['properties']['type']['dynamic_enum']}.#{form.obj["type"]}", :default => form.obj["type"]) %>
       <% else %>
         <%= I18n.t("note.note_singlepart") %>
       <% end %>
@@ -224,7 +224,7 @@
   <div class="subrecord-form-fields" data-type="note_multipart">
     <h3 class="subrecord-form-heading">
       <% if form.readonly? %>
-        <%= I18n.t("enumerations.note_multipart_type.#{form.obj["type"]}", :default => form.obj["type"]) %>
+        <%= I18n.t("enumerations.#{JSONModel(:note_multipart).schema['properties']['type']['dynamic_enum']}.#{form.obj["type"]}", :default => form.obj["type"]) %>
       <% else %>
         <%= I18n.t("note.note_multipart") %>
       <% end %>

--- a/frontend/app/views/repositories/_form_container.html.erb
+++ b/frontend/app/views/repositories/_form_container.html.erb
@@ -71,4 +71,10 @@
       <% form.emit_template("agent_contact", item) %>
     <% end %>
   <% end %>
+
+  <% if form.readonly? %>
+    <%= show_plugins_for("repository", form) %>
+  <% else %>
+    <%= form_plugins_for("repository", form) %>
+  <% end %>
 </fieldset>

--- a/frontend/app/views/resources/_form_container.html.erb
+++ b/frontend/app/views/resources/_form_container.html.erb
@@ -19,6 +19,10 @@
     </h3>
 
     <fieldset>
+      <%= render_plugin_partials("top_of_basic_information_resource",
+                                 :form => form,
+                                 :record => @resource) %>
+
       <%= form.label_and_textarea "title" %>
       <%= form.label_and_fourpartid %>
 
@@ -31,6 +35,10 @@
       <%= form.label_and_boolean "publish", {}, user_prefs["publish"] %>
       <%= form.label_and_boolean "restrictions", {}, form.default_for("restrictions") %>
       <%= form.label_and_textarea "repository_processing_note" %>
+
+      <%= render_plugin_partials("basic_information_resource",
+                                 :form => form,
+                                 :record => @resource) %>
     </fieldset>
   </section>
 

--- a/frontend/app/views/resources/_form_container.html.erb
+++ b/frontend/app/views/resources/_form_container.html.erb
@@ -85,7 +85,7 @@
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "related_accessions", :template => "resource_related_accessions"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "linked_agents", :template => "resource_linked_agent"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "subjects", :template => "subrecord_subject"} %>
-<%= render_aspace_partial :partial => "notes/form", :locals => {:form => form} %>
+<%= render_aspace_partial :partial => "notes/form", :locals => {:form => form, :section_id => 'resource_notes_'} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "rights_statements"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "instances", :custom_action_template => "instances/subrecord_form_action"} %>

--- a/frontend/app/views/resources/_show_inline.html.erb
+++ b/frontend/app/views/resources/_show_inline.html.erb
@@ -93,7 +93,7 @@
         <% end %>
 
         <% if @resource.notes.length > 0 %>
-          <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => @resource.notes, :context => readonly } %>
+          <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => @resource.notes, :context => readonly, :section_id => 'resource_notes_' } %>
         <% end %>
 
         <% if @resource.external_documents.length > 0 %>

--- a/frontend/app/views/resources/_show_inline.html.erb
+++ b/frontend/app/views/resources/_show_inline.html.erb
@@ -15,6 +15,10 @@
           <section id="basic_information">
             <h3><%= I18n.t("resource._frontend.section.basic_information") %></h3>
 
+            <%= render_plugin_partials("top_of_basic_information_resource",
+                                       :form => readonly,
+                                       :record => @resource) %>
+
             <%= readonly.label_and_textarea "title", :field_opts => { :clean => true, :base_url => url_for(:root), :escape => false} %>
             <% if resource.id_0 %><%= readonly.label_and_fourpartid %><% end %>
 
@@ -25,6 +29,11 @@
             <%= readonly.label_and_boolean "publish" %>
             <%= readonly.label_and_boolean "restrictions" %>
             <%= readonly.label_and_textarea "repository_processing_note" %>
+
+            <%= render_plugin_partials("basic_information_resource",
+                                       :form => readonly,
+                                       :record => @resource) %>
+
             <%= display_audit_info(@resource) %>
           </section>
 

--- a/frontend/app/views/resources/_sidebar.html.erb
+++ b/frontend/app/views/resources/_sidebar.html.erb
@@ -11,7 +11,7 @@
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'related_accession', :property => 'related_accessions') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'linked_agent', :property => 'linked_agents') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'subject', :property => 'subjects') %>
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'note', :property => 'notes', :anchor => 'notes') %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'note', :property => 'notes', :anchor => 'resource_notes_') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_document', :property => 'external_documents') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'rights_statement', :property => 'rights_statements') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'instance', :property => 'instances') %>

--- a/frontend/app/views/search/_filter.html.erb
+++ b/frontend/app/views/search/_filter.html.erb
@@ -1,3 +1,4 @@
+<div class="search-listing-filter">
 <% if @search_data.filtered_terms? or @search_data.query? %>
   <div class="well">
     <h3>
@@ -8,14 +9,14 @@
       <% if @search_data.query? %>
         <% query_array = @search_data[:criteria]["q"].split(" AND ") %>
         <% query_array.each do | query | %>
-          <li>
+          <li class="facet-selected">
             <%= link_to "#{h(@search_data.facet_label_for_query(query))} <span class='glyphicon glyphicon-remove'></span>".html_safe, build_search_params({"q" => query_array.reject{ |k| k==query}.join(' AND ')}) %>
           </li>
         <% end %>
       <% end %>
       <% if @search_data.filtered_terms? %>
         <% @search_data[:criteria]["filter_term[]"].each do | filter_term | %>
-          <li>
+          <li class="facet-selected">
             <%= link_to "#{h(@search_data.facet_label_for_filter(filter_term))} <span class='glyphicon glyphicon-remove'></span>".html_safe, build_search_params({"remove_filter_term" => filter_term}) %>
           </li>
         <% end %>
@@ -50,7 +51,7 @@
   <h3><%= I18n.t("search.#{@search_data.get_type}.#{facet_group}", :default => I18n.t("search.multi.#{facet_group}", :default => facet_group)) %></h3>
   <ul>
     <% facets.each do |facet, facet_map| %>
-      <li>
+      <li class="facet">
       	<% if facet_map.has_key?(:q) %>
         	<% opts = {"q" => facet_map[:q]} %>
       	<% else %>
@@ -62,3 +63,4 @@
     <% end %>
   </ul>
 <% end %>
+</div>

--- a/frontend/app/views/sub_containers/_show.html.erb
+++ b/frontend/app/views/sub_containers/_show.html.erb
@@ -23,7 +23,9 @@
 
 <%= readonly_context :sub_container, sub_container do |readonly| %>
   <%= readonly.emit_template ("sub_container") %>
-<% end %>
+  
+  <%= show_plugins_for(JSONModel(:sub_container).from_hash(readonly.obj, :trusted), readonly) %>
+<% end %>  
 
 <% container_locations = sub_container.dig("top_container", "_resolved", "container_locations") %>
 <% if container_locations && container_locations.length > 0 %>

--- a/frontend/app/views/sub_containers/_template.html.erb
+++ b/frontend/app/views/sub_containers/_template.html.erb
@@ -16,6 +16,8 @@
 
     <%= form.label_and_select "type_3", form.possible_options_for('type_3', true) %>
     <%= form.label_and_textfield  "indicator_3" %>
+
+    <%= form_plugins_for("sub_container", form, JSONModel(:sub_container).new._always_valid!) %>
   </div>
 <% end %>
 

--- a/frontend/app/views/subjects/_form.html.erb
+++ b/frontend/app/views/subjects/_form.html.erb
@@ -10,12 +10,20 @@
         <%= I18n.t("subject._frontend.section.basic_information") %>
         <%= link_to_help :topic => "subject_basic_information" %>
       </h3>
+
+      <%= render_plugin_partials("top_of_basic_information_subject",
+                                 :form => form,
+                                 :record => @subject) %>
+
       <%= form.label_and_textfield "authority_id" %>
       <%= form.label_and_select "source", form.possible_options_for("source", true) %>
       <%= form.label_and_textarea "scope_note" %>
 
       <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @subject} if AppConfig[:use_human_readable_urls] %>
 
+      <%= render_plugin_partials("basic_information_subject",
+                                 :form => form,
+                                 :record => @subject) %>
     </section>
   <% end %>
 

--- a/frontend/app/views/subjects/_sidebar.html.erb
+++ b/frontend/app/views/subjects/_sidebar.html.erb
@@ -6,6 +6,6 @@
            }) do |sidebar| %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'terms', :property => 'terms') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_document', :property => 'external_documents') %>
-    <%= sidebar.render_for_view_only(:subrecord_type => 'search_embedded', :property => :none, :anchor => 'search_embedded') %>
+    <%= sidebar.render_for_view_only(:subrecord_type => 'search_embedded', :property => :none, :anchor => 'linked_records') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_id', :property => 'external_ids') if show_external_ids? && sidebar.show_external_ids_sidebar_entry? %>
 <% end %>

--- a/frontend/app/views/subjects/show.html.erb
+++ b/frontend/app/views/subjects/show.html.erb
@@ -42,7 +42,7 @@
         <%= render_aspace_partial :partial => "external_documents/show", :locals => { :external_documents => @subject.external_documents, :section_id => "subject_external_documents_" } %>
       <% end %>
 
-      <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @subject, :filter_term => {"subject_uris" => @subject.uri}.to_json, :heading_text => I18n.t("subject._frontend.section.search_embedded")} %>
+      <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @subject, :section_id => "linked_records", :filter_term => {"subject_uris" => @subject.uri}.to_json, :heading_text => I18n.t("subject._frontend.section.search_embedded")} %>
 
       <% if @subject.external_ids.length > 0 && show_external_ids? %>
         <%= render_aspace_partial :partial => "external_ids/show", :locals => { :external_ids => @subject.external_ids, :section_id => "subject_external_ids_" } %>

--- a/frontend/app/views/subjects/show.html.erb
+++ b/frontend/app/views/subjects/show.html.erb
@@ -16,11 +16,20 @@
         <section id="basic_information">
           <h3><%= I18n.t("subject._frontend.section.basic_information") %></h3>
 
+          <%= render_plugin_partials("top_of_basic_information_subject",
+                                     :form => form,
+                                     :record => @subject) %>
+
           <%= render_aspace_partial :partial => "shared/public_url", :locals => {:form_object => readonly} if AppConfig[:use_human_readable_urls] %>
 
           <%= form.label_and_textfield "authority_id" %>
           <%= form.label_and_select "source", form.possible_options_for("source", true) %>
           <%= form.label_and_textarea "scope_note" %>
+
+          <%= render_plugin_partials("basic_information_subject",
+                                     :form => form,
+                                     :record => @subject) %>
+
           <%= display_audit_info(@subject) %>
         </section>
       <% end %>

--- a/frontend/app/views/top_containers/_form.html.erb
+++ b/frontend/app/views/top_containers/_form.html.erb
@@ -1,6 +1,9 @@
 <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:object => @top_container, :form => form} %>
 
 <% define_template("top_container", jsonmodel_definition(:top_container)) do |form| %>
+  <%= render_plugin_partials("top_of_basic_information_top_container",
+                             :form => form,
+                             :record => @top_container) %>
   <% form.push("container_profile", form.obj["container_profile"] || {}) do %>
       <%= render_aspace_partial :partial => "container_profiles/linker", :locals => {:form => form, :label => I18n.t("container_profile._singular"), :required => false} %>
   <% end %>

--- a/frontend/app/views/top_containers/_form.html.erb
+++ b/frontend/app/views/top_containers/_form.html.erb
@@ -32,6 +32,8 @@
   <div class="subrecord-form-container">
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "container_locations", :section_id => "container_locations"} %>
   </div>
+
+  <%= form_plugins_for("top_container", form) %>
 <% end %>
 
 

--- a/frontend/app/views/top_containers/_form.html.erb
+++ b/frontend/app/views/top_containers/_form.html.erb
@@ -29,6 +29,10 @@
     <%= form.hidden_input("created_for_collection") %>
   <% end %>
 
+  <%= render_plugin_partials("basic_information_top_container",
+                             :form => form,
+                             :record => @top_container) %>
+
   <div class="subrecord-form-container">
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "container_locations", :section_id => "container_locations"} %>
   </div>

--- a/frontend/app/views/top_containers/_sidebar.html.erb
+++ b/frontend/app/views/top_containers/_sidebar.html.erb
@@ -7,6 +7,6 @@
 
   <%= sidebar.render_for_view_only(:subrecord_type => 'basic_information', :property => :none, :anchor => 'basic_information') %>
   <%= sidebar.render_for_view_only(:subrecord_type => 'active_restrictions', :property => :none, :anchor => 'rights_restrictions') %>
-  <%= sidebar.render_for_view_only(:subrecord_type => 'linked_records', :property => :none, :anchor => 'search_embedded') %>
+  <%= sidebar.render_for_view_only(:subrecord_type => 'linked_records', :property => :none, :anchor => 'container_contents') %>
 
 <% end %>

--- a/frontend/app/views/top_containers/show.html.erb
+++ b/frontend/app/views/top_containers/show.html.erb
@@ -99,6 +99,8 @@
 
           <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @top_container, :filter_term => {"top_container_uri_u_sstr" => @top_container.uri}.to_json, :heading_text => I18n.t("location._frontend.section.search_embedded")} %>
 
+          <%= show_plugins_for(@top_container, readonly) %>
+
           <hr>
           <%= display_audit_info(@top_container) %>
         <% end %>

--- a/frontend/app/views/top_containers/show.html.erb
+++ b/frontend/app/views/top_containers/show.html.erb
@@ -15,6 +15,10 @@
 
         <% define_template "top_container", jsonmodel_definition(:top_container) do |form| %>
 
+          <%= render_plugin_partials("top_of_basic_information_top_container",
+                                     :form => form,
+                                     :record => @top_container) %>
+
           <% if @top_container.container_profile %>
             <div class="form-group token-list">
                 <label class="control-label col-sm-2"><%= I18n.t("container_profile._singular") %></label>
@@ -36,6 +40,9 @@
           <%= readonly.label_and_textarea "ils_item_id" %>
           <%= readonly.label_and_textarea "exported_to_ils", :default => I18n.t("top_container.not_exported") %>
 
+          <%= render_plugin_partials("basic_information_top_container",
+                                     :form => readonly,
+                                     :record => @top_container) %>
 
 
           <% if @top_container["container_locations"].length > 0 %>

--- a/frontend/app/views/top_containers/show.html.erb
+++ b/frontend/app/views/top_containers/show.html.erb
@@ -97,7 +97,7 @@
             <% end %>
           </section>
 
-          <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @top_container, :filter_term => {"top_container_uri_u_sstr" => @top_container.uri}.to_json, :heading_text => I18n.t("location._frontend.section.search_embedded")} %>
+          <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @top_container, :section_id => "container_contents", :filter_term => {"top_container_uri_u_sstr" => @top_container.uri}.to_json, :heading_text => I18n.t("location._frontend.section.search_embedded")} %>
 
           <%= show_plugins_for(@top_container, readonly) %>
 

--- a/frontend/config/application.rb
+++ b/frontend/config/application.rb
@@ -165,7 +165,7 @@ Rails.application.config.after_initialize do
 end
 
 # Load plugin init.rb files (if present)
-ASUtils.find_local_directories('frontend').each do |dir|
+ASUtils.order_plugins(ASUtils.find_local_directories('frontend')).each do |dir|
   init_file = File.join(dir, "plugin_init.rb")
   if File.exist?(init_file)
     load init_file

--- a/frontend/config/initializers/plugin.rb
+++ b/frontend/config/initializers/plugin.rb
@@ -32,6 +32,7 @@ module Plugins
 
     @sections = []
     @fields_to_resolve = []
+    @edit_roles = []
   end
 
 
@@ -77,6 +78,17 @@ module Plugins
 
   def self.fields_to_resolve
     @fields_to_resolve
+  end
+
+
+  EditRole = Struct.new(:jsonmodel_type, :role)
+  def self.register_edit_role_for_type(jsonmodel_type, role)
+    @edit_roles << EditRole.new(jsonmodel_type, role)
+  end
+
+
+  def self.edit_roles
+    @edit_roles
   end
 
 

--- a/frontend/config/initializers/plugin.rb
+++ b/frontend/config/initializers/plugin.rb
@@ -31,6 +31,7 @@ module Plugins
     end
 
     @sections = []
+    @fields_to_resolve = []
   end
 
 
@@ -66,6 +67,16 @@ module Plugins
 
   def self.plugins_for(parent)
     @config[:parents][parent] || []
+  end
+
+
+  def self.add_resolve_field(field_name)
+    @fields_to_resolve += ASUtils.wrap(field_name)
+  end
+
+
+  def self.fields_to_resolve
+    @fields_to_resolve
   end
 
 

--- a/frontend/config/initializers/plugin.rb
+++ b/frontend/config/initializers/plugin.rb
@@ -29,6 +29,8 @@ module Plugins
     if @config[:repository_menu_items].length > 0
       puts "Found repository menu items for plug-ins: #{repository_menu_items.inspect}"
     end
+
+    @sections = []
   end
 
 
@@ -66,6 +68,136 @@ module Plugins
     @config[:parents][parent] || []
   end
 
+
+  def self.register_plugin_section(plugin_section)
+    @sections << plugin_section
+  end
+
+  def self.sections_for(record, mode)
+    @sections.select{|plugin_section| plugin_section.supports?(record, mode)}
+  end
+
+
+  class AbstractPluginSection
+    def initialize(plugin, name, jsonmodel_types, opts = {})
+      @plugin = plugin
+      @name = name
+      @jsonmodel_types = ASUtils.wrap(jsonmodel_types)
+
+      parse_opts(opts)
+    end
+
+    def render_edit(view_context, record, form_context)
+      raise "IMPLEMENT ME"
+    end
+
+    def render_readonly(view_context, record, form_context)
+      raise "IMPLEMENT ME"
+    end
+
+    def render_sidebar(view_context, record, mode)
+      "<li>" +
+        "  <a href='##{build_section_id(record['jsonmodel_type'])}'>" +
+        "    #{@sidebar_label}" +
+        "    <span class='glyphicon glyphicon-chevron-right'></span>" +
+        "  </a>" +
+        "</li>".html_safe
+    end
+
+    def supports?(record, mode)
+      @jsonmodel_types.include?(record['jsonmodel_type']) &&
+        (mode == :edit && @show_on_edit ||
+          mode == :readonly && @show_on_readonly)
+    end
+
+    private
+
+    def parse_opts(opts)
+      @show_on_edit = opts.fetch(:show_on_edit, true)
+      @show_on_readonly = opts.fetch(:show_on_readonly, true)
+      @section_id = opts.fetch(:section_id, nil)
+      @sidebar_label = opts.fetch(:sidebar_label, I18n.t("plugins.#{@plugin}.#{@name}.section"))
+    end
+
+    def build_section_id(jsonmodel_type)
+      @section_id ? @section_id : "#{jsonmodel_type}_#{@name}"
+    end
+  end
+
+
+  class PluginSubRecord < AbstractPluginSection
+
+    def render_edit(view_context, record, form_context)
+      view_context.render_aspace_partial(
+        :partial => "shared/subrecord_form",
+        :locals => {
+          :form => form_context,
+          :name => @jsonmodel_field,
+          :cardinality => @cardinality,
+          :template => @template_name,
+          :template_erb => @erb_edit_template_path,
+          :js_template_name => @js_edit_template_name,
+          :section_id => build_section_id(form_context.obj['jsonmodel_type']),
+        })
+    end
+
+    def render_readonly(view_context, record, form_context)
+      view_context.render_aspace_partial(
+        :partial => @erb_readonly_template_path,
+        :locals => { @jsonmodel_field.intern => record.send(@jsonmodel_field.intern),
+                     :context => form_context,
+                     :section_id => build_section_id(form_context.obj['jsonmodel_type']) })
+    end
+
+    def supports?(record, mode)
+      result = super
+      if result && mode == :readonly
+        Array(record.send(@jsonmodel_field.intern)).length > 0
+      else
+        result
+      end
+    end
+
+    private
+
+    def parse_opts(opts)
+      super
+
+      @jsonmodel_field = opts.fetch(:jsonmodel_field, @name)
+      @cardinality = opts.fetch(:cardinality, :zero_to_many)
+      @template_name = opts.fetch(:template_name, @name)
+      @erb_edit_template_path = opts.fetch(:erb_edit_template_path, "#{@name}/template")
+      @js_edit_template_name = opts.fetch(:js_edit_template_name, "template_#{@name}")
+      @erb_readonly_template_path = opts.fetch(:erb_readonly_template_path, "#{@name}/show_as_subrecords")
+    end
+  end
+
+
+  class PluginReadonlySearch < AbstractPluginSection
+
+    def render_readonly(view_context, record, form_context)
+      view_context.render_aspace_partial(
+        :partial => "search/embedded",
+        :locals => {
+          :record => record,
+          :filter_term => @filter_term_proc.call(record),
+          :heading_text => @heading_text,
+          :section_id => @section_id ? @section_id : build_section_id(form_context.obj['jsonmodel_type']),
+        }
+      )
+    end
+
+    private
+
+    def parse_opts(opts)
+      super
+
+      @show_on_edit = false
+      @filter_term_proc = opts.fetch(:filter_term_proc)
+      @heading_text = opts.fetch(:heading_text)
+    end
+
+  end
 end
 
 Plugins::init

--- a/frontend/config/initializers/plugin.rb
+++ b/frontend/config/initializers/plugin.rb
@@ -33,8 +33,47 @@ module Plugins
     @sections = []
     @fields_to_resolve = []
     @edit_roles = []
+
+    @base_facets = []
+    @facets_for_type = {}
+
+    @facet_group_i18n_handlers = {}
   end
 
+
+  def self.add_search_base_facets(*facets)
+    @base_facets ||= []
+    @base_facets += facets
+  end
+
+  def self.add_search_facets(jsonmodel_type, *facets)
+    @facets_for_type[jsonmodel_type.to_s] ||= []
+    @facets_for_type[jsonmodel_type.to_s] += facets
+  end
+
+  def self.search_facets_for_type(jsonmodel_type)
+    @facets_for_type.fetch(jsonmodel_type.to_s, [])
+  end
+
+  def self.search_facets_for_base
+    @base_facets
+  end
+
+  def self.add_facet_group_i18n(facet_group, proc)
+    @facet_group_i18n_handlers[facet_group] = proc
+  end
+
+  # Invoke a handler to determine the i18n key for facet_group and facet.
+  # If there isn't one, return nil.
+  def self.facet_i18n_key(facet_group, facet)
+    handler = @facet_group_i18n_handlers.fetch(facet_group, nil)
+
+    if handler
+      handler.call(facet)
+    else
+      nil
+    end
+  end
 
   def self.system_menu_items
     Array(@config[:system_menu_items]).flatten

--- a/frontend/config/initializers/plugin.rb
+++ b/frontend/config/initializers/plugin.rb
@@ -38,6 +38,8 @@ module Plugins
     @facets_for_type = {}
 
     @facet_group_i18n_handlers = {}
+
+    @note_types_handlers = []
   end
 
 
@@ -137,6 +139,21 @@ module Plugins
 
   def self.sections_for(record, mode)
     @sections.select{|plugin_section| plugin_section.supports?(record, mode)}
+  end
+
+
+  def self.handle_note_types_for(jsonmodel_type, note_types, context)
+    @note_types_handlers.each do |proc|
+      note_types = proc.call(jsonmodel_type, note_types, context)
+    end
+
+    note_types
+  end
+
+  def self.register_note_types_handler(proc)
+    # Ensure your proc returns the note_types as this will be passed to the next
+    # handler and onwards to the template
+    @note_types_handlers << proc
   end
 
 

--- a/frontend/config/initializers/plugin.rb
+++ b/frontend/config/initializers/plugin.rb
@@ -239,7 +239,7 @@ module Plugins
 
     def render_readonly(view_context, record, form_context)
       view_context.render_aspace_partial(
-        :partial => "search/embedded",
+        :partial => @erb_template,
         :locals => {
           :record => record,
           :filter_term => @filter_term_proc.call(record),
@@ -257,6 +257,7 @@ module Plugins
       @show_on_edit = false
       @filter_term_proc = opts.fetch(:filter_term_proc)
       @heading_text = opts.fetch(:heading_text)
+      @erb_template = opts.fetch(:erb_template, "search/embedded")
     end
 
   end

--- a/frontend/config/initializers/plugin.rb
+++ b/frontend/config/initializers/plugin.rb
@@ -138,7 +138,7 @@ module Plugins
   end
 
   def self.sections_for(record, mode)
-    @sections.select{|plugin_section| plugin_section.supports?(record, mode)}
+    @sections.select {|plugin_section| plugin_section.supports?(record, mode)}
   end
 
 

--- a/frontend/spec/selenium/spec/classifications_spec.rb
+++ b/frontend/spec/selenium/spec/classifications_spec.rb
@@ -158,10 +158,10 @@ describe 'Classifications' do
     run_all_indexers
 
     @driver.get_view_page(a_classification)
-    expect(@driver.find_element(:css, '#search_embedded').text).to match(/#{a_resource.title}/)
+    expect(@driver.find_element(:css, '#classifications').text).to match(/#{a_resource.title}/)
     sleep 30
     tree_click(tree_node(a_term))
     @driver.wait_for_ajax
-    expect(@driver.find_element(:css, '#search_embedded').text).to match(/#{an_accession.title}/)
+    expect(@driver.find_element(:css, '#classifications').text).to match(/#{an_accession.title}/)
   end
 end

--- a/frontend/spec/selenium/spec/notes_spec.rb
+++ b/frontend/spec/selenium/spec/notes_spec.rb
@@ -24,19 +24,19 @@ describe 'Notes' do
 
   it 'can attach notes to resources' do
     add_note = proc do |type|
-      @driver.find_element(css: '#notes .subrecord-form-heading .btn.add-note').click
-      @driver.find_last_element(css: '#notes select.top-level-note-type:last-of-type').select_option(type)
+      @driver.find_element(css: '#resource_notes_ .subrecord-form-heading .btn.add-note').click
+      @driver.find_last_element(css: '#resource_notes_ select.top-level-note-type:last-of-type').select_option(type)
     end
 
     3.times do
       add_note.call('note_multipart')
     end
 
-    expect(@driver.blocking_find_elements(css: '#notes > .subrecord-form-container > .subrecord-form-list > li').length).to eq(3)
+    expect(@driver.blocking_find_elements(css: '#resource_notes_ > .subrecord-form-container > .subrecord-form-list > li').length).to eq(3)
   end
 
   it 'confirms before removing a note entry' do
-    notes = @driver.blocking_find_elements(css: '#notes > .subrecord-form-container > .subrecord-form-list > li')
+    notes = @driver.blocking_find_elements(css: '#resource_notes_ > .subrecord-form-container > .subrecord-form-list > li')
 
     notes[0].find_element(css: '.subrecord-form-remove').click
 
@@ -57,7 +57,7 @@ describe 'Notes' do
     @driver.click_and_wait_until_gone(css: '.subrecord-form-removal-confirmation .btn-primary')
 
     # One left!
-    expect(@driver.blocking_find_elements(css: '#notes > .subrecord-form-container > .subrecord-form-list > li').length).to eq(1)
+    expect(@driver.blocking_find_elements(css: '#resource_notes_ > .subrecord-form-container > .subrecord-form-list > li').length).to eq(1)
 
     # Fill it out
     @driver.clear_and_send_keys([:id, 'resource_notes__2__label_'],
@@ -79,7 +79,7 @@ describe 'Notes' do
     end
 
 
-    notes = @driver.blocking_find_elements(css: '#notes .subrecord-form-fields')
+    notes = @driver.blocking_find_elements(css: '#resource_notes_ .subrecord-form-fields')
 
     # Add a sub note
     notes[0].find_element(css: '.collapse-subrecord-toggle').click
@@ -123,12 +123,12 @@ describe 'Notes' do
     end
 
     # Add a multipart note
-    @driver.find_element(css: '#notes > .subrecord-form-heading .btn.add-note').click
+    @driver.find_element(css: '#resource_notes_ > .subrecord-form-heading .btn.add-note').click
     @driver.find_last_element(css: 'select.top-level-note-type').select_option('note_multipart')
     @driver.execute_script("$('#resource_notes__1__subnotes__0__content_').data('CodeMirror').setValue('Note Content')")
     @driver.execute_script("$('#resource_notes__1__subnotes__0__content_').data('CodeMirror').save()")
     @driver.execute_script("$('#resource_notes__1__subnotes__0__content_').data('CodeMirror').toTextArea()")
-    note = @driver.blocking_find_elements(css: '#notes .subrecord-form-fields')[1]
+    note = @driver.blocking_find_elements(css: '#resource_notes_ .subrecord-form-fields')[1]
 
     # Add a subnote with 4 ordered list items
     assert(5) { note.find_element(css: '.subrecord-form-heading .btn:not(.show-all)').click }
@@ -148,7 +148,7 @@ describe 'Notes' do
 
     # Save the resource and confirm items are in proper position
     @driver.find_element(css: "form#resource_form button[type='submit']").click
-    @driver.find_element(css: '#notes #resource_notes__1_ .collapse-subrecord-toggle').click
+    @driver.find_element(css: '#resource_notes_ #resource_notes__1_ .collapse-subrecord-toggle').click
     @driver.wait_for_ajax
 
     [0, 1, 2, 3].each do |i|
@@ -170,7 +170,7 @@ describe 'Notes' do
 
     # Save the resource and confirm all items are in proper position
     @driver.find_element(css: "form#resource_form button[type='submit']").click
-    @driver.find_element(css: '#notes #resource_notes__1_ .collapse-subrecord-toggle').click
+    @driver.find_element(css: '#resource_notes_ #resource_notes__1_ .collapse-subrecord-toggle').click
     @driver.wait_for_ajax
 
     [0, 1, 2, 3, 4, 5].each do |i|
@@ -183,7 +183,7 @@ describe 'Notes' do
 
     bibliography_content = 'Top-level bibliography content'
 
-    @driver.find_element(css: '#notes > .subrecord-form-heading .btn.add-note').click
+    @driver.find_element(css: '#resource_notes_ > .subrecord-form-heading .btn.add-note').click
     @driver.find_last_element(css: 'select.top-level-note-type').select_option('note_bibliography')
 
     @driver.clear_and_send_keys([:id, 'resource_notes__2__label_'], 'Top-level bibliography label')
@@ -205,7 +205,7 @@ describe 'Notes' do
 
   it 'can wrap note content text with EAD mark up' do
     # expand the first note
-    @driver.find_element(css: '#notes .collapse-subrecord-toggle').click
+    @driver.find_element(css: '#resource_notes_ .collapse-subrecord-toggle').click
     @driver.wait_for_ajax
 
     @driver.find_element_orig(:css, '#resource_notes__0__subnotes__0__content_').wait_for_class('initialised')
@@ -397,8 +397,8 @@ describe 'Notes' do
 
   it 'shows a validation error when note content is empty' do
     @driver.get_edit_page(@resource2)
-    @driver.find_element(css: '#notes .subrecord-form-heading .btn.add-note').click
-    @driver.find_last_element(css: '#notes select.top-level-note-type:last-of-type').select_option('note_singlepart')
+    @driver.find_element(css: '#resource_notes_ .subrecord-form-heading .btn.add-note').click
+    @driver.find_last_element(css: '#resource_notes_ select.top-level-note-type:last-of-type').select_option('note_singlepart')
     # Save the resource
     @driver.click_and_wait_until_gone(css: "form#resource_form button[type='submit']")
     assert(5) { expect(@driver.find_element(css: 'div.alert.alert-danger').text).to eq('Content - At least 1 item(s) is required') }

--- a/frontend/spec/selenium/spec/resources_spec.rb
+++ b/frontend/spec/selenium/spec/resources_spec.rb
@@ -64,7 +64,7 @@ describe 'Resources and archival objects' do
     expect(@driver.find_elements(:id, 'resource_collection_management__cataloged_note_').length).to eq(0)
 
     # condition and content descriptions have come across as notes fields
-    notes_toggle = @driver.blocking_find_elements(css: '#notes .collapse-subrecord-toggle')
+    notes_toggle = @driver.blocking_find_elements(css: '#resource_notes_ .collapse-subrecord-toggle')
     notes_toggle[0].click
     @driver.wait_for_ajax
 

--- a/indexer/app/main.rb
+++ b/indexer/app/main.rb
@@ -95,7 +95,7 @@ class ArchivesSpaceIndexer < Sinatra::Base
   configure do
     begin
       # Load plugin init.rb files (if present)
-      ASUtils.find_local_directories('indexer').each do |dir|
+      ASUtils.order_plugins(ASUtils.find_local_directories('indexer')).each do |dir|
         init_file = File.join(dir, "plugin_init.rb")
         if File.exists?(init_file)
           load init_file

--- a/public/config/application.rb
+++ b/public/config/application.rb
@@ -101,7 +101,7 @@ module ArchivesSpacePublic
 end
 
 # Load plugin init.rb files (if present)
-ASUtils.find_local_directories('public').each do |dir|
+ASUtils.order_plugins(ASUtils.find_local_directories('public')).each do |dir|
   init_file = File.join(dir, "plugin_init.rb")
   if File.exist?(init_file)
     load init_file


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Includes 30 commits from the larger #1896  written by @marktriggs @jambun @payten and funded by Queensland State Archives.

- 3dc860ae6913bf570c5b84869cb011fecb548290: Introduce AbstractPluginSection (and examples) to allow arbitrary content to be appended to record's form and readonly views
- 1b60f76524c90487f9deefa87826ef86240e2d53: Introduce Plugins.add_resolve_field to allow a plugin to easily add a resolve[] entry to the ApplicationController.find_opts
- e5e443f22aa4c63cbb87266e604731d74a468348: Introduce Plugin.register_edit_role_for_type to allow a plugin to hook into SearchHelper.can_edit_search_result?
- ab203144279f797bc2eaa7c258409978b8a8a7cd: Add hook to allow plugin to append to date template
- bcf09e99e67e56c98e49b4f3521ea1037d22885b: Add plugin hooks for "Basic Information"
- 59e90a8739791a5fcc57a273f7a70aa75a4d9fa0: Fix both form_plugins_for and show_plugins_for outputting content and causing duplicate data on the assessment readonly view
- 64781fc60b6fc4bd0e222e4cc8766dff5d39646d: Add the ability for plugins to define their own facets and the I18n translations for them
- 07efbdbe82430826ce0d69a11f6843fcfbba3ca8: Extend Plugins::PluginReadonlySearch to allow override of the erb template used
- 40a743ae55145abbc01be7b1b961f23c23799bf7: Add plugin hook for sub_container readonly/form templates
- 1f4f34dd7cc655fc4a6e6d68cd8a5d8ff8c35cf8: Add support for plugins defining dependencies
- deb16fc488916d0e4cff901de738cf0e21655bb9: Allow extra_params to optionally be passed to AjaxTree.prototype.add_new_after to allow extra params on the ajax call to populate the new form for a tree node
- 2124895d542337c51bf083a0506a7d2c6fe44da6: Add plugin sections hook to top_container
- ee86ec53e6ce900050cc643a6f1309cc0ee3c3fd: Added form_plugins_for to top container form
- 9d9829def197c614780706efaa2d44f9856f8955: Add render plugin partials to top container
- 1afcc862a40d5b84437390d70ec89b8089a6453c: Add a new hook to run once all plugins have been loaded
- 2328bac0040b4d914a890d0eb8c69becd5c92e16: Fetch the note enum type from the schema
- c3d9c099b0ece804be416f210125d3e1c66a5727: Add plugin hook for NotesHandler.note_types_for
- f3c9054d670fef63a1d18d8343da6a3d5c46ae58: Add support for post-processing the result of resolving records
- 751b9af03943d916a6c03c72d5d5e247bceee1b7: Trigger on form load to give plugin JS a chance to fire
- 4b34295d8816ca5b2128fa2c7dc2a806dad2d8a4: Add a way to hide irrelevant permissions from users
- 6624524934617e137293a156b75cb099f75676eb: Pass the gemfile & line number through
- ee2eb6ac6d9096919ac7c0213ac6a8ed46cc7b1f: Refactor JobsController so can override download file format/extension via plugins
- 0e88f082c456a39be938f639629eafdb8162e39f: Add Archival Object facets
- a8aa9907431722a83f96f03c0ca91d0eaae3e358: Add some CSS classes to the search listing filter so can style facets
- 829af1088df1ef1f8f69cd4b28b319bdcb1cc505: Move tooltip generation logic into a method
- 887fe736433356bf347327a3774b797c270feb1a: Use a more distinguished section id for resource notes
- 85fd61e13e304a4c1acf4382b58a7ff2e4408ee4: Move Sequence generation outside of the current transaction
- b4050e897b93c854947a76af34e78d8bd9477165: Give search embedded sections unique and descriptive section_ids and corresponding sidebar anchors
- a17c0e4bffd570718151b655f023b8a17413eb66: Add plugin sections hook to repository
- f9958e52ecd8011aa36832767537426f6c351fb2: Extend PluginReadonlySearch to support a new add only_show_if_results so section may only be rendered if there are results


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Additional documentation related to 3dc860ae6913bf570c5b84869cb011fecb548290 has already been PRed and merged into tech docs: https://archivesspace.github.io/tech-docs/customization/plugins.html

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
#1896 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
