### PR TITLE
ANW-1390 Don't error when light mode users edit corp/software/fam records

### DIFF
--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -421,6 +421,7 @@ module ApplicationHelper
   def has_agent_subrecords?(agent)
     # agent_person has all agent subrecord types so is ideal for finding any potential subrecord
     JSONModel(:agent_person).properties_by_tag('agent_subrecord').map(&:first).map(&:to_sym).find do |subrecord|
+      return unless agent.methods.include?(subrecord)
       agent.send(subrecord).length.positive?
     end
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As described in ANW-1390, edit view of non-person agents was throwing errors for users without full record permissions.  The `has_agent_subrecords?` method in `frontend/app/helpers/application_helper.rb` was throwing an undefined method error on non_person agents that didn't have (and will never have) `agent_gender` subrecords.  I modified the method to check whether the subrecord method exists for a given agent type, before moving on to check for the subrecords.  

This was a somewhat difficult thing to spot since it wasn't erroring out on records that _had_ subrecords (the new functionality that would logically be tested), but on records that didn't have subrecords.  So, I added tests as well.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1390

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New tests added and confirmed passing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
