### PR TITLE
ANW-1449 Return key should submit advanced search form

### DIFF
--- a/frontend/app/assets/javascripts/header.js
+++ b/frontend/app/assets/javascripts/header.js
@@ -285,3 +285,11 @@ $(function () {
     });
   }
 });
+
+function processKey(e) {
+  if (null == e) e = window.event;
+  if (e.keyCode == 13) {
+    document.getElementById('advanced-search-btn').click();
+    return false;
+  }
+}

--- a/frontend/app/views/shared/_advanced_search.html.erb
+++ b/frontend/app/views/shared/_advanced_search.html.erb
@@ -185,7 +185,7 @@
       </div>
       <div class="input-group-addon search-value">
         <label for="v${index}"><%= I18n.t "advanced_search.search_text" %></label>
-        <%= text_field_tag "v${index}", "${query.value}", :id => "v${index}", :class => 'form-control'%>
+        <%= text_field_tag "v${index}", "${query.value}", :id => "v${index}", :class => 'form-control', :onkeydown => "return processKey(event)" %>
       </div>
     </div>
   </div>
@@ -286,7 +286,7 @@
     <% if current_page?(root_url) %>
       <div class="col-md-2"></div>
       <div class="col-md-3">
-        <button class="btn btn-primary"><%= I18n.t("advanced_search.button_text") %></button>
+        <button class="btn btn-primary" id="advanced-search-btn"><%= I18n.t("advanced_search.button_text") %></button>
       </div>
       <div class="col-md-1"></div>
     <% else %>
@@ -294,7 +294,7 @@
         <%= link_to I18n.t("advanced_search.reset"), {:controller => :search, :action => :do_search, :advanced => true}, :class => "btn btn-default reset-advanced-search pull-right pull-right" %>
       </div>
       <div class="col-md-1">
-        <button class="btn btn-primary pull-right"><%= I18n.t("advanced_search.button_text") %></button>
+        <button class="btn btn-primary pull-right" id="advanced-search-btn"><%= I18n.t("advanced_search.button_text") %></button>
       </div>
       <div class="col-md-1"></div>
     <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#2356 likely negatively impacted keypress functionality within the staff-side advanced search dropdown/form.  This ensures that hitting return while in the advanced search text field will submit the search (and not trigger the "remove row" button).

This is probably a bit ham-fisted as far as a solution goes, but it works? 🤷‍♀️ 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1449

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
