### PR TITLE
ANW-1353 Fix spreadsheet DO importer

### DIFF
--- a/backend/app/lib/bulk_import/digital_object_handler.rb
+++ b/backend/app/lib/bulk_import/digital_object_handler.rb
@@ -34,53 +34,6 @@ class DigitalObjectHandler < Handler
       else
 =end
       raise BulkImportException.new(I18n.t("bulk_import.error.dig_obj_unique", :id => osn))
-    end
-    unless !thumb && !link
-      files = []
-      if !link.nil? && link.start_with?("http")
-        fv = JSONModel(:file_version).new._always_valid!
-        fv.file_uri = link
-        fv.publish = publish
-        fv.xlink_actuate_attribute = "onRequest"
-        fv.xlink_show_attribute = "new"
-        files.push fv
-      end
-      if !thumb.nil? && thumb.start_with?("http")
-        fv = JSONModel(:file_version).new._always_valid!
-        fv.file_uri = thumb
-        fv.publish = publish
-        fv.xlink_actuate_attribute = "onLoad"
-        fv.xlink_show_attribute = "embed"
-        fv.is_representative = true
-        files.push fv
-      end
-      dig_o = JSONModel(:digital_object).new._always_valid!
-      dig_o.title = title.nil? ? archival_object.display_string : title
-      dig_o.digital_object_id = osn
-      dig_o.file_versions = files
-      dig_o.publish = publish
-      begin
-        dig_o = save(dig_o, DigitalObject)
-      rescue JSONModel::ValidationException => ve
-        report.add_errors(I18n.t("bulk_import.error.dig_validation", :err => ve.errors))
-        return nil
-      rescue Exception => e
-        raise e
-      end
-      report.add_info(I18n.t(@create_key, :what => I18n.t("bulk_import.dig"), :id => "'#{dig_o.title}' #{dig_o.uri} [#{dig_o.digital_object_id}]"))
-      dig_instance = JSONModel(:instance).new._always_valid!
-      dig_instance.instance_type = "digital_object"
-      dig_instance.digital_object = { "ref" => @validate_only ? "http://x" : dig_o.uri }
-    end
-    osn = id || "#{archival_object.ref_id.to_s}d"
-    if !check_digital_id(osn)
-=begin
-      if @validate_only
-        I18n.t("bulk_import.error.dig_obj_unique", :id => osn)
-        report.add_errors(I18n.t("bulk_import.error.dig_obj_unique", :id => osn))
-      else
-=end
-      raise BulkImportException.new(I18n.t("bulk_import.error.dig_obj_unique", :id => osn))
       #      end
     end
     files = []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#2147 inadvertently introduced old/outdated code (refactored in #2027) back into `backend/app/lib/bulk_import/digital_object_handler.rb`, which effectively broke the linking of digital objects to archival objects when dos were added to the bulk import spreadsheet.  This re-removes the improper code.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1353

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
