### PR TITLE
ANW-1305 API examples and permissions

### DIFF
--- a/backend/app/controllers/custom_report_template.rb
+++ b/backend/app/controllers/custom_report_template.rb
@@ -4,6 +4,24 @@ class ArchivesSpaceService < Sinatra::Base
     .description("Create a Custom Report Template")
     .params(["custom_report_template", JSONModel(:custom_report_template), "The record to create", :body => true],
         ["repo_id", :repo_id])
+    .example('shell') do
+      <<~SHELL
+        curl -H 'Content-Type: application/json' \\
+          -H "X-ArchivesSpace-Session: $SESSION" \\
+          -d '{
+                "lock_version": 0,
+                "name": "A New Custom Template",
+                "description": "A custom report template returning old accessions sorted by title.",
+                "data": "{\"fields\":{\"access_restrictions\":{\"value\":\"true\"},\"accession_date\":{\"include\":\"1\",\"narrow_by\":\"1\",\"range_start\":\"2011-01-01\",\"range_end\":\"2019-12-31\"},\"publish\":{\"value\":\"true\"},\"restrictions_apply\":{\"value\":\"true\"},\"title\":{\"include\":\"1\"},\"use_restrictions\":{\"value\":\"true\"},\"create_time\":{\"range_start\":\"\",\"range_end\":\"\"},\"user_mtime\":{\"range_start\":\"\",\"range_end\":\"\"}},\"sort_by\":\"title\",\"custom_record_type\":\"accession\"}",
+                "limit": 100,
+                "jsonmodel_type": "custom_report_template",
+                "repository": {
+                    "ref": "/repositories/2"
+                }
+              }' \\
+          "http://localhost:8089/repositories/2/custom_report_templates"
+      SHELL
+    end
     .permissions(['create_job'])
     .returns([200, :created]) \
   do
@@ -15,6 +33,24 @@ class ArchivesSpaceService < Sinatra::Base
     .params(["id", :id],
             ["custom_report_template", JSONModel(:custom_report_template), "The updated record", :body => true],
             ["repo_id", :repo_id])
+    .example('shell') do
+      <<~SHELL
+        curl -H 'Content-Type: application/json' \\
+          -H "X-ArchivesSpace-Session: $SESSION" \\
+          -d '{
+                "lock_version": 0,
+                "name": "A Newer Custom Template",
+                "description": "A custom report template returning old accessions sorted by title.",
+                "data": "{\"fields\":{\"access_restrictions\":{\"value\":\"true\"},\"accession_date\":{\"include\":\"1\",\"narrow_by\":\"1\",\"range_start\":\"2011-01-01\",\"range_end\":\"2019-12-31\"},\"publish\":{\"value\":\"true\"},\"restrictions_apply\":{\"value\":\"true\"},\"title\":{\"include\":\"1\"},\"use_restrictions\":{\"value\":\"true\"},\"create_time\":{\"range_start\":\"\",\"range_end\":\"\"},\"user_mtime\":{\"range_start\":\"\",\"range_end\":\"\"}},\"sort_by\":\"title\",\"custom_record_type\":\"accession\"}",
+                "limit": 100,
+                "jsonmodel_type": "custom_report_template",
+                "repository": {
+                    "ref": "/repositories/2"
+                }
+              }' \\
+          "http://localhost:8089/repositories/2/custom_report_templates/1"
+      SHELL
+    end
     .permissions(['create_job'])
     .returns([200, :updated]) \
   do
@@ -24,6 +60,12 @@ class ArchivesSpaceService < Sinatra::Base
   Endpoint.get('/repositories/:repo_id/custom_report_templates')
     .description("Get a list of Custom Report Templates")
     .params(["repo_id", :repo_id])
+    .example('shell') do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          "http://localhost:8089/repositories/2/custom_report_templates?page=1"
+      SHELL
+    end
     .paginated(true)
     .permissions(['create_job'])
     .returns([200, "[(:custom_report_template)]"]) \
@@ -37,6 +79,12 @@ class ArchivesSpaceService < Sinatra::Base
     .params(["id", :id],
         ["resolve", :resolve],
         ["repo_id", :repo_id])
+    .example('shell') do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          "http://localhost:8089/repositories/2/custom_report_templates/1"
+      SHELL
+    end
     .permissions(['create_job'])
     .returns([200, "(:custom_report_template)"]) \
   do
@@ -50,6 +98,13 @@ class ArchivesSpaceService < Sinatra::Base
     .description("Delete an Custom Report Template")
     .params(["id", :id],
         ["repo_id", :repo_id])
+    .example('shell') do
+      <<~SHELL
+        curl -H "X-ArchivesSpace-Session: $SESSION" \\
+          -X DELETE \\
+          "http://localhost:8089/repositories/2/custom_report_templates/1"
+      SHELL
+    end
     .permissions(['create_job'])
     .returns([200, :deleted]) \
   do

--- a/backend/app/controllers/reports.rb
+++ b/backend/app/controllers/reports.rb
@@ -31,7 +31,13 @@ class ArchivesSpaceService < Sinatra::Base
 
   Endpoint.get('/reports/custom_data')
   .description('Get a list of availiable options for custom reports')
-  .permissions([])
+  .permissions(['create_job'])
+  .example('shell') do
+    <<~SHELL
+      curl -H "X-ArchivesSpace-Session: $SESSION" \\
+        "http://localhost:8089/reports/custom_data"
+    SHELL
+  end
   .returns([200], "hash of availiable options") \
   do
     json_response(CustomField.registered_fields)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds API example blocks to the two reports controllers.  Also incidentally noticed that no permissions were assigned to the custom report endpoint in `backend/app/controllers/reports.rb` so added a permission there.  We may want to update this (as well as the `custom_report_template.rb`) permissions once ANW-1400 is complete.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1305

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
