### PR TITLE
Use Jetty 9 for the development webservers

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -11,7 +11,6 @@ gem 'jdbc-mysql', '>=8.0', group: :development
 gem 'jruby-jars', '= 9.2.12.0'
 gem 'json', '2.3.0'
 gem 'json-schema', '1.0.10'
-gem 'mizuno', '0.6.11'
 gem 'net-ldap', '~> 0.16.0'
 gem 'nokogiri', '>= 1.10.8'
 gem 'rack-session-sequel', '0.0.1'
@@ -45,6 +44,7 @@ group :development, :test do
   gem 'pry', '~> 0.12.2'
   gem 'pry-debugger-jruby', '>= 1.2.2'
   gem 'pry-nav'
+  gem 'mizuno', git: "https://github.com/quoideneuf/mizuno", branch: "master"
 end
 
 gem 'multi_json', '~> 1.15.0'

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -44,7 +44,7 @@ group :development, :test do
   gem 'pry', '~> 0.12.2'
   gem 'pry-debugger-jruby', '>= 1.2.2'
   gem 'pry-nav'
-  gem 'mizuno', git: "https://github.com/quoideneuf/mizuno", branch: "master"
+  gem 'mizuno', git: "https://github.com/archivesspace/mizuno", branch: "master"
 end
 
 gem 'multi_json', '~> 1.15.0'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/quoideneuf/mizuno
