### PR TITLE
Post-3.0 updates to LCNAF plugin tests

### DIFF
--- a/plugins/lcnaf/frontend/spec/lcnaf_client_spec.rb
+++ b/plugins/lcnaf/frontend/spec/lcnaf_client_spec.rb
@@ -40,11 +40,34 @@ describe "id.loc.gov clientware" do
     end
 
 
-    it "can take a set of IDs and make a marcxml collection of the records" do
-      # TO-DO: This test doesn't do anything but puts a marc file?
+    it "can take a set of agent IDs and prepare them for the auth importer" do
       lccns = %w(no92032176 nr91032543)
       marcxml_file = loc_searcher.results_to_marcxml_file(lccns)
-      puts IO.read(marcxml_file)
+      expect(marcxml_file[:agents][:count]).to eq(2)
+      expect(marcxml_file[:subjects][:count]).to eq(0)
+    end
+
+
+    it "can take a set of subject IDs and prepare them for the bib importer" do
+      lccns = %w(n79053099 n81038610)
+      marcxml_file = loc_searcher.results_to_marcxml_file(lccns)
+      expect(marcxml_file[:agents][:count]).to eq(0)
+      expect(marcxml_file[:subjects][:count]).to eq(2)
+    end
+
+
+    it "can take a mixed set of agent and subject IDs and prepare them for the both importers" do
+      lccns = %w(no92032176 n81038610)
+      marcxml_file = loc_searcher.results_to_marcxml_file(lccns)
+      expect(marcxml_file[:agents][:count]).to eq(1)
+      expect(marcxml_file[:subjects][:count]).to eq(1)
+    end
+
+
+    it "can take a set of IDs and make a marcxml collection of the records" do
+      lccns = %w(no92032176 nr91032543)
+      marcxml_file = loc_searcher.results_to_marcxml_file(lccns)
+      expect(IO.read(marcxml_file[:agents][:file])).to include("<record>")
     end
 
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I've wanted to do this for a while, so finally took the chance to update these.  This fixes all lcnaf plugin tests so that they are now passing (and actually testing things) in a post-3.0 world.  

TO-DO: We should probably discuss adding a github workflow to run `frontend:test:plugin` so that these continue to get tests regularly if plugins (or at least this plugin) is going to remain in core for any period of time.  Currently, the lcnaf plugin is the only plugin in the core code that includes tests.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
