### PR TITLE
Fix request_mailer staff email

### DIFF
--- a/public/app/views/request_mailer/request_received_staff_email.html.erb
+++ b/public/app/views/request_mailer/request_received_staff_email.html.erb
@@ -15,7 +15,7 @@
 
 <div class="request">
   <h2>Record Requested</h2>
-  <%= @request.to_text_array(false).each do |info| %>
+  <% @request.to_text_array(false).each do |info| %>
     <%= info%><br>
   <% end %>
 </div>


### PR DESCRIPTION
I have created a one-character change that fixes the output of the request_mailer staff email.

## Description
When a request for a resource gets processed, emails are sent out to the requester and the staff. The staff email template loops through the request object to output fields, but then at the bottom of the email, it outputs the same information, formatted as a Ruby list.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1379?atlOrigin=eyJpIjoiMjAyYjM0MGI2NzAxNDY5NTk2MzQyZmFlNzc2ODdkZGMiLCJwIjoiaiJ9

## How Has This Been Tested?
I have a local instance of Aspace on WSL (Windows Subsystem for Linux). All of my testing has been manual. I'm new to ArchivesSpace, Rails, and Ruby, otherwise I would have included it already. If this change requires testing, please let me know.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
