### PR TITLE
ANW-1429 Fix staff side advanced search width

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/search.less
+++ b/frontend/app/assets/stylesheets/archivesspace/search.less
@@ -22,7 +22,7 @@
   background-color: #f5f5f5;
   border-bottom: 1px solid #efefef;
   border-top: 1px solid #efefef;
-  width: calc(100vw - 32px);
+  width: ~'calc(100vw - 32px)';
   .box-shadow(0 1px 0 rgba(0,0,0,0.065));
 
   .row {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a regression in staff-side advanced search drop-down styling that resulted from the linting done via #2441 

This returns to using calculation - which has to be escaped in less so that the calculation isn't done by less - as it was prior to #2441   However, it's slightly different than what was originally contributed via #2356 because this now satisfies stylelint and prettier.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1429

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
