### PR TITLE
Add API tree examples and improve parameters/data styling

### DIFF
--- a/_yard/API.erb
+++ b/_yard/API.erb
@@ -380,7 +380,7 @@ As of <%= @time.inspect %> the following REST endpoints exist in the master bran
 
 ## <%= e[:description]%>
 
-<% example =  @examples[e[:uri]][e[:method].to_s] %>
+<% example = @examples[e[:uri]][e[:method].to_s] %>
 
 <% if example %>
 
@@ -472,19 +472,12 @@ curl -H "X-ArchivesSpace-Session: $SESSION" \
 
 <%= e[:examples].reject do |k,v| k == 'shell' end.to_h.values.join("\n\n") %>
 
+<% end %>
+
 __Endpoint__
 
 ```<%= e[:method].map &:upcase %> <%= e[:uri]%> ```
 
-__Description__
-
-<%= e[:description]%>
-
-<%= e[:documentation] %>
-
-<% if !e[:documentation] || e[:prepend_docs] %>
-
-__Parameters__
 <% if e[:deprecated] %>
 <aside class="warning">
   This endpoint is deprecated, and may be removed from a future release of ArchivesSpace.
@@ -492,8 +485,28 @@ __Parameters__
     <p><%= e[:deprecated_description] %></p>
   <% end %>
 </aside>
-
 <% end %>
+
+__Description__
+
+<%= e[:description] + "." %>
+
+<% if e[:documentation] %>
+<br>
+<br>
+<%= e[:documentation] %>
+<% end %>
+
+<% @payload = [] %>
+<% e[:params].each do |p| %>
+  <% next if p.is_a? String %>
+  <% @payload << p if ((p[3] or {})[:body] or p[1] == :body_stream) %>
+<% end %>
+<% params = e[:params] - @payload %>
+
+<% if e[:paginated] || e[:paged] || params.any? %>
+
+__Parameters__
 <% if e[:paginated] %>
 <aside class="notice">
 This endpoint is paginated. :page, :id_set, or :all_ids is required
@@ -504,6 +517,7 @@ This endpoint is paginated. :page, :id_set, or :all_ids is required
   <li>Boolean all_ids &ndash; Return a list of all object ids</li>
 </ul>
 </aside>
+
 <% elsif e[:paged]%>
 <aside class="notice">
 This endpoint is paginated. :page is required
@@ -514,31 +528,58 @@ This endpoint is paginated. :page is required
 </aside>
 <% end %>
 
-<% e[:params].each do |param| %>
-  <% if param.is_a? String %>
-    <% opts = {} %>
-  <% else %>
-    <% opts = (param[3] or {}) %>
-  <% end %>
-  <% unless opts.empty? %>
-    <% vs = opts[:validation] ? " -- #{opts[:validation][0]}" : "" %>
-    <% optional = opts[:optional] ? " (Optional)" : "" %>
-  <% end %>
-  <% if opts[:body] %>
-	  <%= "#{param[1]} <request body> -- #{param[2]}#{vs}" %>
-  <% else %>
-	  <%= "#{param[1]} #{param[0]}#{optional} -- #{param[2]}#{vs}" %>
-  <% end %>
+<% if params.any? %>
+<table>
+  <thead>
+    <tr>
+      <th style="width: 25%;">Parameter</th>
+      <th style="width: 45%;">Description</th>
+      <th style="width: 20%;">Type</th>
+      <th style="width: 10%;">Optional?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% params.each do |param| %>
+        <% if param.is_a? String %>
+          <% opts = {} %>
+        <% else %>
+          <% opts = (param[3] or {}) %>
+        <% end %>
+
+        <% unless opts.empty? %>
+        <% vs = opts[:validation] %>
+        <% optional = opts[:optional] %>
+        <% end %>
+        
+      <tr>      
+        <td><code><%= param[0] %></code></td>
+        <td style="word-break: break-word;">
+            <%= param[2] %>
+            <% if !vs.nil? %>
+            <br>
+            <b><%= "Note: " %></b> <%= vs[0] %>
+            <% end %>
+        </td>
+        <td><%= param[1] %></td>
+        <td><%= optional %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<% end %>
+<% end %>
+
+<% if @payload.any? %>
+__Accepts Payload of Type__
+
+<%= @payload.flatten[1] %>
+
 <% end %>
 
 __Returns__
 
 <% e[:returns].each do |ret| %>
   <%= "\t#{ret[0]} -- #{ret[1]}\n" %>
