### PR TITLE
Updates to pass tests with external Solr (v8)

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -88,7 +88,7 @@ AppConfig[:solr_backup_directory] = proc { File.join(AppConfig[:data_directory],
 # For more information about solr parameters, please consult the solr documentation
 # here: https://lucene.apache.org/solr/
 # Configuring search operator to be AND by default - ANW-427
-AppConfig[:solr_params] = { 'mm' => '100%' }
+AppConfig[:solr_params] = { 'q.op' => 'AND' }
 
 # Set the application's language (see the .yml files in
 # https://github.com/archivesspace/archivesspace/tree/master/common/locales for

--- a/frontend/app/views/agents/_merge_dropdown.html.erb
+++ b/frontend/app/views/agents/_merge_dropdown.html.erb
@@ -15,13 +15,13 @@
 
         <fieldset>
           <div class="alert alert-danger missing-ref-message" style="display: none;"><%= I18n.t "#{singular}._frontend.messages.please_select_a_#{singular}_to_merge" %></div>
-          <%= render_aspace_partial :partial => "#{controller}/linker", 
-                                    :locals => { 
-                                      :form => form,  
-                                      :exclude_ids => [record.uri], 
-                                      :allowed_types => @agent_type,
-                                      :hide_create => true, 
-                                      :multiplicity => multiplicity, 
+          <%= render_aspace_partial :partial => "#{controller}/linker",
+                                    :locals => {
+                                      :form => form,
+                                      :exclude_ids => [record.uri],
+                                      :allowed_types => [@agent_type],
+                                      :hide_create => true,
+                                      :multiplicity => multiplicity,
                                       :layout => 'stacked' }%>
         </fieldset>
         <div class="form-actions">

--- a/frontend/spec/selenium/spec/agents_spec.rb
+++ b/frontend/spec/selenium/spec/agents_spec.rb
@@ -23,7 +23,11 @@ describe "agents merge" do
   it 'displays the full merge page without any errors' do
     @driver.clear_and_send_keys([:id, 'global-search-box'], @first_agent['names'][0]['primary_name'])
     @driver.find_element(id: 'global-search-button').click
-    @driver.find_element(:link, 'Edit').click
+    @driver.click_and_wait_until_element_gone(
+      @driver.
+        find_paginated_element(xpath: "//tr[./td[contains(., '#{@first_agent['names'][0]['primary_name']}')]]").
+        find_element(:link, 'Edit')
+    )
     @driver.find_element(:link, 'Merge').click
     input = @driver.find_element(:id, 'token-input-merge_ref_')
     @driver.typeahead_and_select(input, @second_agent['names'][0]['primary_name'])


### PR DESCRIPTION
These changes are backwards compatible with the embedded Solr.

1. Use q.op for default AND behavior.

Prefer default `'q.op' => 'AND"` to `'mm' => '100%'` because latter can "override" the outcome of generated queries (with Solr > 4) causing them to fail.

For example, using Solr 8.8, suppose that accession id 1 & 2 exist (query generated by the PUI):

```txt
http://localhost:8984/solr/archivesspace/select?q=(id%3A(%22\%2Frepositories\%2F2\%2Faccessions\%2F1%22)+OR+id%3A(%22\%2Frepositories\%2F2\%2Faccessions\%2F2%22))&wt=json&csv.escape=\&csv.encapsulator=%22&csv.header=true&start=0&rows=500&fq=-exclude_by_default%3Atrue&fq=-types%3Apui_only&fq=suppressed%3Afalse&facet=true&mm=100%25

{
  "responseHeader":{
    "status":0,
    "QTime":0,
    "params":{
      "mm":"100%",
      "q":"(id:(\"\\/repositories\\/2\\/accessions\\/1\") OR id:(\"\\/repositories\\/2\\/accessions\\/2\"))",
      "csv.escape":"\\",
      "csv.header":"true",
      "start":"0",
      "csv.encapsulator":"\"",
      "fq":["-exclude_by_default:true",
        "-types:pui_only",
        "suppressed:false"],
      "rows":"500",
      "wt":"json",
      "facet":"true"}},
  "response":{"numFound":0,"start":0,"numFoundExact":true,"docs":[]
...

http://localhost:8984/solr/archivesspace/select?q=(id%3A(%22\%2Frepositories\%2F2\%2Faccessions\%2F1%22)+OR+id%3A(%22\%2Frepositories\%2F2\%2Faccessions\%2F2%22))&wt=json&csv.escape=\&csv.encapsulator=%22&csv.header=true&start=0&rows=500&fq=-exclude_by_default%3Atrue&fq=-types%3Apui_only&fq=suppressed%3Afalse&facet=true&q.op=AND

{
  "responseHeader":{
    "status":0,
    "QTime":0,
    "params":{
      "q":"(id:(\"\\/repositories\\/2\\/accessions\\/1\") OR id:(\"\\/repositories\\/2\\/accessions\\/2\"))",
      "csv.escape":"\\",
      "csv.header":"true",
      "start":"0",
      "csv.encapsulator":"\"",
      "q.op":"AND",
      "fq":["-exclude_by_default:true",
        "-types:pui_only",
        "suppressed:false"],
      "rows":"500",
      "wt":"json",
      "facet":"true"}},
  "response":{"numFound":2,"start":0,"numFoundExact":true,"docs":[
...
```

Reference:
https://solr.apache.org/guide/8_8/the-standard-query-parser.html#standard-query-parser-parameters
https://solr.apache.org/guide/8_8/the-extended-dismax-query-parser.html#extended-dismax-parameters

**Note:** The default mm value is 100% if q.op is "AND" and the query does not contain any explicit operators other than "AND".

https://issues.apache.org/jira/browse/SOLR-8812
https://github.com/apache/solr/blob/main/solr/core/src/test/org/apache/solr/search/TestExtendedDismaxParser.java#L1500

2. Fix agent merge allowed_types to be array:

Current markup and effect on Solr (only manifests when > 4 with default AND, but it is a [subtle] bug regardless):

    HTML: data-types='"agent_corporate_entity"'
    PARAM: ["\"agent_corporate_entity\""]
    SOLR: "types:(\"\"agent_corporate_entity\"\")",
    "parsed_filter_queries":["repository:/repositories/2 repository:global",
      "+(+types: +types:agent_corporate_entity +types:)",
      "-exclude_by_default:true",
      "-(+id:/agents/corporate_entities/2)",
      "-types:pui_only"],

Updated to be array, consistent with all other linker allowed types:

    HTML: data-types='["agent_corporate_entity"]'
    PARAM: ["agent_corporate_entity"]
    SOLR: "types:(\"agent_corporate_entity\")"],
    "parsed_filter_queries":["-exclude_by_default:true",
      "-(+id:/agents/corporate_entities/2)",
      "-types:pui_only",
      "repository:global repository:/repositories/2",
      "+(+types:agent_corporate_entity)"],

This was actually painful to track down :smile: 

3. Tightened up agent spec selector to be consistent when run independently.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
