### PR TITLE
ANW-1060: Fix for multiple ARKs generated for the same record

### DIFF
--- a/backend/app/model/ark_name.rb
+++ b/backend/app/model/ark_name.rb
@@ -102,10 +102,9 @@ class ArkName < Sequel::Model(:ark_name)
   end
 
   def self.ark_name_exists?(id, type)
-    case type
-    when Resource
+    if type == Resource
       id_field = :resource_id
-    when ArchivalObject
+    elsif type == ArchivalObject
       id_field = :archival_object_id
     else
       return false

--- a/backend/spec/model_ark_name_spec.rb
+++ b/backend/spec/model_ark_name_spec.rb
@@ -137,4 +137,30 @@ describe 'ArkName model' do
     ao.delete
   end
 
+  it "does not create extra ArkNames when a resource is edited" do
+    json = build(:json_resource, {:title => 'Initial title'})
+    resource = Resource.create_from_json(json, :repo_id => $repo_id)
+
+    json[:title] = 'Modified title'
+    json[:lock_version] = 0
+    resource.update_from_json(json)
+
+    expect(ArkName.where(:resource_id => resource.id).count).to eq(1)
+
+    resource.delete
+  end
+
+  it "does not create extra ArkNames when an archival object is edited" do
+    json = build(:json_archival_object, :title => 'Initial title')
+    ao = ArchivalObject.create_from_json(json, :repo_id => $repo_id)
+
+    json[:title] = 'Modified title'
+    json[:lock_version] = 0
+    ao.update_from_json(json)
+
+    expect(ArkName.where(:archival_object_id => ao.id).count).to eq(1)
+
+    ao.delete
+  end
+
 end


### PR DESCRIPTION
## Description
I don't know why, probably some subtlety of Ruby semantics, but the _case/when/else_ in the `ArkName.ark_name_exists?()` method only ever executed the _else_ condition, regardless of the _Class_ object passed to it in the _type_ parameter. Hence the calling code in ASModel_crud.rb always got a false response, so created a new ARK every time the record was updated.

Replacing with the logically-identically _if/elsif/else_ equivalent, but which does allow the first two conditions to evaluate to true when the _type_ passed to the method is either _Resource_ or _ArchivalObject_. This fixes the bug of multiple ARKs being generated for the same record.

If an ArchivesSpace system already has multiple ARKs for some or all of its records, this won't change that.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1060

## How Has This Been Tested?
I've added backend tests which, when the test suite is run on master fail, but on this branch they succeed.

Testing manually, following the replication steps in the original issue, it also prevents two ARKs from being generated upon creation of new records in the staff interface. I assume the frontend creates then sends an update, because it doesn't happen when creating a record in the backend.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
