### PR TITLE
ANW-819 Filter by identifiers for all record types

### DIFF
--- a/common/db/migrations/158_reindex_do_and_doc.rb
+++ b/common/db/migrations/158_reindex_do_and_doc.rb
@@ -1,0 +1,19 @@
+require_relative 'utils'
+
+Sequel.migration do
+
+  up do
+    $stderr.puts("Trigger reindex of all digital objects and digital object components with ids")
+
+    # Reindex all digital objects since a digital object id is always required
+    self[:digital_object].update(:system_mtime => Time.now)
+
+    # Reindex digital object components that have an optional component id
+    self[:digital_object_component].exclude(component_id: nil).update(:system_mtime => Time.now)
+  end
+
+
+  down do
+  end
+
+end

--- a/common/search_definitions.rb
+++ b/common/search_definitions.rb
@@ -1,6 +1,6 @@
 AdvancedSearch.define_field(:name => 'keyword', :type => :text, :visibility => [:staff, :public], :solr_field => 'fullrecord')
 AdvancedSearch.define_field(:name => 'title', :type => :text, :visibility => [:staff, :public], :solr_field => 'title')
-AdvancedSearch.define_field(:name => 'identifier', :type => :text, :visibility => [:staff, :public], :solr_field => 'four_part_id')
+AdvancedSearch.define_field(:name => 'identifier', :type => :text, :visibility => [:staff, :public], :solr_field => 'identifier')
 AdvancedSearch.define_field(:name => 'creators', :type => :text, :visibility => [:staff, :public], :solr_field => 'creators_text')
 AdvancedSearch.define_field(:name => 'notes', :type => :text, :visibility => [:staff, :public], :solr_field => 'notes')
 AdvancedSearch.define_field(:name => 'subjects', :type => :text, :visibility => [:staff, :public], :solr_field => 'subjects_text')

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -482,6 +482,7 @@ class IndexerCommon
       if doc['primary_type'] == 'digital_object_component'
         doc['digital_object'] = record['record']['digital_object']['ref']
         doc['digital_object_id'] = record['record']['component_id']
+        doc['identifier'] = record['record']['component_id']
         doc['title'] = record['record']['display_string']
         doc['slug'] = record['record']['slug']
         doc['is_slug_auto'] = record['record']['is_slug_auto']
@@ -513,6 +514,7 @@ class IndexerCommon
         doc['digital_object_type'] = record['record']['digital_object_type']
 
         doc['digital_object_id'] = record['record']['digital_object_id']
+        doc['identifier'] = record['record']['digital_object_id']
         doc['level'] = record['record']['level']
         doc['restrictions'] = record['record']['restrictions']
         doc['slug'] = record['record']['slug']

--- a/indexer/spec/factories.rb
+++ b/indexer/spec/factories.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     JSONModel::JSONModel(key)
   end
 
-  to_create{|instance| instance.save}
+  to_create {|instance| instance.save}
 
   sequence(:generic_title) { |n| "Title: #{n}"}
   sequence(:html_title) { |n| "Title: <emph render='italic'>#{n}</emph>"}
@@ -88,9 +88,29 @@ FactoryBot.define do
     script { generate(:script) }
   end
 
+  factory :json_accession, class: JSONModel(:accession) do
+    id_0 { generate(:alphanumstr) }
+    title { "Accession #{generate(:html_title)}" }
+    repository { build(:json_repository) }
+  end
+
+  factory :json_digital_object, class: JSONModel(:digital_object) do
+    title { "Digital Object #{generate(:html_title)}" }
+    digital_object_id { generate(:alphanumstr) }
+    repository { build(:json_repository) }
+  end
+
+  factory :json_digital_object_component, class: JSONModel(:digital_object_component) do
+    component_id { generate(:alphanumstr) }
+    title { "Digital Object Component #{generate(:html_title)}" }
+    digital_object { {'ref' => create(:json_digital_object).uri} }
+    repository { build(:json_repository) }
+  end
+
   factory :json_resource, class: JSONModel(:resource) do
     title { "Resource #{generate(:html_title)}" }
     id_0 { generate(:alphanumstr) }
+    repository { build(:json_repository) }
     extents { [build(:json_extent)] }
     level { generate(:archival_record_level) }
     lang_materials { [build(:json_lang_material)] }
@@ -99,18 +119,19 @@ FactoryBot.define do
     ead_id { nil_or_whatever }
     finding_aid_date { generate(:alphanumstr) }
     finding_aid_series_statement { generate(:alphanumstr) }
