### PR TITLE
allow developers to work with an invalid solr schema

### DIFF
--- a/backend/app/model/solr.rb
+++ b/backend/app/model/solr.rb
@@ -74,6 +74,10 @@ class Solr
   end
 
   def self.verify_checksum!(config)
+    if AppConfig[:skip_solr_schema_check]
+      Log.warn("Ignoring invalid Solr schema checksum!") unless config.checksum_valid?
+      return true
+    end
     return true if config.checksum_valid?
 
     raise "Solr checksum verification failed (#{config.name}): expected [#{config.internal_checksum}] got [#{config.external_checksum}]"

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -39,6 +39,10 @@ AppConfig[:oai_url] = "http://localhost:8082"
 # set it to something else below.
 AppConfig[:solr_url] = "http://localhost:8983/solr/archivesspace"
 
+# ArchivesSpace checks the solr schema to make sure it matches the current
+# data model and indexing jobs. Leave this alone in production, development only!
+AppConfig[:skip_solr_schema_check] = false
+
 # The ArchivesSpace indexer listens on port 8091 by default.  You can
 # set it to something else below.
 AppConfig[:indexer_url] = "http://localhost:8091"


### PR DESCRIPTION
I'm proposing this workaround to allow developers to keep going when a schema mismatch arises. Mainly because this is an obstacle to developers who are just going to use the docker image, unless we commit to keeping that in sync. But even then issues will arise as people work with different branches that may have different checksums. This is intended as a quick triage as we continue to refine workflows, etc.