### PR TITLE
ANW-1119 Redirect to top containers index page post merge

### DIFF
--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -172,8 +172,12 @@ class ApplicationController < ActionController::Base
 
       flash[:success] = I18n.t("#{merge_type}._frontend.messages.merged")
 
-      resolver = Resolver.new(target_uri)
-      redirect_to(resolver.view_uri)
+      if merge_type == 'top_container'
+        redirect_to(:controller => :top_containers, :action => :index)
+      else
+        resolver = Resolver.new(target_uri)
+        redirect_to(resolver.view_uri)
+      end
     rescue ValidationException => e
       flash[:error] = e.errors.to_s
       redirect_to({:action => :show, :id => id}.merge(extra_params))

--- a/frontend/spec/selenium/spec/instances_and_containers_spec.rb
+++ b/frontend/spec/selenium/spec/instances_and_containers_spec.rb
@@ -122,6 +122,7 @@ describe 'Resource instances and containers' do
 
     # Should be redirected to surviving top container with success message
     expect do
+      @driver.find_element_with_text('//h3', /Top Containers/)
       @driver.find_element_with_text('//div[contains(@class, "alert-success")]', /Top .+ Merged/)
     end.not_to raise_error
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#1764 added the ability to batch merge top containers from the manage top containers page.  Based on the existing `handle_merge` method in application_controller, this meant a successful merge resulted in a redirect to the surviving top container page.  ANW-1119 requested this be changed to redirect back to the Manage Top Containers screen post-merge.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1119

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated existing test to confirm redirect to Manage Top Containers.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
