### PR TITLE
push frontend locales to the front of the public I18n stack

### DIFF
--- a/public/config/initializers/locales.rb
+++ b/public/config/initializers/locales.rb
@@ -1,0 +1,2 @@
+I18n.prioritize_plugins!
+I18n.load_path = I18n.load_path.reject { |p| !p.match /frontend\// } + I18n.load_path.reject { |p| p.match /frontend\// }


### PR DESCRIPTION
Make sure any frontend paths in the public I18n path are at the front of the I18n load path.

## Description
Ensures that frontend translation will not clobber public translation. 

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1222

## How Has This Been Tested?
Tested conflicting translation in plugin/local frontend and public directories.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
