### PR TITLE
Use aspace base to determine location of gem files

### DIFF
--- a/launcher/plugin_gems/initialize-plugin.sh
+++ b/launcher/plugin_gems/initialize-plugin.sh
@@ -24,13 +24,13 @@ if [ "$?" != "0" ]; then
 fi
 
 export JRUBY=
-for dir in ../../gems/gems/jruby-*; do
+for dir in "$ASPACE_LAUNCHER_BASE"/gems/gems/jruby-*; do # UNC override to change path
     JRUBY="$JRUBY:$dir/lib/*"
 done
 
 export GEM_HOME=gems
 
 java $JAVA_OPTS -cp "../../lib/*$JRUBY" org.jruby.Main -S gem install bundler -v "$BUNDLER_VERSION"
-java $JAVA_OPTS -cp "../../lib/*$JRUBY" org.jruby.Main ../../gems/bin/bundle install --gemfile=Gemfile
+java $JAVA_OPTS -cp "../../lib/*$JRUBY" org.jruby.Main "$ASPACE_LAUNCHER_BASE"/gems/bin/bundle install --gemfile=Gemfile
 
 

--- a/launcher/plugin_gems/initialize-plugin.sh
+++ b/launcher/plugin_gems/initialize-plugin.sh
@@ -24,7 +24,7 @@ if [ "$?" != "0" ]; then
 fi
 
 export JRUBY=
-for dir in "$ASPACE_LAUNCHER_BASE"/gems/gems/jruby-*; do # UNC override to change path
+for dir in "$ASPACE_LAUNCHER_BASE"/gems/gems/jruby-*; do
     JRUBY="$JRUBY:$dir/lib/*"
 done
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Plugins with attached gemfiles could not find JRuby to install the needed gems. This PR switches out the hardcoded path to use ASPACE_LAUNCHER_BASE as the default base path to JRuby and gem files

## Related JIRA Ticket or GitHub Issue
https://github.com/archivesspace/archivesspace/issues/2392

## How Has This Been Tested?
Tested by enabling plugins using the changes in this PR

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [x ] I have authority to submit this code.
- [x ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
