### PR TITLE
ANW-1337: Addendum to PR GH-2488 re: PUI citation modal

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -534,11 +534,6 @@ AppConfig[:pui_page_actions_cite] = true
 AppConfig[:pui_page_actions_request] = true
 AppConfig[:pui_page_actions_print] = true
 
-# Set default/active tab for PUI citation modal. If set to 'true' item citation
-# tab will be active by default; if 'false' item description tab will be active.
-# AppConfig[:pui_page_actions_cite] must be set to true for this to take effect.
-AppConfig[:pui_active_citation_tab_item] = true
-
 # Enable / disable search-in-collection form in sidebar when viewing records
 AppConfig[:pui_search_collection_from_archival_objects] = false
 AppConfig[:pui_search_collection_from_collection_organization] = false

--- a/public/spec/features/cite_spec.rb
+++ b/public/spec/features/cite_spec.rb
@@ -27,14 +27,22 @@ describe 'Citation dialog modal', js: true do
     cite_item_btn.click
     item_input = page.find('#tempItemInput')
     item_input.click
-    item_input.send_keys([:control, 'v'])# linux/windows
+    if page.driver.browser.capabilities.platform == 'mac'
+      item_input.send_keys([:command, 'v'])
+    else
+      item_input.send_keys([:control, 'v'])
+    end
     expect(item_input.value).to eq(item_text)
 
     cite_item_desc_btn = page.find('#copy_item_description_citation')
     cite_item_desc_btn.click
     item_desc_input = page.find('#tempItemDescInput')
     item_desc_input.click
-    item_desc_input.send_keys([:control, 'v'])# linux/windows
+    if page.driver.browser.capabilities.platform == 'mac'
+      item_desc_input.send_keys([:command, 'v'])
+    else
+      item_desc_input.send_keys([:control, 'v'])
+    end
     expect(item_desc_input.value).to eq(item_description_text)
   end
 


### PR DESCRIPTION
This PR adds the following changes to #2488

- Remove PUI citation modal default tab config option
- update cite_spec test to check for platform when running keyboard commands