### PR TITLE
ANW-1381 resolve agent sub records pointing to deleted subjects

### DIFF
--- a/backend/spec/model_agent_topics_spec.rb
+++ b/backend/spec/model_agent_topics_spec.rb
@@ -13,4 +13,18 @@ describe 'AgentTopic model' do
       topic = AgentTopic.create_from_json(build(:json_agent_topic, :subjects => []))
     }.to raise_error(JSONModel::ValidationException)
   end
+
+  it "won't let you delete a subject that has a role in a topic" do
+    subject = create(:json_subject)
+    subject_place = create(:json_subject)
+    agent_topic = AgentTopic.create_from_json(build(:json_agent_topic, subjects: [{'ref' => subject.uri}], places: [{'ref' => subject_place.uri}]))
+
+    expect {
+      Subject[subject.id].delete
+    }.to raise_error ConflictException
+
+    expect {
+      Subject[subject_place.id].delete
+    }.to raise_error ConflictException
+  end
 end

--- a/common/db/migrations/157_fk_constraints_for_agent_subrecords.rb
+++ b/common/db/migrations/157_fk_constraints_for_agent_subrecords.rb
@@ -1,0 +1,72 @@
+require_relative 'utils'
+
+Sequel.migration do
+  up do
+    # delete agent subrecord / subject relationships where the subject has been deleted
+    [:subject_agent_subrecord_rlshp, :subject_agent_subrecord_place_rlshp].each do |table|
+      deletes = []
+      self[table].each do |row|
+        subject_id = row[:subject_id]
+        deletes << row[:id] if self[:subject].filter(:id => subject_id).count == 0
+      end
+      self[table].filter(:id => deletes).delete
+    end
+
+    alter_table(:subject_agent_subrecord_rlshp) do
+      add_foreign_key([:subject_id], :subject, key: :id)
+      add_foreign_key([:agent_function_id], :agent_function, key: :id)
+      add_foreign_key([:agent_occupation_id], :agent_occupation, key: :id)
+      add_foreign_key([:agent_place_id], :agent_place, key: :id)
+      add_foreign_key([:agent_topic_id], :agent_topic, key: :id)
+    end
+
+    alter_table(:subject_agent_subrecord_place_rlshp) do
+      add_foreign_key([:subject_id], :subject, key: :id)
+      add_foreign_key([:agent_function_id], :agent_function, key: :id)
+      add_foreign_key([:agent_occupation_id], :agent_occupation, key: :id)
+      add_foreign_key([:agent_topic_id], :agent_topic, key: :id)
+    end
+
+    [:agent_record_control,
+     :agent_alternate_set,
+     :agent_conventions_declaration,
+     :agent_other_agency_codes,
+     :agent_maintenance_history,
+     :agent_maintenance_history,
+     :agent_sources,
+     :structured_date_label,
+     :agent_place,
+     :agent_occupation,
+     :agent_function,
+     :agent_topic,
+     :agent_gender,
+     :agent_identifier,
+     :used_language,
+     :agent_resource,
+    ].each do |table|
+      alter_table(table) do
+        add_foreign_key([:agent_person_id], :agent_person, :key => :id)
+        next if table == :agent_gender
+        add_foreign_key([:agent_family_id], :agent_family, :key => :id)
+        add_foreign_key([:agent_corporate_entity_id], :agent_corporate_entity, :key => :id)
+        add_foreign_key([:agent_software_id], :agent_software, :key => :id)
+      end
+    end
+
+    alter_table(:parallel_name_person) do
+      add_foreign_key([:name_person_id], :name_person, :key => :id)
+    end
+
+    alter_table(:parallel_name_family) do
+      add_foreign_key([:name_family_id], :name_family, :key => :id)
+    end
+
+    alter_table(:parallel_name_corporate_entity) do
+      add_foreign_key([:name_corporate_entity_id], :name_corporate_entity, :key => :id)
+    end
+
+    alter_table(:parallel_name_software) do
+      add_foreign_key([:name_software_id], :name_software, :key => :id)
+    end
+  end
+end

--- a/frontend/app/controllers/subjects_controller.rb
+++ b/frontend/app/controllers/subjects_controller.rb
@@ -155,7 +155,12 @@ class SubjectsController < ApplicationController
 
   def delete
     subject = JSONModel(:subject).find(params[:id])
-    subject.delete
+    begin
+      subject.delete
+    rescue ConflictException => e
+      flash[:error] = I18n.t("subject._frontend.messages.delete_conflict", :error => I18n.t("errors.#{e.conflicts}", :default => e.message))
+      return redirect_to(:controller => :subjects, :action => :show, :id => subject.id)
+    end
 
     flash[:success] = I18n.t("subject._frontend.messages.deleted", JSONModelI18nWrapper.new(:subject => subject))
     redirect_to(:controller => :subjects, :action => :index, :deleted_uri => subject.uri)

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1216,6 +1216,7 @@ en:
         merged: Subject(s) Merged
         merge_description: Select subjects below to merge into
         please_select_a_subject_to_merge: Please select a subject
+        delete_conflict: "Subject could not be deleted: <pre>%{error}</pre>"
       section:
         basic_information: Basic Information
         terms: Terms and Subdivisions


### PR DESCRIPTION
## Description
Agent subrecord tables were created in migration 141, but lacked foreign key constraints for their parent agents. 4 of the agent sub record types can link to subjects through a 'place' or 'topic' relationship, so it cannot be possible to delete a subject while it is being used in one of the relationships (See JIRA). 

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1381

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
