### PR TITLE
ensure untitled object display strings in PUI use date for display

### DIFF
--- a/public/app/models/record.rb
+++ b/public/app/models/record.rb
@@ -85,7 +85,7 @@ class Record
 
   def parse_full_title(infinite_item = false)
     unless infinite_item || json['title_inherited'].blank? || (json['display_string'] || '') == json['title']
-      return "#{I18n.t('inherit.inherited', :level => raw['level'])} #{process_mixed_content(json['title'], :preserve_newlines => true)}"
+      return "#{json['title']}, #{json['display_string']}"
     end
     return process_mixed_content(json['display_string'] || json['title'], :preserve_newlines => true)
   end

--- a/public/spec/models/record_spec.rb
+++ b/public/spec/models/record_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe "Record model" do
 
-  it "builds a display string for an untitled record using its parent's title" do
+  it "builds a display string for an untitled record using its parent resource and its date" do
     solr_result = ASUtils.json_parse(File.read(File.join(FIXTURES_DIR, 'solr_response.json')))
     record = Record.new(solr_result)
-    expect(record.display_string).to eq "From the item: Resource with child inheriting title"
+    expect(record.display_string).to eq "Resource with child inheriting title, bulk: 1900s"
   end
 end


### PR DESCRIPTION
Correct the display of untitled objects in the PUI, ensuring that the display string is PARENT RECORD, DATE EXPRESSION.




## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1431
## How Has This Been Tested?
public/spec/models/record_spec.rb

## Screenshots (if appropriate):
<img width="860" alt="image" src="https://user-images.githubusercontent.com/1626547/142047149-fc51ad31-43a0-4b0b-865f-f8ff9b9ac780.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
