### PR TITLE
Add the missing definition of QUEUE

### DIFF
--- a/backend/app/model/sequence.rb
+++ b/backend/app/model/sequence.rb
@@ -1,6 +1,8 @@
 class Sequence
   # DEPRECATED: this is dead code since ArchivesSpace v2
 
+  QUEUE = java.util.concurrent.ArrayBlockingQueue.new(1024)
+
   def self.init(sequence, value)
     result = java.util.concurrent.CompletableFuture.new
     QUEUE.add({action: :init, sequence: sequence, value: value, result: result})
@@ -76,9 +78,8 @@ class Sequence
         Log.exception($!)
         request[:result].completeExceptionally(java.lang.RuntimeException.new("Unexpected error"))
       end
-
-      raise SequenceError.new("Gave up trying to generate a sequence number for: '#{sequence}'")
     end
+
   end
 
 end


### PR DESCRIPTION
One of the changes contributed from the Queensland State Archives project was this reworking of the `Sequence` class.  Although it's not used in the core code anymore, various plugins do make use of it, and we addressed some issues with concurrency and deadlocking as as part of that project.

The new implementation relies on a queue, but @pobocks noticed that the line that defines that seems to have been dropped accidentally along the way, so I'm just adding it back in here (this gets rid of the warning message on startup too).

I also took out the raise of `SequenceError`, since our new version doesn't do that either--it's just a relic from the original implementation.