### PR TITLE
Improve EAD import performance for unnumbered components

### DIFF
--- a/backend/app/converters/ead_converter.rb
+++ b/backend/app/converters/ead_converter.rb
@@ -1,4 +1,6 @@
 require_relative 'converter'
+require 'set'
+
 class EADConverter < Converter
 
   require 'securerandom'
@@ -21,19 +23,6 @@ class EADConverter < Converter
       self.new(input_file)
     else
       nil
-    end
-  end
-
-
-  # We override this to skip nodes that are often very deep
-  # We can safely assume ead, c, and archdesc will have children,
-  # which greatly helps the performance.
-  def is_node_empty?(node)
-    parent_nodes = %w{ ead e archdesc dsc } + (1..12).collect { |n| "c#{ sprintf('%02d', n)}" }
-    if parent_nodes.include?( node.local_name )
-      return false
-    else
-      return node.inner_xml.strip.empty?
     end
   end
 

--- a/backend/app/converters/lib/sax_xml_reader.rb
+++ b/backend/app/converters/lib/sax_xml_reader.rb
@@ -1,0 +1,93 @@
+class SAXXMLReader
+
+  include Enumerable
+
+  def initialize(source_xml)
+    @source_xml = source_xml
+  end
+
+  def each(&block)
+    empty_node_indexes = Set.new
+
+    # First pass: calculate our empty node indexes.  A node is empty if it has no
+    # children, or if all of its children are blank text nodes or comments.
+    maybe_empty = []
+
+    inner_reader.each_with_index do |node, i|
+      ignorable = (
+        (node.node_type == Nokogiri::XML::Reader::TYPE_COMMENT) ||
+        (node.node_type == Nokogiri::XML::Reader::TYPE_WHITESPACE) ||
+        (node.node_type == Nokogiri::XML::Reader::TYPE_SIGNIFICANT_WHITESPACE) ||
+        (node.node_type == Nokogiri::XML::Reader::TYPE_TEXT && node.value !~ /\S/) ||
+        (node.node_type == Nokogiri::XML::Reader::TYPE_CDATA && node.value !~ /\S/)
+      )
+
+      # This element doesn't count towards making its containing element non-empty
+      next if ignorable
+
+      # Otherwise, any "maybe empty" elements with a depth less than this
+      # (i.e. further up in the tree) are not empty.
+      while maybe_empty.length > 0 && maybe_empty.last[:depth] < node.depth
+        maybe_empty.pop
+      end
+
+      if maybe_empty.length > 0 && maybe_empty.last[:depth] <= node.depth
+        # Either this is a closer for our pending element, or the original element was
+        # self-closing.  Either way, if it's still sitting in `maybe_empty`, it must
+        # have been empty.
+        empty_node_indexes << maybe_empty.pop[:index]
+      end
+
+      # We'll need to keep checking to work out if this one is empty.
+      if node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+        maybe_empty << {index: i, depth: node.depth}
+      end
+    end
+
+    # Second pass: iterate the same nodes and indicate which ones are empty to the
+    # caller.
+    inner_reader.each_with_index do |node, i|
+      block.call(node, empty_node_indexes.include?(i))
+    end
+  end
+
+  private
+
+  def inner_reader
+    reader = Nokogiri::XML::Reader(@source_xml) do |config|
+      config.noblanks.strict
+    end
+
+    InnerReaderWithNodeClearing.new(reader)
+  end
+
+  # Nokogiri under JRuby has historically had problems where all nodes are loaded
+  # into memory.  We do some footwork here to clear the nodes as we finish with
+  # them, allowing the GC to clean up as we go.
+  #
+  # As of 2021, this still looks to be relevant:
+  #
+  # https://github.com/sparklemotion/nokogiri/issues/1066
+  #
+  InnerReaderWithNodeClearing = Struct.new(:reader, :node_queue) do
+    def initialize(reader)
+      self.reader = reader
+
+      # Java reflection to get at Nokogiri's internal node queue.
+      obj = reader.to_java
+      nodeQueueField = obj.get_class.get_declared_field("nodeQueue")
+      nodeQueueField.setAccessible(true)
+      self.node_queue = nodeQueueField.get(obj)
+    end
+
+    def each(&block)
+      i = 0
+
+      self.reader.each do |node|
+        block.call(node)
+        self.node_queue.set(i, nil)
+        i += 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
I noticed that importing certain EAD files would take a long time.  Two in particular, both exported from Smithsonian's ArchivesSpace instance, ran for over an hour before I gave up.

The thing common to the slow files was that both used unnumbered component tags (i.e. `<c>` instead of `<c01>`).  The profiler showed all of the CPU time in this method:

  https://github.com/archivesspace/archivesspace/blob/3663176be821028007b5cdae2c5b01b4ea550e21/backend/app/converters/ead_converter.rb#L28-L38

which is the overridden version of this one:

  https://github.com/archivesspace/archivesspace/blob/3663176be821028007b5cdae2c5b01b4ea550e21/backend/app/converters/lib/xml_sax.rb#L124-L136

the EAD converter version has been modified to short-circuit the check for common tags--including numbered components--but still checks unnumbered components.  So that explains why I'm seeing different performance between my test files.

The trouble with all of this is that the importer is trying to work out whether a given node is empty, but the SAX parsing makes that hard.  Calling `node.inner_xml.strip.empty?` gives the right result, but slows down exponentially as every node in the document traverses every node under it, serializing them all into one huge string and then cloning that string with the final call to `.strip`.

Rather than adding more exceptions, I've worked on speeding up the "is empty?" check.  It requires two passes over the input XML (one to determine which nodes are empty, then one to do the original work), but the end result is much faster.  Here are some indicative numbers:

| File           | Size  | Original version | This version   |
|----------------|-------|------------------|----------------|
| copland.xml    | 5.8MB | 1 min 45 sec     | 1 min 40 secs  |
| Smithsonian 1  | 87MB  | never finished   | 18 mins        |
| hornstein.xml  | 468KB | 25 secs          | 15 secs        |
| Smithsonian 2  | 10MB  | never finished   | 2 mins 10 secs |
| Smithsonian 3  | 3KB   | 5 secs           | 5 secs         |

For the ones that finished, I've verified the results by re-exporting them as EAD under both versions of the code and comparing the results.
