### PR TITLE
Ensure object being viewed is an archival object

### DIFF
--- a/public/app/views/objects/show.html.erb
+++ b/public/app/views/objects/show.html.erb
@@ -30,7 +30,8 @@
           heading_text = t('cont_arr')
         end
       %>
-      <% if AppConfig[:pui_search_collection_from_archival_objects] %>
+
+      <% if AppConfig[:pui_search_collection_from_archival_objects] && @result.instance_of?(ArchivalObject) %>
         <%= render partial: 'shared/search_collection_form', :locals => {:resource_uri => @result.resource_uri, :action_text => "#{t('actions.search_in', :type => t('resource._singular'))}"} %>
       <% end %>
       <%= render partial: 'shared/children_tree', :locals => {:heading_text => heading_text, :root_node_uri => @result.root_node_uri, :current_node_uri => @result.uri} %>


### PR DESCRIPTION
## Description
This is a fix for a bug I introduced in #1831. I thought, because I was adding code inside this existing if statement...
```
<% if !@result.instance_of?(DigitalObject) || @has_children %>
```
...that I didn't need to test that the object being rendered is not a digital object. But, because we don't use digital object components where I work, I had forgotten that if those are present then `@has_children` is true. In which case, it will cause ``undefined method `resource_uri'`` errors.

It only occurs when `AppConfig[:pui_search_collection_from_archival_objects]` is set to true in config.rb (by default it is false) which is probably why it wasn't picked up in testing.

To fix this, I have added an extra check that the object is an archival object, thus ensuring `@result.resource_uri` is always defined.

## Related JIRA Ticket or GitHub Issue
Fix for http://lyralists.lyrasis.org/pipermail/archivesspace_users_group/2021-June/008532.html

## How Has This Been Tested?
On a dev system.

## Screenshots (if appropriate):
N/A

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