+  revision: 43b9eecae66fcd7d6df3bbe8b003c0b778cb23c3
+  branch: master
+  specs:
+    mizuno (0.6.11)
+      childprocess (>= 0.2.6)
+      choice (>= 0.1.0)
+      ffi (>= 1.0.0)
+      rack (>= 1.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -41,11 +52,6 @@ GEM
     ladle (0.2.0-java)
     method_source (0.9.2)
     minitest (5.14.4)
-    mizuno (0.6.11)
-      childprocess (>= 0.2.6)
-      choice (>= 0.1.0)
-      ffi (>= 1.0.0)
-      rack (>= 1.0.0)
     multi_json (1.15.0)
     multipart-post (1.2.0)
     mustermann (1.1.1)
@@ -157,7 +163,7 @@ DEPENDENCIES
   json (= 2.3.0)
   json-schema (= 1.0.10)
   ladle (= 0.2.0)
-  mizuno (= 0.6.11)
+  mizuno!
   multi_json (~> 1.15.0)
   multipart-post (= 1.2.0)
   net-http-persistent (= 2.8)

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
-  remote: https://github.com/quoideneuf/mizuno
-  revision: 43b9eecae66fcd7d6df3bbe8b003c0b778cb23c3
+  remote: https://github.com/archivesspace/mizuno
+  revision: d5c963a70c3ea6144df941801975179b03dfaa5c
   branch: master
   specs:
-    mizuno (0.6.11)
+    mizuno (9.4.44)
       childprocess (>= 0.2.6)
       choice (>= 0.1.0)
       ffi (>= 1.0.0)

--- a/common/test_utils.rb
+++ b/common/test_utils.rb
@@ -60,11 +60,6 @@ module TestUtils
     ' ' + java_opts
   end
 
-  def self.java_build_args(build_args)
-    build_args << "-Dgem_home=#{ENV['GEM_HOME']}" if ENV['GEM_HOME']
-    build_args
-  end
-
   def self.find_ant
     fullpath = ''
     [nil, '..', '../..'].each do |root|
@@ -80,10 +75,13 @@ module TestUtils
     java_opts = build_config_string(config)
     java_opts += " -Daspace.config=#{config_file}" if config_file
 
-    build_args = java_build_args(['backend:devserver:integration',
-                                  "-Daspace.backend.port=#{port}",
-                                  '-Daspace_integration_test=1',
-                                  "-Daspace.config.db_url=#{db_url}"])
+    # although we are testing, we need to pass the db we are using
+    # through as aspace.db_url.dev because the backend:devserver
+    # ant task is harcoded to used that build arg
+    build_args = ['backend:devserver:integration',
+                  "-Daspace.backend.port=#{port}",
+                  '-Daspace_integration_test=1',
+                  "-Daspace.db_url.dev=#{db_url}"]
     java_opts += ' -Xmx1024m'
 
     puts "Spawning backend with opts: #{java_opts}"
@@ -101,8 +99,8 @@ module TestUtils
     java_opts += build_config_string(config)
     java_opts += " -Daspace.config=#{config_file}" if config_file
 
-    build_args = java_build_args(['frontend:devserver:integration',
-                                  "-Daspace.frontend.port=#{port}"])
+    build_args = ['frontend:devserver:integration',
+                  "-Daspace.frontend.port=#{port}"]
     java_opts += ' -Xmx1512m'
 
     puts "Spawning frontend with opts: #{java_opts}"

--- a/frontend/Gemfile
+++ b/frontend/Gemfile
@@ -55,7 +55,7 @@ group :development, :test do
   gem 'pry-debugger-jruby', '>= 1.2.2'
   gem 'pry-nav'
   gem 'pry-rails'
-  gem 'mizuno', git: "https://github.com/quoideneuf/mizuno", branch: "master"
+  gem 'mizuno', git: "https://github.com/archivesspace/mizuno", branch: "master"
 end
 
 group :development do

--- a/frontend/Gemfile
+++ b/frontend/Gemfile
@@ -55,13 +55,12 @@ group :development, :test do
   gem 'pry-debugger-jruby', '>= 1.2.2'
   gem 'pry-nav'
   gem 'pry-rails'
+  gem 'mizuno', git: "https://github.com/quoideneuf/mizuno", branch: "master"
 end
 
 group :development do
   gem 'web-console'
 end
-
-gem 'mizuno', '0.6.11'
 
 gem 'multi_json', '~> 1.15.0'
 gem 'multipart-post', '1.2.0'

--- a/frontend/Gemfile.lock
+++ b/frontend/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/quoideneuf/mizuno
+  revision: 43b9eecae66fcd7d6df3bbe8b003c0b778cb23c3
+  branch: master
+  specs:
+    mizuno (0.6.11)
+      childprocess (>= 0.2.6)
+      choice (>= 0.1.0)
+      ffi (>= 1.0.0)
+      rack (>= 1.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -150,11 +161,6 @@ GEM
     mime-types-data (3.2021.0704)
     mini_mime (1.1.0)
     minitest (5.14.4)
-    mizuno (0.6.11)
-      childprocess (>= 0.2.6)
-      choice (>= 0.1.0)
-      ffi (>= 1.0.0)
-      rack (>= 1.0.0)
     multi_json (1.15.0)
     multipart-post (1.2.0)
     net-http-digest_auth (1.4.1)
@@ -325,7 +331,7 @@ DEPENDENCIES
   less-rails-bootstrap
   loofah (>= 2.2.3)
   mechanize
-  mizuno (= 0.6.11)
+  mizuno!
   multi_json (~> 1.15.0)
   multipart-post (= 1.2.0)
   net-http-persistent (= 2.8)

--- a/frontend/Gemfile.lock
+++ b/frontend/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
-  remote: https://github.com/quoideneuf/mizuno
-  revision: 43b9eecae66fcd7d6df3bbe8b003c0b778cb23c3
+  remote: https://github.com/archivesspace/mizuno
+  revision: d5c963a70c3ea6144df941801975179b03dfaa5c
   branch: master
   specs:
-    mizuno (0.6.11)
+    mizuno (9.4.44)
       childprocess (>= 0.2.6)
       choice (>= 0.1.0)
       ffi (>= 1.0.0)

--- a/frontend/spec/rails_helper.rb
+++ b/frontend/spec/rails_helper.rb
@@ -72,6 +72,5 @@ end
 Capybara.server = :mizuno
 Capybara.default_max_wait_time = 10
 
-
 ActionController::Base.logger.level = Logger::ERROR
 Rails.logger.level = Logger::ERROR

--- a/public/Gemfile
+++ b/public/Gemfile
@@ -54,7 +54,7 @@ group :development, :test do
   gem 'pry', '~> 0.12.2'
   gem 'pry-nav'
   gem 'pry-rails'
-  gem 'mizuno', git: "https://github.com/quoideneuf/mizuno", branch: "master"
+  gem 'mizuno', git: "https://github.com/archivesspace/mizuno", branch: "master"
 end
 
 group :test do

--- a/public/Gemfile
+++ b/public/Gemfile
@@ -15,7 +15,6 @@ gem 'nokogiri', '>= 1.10.8'
 gem 'sprockets-rails', '2.3.3'
 
 gem 'atomic', '= 1.0.1'
-gem 'mizuno', '0.6.11'
 
 # use bootstrap's sass
 gem 'bootstrap-sass', '>= 3.4.1'
@@ -55,6 +54,7 @@ group :development, :test do
   gem 'pry', '~> 0.12.2'
   gem 'pry-nav'
   gem 'pry-rails'
+  gem 'mizuno', git: "https://github.com/quoideneuf/mizuno", branch: "master"
 end
 
 group :test do

--- a/public/Gemfile.lock
+++ b/public/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/quoideneuf/mizuno
+  revision: 43b9eecae66fcd7d6df3bbe8b003c0b778cb23c3
+  branch: master
+  specs:
+    mizuno (0.6.11)
+      childprocess (>= 0.2.6)
+      choice (>= 0.1.0)
+      ffi (>= 1.0.0)
+      rack (>= 1.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -147,11 +158,6 @@ GEM
     method_source (0.9.2)
     mini_mime (1.1.0)
     minitest (5.14.4)
-    mizuno (0.6.11)
-      childprocess (>= 0.2.6)
-      choice (>= 0.1.0)
-      ffi (>= 1.0.0)
-      rack (>= 1.0.0)
     multi_json (1.15.0)
     multipart-post (1.2.0)
     net-http-persistent (2.8)
@@ -308,7 +314,7 @@ DEPENDENCIES
   launchy
   listen
   loofah (>= 2.2.3)
-  mizuno (= 0.6.11)
+  mizuno!
   multipart-post (= 1.2.0)
   net-http-persistent (= 2.8)
   nokogiri (>= 1.10.8)

--- a/public/Gemfile.lock
+++ b/public/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
-  remote: https://github.com/quoideneuf/mizuno
-  revision: 43b9eecae66fcd7d6df3bbe8b003c0b778cb23c3
+  remote: https://github.com/archivesspace/mizuno
+  revision: d5c963a70c3ea6144df941801975179b03dfaa5c
   branch: master
   specs:
-    mizuno (0.6.11)
+    mizuno (9.4.44)
       childprocess (>= 0.2.6)
       choice (>= 0.1.0)
       ffi (>= 1.0.0)


### PR DESCRIPTION
We want to use the same network layer in development as we do in production. For some time, this want has prevented us from making the move to Jetty 9 due to the abandonment of the [mizuno gem](https://github.com/matadon/mizuno), which is what we use to wrap jetty up like a typical rack development server.  But the time has come to take action, so I [forked mizuno](https://github.com/archivesspace/mizuno) and tweaked it to use Jetty 9. 
There is probably some discussion to be had about licensing metadata and where this should live, but I can't think of any reason to bother pushing it through rubygems.



## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
