### PR TITLE
ANW-1402 Add change tracking/standard toolbar to custom report templates

### DIFF
--- a/frontend/app/assets/javascripts/custom_report_templates.crud.js
+++ b/frontend/app/assets/javascripts/custom_report_templates.crud.js
@@ -1,22 +1,17 @@
+//= require form
+
 $(function () {
-  var initCustomReportTemplateForm = function () {
-    $(document).on('change', '#custom_record_type', function () {
-      var selected_record_type = $(this).val();
+  var selected_record_type = $('#custom_record_type').val();
 
-      $('.record_type').hide();
-      $('.record_type.' + selected_record_type).show();
+  $('.record_type').hide();
+  $('.record_type.' + selected_record_type).show();
 
-      $('li.sidebar-entry-basic_information_fields a')[0].href =
-        '#' + selected_record_type + '_basic_information_fields';
-      $('li.sidebar-entry-linked_records a')[0].href =
-        '#' + selected_record_type + '_linked_records';
-      $('li.sidebar-entry-sort_by a')[0].href =
-        '#' + selected_record_type + '_sort_by';
-    });
-    $('#custom_record_type').trigger('change');
-  };
-
-  initCustomReportTemplateForm();
+  $('li.sidebar-entry-basic_information_fields a')[0].href =
+    '#' + selected_record_type + '_basic_information_fields';
+  $('li.sidebar-entry-linked_records a')[0].href =
+    '#' + selected_record_type + '_linked_records';
+  $('li.sidebar-entry-sort_by a')[0].href =
+    '#' + selected_record_type + '_sort_by';
 
   // Don't fire a request for *every* keystroke.  Wait until they stop
   // typing for a moment.
@@ -83,5 +78,19 @@ $(document).ready(function () {
     } else {
       checkboxes.prop('checked', true);
     }
+  });
+
+  $('#custom_record_type').on('change', function () {
+    var selected_record_type = $(this).val();
+
+    $('.record_type').hide();
+    $('.record_type.' + selected_record_type).show();
+
+    $('li.sidebar-entry-basic_information_fields a')[0].href =
+      '#' + selected_record_type + '_basic_information_fields';
+    $('li.sidebar-entry-linked_records a')[0].href =
+      '#' + selected_record_type + '_linked_records';
+    $('li.sidebar-entry-sort_by a')[0].href =
+      '#' + selected_record_type + '_sort_by';
   });
 });

--- a/frontend/app/assets/javascripts/form.js
+++ b/frontend/app/assets/javascripts/form.js
@@ -170,7 +170,7 @@ $(function () {
         }
         $this.data('form_changed', true);
         $('.record-toolbar', $this).addClass('formchanged');
-        $('.record-toolbar .btn-toolbar .btn', $this)
+        $('.record-toolbar .btn-toolbar .btn:not(.no-change-tracking)', $this)
           .addClass('disabled')
           .attr('disabled', 'disabled');
       });

--- a/frontend/app/views/custom_report_templates/_toolbar.html.erb
+++ b/frontend/app/views/custom_report_templates/_toolbar.html.erb
@@ -1,7 +1,25 @@
 <div class="record-toolbar">
+  <% if controller.action_name == 'show' %>
+    <div class="btn-group pull-left">
+      <%= link_to I18n.t("actions.edit"), {:controller => :custom_report_templates, :action => :edit, :id => @custom_report_template.id}, :class => "btn btn-sm btn-primary" %>
+    </div>
+  <% end %>
+  <% if ['new', 'create', 'edit', 'update'].include?(controller.action_name) %>
+    <div class="pull-left save-changes">
+    <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
+    </div>
+  <% end %>
+  <% if ['edit', 'update'].include?(controller.action_name) %>
+    <div class="pull-left revert-changes">
+    <%= link_to I18n.t("actions.revert"), {:controller => :custom_report_templates, :action => :edit, :id => @custom_report_template.id}, :class => "btn btn-sm btn-default" %>
+    <%= I18n.t("actions.toolbar_disabled_message") %>
+    </div>
+  <% end %>
     <div class="btn-toolbar pull-right">
       <div class="btn-group">
-        <button class="btn btn-sm btn-success" type="button" id="check_all" data-checked="<%= I18n.t("actions.check_all") %>" data-unchecked="<%= I18n.t("actions.uncheck_all") %>"><%= I18n.t("actions.check_all") %></button>
+        <% if ['edit', 'update', 'new', 'create'].include?(controller.action_name) %>
+          <button class="btn btn-sm btn-success no-change-tracking" type="button" id="check_all" data-checked="<%= I18n.t("actions.check_all") %>" data-unchecked="<%= I18n.t("actions.uncheck_all") %>"><%= I18n.t("actions.check_all") %></button>
+        <% end %>
         <% if controller.action_name == 'edit' %>
           <%= link_to I18n.t("actions.run"),
             new_job_path(
@@ -12,7 +30,7 @@
             :class => "btn btn-sm btn-info"
           %>
         <% end %>
-        <% if !['new', 'create', 'copy'].include?(controller.action_name) %>
+        <% if ['edit', 'update'].include?(controller.action_name) %>
           <%= link_to I18n.t("actions.copy"), {:controller => :custom_report_templates, :action => :copy, :id =>  @custom_report_template.id}, :class => "btn btn-sm btn-default" %>
           <%= button_delete_action url_for(:controller => :custom_report_templates, :action => :delete, :id => @custom_report_template.id ), { :"data-title" => I18n.t("actions.delete_confirm_title", :title => @custom_report_template.name) } unless @custom_report_template.id.nil? %>
         <% end %>

--- a/frontend/app/views/custom_report_templates/show.html.erb
+++ b/frontend/app/views/custom_report_templates/show.html.erb
@@ -5,6 +5,7 @@
     <%= render_aspace_partial :partial => "sidebar" %>
   </div>
   <div class="col-md-9">
+    <%= render_aspace_partial :partial => "toolbar" %>
     <div class="record-pane">
       <%= link_to_help :topic => "custom_report_template" %>
       <h2><%= @custom_report_template['name'] %></h2>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds standard toolbar elements (Save, Edit, Revert, etc.) to the custom report templates toolbar, which includes typical change tracking and prompts to save when changes are made to the form.

This change tracking conflicted with the record type selection functionality already in `frontend/app/assets/javascripts/custom_report_templates.crud.js` so I changed that up some, but realize it's probably still a little wonky (my js is not great).  So that could probably be tightened up a little more.

Also added the ability to apply a `no-change-tracking` class to toolbar buttons so that they won't be disabled by the change tracking lock.  In this case, for custom report templates, the check all/uncheck all button needs to work even when edits are happening to the form, but I could envision this being useful in other forms in the future.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1402

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
