### PR TITLE
ANW-1395: Add button role to date picker span tags for month, day, year

### DIFF
--- a/frontend/spec/features/accessibility_spec.rb
+++ b/frontend/spec/features/accessibility_spec.rb
@@ -67,6 +67,33 @@ describe 'Accessibility', js: true, db: 'accessibility' do
       end
     end
 
+    it 'should have role=button on datepicker day, month and year selectors' do
+      visit "/resources/1/edit#tree::resource_1"
+
+      page.has_no_css? ".datepicker"
+
+      date_field = find "input#resource_dates__0__begin_.date-field.initialised"
+      date_field.click
+
+      page.has_css? ".datepicker"
+
+      within ".datepicker" do
+        current_day = find "td.day.active"
+        expect(current_day).to have_xpath "self::td[@role='button']"
+
+        selection_bar = find ".datepicker-switch"
+        selection_bar.click
+
+        current_month = find "span.month.active"
+        expect(current_month).to have_xpath "self::span[@role='button']"
+
+        selection_bar = find ".datepicker-switch"
+        selection_bar.click
+
+        current_year = find "span.year.active"
+        expect(current_year).to have_xpath "self::span[@role='button']"
+      end
+    end
   end
 
   context 'Advanced search' do

--- a/frontend/vendor/assets/javascripts/bootstrap-datepicker.js
+++ b/frontend/vendor/assets/javascripts/bootstrap-datepicker.js
@@ -829,7 +829,7 @@
 			i = 0;
 			while (i < 12){
         var focused = localDate && localDate.getMonth() === i ? ' focused' : '';
-				html += '<span class="month' + focused + '">' + dates[this.o.language].monthsShort[i++]+'</span>';
+				html += '<span role="button" class="month' + focused + '">' + dates[this.o.language].monthsShort[i++]+'</span>';
 			}
 			this.picker.find('.datepicker-months td').html(html);
 		},
@@ -947,7 +947,7 @@
 					}
 				}
 
-				html += '<span class="' + classes.join(' ') + '"' + (tooltip ? ' title="' + tooltip + '"' : '') + '>' + thisYear + '</span>';
+				html += '<span role="button" class="' + classes.join(' ') + '"' + (tooltip ? ' title="' + tooltip + '"' : '') + '>' + thisYear + '</span>';
 				thisYear += step;
 			}
 			view.find('td').html(html);
@@ -1038,7 +1038,7 @@
 					clsName = $.unique(clsName);
 				}
 
-				html.push('<td class="'+clsName.join(' ')+'"' + (tooltip ? ' title="'+tooltip+'"' : '') + '>'+prevMonth.getUTCDate() + '</td>');
+				html.push('<td role="button" class="'+clsName.join(' ')+'"' + (tooltip ? ' title="'+tooltip+'"' : '') + '>'+prevMonth.getUTCDate() + '</td>');
 				tooltip = null;
 				if (prevMonth.getUTCDay() === this.o.weekEnd){
 					html.push('</tr>');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bootstrap datepicker tags are missing role=button on the day, month, year elements.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1395

## How Has This Been Tested?
Manual and unit testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
