### PR TITLE
Cache the negative lookup result in ImpliedPublicationCalculator

### DIFF
--- a/backend/app/model/implied_publication_calculator.rb
+++ b/backend/app/model/implied_publication_calculator.rb
@@ -304,7 +304,11 @@ class ImpliedPublicationCalculator
     return true if repo_id.nil?
 
     @repository_published_status ||= {}
-    @repository_published_status[repo_id] ||= (Repository[repo_id].publish == 1)
+
+    unless @repository_published_status.include?(repo_id)
+      @repository_published_status[repo_id] = (Repository[repo_id].publish == 1)
+    end
+
     @repository_published_status[repo_id]
   end
 end


### PR DESCRIPTION
The `repository_published?` method gets called heavily when fetching records that are a part of large collections.  To reduce the overhead of looking up the current repository's publication status, the method keeps a result cache that lives for the duration of the request.

When the repository isn't published, this cache is currently not working.  The construction:

     @repository_published_status[repo_id] ||= (Repository[repo_id].publish == 1)

always evaluates the RHS when the LHS is falsey which, for unpublished repositories, it is, because it's false!  What was intended was to do the lookup if the cache has no entry for `repo_id`.

This would only be an issue for people with large collections in unpublished repositories, so maybe that use case is rare.  I see halved response times in such cases with this fix, so probably still worth doing.