### PR TITLE
ANW-1415: include subject authority_id 65X field, $0

### DIFF
--- a/backend/app/exporters/models/marc21.rb
+++ b/backend/app/exporters/models/marc21.rb
@@ -325,6 +325,8 @@ class MARCModel < ASpaceExport::ExportModel
         sfs << ['2', subject['source']]
       end
 
+      sfs << ['0', subject['authority_id']]
+
       ind1 = code == '630' ? "0" : " "
       df!(code, ind1, ind2).with_sfs(*sfs)
     end

--- a/backend/spec/export_marc_spec.rb
+++ b/backend/spec/export_marc_spec.rb
@@ -413,6 +413,12 @@ describe 'MARC Export' do
 
       expect(xmlnotes.length).to eq(@subjects.length)
     end
+
+    it "maps authority_id to $0" do
+      @subjects.each do |s|
+        expect(@marc).to have_tag "subfield[@code='0']" => "#{s['authority_id']}"
+      end
+    end
   end
 
   describe "strips mixed content" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding subject authority_id to MARC export

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1415

## How Has This Been Tested?
manual and unit testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
