### PR TITLE
ANW-1177: Add a user preference to include unpublished in exports

### DIFF
--- a/common/config/preference_defaults.rb
+++ b/common/config/preference_defaults.rb
@@ -8,6 +8,7 @@ module PreferenceConfig
       'show_suppressed' => false,
       'publish' => false,
       'rde_sort_alpha' => true,
+      'include_unpublished' => false,
       'accession_browse_column_1' => 'title',
       'accession_browse_column_2' => 'identifier',
       'accession_browse_column_3' => 'accession_date',

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -2321,6 +2321,7 @@ en:
   defaults: &defaults_attributes
     general_section: General Settings
     show_suppressed: Show Suppressed?
+    include_unpublished: Include Unpublished Records in Exports?
     show_suppressed_tooltip: Whether to show suppressed records that you have permission to see when browsing.
     publish: Publish?
     rde_sort_alpha: Display RDE Templates Alphabetically?

--- a/common/schemas/defaults.rb
+++ b/common/schemas/defaults.rb
@@ -48,6 +48,12 @@ end
         "default" => true
       },
 
+      "include_unpublished" => {
+        "type" => "boolean",
+        "required" => false,
+        "default" => false
+      },
+
       "locale" => {
         "type" => "string",
         "enum" => locale_enum,

--- a/frontend/app/views/defaults/_template.html.erb
+++ b/frontend/app/views/defaults/_template.html.erb
@@ -5,6 +5,7 @@
       <%= form.label_and_boolean "show_suppressed", {}, form.default_for("show_suppressed") %>
       <%= form.label_and_boolean "publish", {}, form.default_for("publish") %>
       <%= form.label_and_boolean "rde_sort_alpha", {}, form.default_for("rde_sort_alpha") %>
+      <%= form.label_and_boolean "include_unpublished", {}, form.default_for("include_unpublished") %>
       <%= form.label_and_boolean "default_values", {}, form.default_for("default_values") %>
       <%= form.label_and_select "locale", supported_locales_options, supported_locales_default %>
 

--- a/frontend/app/views/resources/_toolbar.html.erb
+++ b/frontend/app/views/resources/_toolbar.html.erb
@@ -1,8 +1,4 @@
-<% if user_prefs['include_unpublished'] %>
-  <% unpublished_checked_string = "checked='checked'" %>
-<% else %>
-  <% unpublished_checked_string = "" %>
-<% end %>
+<% pref_include_unpublished = user_prefs['include_unpublished'] %>
 
 <% if user_can?('update_resource_record') %>
 
@@ -17,7 +13,7 @@
           <fieldset>
             <input type="hidden" name="id", value="<%= @resource.id %>" />
             <label class="checkbox" for="include-unpublished">
-              <input type="checkbox" id="include-unpublished" name="include_unpublished" <%= unpublished_checked_string %> />
+              <input type="checkbox" id="include-unpublished" name="include_unpublished" <% if pref_include_unpublished %> checked="checked" <% end %>/>
               <%= I18n.t("export_options.include_unpublished") %>&#160;
             </label>
             <label class="checkbox" for="include-daos">
@@ -44,7 +40,7 @@
           <fieldset>
             <input type="hidden" name="id", value="<%= @resource.id %>" />
             <label class="checkbox" for="include-unpublished-marc">
-              <input type="checkbox" id="include-unpublished-marc" name="include_unpublished_marc" <%= unpublished_checked_string %> />
+                <input type="checkbox" id="include-unpublished-marc" name="include_unpublished_marc" <% if pref_include_unpublished %> checked="checked" <% end %>/>
               <%= I18n.t("export_options.include_unpublished") %>&#160;
             </label>
             <%# END - MARC %>
@@ -63,7 +59,7 @@
             <div class="dropdown-menu">
               <fieldset>
                 <label class="checkbox" for="include-unpublished-pdf">
-                  <input type="checkbox" id="include-unpublished-pdf" onchange="$('#print-to-pdf-link').attr('href', '<%= url_for :controller => :exports,  :action => :print_to_pdf, :id => @resource.id %>?include_unpublished=' + $(this).prop('checked'))" <%= unpublished_checked_string %> />
+                    <input type="checkbox" id="include-unpublished-pdf" onchange="$('#print-to-pdf-link').attr('href', '<%= url_for :controller => :exports,  :action => :print_to_pdf, :id => @resource.id %>?include_unpublished=' + $(this).prop('checked'))" <% if pref_include_unpublished %> checked="checked" <% end %> />
                   <%= I18n.t("export_options.include_unpublished") %>&#160;
                 </label>
               </fieldset>

--- a/frontend/app/views/resources/_toolbar.html.erb
+++ b/frontend/app/views/resources/_toolbar.html.erb
@@ -1,3 +1,9 @@
+<% if user_prefs['include_unpublished'] %>
+  <% unpublished_checked_string = "checked='checked'" %>
+<% else %>
+  <% unpublished_checked_string = "" %>
+<% end %>
+
 <% if user_can?('update_resource_record') %>
 
   <% unless content_for?(:exports) %>
@@ -11,7 +17,7 @@
           <fieldset>
             <input type="hidden" name="id", value="<%= @resource.id %>" />
             <label class="checkbox" for="include-unpublished">
-              <input type="checkbox" id="include-unpublished" name="include_unpublished" checked="checked"/>
+              <input type="checkbox" id="include-unpublished" name="include_unpublished" <%= unpublished_checked_string %> />
               <%= I18n.t("export_options.include_unpublished") %>&#160;
             </label>
             <label class="checkbox" for="include-daos">
@@ -38,7 +44,7 @@
           <fieldset>
             <input type="hidden" name="id", value="<%= @resource.id %>" />
             <label class="checkbox" for="include-unpublished-marc">
-              <input type="checkbox" id="include-unpublished-marc" name="include_unpublished_marc" checked="checked"/>
+              <input type="checkbox" id="include-unpublished-marc" name="include_unpublished_marc" <%= unpublished_checked_string %> />
               <%= I18n.t("export_options.include_unpublished") %>&#160;
             </label>
             <%# END - MARC %>
@@ -57,7 +63,7 @@
             <div class="dropdown-menu">
               <fieldset>
                 <label class="checkbox" for="include-unpublished-pdf">
-                  <input type="checkbox" id="include-unpublished-pdf" onchange="$('#print-to-pdf-link').attr('href', '<%= url_for :controller => :exports,  :action => :print_to_pdf, :id => @resource.id %>?include_unpublished=' + $(this).prop('checked'))" />
+                  <input type="checkbox" id="include-unpublished-pdf" onchange="$('#print-to-pdf-link').attr('href', '<%= url_for :controller => :exports,  :action => :print_to_pdf, :id => @resource.id %>?include_unpublished=' + $(this).prop('checked'))" <%= unpublished_checked_string %> />
                   <%= I18n.t("export_options.include_unpublished") %>&#160;
                 </label>
               </fieldset>

--- a/frontend/spec/controllers/resource_controller_spec.rb
+++ b/frontend/spec/controllers/resource_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_helper'
+
+describe ResourcesController, type: :controller do
+  render_views
+
+  before(:each) do
+    set_repo($repo)
+  end
+
+  it "sets export menu's 'include unpublished' checkbox per user preferences" do
+    resource = create(:json_resource, instances: [])
+    session = User.login('admin', 'admin')
+    User.establish_session(controller, session, 'admin')
+    controller.session[:repo_id] = JSONModel.repository
+
+    # pretend preference is include_unpublished
+    allow(controller).to receive(:user_prefs).and_return('include_unpublished' => true)
+    get :edit, params: {id: resource.id, inline: true}
+    expect(response.body).to match /id="include-unpublished"[^>]+checked/
+    expect(response.body).to match /id="include-unpublished-marc"[^>]+checked/
+
+    # pretend preference is not to include_unpublished
+    allow(controller).to receive(:user_prefs).and_return('include_unpublished' => false)
+    get :edit, params: {id: resource.id, inline: true}
+    expect(response.body).not_to match /id="include-unpublished"[^>]+checked/
+    expect(response.body).not_to match /id="include-unpublished-marc"[^>]+checked/
+  end
+end

--- a/frontend/spec/selenium/spec/resources_spec.rb
+++ b/frontend/spec/selenium/spec/resources_spec.rb
@@ -633,14 +633,20 @@ describe 'Resources and archival objects' do
     end
   end
 
+  # this test doesn's work -- the dropdown menu affected only appears on mouseover, and as far as I can tell, can't be simulated.
+  # https://stackoverflow.com/questions/17226676/how-do-i-simulate-a-mouseover-in-pure-javascript-that-activates-the-css-hover
+  # tried looking for the checked attribute via a find_element query but that doesn't work as the element is not visible.
   it 'sets include unpublished option based on user preference' do
+    #@driver.navigate.to($frontend + "/preferences/0/edit")
+    #@driver.find_element(:css, "#preference_defaults__include_unpublished_").click
+    #@driver.click_and_wait_until_gone(css: "form#new_preference button[type='submit']")
 
-    @driver.navigate.to($frontend + "/preferences/0/edit")
-    @driver.find_element(:css, "#preference_defaults__include_unpublished_").click
-    @driver.click_and_wait_until_gone(css: "form#new_preference button[type='submit']")
+    #@driver.get_edit_page(@resource)
+    #@driver.find_element(:link, 'Export').click
 
-    @driver.get_edit_page(@resource)
-    @driver.find_element(:link, 'Export').click
+    #expect(@driver.find_element(css: 'input#include-unpublished').attribute('checked')).not_to be_nil
+    #expect(@driver.find_element(css: 'input#include-unpublished-marc').attribute('checked')).not_to be_nil
+    #expect(@driver.find_element(css: 'input#include-unpublished-pdf').attribute('checked')).not_to be_nil
   end
 
   it 'shows component id in browse view for archival objects' do

--- a/frontend/spec/selenium/spec/resources_spec.rb
+++ b/frontend/spec/selenium/spec/resources_spec.rb
@@ -633,6 +633,16 @@ describe 'Resources and archival objects' do
     end
   end
 
+  it 'sets include unpublished option based on user preference' do
+
+    @driver.navigate.to($frontend + "/preferences/0/edit")
+    @driver.find_element(:css, "#preference_defaults__include_unpublished_").click
+    @driver.click_and_wait_until_gone(css: "form#new_preference button[type='submit']")
+
+    @driver.get_edit_page(@resource)
+    @driver.find_element(:link, 'Export').click
+  end
+
   it 'shows component id in browse view for archival objects' do
     @driver.find_element(:link, 'Browse').click
     @driver.wait_for_dropdown

--- a/frontend/spec/selenium/spec/resources_spec.rb
+++ b/frontend/spec/selenium/spec/resources_spec.rb
@@ -633,22 +633,6 @@ describe 'Resources and archival objects' do
     end
   end
 
-  # this test doesn's work -- the dropdown menu affected only appears on mouseover, and as far as I can tell, can't be simulated.
-  # https://stackoverflow.com/questions/17226676/how-do-i-simulate-a-mouseover-in-pure-javascript-that-activates-the-css-hover
-  # tried looking for the checked attribute via a find_element query but that doesn't work as the element is not visible.
-  it 'sets include unpublished option based on user preference' do
-    #@driver.navigate.to($frontend + "/preferences/0/edit")
-    #@driver.find_element(:css, "#preference_defaults__include_unpublished_").click
-    #@driver.click_and_wait_until_gone(css: "form#new_preference button[type='submit']")
-
-    #@driver.get_edit_page(@resource)
-    #@driver.find_element(:link, 'Export').click
-
-    #expect(@driver.find_element(css: 'input#include-unpublished').attribute('checked')).not_to be_nil
-    #expect(@driver.find_element(css: 'input#include-unpublished-marc').attribute('checked')).not_to be_nil
-    #expect(@driver.find_element(css: 'input#include-unpublished-pdf').attribute('checked')).not_to be_nil
-  end
-
   it 'shows component id in browse view for archival objects' do
     @driver.find_element(:link, 'Browse').click
     @driver.wait_for_dropdown

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -88,8 +88,8 @@ RSpec.configure do |config|
 
     Factories.init
 
-    repo = create(:repo, :repo_code => "test_#{Time.now.to_i}", publish: true)
-    set_repo repo
+    $repo = create(:repo, :repo_code => "test_#{Time.now.to_i}", publish: true)
+    set_repo $repo
     create(:accession)
     create(:resource)
     run_index_round


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows user to set whether the "include unpublished" checkbox is on or off by default

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1177

## How Has This Been Tested?
Manual in-browser testing. Added an automated test stub as I haven't been able to figure out how to have the menu (which requires a mouseover to appear) to show programmatically. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
