### PR TITLE
prevent enabling custom reports for now

### DIFF
--- a/common/config/config-aliases.rb
+++ b/common/config/config-aliases.rb
@@ -8,3 +8,5 @@ AppConfig.add_alias(:option => :public_prefix,
 
 AppConfig.add_deprecated(:bulk_import_rows)
 AppConfig.add_deprecated(:bulk_import_size)
+
+AppConfig.ensure_false(:enable_custom_reports)

--- a/common/config/config-distribution.rb
+++ b/common/config/config-distribution.rb
@@ -25,6 +25,11 @@ class AppConfig
       $stderr.puts("WARNING: The parameter '#{parameter}' was already set")
     end
 
+    if forced_off_parameters.include?(parameter) && value
+      $stderr.puts("WARNING: The parameter '#{parameter}' cannot be enabled in this version of ArchivesSpace")
+      return
+    end
+
     @@changed_from_default[parameter] = true
     @@parameters[parameter] = value
   end
@@ -58,6 +63,9 @@ class AppConfig
     @@deprecated_parameters ||= {}
   end
 
+  def self.forced_off_parameters
+    @@forced_off_parameters ||= []
+  end
 
   def self.has_key?(parameter)
     @@parameters.has_key?(resolve_alias(parameter))
@@ -206,6 +214,10 @@ class AppConfig
 
   def self.add_deprecated(parameter)
     deprecated_parameters[parameter] = true
+  end
+
+  def self.ensure_false(parameter)
+    forced_off_parameters << parameter
   end
 
   def self.parse_value(value)


### PR DESCRIPTION
This just turns off custom report configurability for the time being.


## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
