### PR TITLE
Temporary fix to reports permissions

### DIFF
--- a/backend/app/controllers/reports.rb
+++ b/backend/app/controllers/reports.rb
@@ -31,7 +31,7 @@ class ArchivesSpaceService < Sinatra::Base
 
   Endpoint.get('/reports/custom_data')
   .description('Get a list of availiable options for custom reports')
-  .permissions(['create_job'])
+  .permissions([])
   .example('shell') do
     <<~SHELL
       curl -H "X-ArchivesSpace-Session: $SESSION" \\


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In #2431 I decided to be "helpful" and remedy the fact that the `reports/custom_data` endpoint didn't have any permissions attributed to it.  I added a `create_job` permission.  Turns out that was a bad idea.  `create_job` is a repo-scoped permission, but to work the `custom_data` endpoint has no repo assigned in it.  

This reverts that permission back to nothing until we can do further review/make decisions about what the permissions should be here. 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
