### PR TITLE
ANW-1347 Fix setting language preferences in staff interface

### DIFF
--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -31,7 +31,7 @@ class ApplicationController < ActionController::Base
 
   before_action :unauthorised_access
 
-  before_action :set_locale
+  around_action :set_locale
 
   def self.permission_mappings
     Array(@permission_mappings)
@@ -788,12 +788,13 @@ class ApplicationController < ActionController::Base
     }
   end
 
-  def set_locale
+  def set_locale(&action)
     if session['user']
-      I18n.locale = user_prefs.key?('locale') ? user_prefs['locale'].to_sym : I18n.default_locale
+      locale = user_prefs.key?('locale') ? user_prefs['locale'].to_sym : I18n.default_locale
     else
-      I18n.locale = I18n.default_locale
+      locale = I18n.default_locale
     end
+    I18n.with_locale(locale, &action)
   end
 
   def current_record


### PR DESCRIPTION
I18n cache optimization did not include the locale, resulting in
cache hits irrespective of the locale, based on first encountered.

This prefixes the cache entries with the locale to restore the
original functionality. Also supports resetting the cache which
may be useful in the future and updates the locale switching code
to mirror Rails documentation (around_action and with_locale).
