### PR TITLE
ANW-979

### DIFF
--- a/backend/app/lib/exceptions.rb
+++ b/backend/app/lib/exceptions.rb
@@ -59,7 +59,12 @@ class TransferConstraintError < StandardError
   end
 
   def add_conflict(uri, property)
-    @conflicts[uri] = property
+    if property.is_a? Hash
+      @conflicts[uri] ||= []
+      @conflicts[uri] << property
+    else
+      @conflicts[uri] = property
+    end
   end
 
   def to_s

--- a/backend/app/model/mixins/transferable.rb
+++ b/backend/app/model/mixins/transferable.rb
@@ -106,6 +106,9 @@ module Transferable
     topcon_rlshp = SubContainer.find_relationship(:top_container_link)
     # now we get  all the relationships in this graph
     all_ids = graph.ids_for(topcon_rlshp)
+    # add any conflicts to this, then raise unless it is empty
+    error = TransferConstraintError.new
+    top_container_transferees = []
 
     DB.open do |db|
       # Find relationships that are in our set of IDs that haven't been
@@ -115,7 +118,12 @@ module Transferable
         .filter(:top_container_link_rlshp__id => all_ids)
         .filter(:top_container__repo_id => self.class.active_repository)
         .each do |tc_rel|
-        # lets get all the top_containers outside this graph
+
+        top_container = TopContainer.this_repo.filter(id: tc_rel[:top_container_id]).first
+        # Already transferred
+        next unless top_container
+
+        # lets get all this container's links outside transferred object's graph
         number_of_tc_links = db[:top_container_link_rlshp]
                              .join(:top_container, :id => :top_container_id)
                              .filter(:top_container__repo_id => self.class.active_repository)
@@ -123,28 +131,26 @@ module Transferable
                              .exclude(:top_container_link_rlshp__id => all_ids)
                              .count
 
-        if number_of_tc_links < 1
-          # this tc is only linked in this graph..so we transfer
-          top_container = TopContainer.this_repo.filter(id: tc_rel[:top_container_id]).first
-
-          if top_container
-            if top_container.barcode && TopContainer.any_repo[:barcode => top_container.barcode, :repo_id => repository.id]
-              # There's already a top container with our barcode in the target
-              # repository.  Not sure if merging them is the right strategy or
-              # not, so throwing an error for now
-              raise TransferConstraintError.new(top_container.uri => "Top Container barcode '#{top_container.barcode}' already in use in target repository")
-            end
-
-            top_container.transfer_to_repository(repository, transfer_group + [self]) # i guess we always add self just in case. dups are uniqed out.
-          else
-            # Already transferred
-          end
-        else
+        # this tc linked beyond this graph..so it's an error
+        if number_of_tc_links > 0
           # ANW-979
           # Cancel transfer and let user know that they must unlink other top container
-
-          raise TransferConstraintError.new({'values' => 'Top Container is linked to other records, unlink them to continue'})
+          error.add_conflict(top_container.uri, message: "TOP_CONTAINER_IN_USE")
         end
+
+        if top_container.barcode && TopContainer.any_repo[:barcode => top_container.barcode, :repo_id => repository.id]
+          # There's already a top container with our barcode in the target
+          # repository.  Not sure if merging them is the right strategy or
+          # not, so throwing an error for now
+          error.add_conflict("#{top_container.uri}", message: "BARCODE_IN_USE")
+        end
+
+        top_container_transferees << top_container
+      end
+      raise error unless error.conflicts.empty?
+
+      top_container_transferees.each do |top_container|
+        top_container.transfer_to_repository(repository, transfer_group + [self]) # i guess we always add self just in case. dups are uniqed out.
       end
     end
 

