### PR TITLE
ANW-730: Add PUI expand/collapse all config option

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -529,6 +529,9 @@ AppConfig[:pui_display_identifiers_in_resource_tree] = false
 #The number of characters to truncate before showing the 'Read More' link on notes
 AppConfig[:pui_readmore_max_characters] = 450
 
+# Whether to expand all additional information blocks at the bottom of record pages by default. `true` expands all blocks, `false` collapses all blocks.
+AppConfig[:pui_expand_all] = true
+
 # Enable / disable PUI resource/archival object page actions
 AppConfig[:pui_page_actions_cite] = true
 AppConfig[:pui_page_actions_request] = true

--- a/public/app/assets/javascripts/handle_accordion.js
+++ b/public/app/assets/javascripts/handle_accordion.js
@@ -3,7 +3,14 @@
 var expand_text = '';
 var collapse_text = '';
 /* we don't provide a button if there's only one panel; neither do we collapse that one panel */
-function initialize_accordion(what, ex_text, col_text) {
+
+/**
+ * @param {string} what accordion panels selector
+ * @param {string} ex_text 'expand text' i18n
+ * @param {string} col_text 'collapse text' i18n
+ * @param {boolean} expand_all
+ */
+function initialize_accordion(what, ex_text, col_text, expand_all) {
   expand_text = ex_text;
   collapse_text = col_text;
   if ($(what).size() > 1 && $(what).parents('.acc_holder').size() === 1) {
@@ -14,21 +21,33 @@ function initialize_accordion(what, ex_text, col_text) {
           "<a  class='btn btn-primary btn-sm acc_button' role='button' ></a>"
         );
     }
-    collapse_all(what, true);
+    expandAllByDefault(what, expand_all);
   }
 }
-function collapse_all(what, expand) {
+
+/**
+ * @param {string} what accordion panels selector
+ * @param {boolean} expand to expand or not
+ */
+function expandAllByDefault(what, expand) {
   $(what).each(function () {
     $(this).collapse(expand ? 'show' : 'hide');
   });
   set_button(what, !expand);
 }
 
+/**
+ * @param {string} what accordion panels selector
+ * @param {boolean} expand to expand or not
+ */
 function set_button(what, expand) {
   $holder = $(what).parents('.acc_holder');
   $btn = $holder.children('.acc_button');
   if ($btn.size() === 1) {
     $btn.text(expand ? expand_text : collapse_text);
-    $btn.attr('href', "javascript:collapse_all('" + what + "'," + expand + ')');
+    $btn.attr(
+      'href',
+      "javascript:expandAllByDefault('" + what + "'," + expand + ')'
+    );
   }
 }

--- a/public/app/views/agents/show.html.erb
+++ b/public/app/views/agents/show.html.erb
@@ -64,7 +64,7 @@
         </div>
       </div>
       <script type="text/javascript" >
-          initialize_accordion("#agent_accordion .note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>");
+          initialize_accordion("#agent_accordion .note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>", <%= AppConfig[:pui_expand_all] %>);
       </script>
   <% end %>
 

--- a/public/app/views/shared/_record_innards.html.erb
+++ b/public/app/views/shared/_record_innards.html.erb
@@ -132,5 +132,5 @@
         <%= render :file => template if File.exists?(template) %>
       <% end %>
     </div>
-    <script type="text/javascript" >initialize_accordion(".note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>");
+    <script type="text/javascript" >initialize_accordion(".note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>", <%= AppConfig[:pui_expand_all] %>);
     </script>

--- a/public/app/views/subjects/show.html.erb
+++ b/public/app/views/subjects/show.html.erb
@@ -33,7 +33,7 @@
         </div>
       </div>
       <script type="text/javascript" >
-        initialize_accordion(".note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>");
+        initialize_accordion(".note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>", <%= AppConfig[:pui_expand_all] %>);
       </script>
       <% unless @results.blank? || @results['total_hits'] == 0 %>
         <%= render partial: 'shared/facets' %>

--- a/public/spec/features/record_accordion_spec.rb
+++ b/public/spec/features/record_accordion_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Accordion of additional record information blocks', js: true do
+  before(:each) do
+    visit('/')
+    click_link 'Collections'
+    expect(current_path).to eq ('/repositories/resources')
+    resource = first("a.record-title")
+    visit(resource['href'])
+
+    $panels = page.all('.upper-record-details + .acc_holder div.panel.panel-default')
+  end
+
+  it 'should be found after the upper record details of a resource page' do
+    expect(page).to have_css('div.upper-record-details + div.acc_holder')
+  end
+
+  it 'should have all panels expanded by default' do
+    $panels.each do |panel|
+      expect(panel).to have_css('.note_panel[aria-expanded="true"]', visible: true)
+    end
+
+  end
+
+  it 'should collapse then expand all panels on button clicks' do
+    accordion_toggle_btn = page.find('.upper-record-details + .acc_holder > a.acc_button')
+    accordion_toggle_btn.click
+
+    $panels.each do |panel|
+      expect(panel).to have_css('.note_panel[aria-expanded="false"]', visible: :hidden)
+    end
+
+    accordion_toggle_btn.click
+
+    $panels.each do |panel|
+      expect(panel).to have_css('.note_panel[aria-expanded="true"]', visible: true)
+    end
+
+  end
+
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR solves [ANW-730](https://archivesspace.atlassian.net/browse/ANW-730) by adding a global PUI config option for toggling on/off the "expand all information blocks" by default at the bottom of record pages.

⚠️ **The expand all option has been set to `true` by default.** ⚠️

![anw-730-pui-expand-all](https://user-images.githubusercontent.com/3411019/144675431-405e0107-9774-415e-9f97-6d3dcff000a9.gif)

## Description

1. Add new config option to common/config/config-defaults.rb
2. Add new parameter to `initialize_accordion()`, clean up handle_accordion.js
3. Pass new arguments to uses of `initialize_accordion()`
4. Add tests

## Related JIRA Ticket or GitHub Issue

ANW-730

## How Has This Been Tested?

See [public/spec/features/record_accordion_spec.rb](https://github.com/brianzelip/archivesspace/blob/ANW-730-pui-expand-all-config/public/spec/features/record_accordion_spec.rb)

## Screenshots (if appropriate):

See above

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [x] Documentation has been updated
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
