### PR TITLE
Refer to archival object's id and identifier instead of root record's

### DIFF
--- a/reports/assessments/assessment_linked_records_subreport/assessment_linked_records_subreport.rb
+++ b/reports/assessments/assessment_linked_records_subreport/assessment_linked_records_subreport.rb
@@ -18,10 +18,10 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
     union
 
     (select
-      resource.id as record_id,
+      archival_object.id as record_id,
       'Archival Object' as linked_record_type,
       ifnull(archival_object.title, archival_object.display_string) as record_title,
-      resource.identifier as identifier
+      archival_object.component_id as identifier
     from assessment_rlshp
       join archival_object on assessment_rlshp.archival_object_id = archival_object.id
       join resource on archival_object.root_record_id = resource.id
@@ -51,7 +51,7 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
   end
 
   def fix_row(row)
-    ReportUtils.fix_identifier_format(row) unless row[:linked_record_type] == 'Digital Object'
+    ReportUtils.fix_identifier_format(row) unless row[:linked_record_type].include?('Object')
     ReportUtils.fix_id(row)
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This minor pull request adjusts the output of the assessment linked records subreport to resolve an apparent bug. Previously, if an archival object appeared in the assessment record list report, its record id would be given as `archival_object_{root_record_id}` rather than `archival_object_{id}`, and its identifier would be given as its root record's identifier. This meant that the identifier didn't match up with the title given, and the record id was inevitably for a completely different record.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
This issue was spotted during local testing and hasn't been submitted as a JIRA Ticket or GitHub issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally tested and backend and frontend test suites run (though this functionality didn't appear to be covered by any tests).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
