### PR TITLE
ANW-1317 Ensure rights statements linked agents work in Derby

### DIFF
--- a/backend/app/model/mixins/agent_manager.rb
+++ b/backend/app/model/mixins/agent_manager.rb
@@ -114,7 +114,7 @@ module AgentManager
 
 
     def linked_agent_roles
-      role_ids = self.class.find_relationship(:linked_agents).values_for_property(self, :role_id).uniq
+      role_ids = self.class.find_relationship(:linked_agents).values_for_property(self, :role_id).uniq.compact
 
       # Hackish: we only want to return roles corresponding to linked archival
       # records (not events), so we filter it at this level.

--- a/backend/spec/model_agent_person_spec.rb
+++ b/backend/spec/model_agent_person_spec.rb
@@ -217,6 +217,21 @@ describe 'Agent model' do
   end
 
 
+  it "can link an agent without a role to a rights statement" do
+    agent = create(:json_agent_person)
+    resource = create(:json_resource,
+                      'rights_statements' => [build(:json_rights_statement,
+                                                    'linked_agents' => [{
+                                                        'ref' => agent.uri
+                                                      }])
+                                              ])
+
+    expect {
+      AgentPerson.sequel_to_jsonmodel([AgentPerson[agent.id]])
+    }.not_to raise_error
+  end
+
+
   it "can mark an agent's name as authorized" do
     person_agent = AgentPerson.create_from_json(build(:json_agent_person,
                                                       :names => [build(:json_name_person, 'authorized' => false),

--- a/frontend/app/views/linked_agents/_show.html.erb
+++ b/frontend/app/views/linked_agents/_show.html.erb
@@ -20,11 +20,13 @@
           <% linked_agents.each_with_index do | link, index | %>
             <tr>
               <td>
-                <%= I18n.t("enumerations.linked_agent_role.#{link["role"]}", :default => link["role"]) %>
+                <% if link["role"] %>
+                  <%= I18n.t("enumerations.linked_agent_role.#{link["role"]}", :default => link["role"])%>
+                <% end %>
               </td>
               <td>
                 <% if link["relator"] %>
-                <%= I18n.t("enumerations.#{relator_enumeration}.#{link["relator"]}", :default => link["relator"]) %>
+                  <%= I18n.t("enumerations.#{relator_enumeration}.#{link["relator"]}", :default => link["relator"])%>
                 <% end %>
               </td>
               <td class="token-list">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The `linked_agent_roles` method in `backend/app/model/mixins/agent_manager.rb` behaved differently when run in mysql vs. Derby.  In Derby, the method returned a `nil` leading to the error reported in JIRA when creating/saving/viewing a record (resource, accession, etc.) with a rights_statement that included one or many linked agents since agents linked through rights statements subrecords will (rightly) never have a role.  The resolves the reported issue when running in Derby.

Also:

- Added several tests;
- Corrected a minor issue with the show-only view of linked agents in rights statements so that a translation missing error wasn't provided for role-less linked agents.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1317

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New tests run under Derby and MySql, as well as existing tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
