### PR TITLE
force plugin load paths to the back

### DIFF
--- a/common/aspace_i18n.rb
+++ b/common/aspace_i18n.rb
@@ -17,7 +17,6 @@ I18n.load_path += Dir[File.join(ASUtils.find_base_directory, 'reports', '**', '*
 
 I18n.default_locale = AppConfig[:locale]
 
-
 module I18n
 
   LOCALES = {
@@ -33,6 +32,10 @@ module I18n
 
   def self.t(*args)
     self.t_raw(*args)
+  end
+
+  def self.prioritize_plugins!
+    self.load_path = self.load_path.reject { |p| p.match /plugins\// } + self.load_path.reject { |p| !p.match /plugins\// }
   end
 
 end

--- a/frontend/config/application.rb
+++ b/frontend/config/application.rb
@@ -162,6 +162,7 @@ Rails.application.config.after_initialize do
   JSONModel(:top_container)
   JSONModel(:sub_container)
   JSONModel(:container_profile)
+  I18n.prioritize_plugins!
 end
 
 # Load plugin init.rb files (if present)


### PR DESCRIPTION
Rather than risk breaking anything by refactoring load path loading, just tack on a reorder at the end. But they should be refactored and normalized between frontend and public. 

## Description
Solves the problem of local locale overrides not affecting the staff application.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1222

## How Has This Been Tested?
It is hard to test this - perhaps we need a separate build task for testing plugins.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
