### PR TITLE
Docker distributed aspace cfg example (aspace N instances)

### DIFF
--- a/.env.docker.release
+++ b/.env.docker.release
@@ -7,5 +7,11 @@ APPCONFIG_SOLR_URL="http://solr:8983/solr/archivesspace"
 APPCONFIG_FRONTEND_PROXY_URL="http://localhost/staff/"
 APPCONFIG_OAI_PROXY_URL="http://localhost/oai"
 APPCONFIG_PUBLIC_PROXY_URL="http://localhost/"
+# session & system user config
+APPCONFIG_FRONTEND_COOKIE_SECRET=secret
+APPCONFIG_PUBLIC_COOKIE_SECRET=secret
+APPCONFIG_PUBLIC_USER_SECRET=secret
+APPCONFIG_SEARCH_USER_SECRET=secret
+APPCONFIG_STAFF_USER_SECRET=secret
 # java config
 JAVA_OPTS="-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xss512k -Djavax.accessibility.assistive_technologies=''"

--- a/docker-compose-dist.yml
+++ b/docker-compose-dist.yml
@@ -1,0 +1,48 @@
+# docker-compose -f docker-compose-dist.yml build
+# docker-compose -f docker-compose-dist.yml up -d db solr app # allow the migrations to run 1st or trouble
+# docker-compose -f docker-compose-dist.yml up # bring up everything else
+
+version: '3.8'
+services:
+  app:
+    image: archivesspace/archivesspace:latest
+    restart: on-failure
+    depends_on:
+      - db
+      - solr
+    env_file:
+      - .env.docker.release
+  app2:
+    image: archivesspace/archivesspace:latest
+    restart: on-failure
+    depends_on:
+      - db
+      - solr
+    env_file:
+      - .env.docker.release
+  db:
+    container_name: as_dist_db
+    image: mysql:8.0
+    command: --character-set-server=UTF8MB4 --innodb_buffer_pool_size=2G --innodb_buffer_pool_instances=2 --log_bin_trust_function_creators=1
+    ports:
+      - "3309:3306"
+    env_file:
+      - .env.docker.db
+  solr:
+    container_name: as_dist_solr
+    build:
+      context: ./solr
+    image: archivesspace/solr:8.8
+    command: solr-create -p 8983 -c archivesspace -d /archivesspace
+    ports:
+      - "8986:8983"
+  web:
+    container_name: as_dist_proxy
+    build:
+      context: ./proxy
+    image: archivesspace/proxy:1.13
+    ports:
+      - "80:80"
+    depends_on:
+      - app
+      - app2

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -1,17 +1,21 @@
 upstream app_api {
   server app:8089;
+  server app2:8089;
 }
 
 upstream app_oai {
   server app:8082;
+  server app2:8082;
 }
 
 upstream app_public {
   server app:8081;
+  server app2:8081;
 }
 
 upstream app_staff {
   server app:8080;
+  server app2:8080;
 }
 
 server {


### PR DESCRIPTION
This is for illustrative purposes -- running multiple aspace instances via a single proxy with MySQL and external Solr (does not address duplicative indexer state).