--- a/frontend/app/helpers/errors_helper.rb
+++ b/frontend/app/helpers/errors_helper.rb
@@ -1,0 +1,26 @@
+module ErrorsHelper
+  def transfer_errors_by_message(transfer_errors)
+    results = {}
+    transfer_errors.each do |uri, errors|
+      errors.each do |err|
+        next unless err['message']
+        results[err['message']] ||= {}
+        results[err['message']][uri] = err
+      end
+    end
+    results.transform_keys { |k|
+      case k
+      when 'DIGITAL_OBJECT_IN_USE'
+        I18n.t('actions.transfer_failed_records_using_digital_objects')
+      when 'DIGITAL_OBJECT_HAS_LINK'
+        I18n.t('actions.transfer_failed_digital_objects_linked_to_records')
+      when 'TOP_CONTAINER_IN_USE'
+        I18n.t('actions.transfer_failed_top_containers_in_use')
+      when 'BARCODE_IN_USE'
+        I18n.t('actions.transfer_failed_barcodes_in_use')
+      else
+        k
+      end
+    }
+  end
+end

--- a/frontend/app/views/transfer/_transfer_failures.html.erb
+++ b/frontend/app/views/transfer/_transfer_failures.html.erb
@@ -1,29 +1,21 @@
 <% if @transfer_errors %>
     <%# Pull in the relevant javascript for the 'show' view to make sure trees are loaded %>
     <%= javascript_include_tag "#{controller.controller_name}.show" if File.exist?("#{Rails.root}/app/assets/javascripts/#{controller_name}.show.js") ||  File.exist?("#{Rails.root}/app/assets/javascripts/#{controller_name}.show.js.erb") %>
-
+    <% errors_by_message = transfer_errors_by_message(@transfer_errors) %>
     <div class="alert alert-danger">
         <h3><%= I18n.t('actions.transfer_failed') %></h3>
-
-        <% if @transfer_errors.values.all? {|e| e['message'] == 'DIGITAL_OBJECT_IN_USE'} %>
+        <% errors_by_message.each do |message, errors| %>
+            <% inspect_error = false %>
             <p>
-                <%= I18n.t('actions.transfer_failed_records_using_digital_objects') %>:
+                <%= message %>:
                 <ul>
-                    <% @transfer_errors.keys.each do |uri| %>
+                    <% errors.keys.each do |uri| %>
                         <li><%= link_to uri, {:controller => :resolver, :action => :resolve_readonly, :uri => uri} %></li>
                     <% end %>
                 </ul>
             </p>
-        <% elsif @transfer_errors.values.all? {|e| e['message'] == 'DIGITAL_OBJECT_HAS_LINK'} %>
-            <p>
-                <%= I18n.t('actions.transfer_failed_digital_objects_linked_to_records') %>:
-                <ul>
-                    <% @transfer_errors.keys.each do |uri| %>
-                        <li><%= link_to uri, {:controller => :resolver, :action => :resolve_readonly, :uri => uri} %></li>
-                    <% end %>
-                </ul>
-            </p>
-        <% else %>
+        <% end %>
+        <% if errors_by_message.empty? %>
             <%# Shouldn't happen, but give something to report... %>
             <%= @transfer_errors.inspect %>
         <% end %>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -71,6 +71,8 @@ en:
     transfer_failed: Transfer Failed
     transfer_failed_records_using_digital_objects: "The following records link to digital objects that would be transferred, but doing so would break their instance links"
     transfer_failed_digital_objects_linked_to_records: "This digital object links to other records held in this repository. To proceed with this transfer, remove the links in the following records"
+    transfer_failed_top_containers_in_use: "The following top containers are linked to other top-level records in this repository, and cannot be transferred until those links are severed"
+    transfer_failed_barcodes_in_use: "The following top containers use barcodes that are used in the target repository, and cannot be transferred until those conflicts are fixed"
     unset_default: Unset Default
     unsuppress: Unsuppress
     unsuppress_confirm_title: Unsuppress this Record?


### PR DESCRIPTION
Refactor transferable mixin to allow multiple errors to accumulate
when top containers are in use. Normilize TransferConstraintError
so message codes are accessed like this: error[URI][0][:message]

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
