### PR TITLE
ANW-511: moving publish form controls in accession edit/new form towards top o…

### DIFF
--- a/frontend/app/views/accessions/_form.html.erb
+++ b/frontend/app/views/accessions/_form.html.erb
@@ -17,6 +17,7 @@
        <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @accession} if AppConfig[:use_human_readable_urls] %>
 
        <%= form.label_and_date "accession_date" %>
+       <%= form.label_and_boolean "publish", {}, user_prefs["publish"] %>
        <%= form.label_and_textarea "content_description" %>
        <%= form.label_and_textarea "condition_description" %>
        <%= form.label_and_textarea "disposition" %>
@@ -27,7 +28,6 @@
        <%= form.label_and_select "acquisition_type", form.possible_options_for("acquisition_type", true) %>
        <%= form.label_and_select "resource_type", form.possible_options_for("resource_type", true) %>
        <%= form.label_and_boolean "restrictions_apply", {}, form.default_for("restrictions_apply") %>
-       <%= form.label_and_boolean "publish", {}, user_prefs["publish"] %>
        <%= form.label_and_boolean "access_restrictions", {}, form.default_for("access_restrictions") %>
        <%= form.label_and_textarea "access_restrictions_note" %>
        <%= form.label_and_boolean "use_restrictions", {}, form.default_for("use_restrictions") %>


### PR DESCRIPTION
…f page

<!--- Provide a general summary of your changes in the Title above -->

## Description
For improved UI and accessibility, move publish option higher up on the page for the accession edit/new form

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-511?filter=myopenissues

## How Has This Been Tested?
Manual in browser testing 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
