### PR TITLE
ANW-1441 Widen title area in staff side tree

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/largetree.less
+++ b/frontend/app/assets/stylesheets/archivesspace/largetree.less
@@ -94,6 +94,9 @@
     }
   }
 
+  .title {
+    width: 46%;
+  }
   .resource-level {
     width: 8%;
   }
@@ -108,7 +111,7 @@
     width: 12%;
   }
   .file-uri-summary {
-    width: 28%;
+    width: 42%;
   }
 
   td,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
So, I still haven't quite figured out how this was working as it was prior to #2322 moved from the tree using a table to divs, but that's probably unimportant.  This sets the title columns in both resource and do staff side trees to 46% (100 -the sum of all the other already defined columns), and returns the tree widths to what they were prior to v3.1.  (Compare to sandbox which as of now is still on 3.0.2).  Also, widened the last column in the do tree since there was no reason for it to be squished like that (more real estate was available).

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1441

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15144646/140178164-70dcf52b-a807-4fab-a356-c01e839ee5bd.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
