### PR TITLE
ANW-1316, ANW-1323 Provide keyboard-only resizing of PUI sidebar

### DIFF
--- a/public/app/assets/javascripts/resizable_sidebar.js
+++ b/public/app/assets/javascripts/resizable_sidebar.js
@@ -17,9 +17,12 @@ function ResizableSidebar($sidebar) {
 };
 
 ResizableSidebar.prototype.add_handle = function() {
-    var $handle = $('<a>').attr('href', 'javascript:void(0);');
-    $handle.attr('aria-hidden', 'true');
+    var $handle = $('<input>').attr('type', 'range');
+    $handle.attr('value', 75);
+    $handle.attr('max', 88);
+    $handle.attr('min', 24);
     $handle.attr('aria-label', 'resizable sidebar handle');
+    $handle.attr('id', 'accessible_slider');
     $handle.addClass('resizable-sidebar-handle');
 
     this.$sidebar.append($handle);
@@ -30,9 +33,8 @@ ResizableSidebar.prototype.add_handle = function() {
 ResizableSidebar.prototype.bind_events = function() {
     var self = this;
 
-    self.$handle.on('mousedown', function (e) {
+    self.$handle.on('mousedown keydown', function (e) {
         self.isResizing = true;
-        self.lastDownX = e.clientX;
     });
 
     $(document).on('mousemove', function (e) {
@@ -55,6 +57,32 @@ ResizableSidebar.prototype.bind_events = function() {
             $('.infinite-record-scrollbar').css('left', self.$row.offset().left + new_content_width - 20);
         }
     }).on('mouseup', function (e) {
+        self.isResizing = false;
+    });
+    
+    // ANW-1316: Make resizable input slider work with keyboard commands alone
+    $(document).on('keydown', function (e) {
+        if (!self.isResizing) {
+            return;
+        }
+        
+        var content_width = document.getElementById("content").offsetWidth;
+        var slider = document.getElementById("accessible_slider").value;
+
+        var right_offset = (self.$row.width() + self.$row.offset().left) - (content_width * (slider/100));
+
+        right_offset = Math.max(right_offset, 200);
+        var new_content_width = Math.max(self.$row.width() - right_offset, 300);
+
+        self.$sidebar.css('width', 0);
+        self.$content_pane.css('width', new_content_width);
+        self.$sidebar.css('width', self.$row.width() - new_content_width);
+
+        // position the infinite scrollbar too, if it's about
+        if ($('.infinite-record-scrollbar').length > 0) {
+            $('.infinite-record-scrollbar').css('left', self.$row.offset().left + new_content_width - 20);
+        }
+    }).on('keyup', function (e) {
         self.isResizing = false;
     });
 };

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -868,9 +868,25 @@ span.head {
       background-repeat: no-repeat;
       background-position: 1px center;
       border-right: 1px solid #CCC;
+      appearance: none;
+      -webkit-appearance: none;
+      -moz-appearance: none;
+    }
+    
+    .resizable-sidebar-handle::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+    }
+
+    .resizable-sidebar-handle::-moz-range-thumb {
+        -moz-appearance: none;
+        appearance: none;
+        background: none;
+        border: none;
     }
   }
 }
+
 @media (max-width: 991px) {
   .row.has-resizable-content {
     > .col-sm-9, > .resizable-sidebar {

--- a/public/app/views/resources/_resource_tab.erb
+++ b/public/app/views/resources/_resource_tab.erb
@@ -13,7 +13,7 @@
 
     <%=
       link_to_unless active || !enabled, text, url  do
-        link_to_if active, text, '#', :class => "active" do
+        link_to_if active, text, '#', :class => "active", :'aria-current' => 'page' do
           link_to text, "#"
         end
       end

--- a/public/app/views/shared/_accordion_panel.html.erb
+++ b/public/app/views/shared/_accordion_panel.html.erb
@@ -1,16 +1,16 @@
 <% if !p_body.strip.blank? %>
-   <div class="panel panel-default">
-     <div class="panel-heading">
-       <h3 class="panel-title">
-	 <a class="accordion-toggle" data-toggle="collapse"  href="#<%= p_id %>">
-           <%= p_title %>
-	 </a>
- </h3>
-     </div>
-     <div id="<%= p_id %>" class="panel-collapse collapse note_panel in">
-       <div class="panel-body">
-	 <%= p_body %>
-       </div>
-     </div>
-   </div>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title">
+        <a class="accordion-toggle" data-toggle="collapse"  href="#<%= p_id %>" aria-expanded="true">
+          <%= p_title %>
+        </a>
+      </h3>
+    </div>
+    <div id="<%= p_id %>" class="panel-collapse collapse note_panel in">
+      <div class="panel-body">
+        <%= p_body %>
+      </div>
+    </div>
+  </div>
 <% end %>

--- a/public/spec/features/accessibility_spec.rb
+++ b/public/spec/features/accessibility_spec.rb
@@ -50,10 +50,35 @@ describe 'Accessibility', js: true do
     end
 
     context 'individual resource page' do
+      before (:each) do
+        within all('.col-sm-12')[1] do
+          first("a[class='record-title']").click
+        end
+      end
+
       it 'should not skip a heading level' do
         expect(page).to have_css('h3') if page.has_css? 'h4'
         expect(page).to have_css('h2') if page.has_css? 'h3'
         expect(page).to have_css('h1') if page.has_css? 'h2'
+      end
+
+      it 'should support resizing sidebar with keyboard' do
+        sidebar_width = find('div.sidebar').evaluate_script("window.getComputedStyle(this)['width']")
+        handle = find('input.resizable-sidebar-handle')
+
+        5.times do
+          handle.native.send_keys :arrow_left
+        end
+
+        new_sidebar_width = find('div.sidebar').evaluate_script("window.getComputedStyle(this)['width']")
+        expect(new_sidebar_width).to be > sidebar_width
+
+        10.times do
+          handle.native.send_keys :arrow_right
+        end
+
+        newest_sidebar_width = find('div.sidebar').evaluate_script("window.getComputedStyle(this)['width']")
+        expect(newest_sidebar_width).to be < sidebar_width
       end
 
       it 'should not duplicate ids' do
@@ -61,9 +86,6 @@ describe 'Accessibility', js: true do
         expect(page).to be_axe_clean.checking_only :'duplicate-id'
 
         # Collection Organization
-        within all('.col-sm-12')[1] do
-          first("a[class='record-title']").click
-        end
         click_link 'Collection Organization'
         expect(page).to be_axe_clean.checking_only :'duplicate-id'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The drag to resize functionality of the PUI sidebar is presently only usable with a mouse.  For accessibility purposes, this functionality should be extended to allow for the same user experience with keyboard commands alone.  This is a first pass at accomplishing that primary goal.

Additional unrelated issues also noted in ANW-1316 are also addressed here, including programmatically providing information on the expanded/collapsed and active state of some features (including on initial page load).

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1316
https://archivesspace.atlassian.net/browse/ANW-1323

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Edge, Firefox, and Chrome, though additional testing would be ideal.

## Screenshots (if appropriate):
https://user-images.githubusercontent.com/15144646/126833447-975c984c-9e1b-45d1-bb47-ac1a5fd33da2.mov

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
