### PR TITLE
ANW-1439 and ANW-1432 Improve custom report template show page

### DIFF
--- a/frontend/app/controllers/custom_report_templates_controller.rb
+++ b/frontend/app/controllers/custom_report_templates_controller.rb
@@ -88,8 +88,7 @@ class CustomReportTemplatesController < ApplicationController
       .to_unsafe_h.to_hash
     data['custom_record_type'] = record_type
     data['fields'].each do |name, defn|
-      next unless defn.is_a?(Hash) && defn["values"]
-      #raise defn["values"] if defn["values"].match(/busche/)
+      next unless defn.is_a?(Hash) && defn["values"] && !defn['values'].is_a?(Array)
       if defn.has_key? "values"
         defn["values"] = defn["values"].gsub("\r\n", "\n").split("\n")
       end

--- a/frontend/app/views/custom_report_templates/show.html.erb
+++ b/frontend/app/views/custom_report_templates/show.html.erb
@@ -34,12 +34,6 @@
 
           <% enums = JSONModel(:enumeration).all %>
 
-          <% users = [] %>
-          <% JSONModel::HTTP::get_json("/users", :all_ids => true).each do |id| %>
-            <% user = JSONModel(:user).find(id) %>
-            <% users.push([user.name, user.username]) %>
-          <% end %>
-
           <% record_types.each do |record_type| %>
 
             <% record_data = record_type == data['custom_record_type'] ? data : {} %>
@@ -67,7 +61,12 @@
                       <div class="form-group">
                         <%= readonly.label 'display', :class => "col-sm-2 control-label" %>
                         <div class="col-sm-9 label-only">
-                          <%= I18n.t("boolean.true") %>
+                          <% if field[1]['include'] == '1' %>
+                            <% display = true %>
+                            <%= I18n.t("boolean.true") %>
+                          <% else %>
+                            <%= I18n.t("boolean.false") %>
+                          <% end %>
                         </div>
                       </div>
 
@@ -75,64 +74,78 @@
 
                     <% if (field[0] == 'created_by' || field[0] == 'last_modified_by') %>
                       <% if field[1].has_key? 'values' %>
-                        <% u_array = [] %>
-                        <% field[1]['values'].each do |u_val| %>
-                          <% user = users.find { |u| u[1] == u_val } %>
-                          <% u_array.push(user[0]) %>
+                        <% unless field[1]['values'].empty? %>
+                          <div class="form-group">
+                            <%= readonly.label "values", :class => "col-sm-2 control-label" %>
+                            <div class="col-sm-9 label-only">
+                              <%= text_area_tag "values", array_for_textarea(field[1]['values']), :readonly => true %>
+                            </div>
+                          </div>
                         <% end %>
+                      <% end %>
+                    <% elsif field[1].has_key? 'range_start' %>
+                      <% unless field[1]['range_start'].empty? %>
                         <div class="form-group">
-                          <%= readonly.label "narrow_by", :class => "col-sm-2 control-label" %>
+                          <%= readonly.label "start_date", :class => "col-sm-2 control-label" %>
                           <div class="col-sm-9 label-only">
-                            <%= u_array %>
+                            <%= field[1]['range_start'] %>
                           </div>
                         </div>
                       <% end %>
-                    <% elsif field[1].has_key? 'range_start' && !field[1]['range_start'].nil? %>
-                      <div class="form-group">
-                        <%= readonly.label "narrow_by", :class => "col-sm-2 control-label" %>
-                        <div class="col-sm-9 label-only">
-                          <%= "#{field[1]['range_start']}" %>
-                          <%= " to #{field[1]['range_end']}" %>
+                      <% unless field[1]['range_end'].empty? %>
+                        <div class="form-group">
+                          <%= readonly.label "end_date", :class => "col-sm-2 control-label" %>
+                          <div class="col-sm-9 label-only">
+                            <%= field[1]['range_end'] %>
+                          </div>
                         </div>
-                      </div>
+                      <% end %>
                     <% elsif field[1].has_key? 'value' %>
