### PR TITLE
Do not set up PUI route for handling ARK URLs if arks_enabled is false

### DIFF
--- a/public/config/routes.rb
+++ b/public/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
 
     get '/welcome', to: 'welcome#show'
 
-    get '/*ark_tag/:naan/:id' => 'ark_name#show', constraints: { ark_tag: 'ark:' }
+    if AppConfig[:arks_enabled]
+      get '/*ark_tag/:naan/:id' => 'ark_name#show', constraints: { ark_tag: 'ark:' }
+    end
 
     # I don't think this is used anywhere...
     post '/cite', to: 'cite#show'

--- a/public/spec/spec_helper.rb
+++ b/public/spec/spec_helper.rb
@@ -33,6 +33,7 @@ $expire = 30000
 
 AppConfig[:backend_url] = $backend
 AppConfig[:pui_hide][:record_badge] = false # we want this for testing
+AppConfig[:arks_enabled] = true # ARKs have to be enabled to be able to test them
 
 $backend_start_fn = proc {
   TestUtils::start_backend($backend_port,


### PR DESCRIPTION
## Description
At the moment, if `AppConfig[:arks_enabled]` is set to its default value of false, the backend will not generate ARKs, nor will the staff inteface allow you to add an "External ARK URL" to records. But the public user interface will still respond to requests for URLs such as http://test.archivesspace.org/ark:/12345/123 by looking up whether the id 123 is in the _ark_name_ table. That is unnecessary, potentially confusing, and it prevents any plug-in which wants to handle ARKs differently from easily overriding the core functionality.

## Related JIRA Ticket or GitHub Issue
None

## How Has This Been Tested?
It works on a development system. The route is no longer recognized. The ARK tests in the public test suite fail, so I have added a line to enable them before running the tests. Possibly there is a better way of handling that?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
