### PR TITLE
ANW-1338 Ensure PUI DO captions will wrap regardless of device size

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -851,6 +851,21 @@ span.head {
 	margin-top: 20px;
 }
 
+.panel-heading {
+  word-break: break-word;
+  white-space: normal;
+  overflow-wrap: break-word;
+}
+
+.tab-pane, .page-actions {
+   word-break: break-word;
+   overflow-wrap: anywhere;
+}
+
+.badge-and-identifier {
+  overflow: scroll;
+}
+
 @media (min-width: 992px) {
   #sidebar.resizable-sidebar {
     position: relative;
@@ -943,18 +958,4 @@ span.head {
 .honeypot {
   position: absolute;
   left: -9999px;
-}
-
-@media (max-width: 768px) {
-  div {
-     overflow: scroll;
-     overflow-wrap: anywhere;
-     word-break: break-word;
-  }
-
-  .panel-heading {
-     overflow-wrap: anywhere;
-     word-break: break-all;
-     white-space: normal;
-  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#2311 and #2243 implemented fixes to ensure digital object captions in the PUI would wrap on small devices/screen sizes.  However, as https://archivesspace.atlassian.net/browse/ANW-1338 explains, this issue wasn't specifically related to device/screen size, but, rather, happened whenever the screen size was too small OR the caption length too long (regardless of screen size).  These CSS changes extend/update the prior fixes to work regardless of device size, while also addressing some regressions that were introduced in prior fixes (namely, subrecord text was no longer wrapping around DO images). 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1338

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Larger screen:
![image](https://user-images.githubusercontent.com/15144646/130860888-171724df-cb6c-4182-8efb-295f2378b818.png)

Mobile device:
![image](https://user-images.githubusercontent.com/15144646/130860723-860872b4-5804-4c4f-856d-f3063f778dd7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
