### PR TITLE
ANW-1243 Retain label attribute for abstract note

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -642,7 +642,7 @@ class EADSerializer < ASpaceExport::Serializer
             sanitize_mixed_content( content, xml, fragments, ASpaceExport::Utils.include_p?(note['type']) )
           }
         }
-      when 'physdesc'
+      when 'physdesc', 'abstract'
         att[:label] = note['label'] if note['label']
         xml.send(note['type'], att.merge(audatt)) {
           sanitize_mixed_content(content, xml, fragments, ASpaceExport::Utils.include_p?(note['type']))

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -157,13 +157,12 @@ describe "EAD export mappings" do
     end
   end
 
-
-  def build_archival_object_notes(max = 5)
-    note_types = %w(odd dimensions physdesc materialspec physloc phystech physfacet processinfo separatedmaterial arrangement fileplan accessrestrict abstract scopecontent prefercite acqinfo bibliography index altformavail originalsloc userestrict legalstatus relatedmaterial custodhist appraisal accruals bioghist)
+  def build_multipart_notes(max = 5)
+    note_types = %w(odd dimensions phystech processinfo separatedmaterial arrangement fileplan accessrestrict scopecontent prefercite acqinfo altformavail originalsloc userestrict legalstatus relatedmaterial custodhist appraisal accruals bioghist)
     notes = []
     brake = 0
     while !(note_types - notes.map {|note| note['type']}).empty? && brake < max do
-      notes << build("json_note_#{['singlepart', 'multipart', 'multipart_gone_wilde', 'index', 'bibliography'].sample}".intern, {
+      notes << build("json_note_#{['multipart', 'multipart_gone_wilde'].sample}".intern, {
                        :publish => true,
                        :label => generate(:alphanumstr),
                        :persistent_id => [nil, generate(:alphanumstr)].sample
@@ -171,6 +170,37 @@ describe "EAD export mappings" do
       brake += 1
     end
 
+    notes
+  end
+
+  def build_singlepart_notes(max = 5)
+    note_types = %w(physdesc materialspec physloc physfacet abstract)
+    notes = []
+    brake = 0
+    while !(note_types - notes.map {|note| note['type']}).empty? && brake < max do
+      notes << build(:json_note_singlepart, {
+                       :publish => true,
+                       :label => generate(:alphanumstr),
+                       :persistent_id => [nil, generate(:alphanumstr)].sample
+                     })
+      brake += 1
+    end
+
+    notes
+  end
+
+  def build_archival_object_notes(max = 2)
+    note_types = %w(bibliography index)
+    notes = []
+    note_types.each do |note_type|
+      notes << build("json_note_#{note_type}".intern, {
+                       :publish => true,
+                       :label => generate(:alphanumstr),
+                       :persistent_id => [nil, generate(:alphanumstr)].sample
+                     })
+    end
+
+    notes = notes + build_singlepart_notes(max) + build_multipart_notes(max)
     notes
   end
 
@@ -608,6 +638,8 @@ describe "EAD export mappings" do
           else
             mt(nil, path, "id")
           end
+
+          mt(note['label'], path, "label")
         end
       end
 
@@ -634,7 +666,7 @@ describe "EAD export mappings" do
             mt(nil, path, "id")
           end
 
-          mt(note['label'], path, "label") if note['label']
+          mt(note['label'], path, "label")
         end
       end
 
@@ -686,7 +718,8 @@ describe "EAD export mappings" do
           path += id ? "[@id='#{id}']" : "[p[contains(text(), #{content})]]"
           full_path = "#{desc_path}/#{path}"
           mt(content, full_path)
-          mt(note['label'], full_path, "label") if note['label']
+
+          mt(note['label'], full_path, "label")
         end
       end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Minor update to ead export to ensure that the label attribute for an abstract note is retained, which results in the label persisting into the staff-side PDF export.

Also includes updates to the ead export tests to ensure that the sample notes created are actually valid notes.  Previously, the sampling method used could create notes with mismatching types/note_types (e.g. an abstract note that has a multipart note type, when it is a singlepart note).  Also ensures enough notes are created so that tests are actually testing data, and not just being skipped because a relevant note type (e.g. an abstract note) doesn't exist in this run of the test.

Note: Since this was scoped to the ticket which only concerns staff-side PDF output, this only impacts EAD 2002 export.  No changes have been made to EAD3.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1243

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
