### PR TITLE
allow a title field if the agent is a subject or creator

### DIFF
--- a/frontend/app/assets/javascripts/agents.crud.js
+++ b/frontend/app/assets/javascripts/agents.crud.js
@@ -147,7 +147,7 @@ $(function() {
       }
 
       var creator_title = $subform.find('.agent-creator-title').show();
-      if ($(this).val() == 'creator') {
+      if ($(this).val() == 'creator' || $(this).val() == 'subject') {
         creator_title.show().find(':input').removeAttr('disabled');
       } else {
         creator_title.hide().find(':input').attr('disabled', 'disabled');


### PR DESCRIPTION
Don't hide the 'title' field when the linked agent is a subject.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-530

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
