### PR TITLE
ANW-1370: Expand / collapse state of the element is incorrect

### DIFF
--- a/frontend/app/assets/javascripts/merge_dropdown.js.erb
+++ b/frontend/app/assets/javascripts/merge_dropdown.js.erb
@@ -40,6 +40,14 @@ $(function () {
     $(".merge-form .linker-wrapper .dropdown-toggle").on("click", function(event) {
       event.stopPropagation();
       $(this).parent().toggleClass("open");
+
+
+      if($(this).parent().hasClass("open")) {
+        $(this).attr('aria-expanded', true);
+      } 
+      else {
+        $(this).attr('aria-expanded', false);
+      }
     });
 
 

--- a/frontend/app/views/resources/_linker.html.erb
+++ b/frontend/app/views/resources/_linker.html.erb
@@ -55,7 +55,7 @@
 
          <% end %>
          <div class="input-group-btn">
-           <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" title="Link to <%= I18n.t("#{record_types}._singular").downcase %>" aria-label="Link to <%= I18n.t("#{record_types}._singular").downcase %>"><span class="caret"></span></a>
+           <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" title="Link to <%= I18n.t("#{record_types}._singular").downcase %>" aria-expanded="false" aria-label="Link to <%= I18n.t("#{record_types}._singular").downcase %>"><span class="caret"></span></a>
            <ul class="dropdown-menu">
              <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
            </ul>

--- a/frontend/spec/features/accessibility_spec.rb
+++ b/frontend/spec/features/accessibility_spec.rb
@@ -144,7 +144,7 @@ describe 'Accessibility', js: true, db: 'accessibility' do
       expect(page).to have_no_xpath("//a[not(@href)]")
     end
 
-    # 519100
+    # 519100, #519357
     it "supports aria-expanded for event and merge dropdowns" do
       visit "/resources/1"
       page.has_css? "div.record-toolbar"
@@ -160,6 +160,17 @@ describe 'Accessibility', js: true, db: 'accessibility' do
           dropdown_ctrl.click
           expect(dropdown_ctrl).to have_xpath("self::*[@aria-expanded='false']")
         end
+
+        # #merge-dropdown a.dropdown-toggle is inside the merge menu, so we need to drop that down first so the target element is visible
+        find("#merge-dropdown button.merge-action").click
+
+        dropdown_ctrl = find("#merge-dropdown a.dropdown-toggle")
+
+        expect(dropdown_ctrl).to have_xpath("self::*[@aria-expanded='false']")
+        dropdown_ctrl.click
+        expect(dropdown_ctrl).to have_xpath("self::*[@aria-expanded='true']")
+        dropdown_ctrl.click
+        expect(dropdown_ctrl).to have_xpath("self::*[@aria-expanded='false']")
       end
     end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Element inside of the merge dropdown is missing aria-expanded attribute.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1370

## How Has This Been Tested?
Manual and in browser testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