-<% end %>
-
-<%# end prepend check %>
-<% end %>
 <% end %>
 
 <% end %>
@@ -548,7 +589,6 @@ __Returns__
 <p>An index of routes available in the ArchivesSpace API, alphabetically by URI.</p>
 
 <table>
-  <thead>></thead>
   <thead>
     <tr>
       <th>Route</th> <th>Method(s)</th> <th>Description</th>

--- a/backend/app/controllers/classification.rb
+++ b/backend/app/controllers/classification.rb
@@ -84,6 +84,12 @@ class ArchivesSpaceService < Sinatra::Base
     .params(["id", :id],
             ["repo_id", :repo_id],
             ["published_only", BooleanParam, "Whether to restrict to published/unsuppressed items", :default => false])
+    .example("shell") do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          "http://localhost:8089/repositories/2/classifications/1/tree/root"
+      SHELL
+    end
     .permissions([:view_repository])
     .returns([200, TreeDocs::ROOT_DOCS]) \
   do
@@ -97,6 +103,12 @@ class ArchivesSpaceService < Sinatra::Base
             ["offset", Integer, "The page of records to return"],
             ["parent_node", String, "The URI of the parent of this waypoint (none for the root record)", :optional => true],
             ["published_only", BooleanParam, "Whether to restrict to published/unsuppressed items", :default => false])
+    .example("shell") do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          "http://localhost:8089/repositories/2/classifications/1/tree/waypoint?offset=0&parent_node=/repositories/2/classification_terms/1"
+      SHELL
+    end
     .permissions([:view_repository])
     .returns([200, TreeDocs::WAYPOINT_DOCS]) \
   do
@@ -118,6 +130,12 @@ class ArchivesSpaceService < Sinatra::Base
             ["repo_id", :repo_id],
             ["node_uri", String, "The URI of the Classification Term record of interest"],
             ["published_only", BooleanParam, "Whether to restrict to published/unsuppressed items", :default => false])
+    .example("shell") do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          "http://localhost:8089/repositories/2/classifications/1/tree/node?node_uri=/repositories/2/classification_terms/1"
+      SHELL
+    end
     .permissions([:view_repository])
     .returns([200, TreeDocs::NODE_DOCS]) \
   do
@@ -132,6 +150,12 @@ class ArchivesSpaceService < Sinatra::Base
             ["repo_id", :repo_id],
             ["node_ids", [Integer], "The IDs of the Classification Term records of interest"],
             ["published_only", BooleanParam, "Whether to restrict to published/unsuppressed items", :default => false])
+    .example("shell") do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          "http://localhost:8089/repositories/2/classifications/1/tree/node_from_root?node_ids[]=1"
+      SHELL
+    end
     .permissions([:view_repository])
     .returns([200, TreeDocs::NODE_FROM_ROOT_DOCS]) \
   do

--- a/backend/app/controllers/digital_object.rb
+++ b/backend/app/controllers/digital_object.rb
@@ -96,6 +96,12 @@ class ArchivesSpaceService < Sinatra::Base
     .params(["id", :id],
             ["repo_id", :repo_id],
             ["published_only", BooleanParam, "Whether to restrict to published/unsuppressed items", :default => false])
+    .example("shell") do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          "http://localhost:8089/repositories/2/digital_objects/1/tree/root"
+      SHELL
+    end
     .permissions([:view_repository])
     .returns([200, TreeDocs::ROOT_DOCS]) \
   do
@@ -109,6 +115,12 @@ class ArchivesSpaceService < Sinatra::Base
             ["offset", Integer, "The page of records to return"],
             ["parent_node", String, "The URI of the parent of this waypoint (none for the root record)", :optional => true],
             ["published_only", BooleanParam, "Whether to restrict to published/unsuppressed items", :default => false])
+    .example("shell") do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          "http://localhost:8089/repositories/2/digital_objects/1/tree/waypoint?offset=0&parent_node=/repositories/2/digital_object_components/1"
+      SHELL
+    end
     .permissions([:view_repository])
     .returns([200, TreeDocs::WAYPOINT_DOCS]) \
   do
