### PR TITLE
ANW-1328 Staff interface tree labels, contrast, headings

### DIFF
--- a/frontend/app/assets/javascripts/tree.js.erb
+++ b/frontend/app/assets/javascripts/tree.js.erb
@@ -17,6 +17,7 @@
 
     function Tree(datasource_url, tree_container, form_container, toolbar_container, root_uri, read_only, root_record_type) {
         var self = this;
+        var label = '<%= I18n.t("tree.resize") %>';
 
         self.datasource = new TreeDataSource(datasource_url);
 
@@ -33,7 +34,7 @@
                                         tree_renderer, 
                                         function() {
                                             self.ajax_tree = new AjaxTree(self, form_container);
-                                            self.resizer = new TreeResizer(self, tree_container);
+                                            self.resizer = new TreeResizer(self, tree_container, label);
                                         },
                                         function(node, tree) {
                                             self.toolbar_renderer.render(node);

--- a/frontend/app/assets/javascripts/tree_resizer.js
+++ b/frontend/app/assets/javascripts/tree_resizer.js
@@ -3,12 +3,13 @@
 var DEFAULT_TREE_PANE_HEIGHT = 100;
 var DEFAULT_TREE_MIN_HEIGHT = 60;
 
-function TreeResizer(tree, container) {
+function TreeResizer(tree, container, label) {
     this.tree = tree;
     this.container = container;
+    this.label = label;
 
     this.setup();
-};
+}
 
 TreeResizer.prototype.setup = function() {
     var self = this;
@@ -27,7 +28,10 @@ TreeResizer.prototype.setup = function() {
         }
     });
 
-    self.$toggle = $('<a>').addClass('tree-resize-toggle');
+    self.$toggle = $('<button>').addClass('tree-resize-toggle');
+    self.$toggle.attr('aria-expanded', 'false')
+                .attr('title', self.label)
+                .attr('aria-label', self.label);
     self.resize_handle.append(self.$toggle);
 
     self.$toggle.on('click', function() {
@@ -35,7 +39,7 @@ TreeResizer.prototype.setup = function() {
     });
 
     self.reset();
-}
+};
 
 TreeResizer.prototype.get_height = function() {
     if (AS.prefixed_cookie("archives-tree-container::height")) {
@@ -70,15 +74,16 @@ TreeResizer.prototype.minimize = function() {
 
 TreeResizer.prototype.maximized = function() {
     return this.resize_handle.is('.maximized');
-}
+};
 
 TreeResizer.prototype.toggle_height = function() {
     var self = this;
 
     if (self.maximized()) {
         self.minimize();
+        self.$toggle.attr('aria-expanded', 'false');
     } else {
         self.maximize();
+        self.$toggle.attr('aria-expanded', 'true');
     }
 };
-

--- a/frontend/app/assets/stylesheets/archivesspace/largetree.less
+++ b/frontend/app/assets/stylesheets/archivesspace/largetree.less
@@ -104,11 +104,6 @@
         line-height: 2em;
     }
 
-    .expandme:focus {
-        border: 0;
-        outline-style: none;
-    }
-
     .expandme-icon.expanded {
         transform: rotate(90deg);
         transition:transform 100ms ease-out;
@@ -215,6 +210,7 @@
     .tree-resize-toggle {
         font-family: 'Glyphicons Halflings';
         position: absolute;
+        border: none;
         font-size: 8px;
         right: 0;
         top: 0px;
@@ -222,7 +218,7 @@
         cursor: pointer;
         background: rgba(0,0,0,0.1);
         line-height: 8px;
-        color: #888;
+        color: #787878;
 
         &:before {
             content: '\e114';

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -646,6 +646,7 @@ en:
       after: Add Items After
       as_child: Add Items as Children
     unexpected_failure: Oops! We're having trouble fetching this tree. Please try refreshing the page.
+    resize: Expand/Collapse Tree Area
 
   errors:
     sidebar_label: Errors and Warnings

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -648,6 +648,7 @@ es:
       after: Añadir artículos después
       as_child: Añadir artículos como niños
     unexpected_failure: Ups! Estamos teniendo problemas para ir a buscar este árbol. Por favor, intente actualizar la página.
+    resize: Expandir / Contraer el área del árbol
 
   errors:
     merge_denied_for_system_user: Uno o más agentes es un usuario del sistema.

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -646,6 +646,7 @@ fr:
       after: Ajouter items après
       as_child: Ajouter items comme fils
     unexpected_failure: Oups! Impossible de récupérer cette arborescence. Veuillez rafraîchir la page.
+    resize: Développer/Réduire la zone de l'arborescence
 
   errors:
     merge_denied_for_system_user: Un ou plusieurs agents est un utilisateur système.

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -656,6 +656,7 @@ ja:
       after: 後に項目を追加
       as_child: 子供としてアイテムを追加する
     unexpected_failure: おっとっと！このツリーを取得する際に問題が発生しています。ページをリフレッシュしてみてください。
+    resize: ツリー領域の展開/折りたたみ
 
   errors:
     merge_denied_for_system_user: 1人以上のエージェントがシステムユーザーです。

--- a/frontend/spec/selenium/common/tree_helper.rb
+++ b/frontend/spec/selenium/common/tree_helper.rb
@@ -102,11 +102,11 @@ module TreeHelperMethods
   def expand_tree_pane
     # if we're already maximized, we unmaximize first ( since it's possible
     # there been children added since last maximization, so we need to resize )
-    @driver.find_element_orig(css: '.ui-resizable-handle.ui-resizable-s.maximized').find_element('a.tree-resize-toggle')
+    @driver.find_element_orig(css: '.ui-resizable-handle.ui-resizable-s.maximized').find_element('button.tree-resize-toggle')
   rescue Selenium::WebDriver::Error::NoSuchElementError, Selenium::WebDriver::Error::StaleElementReferenceError => e
     # we aren't currently maximized, so please continue..
   ensure
     # now we maximize!
-    @driver.find_element(css: 'a.tree-resize-toggle').click
+    @driver.find_element(css: 'button.tree-resize-toggle').click
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Accessibility enhancements to staff and PUI trees, including:

- labels, darkens, assigns aria-expanded and aria-labels, and makes keyboard accessible the staff-side expand/collapse tree toggle;
- transitions expand/collage tree toggle from an empty <a> to a <button>; and, 
- CSS and yml changes as needed.

Not, this does not address the missing table headings noted in the accessibility audit as #2322 altered the largetree to employ `<div>s` instead of a `<table>`.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1328

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
