### PR TITLE
ANW-1444 more fixing of css selectors for large tree after DOM access…

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/largetree.less
+++ b/frontend/app/assets/stylesheets/archivesspace/largetree.less
@@ -226,7 +226,7 @@
     width: 384px;
   }
 
-  tr#new {
+  div.table-row#new {
     .indentor,
     .new-title {
       float: left;
@@ -244,8 +244,8 @@
     }
   }
 
-  tr.cut {
-    td {
+  div.table-row.cut {
+    div.table-cell {
       background-color: #ccc;
       box-shadow: inset 0 1px 2px #999;
     }
@@ -354,15 +354,15 @@
 }
 
 .largetree-container.drag-enabled {
-  tr.drag-drop-over {
+  .drag-drop-over {
     outline: 1px solid rgb(2, 132, 130);
-    td {
+    .table-cell {
       background-color: #f0fff0;
     }
   }
-  tr.drag-drop-over-disallowed {
+  .drag-drop-over-disallowed {
     outline: 1px solid #c82829;
-    td {
+    .table-cell {
       background-color: #fff0f0;
     }
   }


### PR DESCRIPTION
More changes to the css selectors for the large tree after changes made here: https://github.com/archivesspace/archivesspace/commit/f7c83a9f7f

This fixes the missing green highlighting when a reorder mode operation is taking place to show where the node being moved will land.



## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1444

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