-                      <div class="form-group">
-                        <%= readonly.label "narrow_by", :class => "col-sm-2 control-label" %>
-                        <div class="col-sm-9 label-only">
-                          <%= I18n.t("custom_report_template.#{field[1]['value']}") %>
+                      <% unless field[1]['value'].empty? %>
+                        <div class="form-group">
+                          <%= readonly.label "value", :class => "col-sm-2 control-label" %>
+                          <div class="col-sm-9 label-only">
+                            <%= I18n.t("custom_report_template.#{field[1]['value']}") %>
+                          </div>
                         </div>
-                      </div>
+                      <% end %>
                     <% elsif field[1].has_key? 'values' %>
-                      <% if record_type == 'agent' %>
-                        <div class="form-group">
-                          <%= readonly.label "narrow_by", :class => "col-sm-2 control-label" %>
-                          <div class="col-sm-9 label-only">
-                            <% val_array = [] %>
-                            <% field[1]['values'].each do |f_val| %>
-                              <% val_array.push(I18n.t("#{record_type}.#{record_type}_#{field[0]}.#{f_val}")) %>
-                            <% end %>
-                            <%= val_array %>
+                      <% unless field[1]['values'].empty? %>
+                        <% if record_type == 'agent' %>
+                          <div class="form-group">
+                            <%= readonly.label "values", :class => "col-sm-2 control-label" %>
+                            <div class="col-sm-9 label-only">
+                              <% val_array = [] %>
+                              <% field[1]['values'].each do |f_val| %>
+                                <% val_array.push(I18n.t("#{record_type}.#{record_type}_#{field[0]}.#{f_val}")) %>
+                              <% end %>
+                              <% val_array.each do |v| %>
+                                <%= v %><br/>
+                              <% end %>
+                            </div>
                           </div>
-                        </div>
-                      <% else %>
-                        <% if (record_type == 'resource' || record_type == 'archival_object') && field[0] == 'level' %>
-                          <% enum_name = "archival_record_level" %>
                         <% else %>
-                          <% enum_name = "#{record_type}_#{field[0]}" %>
-                        <% end %>
-                        <% enum = enums.find {|obj| obj.name == enum_name} if enum_name%>
+                          <% if (record_type == 'resource' || record_type == 'archival_object') && field[0] == 'level' %>
+                            <% enum_name = "archival_record_level" %>
+                          <% else %>
+                            <% enum_name = "#{record_type}_#{field[0]}" %>
+                          <% end %>
+                          <% enum = enums.find {|obj| obj.name == enum_name} if enum_name%>
 
-                        <div class="form-group">
-                          <%= readonly.label "narrow_by", :class => "col-sm-2 control-label" %>
-                          <div class="col-sm-9 label-only">
-                            <% val_array = [] %>
-                            <% field[1]['values'].each do |f_val| %>
-                              <% val = enum['enumeration_values'].find { |h| h['id'] == f_val.to_i } if enum %>
-                              <% val_array.push(I18n.t("enumerations.#{enum_name}.#{val['value']}")) if val %>
-                            <% end %>
-                            <%= val_array %>
+                          <div class="form-group">
+                            <%= readonly.label "values", :class => "col-sm-2 control-label" %>
+                            <div class="col-sm-9 label-only">
+                              <% val_array = [] %>
+                              <% field[1]['values'].each do |f_val| %>
+                                <% val = enum['enumeration_values'].find { |h| h['id'] == f_val.to_i } if enum %>
+                                <% val_array.push(I18n.t("enumerations.#{enum_name}.#{val['value']}")) if val %>
+                              <% end %>
+                              <% val_array.each do |v| %>
+                                <%= v %><br/>
+                              <% end %>
+                            </div>
                           </div>
-                        </div>
+                        <% end %>
                       <% end %>
                     <% end %>
                   </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Recent changes to the custom report templates edit pages, weren't reflected in the show/view pages.  This updates the view only page, primarily fixing translation missing errors (ANW-1432) and all fields incorrectly being shown as displayed (ANW-1439).

While working on this, I also discovered that changes to the frontend controller to handle the new user form fields, broke the enumeration based fields (can be replicated on test if you attempt to save a template with any values selected in controlled value fields).  This fixes that as well.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1432
https://archivesspace.atlassian.net/browse/ANW-1439

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
