### PR TITLE
add public directory to frontend warble config

### DIFF
--- a/frontend/app/controllers/bulk_import_templates_controller.rb
+++ b/frontend/app/controllers/bulk_import_templates_controller.rb
@@ -40,6 +40,6 @@ class BulkImportTemplatesController < ApplicationController
   end
 
   def download
-    send_file "public/bulk_import_templates/#{params['filename']}", status: 202
+    send_file "#{Rails.root}/public/bulk_import_templates/#{params['filename']}", status: 202
   end
 end

--- a/frontend/config/warble.rb
+++ b/frontend/config/warble.rb
@@ -11,7 +11,7 @@ Warbler::Config.new do |config|
   config.features = []
 
   # Application directories to be included in the webapp.
-  config.dirs = %w(app config lib log vendor tmp .bundle)
+  config.dirs = %w(app config lib log vendor tmp .bundle public)
 
   # Additional files/directories to include, above those in config.dirs
   #
@@ -110,6 +110,7 @@ Warbler::Config.new do |config|
   # Files to be included in the root of the webapp.  Note that files in public
   # will have the leading 'public/' part of the path stripped during staging.
   # config.public_html = FileList["public/**/*", "doc/**/*"]
+  config.public_html = FileList["public/bulk_import_templates/*"]
 
   # Pathmaps for controlling how public HTML files are copied into the .war
   # config.pathmaps.public_html = ["%{public/,}p"]


### PR DESCRIPTION
I confess to not being entirely sure why public was not already part of the `config.dirs` list in the warble config. But I suspect it is just because there are some assumptions about `public/assets` in the warble gem. 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
