### PR TITLE
Frontend locale cleanup

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -5,7 +5,6 @@ ignore: |
   /common/locales/*.yml
   docker*
   /docs/
-  /frontend/
   /.github/
   /plugins/
   /public/
@@ -19,6 +18,8 @@ rules:
   document-start:
     present: false
   line-length:
+    ignore: |
+      /frontend/
     max: 100
     allow-non-breakable-words: true
     allow-non-breakable-inline-mappings: false

--- a/frontend/config/help.yml
+++ b/frontend/config/help.yml
@@ -148,4 +148,3 @@ topics:
 
   # Preferences
   preference: '892239901/Setting+Preferences+as+of+v2.8.1'
-

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -857,6 +857,8 @@ en:
         add: Add Date
 
   dates_of_existence:
+    _singular: Date of Existence
+    _plural: Dates of Existence
     _frontend:
       action:
         add: Add Date
@@ -1173,7 +1175,7 @@ en:
         spawned: "A new Resource has been spawned from Accession <strong>%{accession.display_string}</strong>"
         deleted: "Resource <strong>%{resource.title}</strong> deleted"
         published: "The Resource <strong>%{resource.title}</strong>, its subrecords and components have been published"
-        unpublished:  "The Resource <strong>%{resource.title}</strong>, its children, subrecords and components have been unpublished"
+        unpublished: "The Resource <strong>%{resource.title}</strong>, its children, subrecords and components have been unpublished"
         merge_description: Select resources below to merge into
         please_select_a_resource_to_merge: Please select a resource
         merged: Resource(s) Merged
@@ -1909,10 +1911,6 @@ en:
     gender: Gender
     note: Note
     dates: Dates
-
-  dates_of_existence:
-    _singular: Date of Existence
-    _plural: Dates of Existence
 
   agent_genders:
     <<: *agent_gender_attributes

--- a/frontend/config/locales/help/en.yml
+++ b/frontend/config/locales/help/en.yml
@@ -135,7 +135,7 @@ en:
       agent_identifiers: Help on Entity IDs
       agent_genders: Help on Genders
       agent_place: Help on Places
-      agent_occupation: Help on Occupations 
+      agent_occupation: Help on Occupations
       agent_function: Help on Functions
       agent_topic: Help on Topics
       agent_used_language: Help on Used Language
@@ -173,4 +173,3 @@ en:
 
       # Preference
       preference: Help on Preferences
-      


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Small changes to `frontend/config/locales/en.yml` to enable importing these translations into Weblate.  As it stands now, Weblate won't import this set of translations due to the duplicate `dates_of_existence` keys (removed below).

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