-    finding_aid_language {  [generate(:finding_aid_language)].sample  }
-    finding_aid_script {  [generate(:finding_aid_script)].sample  }
+    finding_aid_language { [generate(:finding_aid_language)].sample }
+    finding_aid_script { [generate(:finding_aid_script)].sample }
     finding_aid_language_note { nil_or_whatever }
     finding_aid_note { generate(:alphanumstr) }
     ead_location { generate(:alphanumstr) }
     instances { [ build(:json_instance) ] }
-    revision_statements {  [build(:json_revision_statement)]  }
+    revision_statements { [build(:json_revision_statement)] }
   end
 
   factory :json_repository, class: JSONModel(:repository) do
     repo_code { generate(:alphanumstr) }
     name { generate(:alphanumstr) }
+    publish { true }
   end
 
   factory :json_revision_statement, class: JSONModel(:revision_statement) do
@@ -133,7 +154,7 @@ FactoryBot.define do
     email_signature { [nil, generate(:alphanumstr)].sample }
     notes { [build(:json_note_contact_note)] }
   end
-  
+
   factory :json_note_contact_note, class: JSONModel(:note_contact_note) do
     date_of_contact { generate(:alphanumstr) }
     contact_notes { generate(:alphanumstr) }
@@ -141,7 +162,7 @@ FactoryBot.define do
 
   factory :json_telephone, class: JSONModel(:telephone) do
     number_type { [nil, 'business', 'home', 'cell', 'fax'].sample }
-    number {  generate(:phone_number) }
+    number { generate(:phone_number) }
     ext { [nil, generate(:alphanumstr)].sample }
   end
 

--- a/public/app/controllers/search_controller.rb
+++ b/public/app/controllers/search_controller.rb
@@ -8,7 +8,7 @@ class SearchController < ApplicationController
     'resolve[]' => ['repository:id', 'resource:id@compact_resource', 'ancestors:id@compact_resource', 'top_container_uri_u_sstr:id'],
     'facet.mincount' => 1
   }
-  DEFAULT_TYPES = %w{archival_object digital_object agent resource repository accession classification subject}
+  DEFAULT_TYPES = %w{archival_object digital_object digital_object_component agent resource repository accession classification subject}
 
 
   def search

--- a/public/app/models/digital_object_component.rb
+++ b/public/app/models/digital_object_component.rb
@@ -5,4 +5,8 @@ class DigitalObjectComponent < DigitalObject
     json.fetch('digital_object').fetch('ref')
   end
 
+  def parse_identifier
+    json['component_id']
+  end
+
 end

--- a/public/app/views/repositories/show.html.erb
+++ b/public/app/views/repositories/show.html.erb
@@ -25,5 +25,5 @@
             ["#{t('search_results.filter.creators')}",'creators_text'],
             ["#{t('search_results.filter.subjects')}",'subjects_text'],
             ["#{t('search_results.filter.notes')}", 'notes'],
-            ["#{t('search_results.filter.identifier')}", 'four_part_id'] ] } %>
+            ["#{t('search_results.filter.identifier')}", 'identifier'] ] } %>
 </div>

--- a/public/app/views/search/search_results.html.erb
+++ b/public/app/views/search/search_results.html.erb
@@ -17,7 +17,7 @@
                                                                        ["#{t('search_results.filter.creators')}",'creators_text'],
                                                                        ["#{t('search_results.filter.subjects')}",'subjects_text'],
                                                                        ["#{t('search_results.filter.notes')}", 'notes'],
-                                                                       ["#{t('search_results.filter.identifier')}", 'four_part_id'] ],
+                                                                       ["#{t('search_results.filter.identifier')}", 'identifier'] ],
                                                     :header_size => '2',
                                                     :show_header => true } %>
   <% else %>
@@ -44,7 +44,7 @@
                                                                          ["#{t('search_results.filter.creators')}",'creators_text'],
                                                                          ["#{t('search_results.filter.subjects')}",'subjects_text'],
                                                                          ["#{t('search_results.filter.notes')}", 'notes'],
-                                                                         ["#{t('search_results.filter.identifier')}", 'four_part_id'] ],
+                                                                         ["#{t('search_results.filter.identifier')}", 'identifier'] ],
                                                       :show_header => false } %>
       </div>
     </div>

--- a/public/app/views/welcome/show.html.erb
+++ b/public/app/views/welcome/show.html.erb
@@ -20,6 +20,6 @@
             ["#{t('search_results.filter.creators')}",'creators_text'],
             ["#{t('search_results.filter.subjects')}",'subjects_text'],
             ["#{t('search_results.filter.notes')}", 'notes'],
