### PR TITLE
ANW-1303_cont Minor tweak to pdf export job runner

### DIFF
--- a/backend/app/lib/job_runners/print_to_pdf_runner.rb
+++ b/backend/app/lib/job_runners/print_to_pdf_runner.rb
@@ -51,7 +51,6 @@ class PrintToPDFRunner < JobRunner
           File.unlink(pdf.path)
         end
 
-        @job.record_modified_uris( [@json.job["source"]] )
         @job.write_output("All done. Please click refresh to view your download link.")
         self.success!
         job_file


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Incidentally discovered this while reviewing #2446 .  For no apparent reason, the generate pdf job adds some modified uris, though generating a PDF is never going to actually modify a record.  This can go away (with the added benefit that this means that, once #2446 is in, the "New & Modified Records Section" won't display following the completion of a generate PDF job).

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
