### PR TITLE
ANW-1191 Returns contact notes to repository records

### DIFF
--- a/frontend/app/views/agents/_contact_details.html.erb
+++ b/frontend/app/views/agents/_contact_details.html.erb
@@ -41,9 +41,7 @@
     
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => { :form => form,  :name => "telephones", :heading_size => "h4" } %>
 
-    <% unless @repository %>
-      <%= render_aspace_partial :partial => "notes/form", :locals => {:form => form, :all_note_types => note_types_for("agent_contact"), :section_id => "agent_contact_notes", :nested_note_jsonmodel => "agent_contact", :header_size => "h4", :add_button_text => "note._frontend.action.add_for_contact_note", :show_apply_note_order_action => false} %>
-    <% end %>
+    <%= render_aspace_partial :partial => "notes/form", :locals => {:form => form, :all_note_types => note_types_for("agent_contact"), :section_id => "agent_contact_notes", :nested_note_jsonmodel => "agent_contact_notes", :header_size => "h4", :add_button_text => "note._frontend.action.add_for_contact_note", :show_apply_note_order_action => false} %>
 
   </div>
 <% end %>

--- a/frontend/app/views/notes/_form.html.erb
+++ b/frontend/app/views/notes/_form.html.erb
@@ -14,7 +14,7 @@
 <%= render_aspace_partial :partial => "notes/template", :locals =>  { :all_note_types => all_note_types, :form_note_type => section_id, :nested_in_jsonmodel => nested_in_jsonmodel } %>
 
 <section id="<%= section_id %>"
-         class="subrecord-form notes-form  <%= "note-inline" if inline? %>"
+         class="subrecord-form notes-form <%= "note-inline" if inline? %>"
          <%= "data-template=template_#{nested_note_jsonmodel}_note_type_selector_inline" if nested_note_jsonmodel %>>
   <<%= header_size%> class="subrecord-form-heading">
     <%= wrap_with_tooltip(I18n.t("note._plural"), "#{form.i18n_for('notes')}_tooltip", "subrecord-form-heading-label") %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Following changes in #2276 and proposed changes in #2277, return note subrecord to the agent contact section of a repository page.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This required updating the `nested_note_jsonmodel` name so that the disabled remove button on the top-level agent contact, wasn't also incorrectly being applied to the embedded notes as well.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Continuation of https://archivesspace.atlassian.net/browse/ANW-1191

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
