### PR TITLE
Fixes ANW-1376 and handles incorrectly NSed @target permissively

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -99,13 +99,8 @@ class EADSerializer < ASpaceExport::Serializer
 
   # If content looks like it contains a valid XML element with an attribute from the expected list,
   # then replace the attribute like " foo=" with " xlink:foo=".
-
-  # References used for valid element and attribute names:
-  # https://www.xml.com/pub/a/2001/07/25/namingparts.html
-  # https://razzed.com/2009/01/30/valid-characters-in-attribute-names-in-htmlxml/
-
   def add_xlink_prefix(content)
-    %w{ actuate arcrole entityref from href id linktype parent role show target title to xpointer }.each do |xa|
+    %w{ actuate arcrole from href role show title to}.each do |xa|
       content.gsub!(/ #{xa}=/) {|match| " xlink:#{match.strip}"} if content =~ / #{xa}=/
     end
     content

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1262,18 +1262,18 @@ describe "EAD export mappings" do
     end
 
     it "adds xlink prefix to attributes in mixed content" do
-      expect(serializer.add_xlink_prefix(note_with_extref)).to eq("<extref xlink:linktype='simple' xlink:entityref='site' xlink:title='title' xlink:actuate='onrequest' xlink:show='new' xlink:href='http://duckduckgo.com'>A Good Search Engine</p>")
+      expect(serializer.add_xlink_prefix(note_with_extref)).to eq("<extref linktype='simple' entityref='site' xlink:title='title' xlink:actuate='onrequest' xlink:show='new' xlink:href='http://duckduckgo.com'>A Good Search Engine</p>")
       expect(serializer.add_xlink_prefix(note_with_archref)).to eq("<archref audience='external'/>")
       expect(serializer.add_xlink_prefix(note_with_bibref)).to eq("<bibref audience='internal'/>")
-      expect(serializer.add_xlink_prefix(note_with_extptr)).to eq("<extptr xlink:linktype='simple' xlink:entityref='entref' xlink:title='title' xlink:show='embed'/>")
+      expect(serializer.add_xlink_prefix(note_with_extptr)).to eq("<extptr linktype='simple' entityref='entref' xlink:title='title' xlink:show='embed'/>")
       expect(serializer.add_xlink_prefix(note_with_extptrloc)).to eq("<extptrloc xlink:href='http://www.example.com'/>")
       expect(serializer.add_xlink_prefix(note_with_extrefloc)).to eq("<extrefloc xlink:href='http://www.example.com'/>")
-      expect(serializer.add_xlink_prefix(note_with_linkgrp)).to eq("<linkgrp xlink:linktype='extended'><extrefloc xlink:href='http://www.someserver.edu/findaids/3270.xml'><archref>archref</archref></extrefloc><extrefloc xlink:href='http://www.someserver.edu/findaids/9248.xml'><archref>archref</archref></extrefloc></linkgrp>")
-      expect(serializer.add_xlink_prefix(note_with_ptr)).to eq("<ptr xlink:linktype='simple' xlink:actuate='onrequest' xlink:show='replace' xlink:target='mss1982-062_add2'/>")
+      expect(serializer.add_xlink_prefix(note_with_linkgrp)).to eq("<linkgrp linktype='extended'><extrefloc xlink:href='http://www.someserver.edu/findaids/3270.xml'><archref>archref</archref></extrefloc><extrefloc xlink:href='http://www.someserver.edu/findaids/9248.xml'><archref>archref</archref></extrefloc></linkgrp>")
+      expect(serializer.add_xlink_prefix(note_with_ptr)).to eq("<ptr linktype='simple' xlink:actuate='onrequest' xlink:show='replace' target='mss1982-062_add2'/>")
       expect(serializer.add_xlink_prefix(note_with_ptrloc)).to eq("<ptrloc audience='external'/>")
-      expect(serializer.add_xlink_prefix(note_with_ref)).to eq("<ref xlink:linktype='simple' xlink:target='NonC:21-2' xlink:show='replace' xlink:actuate='onrequest'>")
-      expect(serializer.add_xlink_prefix(note_with_refloc)).to eq("<refloc xlink:target='a9'></refloc>")
-      expect(serializer.add_xlink_prefix(note_with_resource)).to eq("<resource xlink:linktype='resource' label='start'/>")
+      expect(serializer.add_xlink_prefix(note_with_ref)).to eq("<ref linktype='simple' target='NonC:21-2' xlink:show='replace' xlink:actuate='onrequest'>")
+      expect(serializer.add_xlink_prefix(note_with_refloc)).to eq("<refloc target='a9'></refloc>")
+      expect(serializer.add_xlink_prefix(note_with_resource)).to eq("<resource linktype='resource' label='start'/>")
       expect(serializer.add_xlink_prefix(note_with_title)).to eq("<title render='italic'/>")
     end
 

--- a/stylesheets/as-ead-pdf.xsl
+++ b/stylesheets/as-ead-pdf.xsl
@@ -1104,7 +1104,7 @@
 
    <!-- Linking elmenets -->
     <xsl:template match="ead:ref">
-        <fo:basic-link internal-destination="{@target}" xsl:use-attribute-sets="ref">
+        <fo:basic-link internal-destination="{@*:target}" xsl:use-attribute-sets="ref">
             <xsl:choose>
                 <xsl:when test="text()">
                     <xsl:value-of select="."/>
@@ -1113,13 +1113,13 @@
                     <xsl:value-of select="@*:title"/>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:value-of select="@target"/>
+                    <xsl:value-of select="@*:target"/>
                 </xsl:otherwise>
             </xsl:choose>
         </fo:basic-link>
     </xsl:template>
     <xsl:template match="ead:ptr">
-        <fo:basic-link external-destination="url('{@target}')" xsl:use-attribute-sets="ref">
+        <fo:basic-link external-destination="url('{@*:target}')" xsl:use-attribute-sets="ref">
             <xsl:choose>
                 <xsl:when test="child::*">
                     <xsl:value-of select="."/>
@@ -1128,7 +1128,7 @@
                     <xsl:value-of select="@*:title"/>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:value-of select="@target"/>
+                    <xsl:value-of select="@*:target"/>
                 </xsl:otherwise>
             </xsl:choose>
         </fo:basic-link>


### PR DESCRIPTION
## Description
Changes add_xlink_prefix in EAD serializer to only prefix those attributes that exist in XLink 1.1.

Additionally, alters the stylesheet used for PDF generation to allow
for incorrect xlink (or arbitrary namespace) on target attribute.

Note that this still does not make PDF generation correct for all
permitted EAD constructs: ref is legal without any attributes, though
I have no idea what the use of such a thing would be.

This allows resources with refs (with valid targets) in mixed content to successfully generate PDFs.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1376

## How Has This Been Tested?
Made changes in local ASpace, generated PDF from a record with an AO having a ref in its related materials note.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
