### PR TITLE
ANW-1335 Fix API examples for arrays

### DIFF
--- a/_yard/API.erb
+++ b/_yard/API.erb
@@ -398,15 +398,17 @@ As of <%= @time.inspect %> the following REST endpoints exist in the master bran
   <% url_param_examples = [] %>
   <% url_params.each do |param| %>
     <% if param == "resolve" %>
-      <% url_param_examples << "#{param}[]=[record_types, to_resolve]" %>
-    <% elsif example[param] %>
+      <% url_param_examples << "#{param}[]=record_type_to_resolve" %>
+    <% elsif example[param] || example["#{param}[]"] %>
       <% if example[param] == "BooleanParam" %>
         <% url_param_examples << "#{param}=true" %>
+      <% elsif ep = example["#{param}[]"] %>
+        <% url_param_examples << "#{param}[]=#{ep}" %>
       <% else %>
         <% url_param_examples << "#{param}=#{example[param]}" %>
       <% end %>
-        <% elsif param.is_a? String %>
-          <% url_param_examples << "#{param}=#{param}" %>
+    <% elsif param.is_a? String %>
+      <% url_param_examples << "#{param}=#{param}" %>
     <% end %>
   <% end %>
   <% request_uri += "?#{url_param_examples.join("&")}" %>

--- a/backend/spec/documentation_spec.rb
+++ b/backend/spec/documentation_spec.rb
@@ -42,10 +42,15 @@ describe "Generate REST Documentation" do
           else
             record = generate(klass.name.downcase.to_sym)
           end
+
           if p.is_a? String
             output[e[:uri]][e[:method]][p] = record
           else
-            output[e[:uri]][e[:method]][p[0]] = record
+            if p[1].is_a?(Array)
+              output[e[:uri]][e[:method]]["#{p[0]}[]"] = record
+            else
+              output[e[:uri]][e[:method]][p[0]] = record
+            end
           end
         rescue => err
           problems << { :class => klass, :backtrace => err.backtrace, :message => err.message }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As noted in the JIRA ticket, the API documentation has long been wrong in generating examples for parameters that expect an array.  This corrects the automatically generated docs to accommodate situations where the parameter should take the form of:

`param_name[]=string_value`

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1335

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