@@ -130,6 +142,12 @@ class ArchivesSpaceService < Sinatra::Base
             ["repo_id", :repo_id],
             ["node_uri", String, "The URI of the Digital Object Component record of interest"],
             ["published_only", BooleanParam, "Whether to restrict to published/unsuppressed items", :default => false])
+    .example("shell") do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          "http://localhost:8089/repositories/2/digital_objects/1/tree/node?node_uri=/repositories/2/digital_object_components/1"
+      SHELL
+    end
     .permissions([:view_repository])
     .returns([200, TreeDocs::NODE_DOCS]) \
   do
@@ -144,6 +162,12 @@ class ArchivesSpaceService < Sinatra::Base
             ["repo_id", :repo_id],
             ["node_ids", [Integer], "The IDs of the Digital Object Component records of interest"],
             ["published_only", BooleanParam, "Whether to restrict to published/unsuppressed items", :default => false])
+    .example("shell") do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          "http://localhost:8089/repositories/2/digital_objects/1/tree/node_from_root?node_ids[]=1"
+      SHELL
+    end
     .permissions([:view_repository])
     .returns([200, TreeDocs::NODE_FROM_ROOT_DOCS]) \
   do

--- a/backend/app/controllers/resource.rb
+++ b/backend/app/controllers/resource.rb
@@ -199,6 +199,12 @@ class ArchivesSpaceService < Sinatra::Base
     .params(["id", :id],
             ["repo_id", :repo_id],
             ["published_only", BooleanParam, "Whether to restrict to published/unsuppressed items", :default => false])
+    .example("shell") do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          "http://localhost:8089/repositories/2/resources/1/tree/root"
+      SHELL
+    end
     .permissions([:view_repository])
     .returns([200, TreeDocs::ROOT_DOCS]) \
   do
@@ -212,6 +218,12 @@ class ArchivesSpaceService < Sinatra::Base
             ["offset", Integer, "The page of records to return"],
             ["parent_node", String, "The URI of the parent of this waypoint (none for the root record)", :optional => true],
             ["published_only", BooleanParam, "Whether to restrict to published/unsuppressed items", :default => false])
+    .example("shell") do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          "http://localhost:8089/repositories/2/resources/1/tree/waypoint?offset=0&parent_node=/repositories/2/archival_objects/1"
+      SHELL
+    end
     .permissions([:view_repository])
     .returns([200, TreeDocs::WAYPOINT_DOCS]) \
   do
@@ -233,6 +245,12 @@ class ArchivesSpaceService < Sinatra::Base
             ["repo_id", :repo_id],
             ["node_uri", String, "The URI of the Archival Object record of interest"],
             ["published_only", BooleanParam, "Whether to restrict to published/unsuppressed items", :default => false])
+    .example("shell") do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          "http://localhost:8089/repositories/2/resources/1/tree/node?node_uri=/repositories/2/archival_objects/1"
+      SHELL
+    end
     .permissions([:view_repository])
     .returns([200, TreeDocs::NODE_DOCS]) \
   do
@@ -247,6 +265,12 @@ class ArchivesSpaceService < Sinatra::Base
             ["repo_id", :repo_id],
             ["node_ids", [Integer], "The IDs of the Archival Object records of interest"],
             ["published_only", BooleanParam, "Whether to restrict to published/unsuppressed items", :default => false])
+    .example("shell") do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          "http://localhost:8089/repositories/2/resources/1/tree/node_from_root?node_ids[]=1"
+      SHELL
+    end
     .permissions([:view_repository])
     .returns([200, TreeDocs::NODE_FROM_ROOT_DOCS]) \
   do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I was trying to help someone use the various `/tree` API endpoints, and found them to be a little cryptic.  Additionally problematic because these may find increased usage as we deprecate the now outdated `/tree` endpoints in favor of `tree/root`, `tree/waypoint`, and `tree/node`. I decided to add some API examples to the controllers, but then was frustrated by how bad they looked in Slate.  So, I also decided to (slightly) improve the way parameters and JSON payloads are represented in the Slate docs (screenshots below).

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before: 
<img width="666" alt="API_Reference_before" src="https://user-images.githubusercontent.com/15144646/134054781-1f4a7969-f621-48d7-91f9-de7d83eeb1d4.png">

After: 
<img width="828" alt="API_Reference" src="https://user-images.githubusercontent.com/15144646/134054656-f1d5f35a-a5a0-49dc-88b7-6cdfe11a80fa.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
