### PR TITLE
ANW-1373: accessibility: set role as none for lists in transfer and merge dropd…

### DIFF
--- a/frontend/app/views/shared/_merge_dropdown.html.erb
+++ b/frontend/app/views/shared/_merge_dropdown.html.erb
@@ -8,7 +8,7 @@
     <button class="btn btn-sm btn-default dropdown-toggle merge-action" data-toggle="dropdown" role="button" aria-expanded="false" title="<%= I18n.t("actions.merge") %>">
       <%= I18n.t("actions.merge") %> <span class="caret"></span>
     </button>
-    <ul class="dropdown-menu merge-form open-aligned-right">
+    <ul class="dropdown-menu merge-form open-aligned-right" role="none">
       <li>
       <p><%= I18n.t("#{singular}._frontend.messages.merge_description") %>   <%= record.title %></p>
         <%= form_context :merge, {} do |form| %>

--- a/frontend/app/views/shared/_transfer_dropdown.html.erb
+++ b/frontend/app/views/shared/_transfer_dropdown.html.erb
@@ -10,7 +10,7 @@
     <button class="btn btn-sm btn-default dropdown-toggle transfer-action" data-toggle="dropdown" role="button" aria-expanded="false" title="<%= I18n.t("actions.transfer") %>">
       <%= I18n.t("actions.transfer") %> <span class="caret"></span>
     </button>
-    <ul class="dropdown-menu open-aligned-right transfer-form">
+    <ul class="dropdown-menu open-aligned-right transfer-form" role="none">
       <li>
         <p><%= I18n.t("#{singular}._frontend.messages.transfer_description") %></p>
         <%= form_context :transfer, {} do |form| %>

--- a/frontend/spec/features/accessibility_spec.rb
+++ b/frontend/spec/features/accessibility_spec.rb
@@ -205,6 +205,30 @@ describe 'Accessibility', js: true , db: 'accessibility' do
         searchbox.assert_matches_selector("input[aria-controls='merge_ref__listbox']")
       end
     end
+
+    # 519396
+    it "sets role as none for ul element in merge dropdown" do
+      visit "/resources/1"
+
+      find("#merge-dropdown button.merge-action").click
+
+      within "div#merge-dropdown" do
+        list = find("ul[role='none']")
+        expect(list).to_not be_nil
+      end
+    end
+
+    # 519396
+    it "sets role as none for ul element in transfer dropdown" do
+      visit "/resources/1"
+
+      find("#transfer-dropdown button.transfer-action").click
+
+      within "div#transfer-dropdown" do
+        list = find("ul[role='none']")
+        expect(list).to_not be_nil
+      end
+    end
   end
 
 end


### PR DESCRIPTION
…owns since

it's semantically not a list

<!--- Provide a general summary of your changes in the Title above -->

## Description
add a role attribute to the ul tags referenced above to denote that they are semantically not a list

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1373

## How Has This Been Tested?
Manual and unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
