### PR TITLE
ANW-1311 Darken placeholder text on PUI

### DIFF
--- a/public/app/assets/stylesheets/application.scss
+++ b/public/app/assets/stylesheets/application.scss
@@ -13,13 +13,17 @@
  * NO = require_tree .
  * NO = require_self
  */
+
+// Adding these first so they can override bootstrap variables.
+// See: https://stackoverflow.com/questions/11773583/can-i-override-sass-variables-after-they-have-been-imported
+@import "archivesspace/fonts";
+@import "archivesspace/colors";
+@import "archivesspace/variables";
+
 // "bootstrap-sprockets" must be imported before "bootstrap" and "bootstrap/variables"
 @import "bootstrap-sprockets";
 @import "bootstrap";
 
-@import  "archivesspace/fonts";
-@import "archivesspace/colors";
-@import "archivesspace/variables";
 //font-awesome
 @import "font-awesome-sprockets";
 @import "font-awesome";

--- a/public/app/assets/stylesheets/archivesspace/variables.scss
+++ b/public/app/assets/stylesheets/archivesspace/variables.scss
@@ -1,21 +1,10 @@
-
 $sans-font: 'PT Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 $serif-font: 'Roboto Slab', serif;
-$font-family-sans-serif: $sans-font;
 $font-family-serif: $serif-font;
+
+$text-color: $darkest;
+$input-color-placeholder: #767676;
 
 $fi-path: "foundation-icon-fonts";
 
-/* Bootstrap icons only */
-$icon-font-path: "bootstrap-sass/";
-$icon-font-name: "glyphicons-halflings-regular";
-$icon-font-svg-id: "";
-$bootstrap-sass-asset-helper: false;
-
-
-
 $row-width: 100%;
-
-$body-font-family: $sans-font;
-
-$text-color: $darkest;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Overrides the default `$input-color-placeholder` to darken the PUI placeholder text to achieve desired color contrast on Firefox.  To accomplish this without altering bootstrap files themselves, the load order of the sass files in `application.scss` had to be corrected so that our overrides come first.  This required some additional cleanup and reorganization, namely removing unnecessary/previously unused styling that was in `variables.scss`, in order to only change/update the placeholder text (and not additional elements).

Note: The "4.5:1 contrast ratio on hover or focus" issues attached to this JIRA were previously resolved with #2317 .

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1311

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
