### PR TITLE
Handle relative paths for `AppConfig[:plugins_directory]`

### DIFF
--- a/common/asutils.rb
+++ b/common/asutils.rb
@@ -110,7 +110,9 @@ module ASUtils
     # we use that. Otherwise, find the 'plugins' dir in the
     # aspace base.
     if AppConfig.changed?(:plugins_directory)
-      AppConfig[:plugins_directory]
+      # Yields something relative to our base directory if a relative path is used.
+      # Absolute paths will pass through unchanged.
+      File.absolute_path(AppConfig[:plugins_directory], self.find_base_directory)
     else
       File.join( *[ self.find_base_directory, 'plugins'])
     end


### PR DESCRIPTION
The default value for the `AppConfig[:plugins_directory]` is:

     # AppConfig[:plugins_directory] = "plugins"

but if you uncomment that line in the standard config.rb, it fails to
find your plugins.  Someone hit that here:

https://groups.google.com/g/archivesspace/c/22bOn1sou0s

The `ASUtils.plugin_base_directory` method was mistakenly interpreting
relative paths against the backend directory, rather than the
ArchivesSpace base directory.