### PR TITLE
ANW-573: Allow less granular staff advanced search date strings

### DIFF
--- a/backend/app/model/advanced_query_string.rb
+++ b/backend/app/model/advanced_query_string.rb
@@ -2,7 +2,7 @@ require 'time'
 
 class AdvancedQueryString
   def initialize(query, use_literal)
-    @query = query
+    @query = query.transform_keys { |k| k.to_s }
     @use_literal = use_literal
   end
 
@@ -40,7 +40,8 @@ class AdvancedQueryString
 
   def value
     if date?
-      base_time = Time.parse(@query["value"]).utc.iso8601
+      date_string = JSONModel::Validations.normalise_date(@query["value"])
+      base_time = Time.parse(date_string).utc.iso8601
 
       if @query["comparator"] == "lesser_than"
         "[* TO #{base_time}-1MILLISECOND]"

--- a/backend/spec/model_advanced_query_string_spec.rb
+++ b/backend/spec/model_advanced_query_string_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe "AdvancedQueryString" do
+
+  it "can support date granularity of day, month, or year" do
+    query = {"field": "create_time", "value": "1911-03-01", "comparator": "greater_than", "jsonmodel_type": "date_field_query", "negated": false}
+    advancedQueryString = AdvancedQueryString.new(query, false)
+    expect(advancedQueryString.to_solr_s).to match /create_time:\[1911-03-01T\d{2}:00:00Z\+1DAY TO \*\]/
+
+    query = {"field": "create_time", "value": "1911-03", "comparator": "greater_than", "jsonmodel_type": "date_field_query", "negated": false}
+    advancedQueryString = AdvancedQueryString.new(query, false)
+    expect(advancedQueryString.to_solr_s).to match /create_time:\[1911-03-01T\d{2}:00:00Z\+1DAY TO \*\]/
+
+    query = {"field": "create_time", "value": "1911", "comparator": "greater_than", "jsonmodel_type": "date_field_query", "negated": false}
+    advancedQueryString = AdvancedQueryString.new(query, false)
+    expect(advancedQueryString.to_solr_s).to match /create_time:\[1911-01-01T\d{2}:00:00Z\+1DAY TO \*\]/
+  end
+end

--- a/common/advanced_query_builder.rb
+++ b/common/advanced_query_builder.rb
@@ -148,6 +148,7 @@ class AdvancedQueryBuilder
     if query_data.is_a?(JSONModelType)
       query_data
     elsif query_data['type'] == "date"
+      query_data['value'] = JSONModel::Validations.normalise_date(query_data['value'])
       JSONModel::JSONModel(:date_field_query).from_hash(query_data)
     elsif query_data['type'] == "boolean"
       JSONModel::JSONModel(:boolean_field_query).from_hash(query_data)

