### PR TITLE
Remove deprecated config options for bulk import (again)

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -687,10 +687,5 @@ AppConfig[:max_search_columns] = 7
 # specifies whether the "Load Digital Objects" button is available at the Resource Level
 AppConfig[:hide_do_load] = false
 
-# upper row limit for an excel spreadsheet
-AppConfig[:bulk_import_rows] = 1000
-# maximum size (in KiloBytes) for an excel spreadsheet
-AppConfig[:bulk_import_size] = 256
-
 # For Agents Export
 AppConfig[:export_eac_agency_code] = false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#2040 properly removed the config settings `AppConfig[:bulk_import_rows]` and `AppConfig[:bulk_import_size]`, however they were then accidentally added back via #1804.  This removes them again (with the added benefit that it will stop the startup deprecation warning for these config settings).

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
