### PR TITLE
ANW-979: Abort transfer of records to another repository if record has shared top container

### DIFF
--- a/backend/app/controllers/repository_transfer.rb
+++ b/backend/app/controllers/repository_transfer.rb
@@ -75,30 +75,8 @@ class ArchivesSpaceService < Sinatra::Base
       end
     end
 
-    #ANW-979: see if this record has any top containers that are shared with another record
-    check_top_containers(model, id)
-
     model.get_or_die(id).transfer_to_repository(target)
 
     moved_response(id, target)
-  end
-
-  def check_top_containers(model, id)
-    case model.to_s
-    when "Resource"
-      model_json = Resource.to_jsonmodel(id)
-    when "Accession"
-      model_json = Accession.to_jsonmodel(id)
-    end
-
-    model_json["instances"].each do |instance|
-      sc = instance['sub_container'] 
-      tc = sc["top_container"] if sc
-
-      # we need the ID. URI looks like /repositories/2/top_containers/364, so split it up to isolate ID.
-      tc_id   = tc['ref'].split('/')[4]
-
-      tc_json = TopContainer.to_jsonmodel(tc_id)
-    end
   end
 end

--- a/backend/app/controllers/repository_transfer.rb
+++ b/backend/app/controllers/repository_transfer.rb
@@ -75,10 +75,30 @@ class ArchivesSpaceService < Sinatra::Base
       end
     end
 
+    #ANW-979: see if this record has any top containers that are shared with another record
+    check_top_containers(model, id)
+
     model.get_or_die(id).transfer_to_repository(target)
 
     moved_response(id, target)
   end
 
+  def check_top_containers(model, id)
+    case model.to_s
+    when "Resource"
+      model_json = Resource.to_jsonmodel(id)
+    when "Accession"
+      model_json = Accession.to_jsonmodel(id)
+    end
 
+    model_json["instances"].each do |instance|
+      sc = instance['sub_container'] 
+      tc = sc["top_container"] if sc
+
+      # we need the ID. URI looks like /repositories/2/top_containers/364, so split it up to isolate ID.
+      tc_id   = tc['ref'].split('/')[4]
+
+      tc_json = TopContainer.to_jsonmodel(tc_id)
+    end
+  end
 end

--- a/backend/app/model/mixins/transferable.rb
+++ b/backend/app/model/mixins/transferable.rb
@@ -140,10 +140,10 @@ module Transferable
             # Already transferred
           end
         else
-          # something outside the graph is linked to it, add it to the list and we'll clone after transfer
-          tc_id = tc_rel[:top_container_id]
-          containers_to_clone[tc_id] ||= []
-          containers_to_clone[tc_id] <<  tc_rel[:sub_container_id]
+          # ANW-979
+          # Cancel transfer and let user know that they must unlink other top container
+
+          raise TransferConstraintError.new({'values' => 'Top Container is linked to other records, unlink them to continue'})
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previous behavior was to clone top containers when transferring a record to another repository.
This changes behavior so that transfer is aborted, warning user that shared top containers must be unlinked.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-979

## How Has This Been Tested?
manual and unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
