### PR TITLE
stylesheets should be cp -r too

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -12,7 +12,7 @@ if [[ -v ASPACE_DEPLOY_PKG_URL ]]; then
     unzip -o /archivesspace/deploy_pkg.zip -d /archivesspace/tmp
     cp /archivesspace/tmp/config/config.rb /archivesspace/config/config.rb || true
     cp -r /archivesspace/tmp/plugins/* /archivesspace/plugins/ || true
-    cp /archivesspace/tmp/stylesheets/* /archivesspace/stylesheets/ || true
+    cp -r /archivesspace/tmp/stylesheets/* /archivesspace/stylesheets/ || true
   fi
 fi
 


### PR DESCRIPTION
fails with 
```
[2021-12-06T08:58:11-05:00] (name)   inflating: /archivesspace/tmp/stylesheets/fonts/Bitter-Italic.ttf
[2021-12-06T08:58:11-05:00] (name) cp: -r not specified; omitting directory '/archivesspace/tmp/stylesheets/fonts'
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
