### PR TITLE
Don't show scrollbars on Windows in badge-and-identifier

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -863,7 +863,7 @@ span.head {
 }
 
 .badge-and-identifier {
-  overflow: scroll;
+  overflow: auto;
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Windows users are seeing unwanted scroll bars in the badge-and-identifier section of the PUI, likely stemming from #2372 and the related quirk with overflow styling noted here: https://stackoverflow.com/questions/51250934/chrome-scrollbar-is-showing-on-windows-but-not-mac

I can't directly test this, but I *think* it should resolve the bug.  (It certainly doesn't hurt or change anything for the worse on Mac).

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