-            ["#{t('search_results.filter.identifier')}", 'four_part_id']
+            ["#{t('search_results.filter.identifier')}", 'identifier']
            ]
     } %>

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -105,8 +105,6 @@ en:
       \ <span class='searchterm'>%{kw}</span>"
     identifier_contain: "the <strong>identifier</strong> contains\
       \ <span class='searchterm'>%{kw}</span>"
-    four_part_id_contain: "the <strong>identifier</strong> contains\
-      \ <span class='searchterm'>%{kw}</span>"
     in_repository: " in <strong>%{name}</strong>"
     anything: "*"
     search_term: Search term

--- a/public/spec/controllers/search_controller_spec.rb
+++ b/public/spec/controllers/search_controller_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe SearchController, type: :controller do
+  # Since test data is created in both `spec_helper` as well as in some of the individual
+  # controller tests, predicting total numbers of results is tricky.  Just hardcoding
+  # the repo id of these new tests to '2' (the `spec_helper` test data) for now.
+
+  it 'should return all records' do
+    response = get(:search, params: {
+      :rid => 2,
+      :q => ['*'],
+      :op => ['OR'],
+      :field => ['']
+    })
+    result_data = controller.instance_variable_get(:@results)
+
+    expect(response).to have_http_status(200)
+    expect(response).to render_template('search/search_results')
+    expect(result_data['total_hits']).to eq(33)
+  end
+
+  it 'should return all digital objects when filtered' do
+    response = get(:search, params: {
+      :rid => 2,
+      :q => ['*'],
+      :op => ['OR'],
+      :limit => 'digital_object',
+      :field => ['']
+    })
+    result_data = controller.instance_variable_get(:@results)
+
+    expect(response).to have_http_status(200)
+    expect(response).to render_template('search/search_results')
+    expect(result_data['total_hits']).to eq(4)
+  end
+
+  it 'should return digital object component with identifier search' do
+    response = get(:search, params: {
+     :rid => 2,
+     :q => ['12345'],
+     :op => ['OR'],
+     :field => ['identifier']
+    })
+    result_data = controller.instance_variable_get(:@results)
+
+    expect(response).to have_http_status(200)
+    expect(response).to render_template('search/search_results')
+    expect(result_data['total_hits']).to eq(1)
+  end
+
+  it 'should return a linked resource with subject search' do
+    response = get(:search, params: {
+     :rid => 2,
+     :q => ['Term 1'],
+     :op => ['OR'],
+     :field => ['subjects_text']
+    })
+    result_data = controller.instance_variable_get(:@results)
+
+    expect(response).to have_http_status(200)
+    expect(response).to render_template('search/search_results')
+    expect(result_data['total_hits']).to eq(1)
+  end
+
+end

--- a/public/spec/factories.rb
+++ b/public/spec/factories.rb
@@ -187,6 +187,7 @@ module AspaceFactories
       factory :digital_object_component, class: JSONModel(:digital_object_component) do
         component_id { generate(:alphanumstr) }
         title { generate :digital_object_component_title }
+        digital_object { {'ref' => create(:digital_object).uri} }
       end
 
       factory :instance_digital, class: JSONModel(:instance) do

--- a/public/spec/spec_helper.rb
+++ b/public/spec/spec_helper.rb
@@ -64,7 +64,7 @@ def setup_test_data
 
   digi_obj = create(:digital_object, title: 'Born digital', publish: true)
 
-  subject = create(:subject, title: 'Subject')
+  subject = create(:subject, terms: [build(:term, term: 'Term 1')])
 
   create(:agent_person,
          names: [build(:name_person,
@@ -154,6 +154,10 @@ def setup_test_data
     create(:archival_object,
            resource: { 'ref' => resource_with_scope.uri }, publish: true)
   end
+
+  create(:digital_object_component,
+         publish: true,
+         component_id: '12345')
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This started with the ticket requesting the ability to search by identifier (in this case, component_ids) for digital object components in the PUI, but it ended up growing a good bit because I discovered a bunch of things (like, there's currently no way in the PUI to search for a digital object component - keyword, identifier, record type, etc.). So this PR:

- Adds digital_object_components to the default search types in the search_controller;
- Adds some PUI search tests (which could be improved) in `search_controller_spec` (there were none before);
- Adds indexer tests (specifically to test the new/existing identifier fields);
- Adds "identifiers" (in this case, component_id for docs and digital_object_ids for dos) to the index;
- Adds a migration to bump the system time and trigger a reindex of do and doc records with new identifiers; and, finally,
- Updates to the PUI ui were made to point the search field to identifier instead of four part id.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-819

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
