### PR TITLE
Remove unnecessary warning log triggered on concurrent logins

### DIFF
--- a/backend/app/model/authentication_manager.rb
+++ b/backend/app/model/authentication_manager.rb
@@ -46,8 +46,6 @@ class AuthenticationManager
             # We'll swallow these because they only really mean that the user
             # logged in twice simultaneously.  As long as one of the updates
             # succeeded it doesn't really matter.
-            Log.warn("Got an optimistic locking error when updating user: #{e}")
-
             user = User.find(:username => username)
           end
         else


### PR DESCRIPTION
A few people on the listserv commented that they were seeing this message a lot, due to integrations that were logging in as system users multiple times concurrently.

The log message isn't really helpful anyway: it doesn't indicate a problem and there's nothing to be done about it.  The comment in the code explains what's happening, so I've dropped the logging.