--- a/frontend/app/assets/javascripts/header.js
+++ b/frontend/app/assets/javascripts/header.js
@@ -179,15 +179,49 @@ $(function() {
         }
 
         function isValidDate(dateString) {
-          var dateRegex = /^\d\d\d\d\-\d\d-\d\d$/;
-          var isValidDateString = dateRegex.test(dateString);
+          var dateRegex =
+            /^((0(?!\d)|[1-9])[0-9]{0,3})(?!-1[3-9]|-[2-9][2-9])(-0[1-9]|-1[012])?(-0[1-9]|-[12][0-9]|-3[01])?$/;
+          /**
+           * ^((0(?!\d)|[1-9])[0-9]{0,3})
+           * years 0 - 9999
+           * 
+           * (0(?!\d)|[1-9])
+           * if year starts with 0 it can't be followed by other digits, ie: 0, !01
+           * 
+           * ^((0(?!\d)|[1-9])[0-9]{0,3})(?!-1[3-9]|-[2-9][2-9])
+           * year can't be followed by any number > 12
+           * negative lookahead (for year value) since lookbehind (for day value)
+           * not available in all browsers
+           * 
+           * (-0[1-9]|-1[012])?
+           * 0 or 1 month
+           * 
+           * (-0[1-9]|-[12][0-9]|-3[01])?$
+           * 0 or 1 day
+           */
 
-          if (!isValidDateString) {
+          if (!dateRegex.test(dateString)) {
             return false;
           }
 
+          var dateArray = dateString.split('-');
+          var year = Number(dateArray[0]);
+          var month = dateArray[1] ? Number(dateArray[1]) : undefined;
+          var day = dateArray[2] ? Number(dateArray[2]) : undefined;
+
+          var daysInMonths = [31,28,31,30,31,30,31,31,30,31,30,31];
+          var isLeapYear = new Date(year,1,29).getDate() == 29; // via proleptic Gregorian calendar
+
+          if(isLeapYear) {
+            daysInMonths[1] = 29;
+          }
+
+          if (day) {
+            return day <= daysInMonths[--month];
+          }
+
           return true;
-        };
+        }
 
         if (isValidDate($(this).val())) {
           enableAdvancedSearch();

--- a/frontend/app/views/shared/_advanced_search.html.erb
+++ b/frontend/app/views/shared/_advanced_search.html.erb
@@ -202,7 +202,7 @@
           <% end %>
         </select>
       </div>
-      <%= text_field_tag "v${index}", "${query.value}", :id => "v${index}", :class => "date-field form-control", :"data-format" => "yyyy-mm-dd", :"data-date" => Date.today.strftime('%Y-%m-%d') %>
+      <%= text_field_tag "v${index}", "${query.value}", :id => "v${index}", :class => "date-field form-control", :"data-format" => "yyyy-mm-dd", :"data-force-parse" => false %>
     </div>
   </div>
 --></div>

--- a/frontend/spec/features/advanced_search_dates_spec.rb
+++ b/frontend/spec/features/advanced_search_dates_spec.rb
@@ -1,0 +1,62 @@
+require 'date'
+require 'spec_helper.rb'
+require 'rails_helper.rb'
+
+describe 'AdvancedSearchDates', js: true do
+
+  before(:each) do
+    visit '/'
+    page.has_xpath? '//input[@id="login"]'
+
+    within "form.login" do
+      fill_in "username", with: "admin"
+      fill_in "password", with: "admin"
+
+      click_button "Sign In"
+    end
+
+    page.has_no_xpath? '//input[@id="login"]'
+
+    page.has_css? 'button[title="Show Advanced Search"]'
+    click_button('button[title="Show Advanced Search"]')
+    click_link('.advanced-search-add-row-dropdown')
+    click_link('.advanced-search-add-date-row')
+    page.has_css? 'input#v1.date-field'
+
+    date_field = find 'input#v1.date-field'
+    submit_btn = find 'form.advanced-search .btn.btn-primary'
+
+    now = DateTime.now
+    year = now.strftime('%Y')
+    month = now.strftime('%Y-%m')
+    day = now.strftime('%Y-%m-%d')
+  end
+
+  it 'accepts a year date in yyyy format' do
+    within "form.advanced-search" do
+      date_field.fill_in(with: year)
+      submit_btn.click
+    end
+
+    expect(page).to have_text 'Search Results'
+  end
+
+  it 'accepts a month date in yyyy-mm format' do
+    within "form.advanced-search" do
+      date_field.fill_in(with: month)
+      submit_btn.click
+    end
+
+    expect(page).to have_text 'Search Results'
+  end
+
+  it 'accepts a day date in yyyy-mm-dd format' do
+    within "form.advanced-search" do
+      date_field.fill_in(with: day)
+      submit_btn.click
+    end
+
+    expect(page).to have_text 'Search Results'
+  end
+
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This PR allows less granular advanced search dates strings in the staff interface. (YYYY-MM-DD, YYYY-MM, YYYY)

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

[ANW-573](https://archivesspace.atlassian.net/browse/ANW-573)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

This screenshot shows valid advanced search dates that are less granular than days (ie: months and years).

![advanced-search-y-m-d](https://user-images.githubusercontent.com/3411019/129978149-993d8552-9f00-4548-84b8-73ccf9121211.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
