### PR TITLE
Don't drop agent contact notes on migration

### DIFF
--- a/common/db/migrations/142_update_existing_tables_for_agents.rb
+++ b/common/db/migrations/142_update_existing_tables_for_agents.rb
@@ -1,5 +1,29 @@
 require_relative 'utils'
 
+def migrate_contact_notes(ac_notes)
+  # Find all agent_contact notes
+  ac_notes.each do |ac|
+    self[:note].insert(
+      :notes_json_schema_version => 1,
+      :notes => blobify(self, JSON.generate({
+                                  'jsonmodel_type' => 'note_contact_note',
+                                  'date_of_contact' => "Before #{Time.now.strftime("%Y-%m-%d")}",
+                                  'contact_notes' => ac[:note],
+                                  'persistent_id' => SecureRandom.hex
+                                })),
+      :last_modified_by => ac[:last_modified_by],
+      :created_by => 'admin',
+      :create_time => ac[:create_time],
+      :system_mtime => Time.now,
+      :user_mtime => ac[:user_mtime],
+      :agent_contact_id => ac[:id]
+      )
+
+    self[:agent_contact].where(id: ac[:id]).update(note: nil)
+
+  end
+end
+
 Sequel.migration do
   $stderr.puts "Creating new agents tables"
   up do
@@ -41,14 +65,24 @@ Sequel.migration do
       add_column(:agent_function_id, Integer, :null => true)
       add_column(:agent_gender_id, Integer, :null => true)
       add_column(:used_language_id, Integer, :null => true)
-    end
-
-    alter_table(:agent_contact) do
-      drop_column(:note)
-    end
-
-    alter_table(:note) do
       add_column(:agent_contact_id, Integer, :null => true)
     end
+
+    ac_notes = self[:agent_contact].filter(Sequel.~(:note => nil))
+    migrate_contact_notes(ac_notes) unless ac_notes.count == 0
+
+    # Attempt to delete old agent contact notes
+    if ac_notes.count == 0
+      alter_table(:agent_contact) do
+        drop_column(:note)
+      end
+    else
+      $stderr.puts("WARNING: we tried to drop the column " +
+                   "'agent_contact.note' as a part of " +
+                   "migration 142_update_existing_tables_for_agents.rb but " +
+                   "there's still data in it.  Please contact " +
+                   "support as your migration may be incomplete.")
+    end
+
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Corrects issues introduced in original 142 migration wherein `notes` that contained data were dropped from the `agent_contact` table instead of being migrated to the `notes` tables.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
