### PR TITLE
Add devcontainer cfg

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,52 @@
+FROM mcr.microsoft.com/vscode/devcontainers/java:11
+
+ARG GECKODRIVER_VERSION \
+    MYSQL_CONNECTOR_VERSION \
+    SOLR_VERSION
+
+# PERSIST VERSIONS IN ENV FOR REFERENCE
+ENV APPCONFIG_DB_URL="jdbc:mysql://localhost:3306/asdev?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false&allowPublicKeyRetrieval=true" \
+    APPCONFIG_SOLR_URL="http://localhost:8983/solr/asdev" \
+    ASPACE_TEST_DB_URL="jdbc:mysql://localhost:3306/astest?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false&allowPublicKeyRetrieval=true" \
+    ASPACE_TEST_SOLR_URL="http://localhost:8983/solr/astest" \
+    DEBIAN_FRONTEND=noninteractive \
+    GECKODRIVER_VERSION=${GECKODRIVER_VERSION} \
+    LANG=C.UTF-8 \
+    MYSQL_CONNECTOR_VERSION=$MYSQL_CONNECTOR_VERSION \
+    SOLR_VERSION=${SOLR_VERSION} \
+    TZ=UTC
+
+RUN apt-get update && \
+    # INSTALL DEPENDENCIES
+    apt-get -y install --no-install-recommends \
+        curl \
+        firefox-esr \
+        git \
+        libmariadbclient-dev \
+        mariadb-server \
+        mycli \
+        python3-pkg-resources \
+        python3-setuptools \
+        shared-mime-info \
+        supervisor \
+        vim \
+        wget && \
+    # DOWNLOAD & INSTALL SOLR
+    wget https://dlcdn.apache.org/lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz && \
+    tar xzf solr-$SOLR_VERSION.tgz solr-$SOLR_VERSION/bin/install_solr_service.sh --strip-components=2 && \
+    ./install_solr_service.sh solr-$SOLR_VERSION.tgz && \
+    # DOWNLOAD GECKODRIVER
+    wget https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz && \
+    tar -zxvf geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz && \
+    mv geckodriver /usr/local/bin
+
+# TODO: evaluate pros/cons of pre-bootstrapping
+# GRAB MASTER BRANCH FOR AN INITIAL BOOTSTRAP TO SPEEDUP ./setup ?
+# RUN git clone --branch master --single-branch https://github.com/archivesspace/archivesspace.git /tmp/archivesspace && \
+# WORKDIR /tmp/archivesspace
+# RUN ./build/run bootstrap && \
+#     mkdir /tmp/build && \
+#     cp -r ./build/gems/ /tmp/build/ && \
+#     cp ./build/*.jar /tmp/build/ && \
+#     cp ./build/*.war /tmp/build/ && \
+#     rm -rf /tmp/archivesspace

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,15 @@
+# Devcontainer
+
+Integrate with vscode to run an ArchivesSpace development environment in Docker.
+
+## Secrets
+
+Create a file `.devcontainer/secrets` with variables to be exported:
+
+```bash
+export REMOTE_DB_HOST=host
+export REMOTE_DB_PORT=port
+export REMOTE_DB_NAME=name
+export REMOTE_DB_USER=user
+export REMOTE_DB_PASSWORD=password
+```

