### PR TITLE
ANW-810 add thumbnails of linked digital objects to collections / resources in the PUI-- the same way it does for archival objects

### DIFF
--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -159,6 +159,12 @@ class ResourcesController < ApplicationController
       ]
 #      @rep_image = get_rep_image(@result['json']['instances'])
       fill_request_info
+      if @result['primary_type'] == 'digital_object' || @result['primary_type'] == 'digital_object_component'
+        @dig = process_digital(@result['json'])
+      else
+        @dig = process_digital_instance(@result['json']['instances'])
+        process_extents(@result['json'])
+      end
     rescue RecordNotFound
       record_not_found(uri, 'resource')
     end

--- a/public/spec/controllers/resources_controller_spec.rb
+++ b/public/spec/controllers/resources_controller_spec.rb
@@ -7,8 +7,9 @@ describe ResourcesController, type: :controller do
     set_repo @repo
     @accession = create(:accession,
                         collection_management: build(:collection_management))
-
-    @resource = create(:resource, publish: true)
+    @digital_object = create(:digital_object)
+    @resource = create(:resource, publish: true,
+                       instances: [build(:instance_digital, digital_object: { ref: @digital_object.uri })])
     @unpublished_resource = create(:resource)
 
     @a1 = create(:archival_object,
@@ -89,6 +90,14 @@ describe ResourcesController, type: :controller do
       get(:tree_node_from_root, params: { rid: @repo.id, id: @resource.id,
                                           node_ids: ['notaId'] })
       expect(response.status).to eq(404)
+    end
+  end
+
+  describe "show action" do
+    it "passes digital object instance data to the view" do
+      get(:show, params: { rid: @repo.id, id: @resource.id })
+      instance_data = controller.instance_variable_get(:@dig)
+      expect(instance_data[0]['caption']).to eq(@digital_object.title)
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
made changes so that linked digital objects would show up as a thumbnail on the collections / resources PUI page -- the same way the linked digital objects do for archival objects
<!--- Why is this change required? What problem does it solve? -->
Our institution was interested in it-- and there was an existing Jira issue archivesspace/ANW-810

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
ANW-810

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested it where a resource could have zero to many linked digital objects and it would display accordingly.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
sorry-- i need to figure out how to get these running as when i tried it gave me errors