--- a/.devcontainer/aliases
+++ b/.devcontainer/aliases
@@ -1,0 +1,17 @@
+## ARCHIVESSPACE BUILD
+alias api="supervisord -c supervisord/api.conf"
+alias br="build/run"
+alias brb="build/run bootstrap"
+alias run="supervisord -c supervisord/archivesspace.conf"
+# database migrate
+alias brdm="build/run db:migrate"
+# solr reset
+alias brsr="build/run solr:reset"
+## GIT
+alias gdc="git diff --cached"
+alias gdf="git diff"
+alias gst="git status"
+## MYSQL
+alias myasd="mycli --user=as --password=as123 --database=asdev --auto-vertical-output"
+alias myast="mycli --user=as --password=as123 --database=astest --auto-vertical-output"
+alias restore='mysqldump -h $REMOTE_DB_HOST -u $REMOTE_DB_USER -p"$REMOTE_DB_PASSWORD" $REMOTE_DB_NAME | mysql -h 127.0.0.1 --user=as --password=as123 asdev'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "ArchivesSpace",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+    "args": {
+      "GECKODRIVER_VERSION": "0.29.1",
+      "MYSQL_CONNECTOR_VERSION": "8.0.23",
+      "SOLR_VERSION": "8.10.0"
+    }
+  },
+  "forwardPorts": [
+    3000,
+    3001,
+    3306,
+    4567,
+    8983
+  ],
+  "settings": {},
+  "extensions": [
+    "misogi.ruby-rubocop",
+    "rebornix.Ruby"
+  ],
+  "postCreateCommand": ".devcontainer/setup",
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/setup
+++ b/.devcontainer/setup
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -eu
+echo "Copying config files"
+cp .devcontainer/aliases ~/.bash_aliases
+SECRETS=.devcontainer/secrets && test -f $SECRETS && echo "source $SECRETS" >> ~/.bashrc
+
+echo "Starting MySQL (MariaDB) and Solr"
+sudo service mysql start
+sudo service solr start
+
+# TODO: this section will be deleted when Solr 4.x gone
+mkdir -p /tmp/solr/
+cp ./solr/schema-8.8.min.xml /tmp/solr/schema.xml
+cp ./solr/solrconfig-8.8.min.xml /tmp/solr/solrconfig.xml
+cp ./solr/stopwords.txt /tmp/solr/stopwords.txt
+cp ./solr/synonyms.txt /tmp/solr/synonyms.txt
+
+echo "Creating dev & test Solr cores"
+sudo su - solr -c "/opt/solr/bin/solr create -p 8983 -c asdev -d /tmp/solr" # /workspaces/archivesspace/solr
+sudo su - solr -c "/opt/solr/bin/solr create -p 8983 -c astest -d /tmp/solr" # /workspaces/archivesspace/solr
+
+echo "Downloading MySQL connector"
+wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/$MYSQL_CONNECTOR_VERSION/mysql-connector-java-$MYSQL_CONNECTOR_VERSION.jar && mv mysql-connector-java-$MYSQL_CONNECTOR_VERSION.jar ./common/lib/
+
+echo "Creating dev & test DB"
+MYSQL_PWD=root sudo mysql -uroot <<SQL
+CREATE USER IF NOT EXISTS 'as'@'localhost' IDENTIFIED BY 'as123';
+CREATE DATABASE IF NOT EXISTS asdev  DEFAULT CHARACTER SET utf8mb4;
+CREATE DATABASE IF NOT EXISTS astest DEFAULT CHARACTER SET utf8mb4;
+GRANT ALL PRIVILEGES ON asdev.* to 'as'@'localhost';
+GRANT ALL PRIVILEGES ON astest.* to 'as'@'localhost';
+SQL
+
+# echo "Copying pre-bootstrapped build directory"
+# sudo chown -R vscode:vscode /tmp/build
+# cd build && rm -rf .bundle/ .gem/ gems/ *.jar *.war && cd ..
+# cp -r /tmp/build/* build/
+
+# TODO: make this conditional (or remove?) if pre-bootstrapping
+# the pre-bootstrapped env will be right most of the time
+# and this can be run manually in the container when necessary
+echo "Running bootstrap"
+./build/run bootstrap
+
+echo "Running database migrations"
+./build/run db:migrate

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ build/test/
 backend/tests/ladle-server*
 webdriver-profile*
 common/ARCHIVESSPACE_VERSION
+.devcontainer/secrets
 .yardoc
 API.md
 endpoint_examples*


### PR DESCRIPTION
For development only.

Allows integration with vscode for running a batteries included dev environment for aspace  in Docker. Used locally this is only really practical on Linux, WSL and faster Intel Macs (latter is a maybe, haven't actually tried it). But in the future this can be used with [codespaces](https://github.com/features/codespaces) to run aspace on GitHub infrastructure with a local or browser based vscode.
