### PR TITLE
ANW-1448 Fix tooltip bug in staff tree toolbar

### DIFF
--- a/frontend/app/assets/javascripts/tree_toolbar.js.erb
+++ b/frontend/app/assets/javascripts/tree_toolbar.js.erb
@@ -323,7 +323,7 @@ var TreeToolbarConfiguration = {
             onToolbarRendered: function(btn, toolbarRenderer) {
                 $(btn).addClass('disabled');
                 $(btn).after(AS.renderTemplate('template_load_via_spreadsheet_help_icon'));
-                $(btn).siblings("a").hover(function() {
+                $(btn).next("a").hover(function() {
                     $('#tt_load_via_spreadsheet').toggle();
                 })
             },
@@ -410,7 +410,7 @@ var TreeToolbarConfiguration = {
             onToolbarRendered: function(btn, toolbarRenderer) {
                 $(btn).addClass('disabled');
                 $(btn).after(AS.renderTemplate('template_load_via_spreadsheet_help_icon'));
-                $(btn).siblings("a").hover(function() {
+                $(btn).next("a").hover(function() {
                     $('#tt_load_via_spreadsheet').toggle();
                 })
             },

--- a/frontend/spec/features/largetree_toolbar_tooltip_spec.rb
+++ b/frontend/spec/features/largetree_toolbar_tooltip_spec.rb
@@ -1,0 +1,144 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Largetree toolbar tooltip', js: true do
+  before(:each) do
+    visit '/'
+    page.has_xpath? '//input[@id="login"]'
+    within "form.login" do
+      fill_in "username", with: "admin"
+      fill_in "password", with: "admin"
+      click_button "Sign In"
+    end
+
+    page.has_no_xpath? '//input[@id="login"]'
+  end
+
+  it 'should be hidden on edit resource page load' do
+    click_link 'Browse'
+    click_link 'Resources'
+    find("#tabledSearchResults .btn-primary", match: :first).click
+
+    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+  end
+
+  it 'should be hidden on edit resource page when help button\'s neighboring buttons are hovered' do
+    click_link 'Browse'
+    click_link 'Resources'
+    find("#tabledSearchResults .btn-primary", match: :first).click
+
+    find_link('Enable Reorder Mode').hover
+    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+
+    find_link('Add Child').hover
+    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+
+    find_link('Load via Spreadsheet').hover
+    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+
+    find_link('Rapid Data Entry').hover
+    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+  end
+
+  it 'should be visible on edit resource page when help button is hovered' do
+    click_link 'Browse'
+    click_link 'Resources'
+    find("#tabledSearchResults .btn-primary", match: :first).click
+
+    find('#load_via_spreadsheet_help_icon').hover
+    expect(page).to have_css('#tt_load_via_spreadsheet', visible: true)
+  end
+
+  it 'should be hidden on edit archival object page load' do
+    @resource = create(:json_resource)
+    @parent = create(:json_archival_object,
+                     :resource => {'ref' => @resource.uri},
+                     :title => "Parent")
+    @child1 = create(:json_archival_object,
+                     :resource => {'ref' => @resource.uri},
+                     :parent => {'ref' => @parent.uri},
+                     :title => "Child 1")
+
+    $index.run_index_round
+
+    click_link 'Browse'
+    click_link 'Resources'
+    within('table#tabledSearchResults > tbody > tr:nth-of-type(2)') do
+      find(".btn-primary").click
+    end
+
+    within("#tree-container .table-row-group") do
+      find("a.record-title").click
+    end
+
+    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+  end
+
+  it 'should be hidden on edit archival object page when help button\'s neighboring buttons are hovered' do
+    @resource = create(:json_resource)
+    @parent = create(:json_archival_object,
+                     :resource => {'ref' => @resource.uri},
+                     :title => "Parent")
+    @child1 = create(:json_archival_object,
+                     :resource => {'ref' => @resource.uri},
+                     :parent => {'ref' => @parent.uri},
+                     :title => "Child 1")
+
+    $index.run_index_round
+
+    click_link 'Browse'
+    click_link 'Resources'
+    within('table#tabledSearchResults > tbody > tr:nth-of-type(2)') do
+      find(".btn-primary").click
+    end
+
+    within("#tree-container .table-row-group") do
+      find("a.record-title").click
+    end
+
+    find_link('Enable Reorder Mode').hover
+    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+
+    find_link('Add Child').hover
+    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+
+    find_link('Add Sibling').hover
+    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+
+    find_link('Load via Spreadsheet').hover
+    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+
+    find_link('Transfer').hover
+    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+
+    find_link('Rapid Data Entry').hover
+    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+  end
+
+  it 'should be visible on edit archival object page when help button is hovered' do
+    @resource = create(:json_resource)
+    @parent = create(:json_archival_object,
+                     :resource => {'ref' => @resource.uri},
+                     :title => "Parent")
+    @child1 = create(:json_archival_object,
+                     :resource => {'ref' => @resource.uri},
+                     :parent => {'ref' => @parent.uri},
+                     :title => "Child 1")
+
+    $index.run_index_round
+
+    click_link 'Browse'
+    click_link 'Resources'
+    within('table#tabledSearchResults > tbody > tr:nth-of-type(2)') do
+      find(".btn-primary").click
+    end
+
+    within("#tree-container .table-row-group") do
+      find("a.record-title").click
+    end
+
+    find('#load_via_spreadsheet_help_icon').hover
+    expect(page).to have_css('#tt_load_via_spreadsheet', visible: true)
+  end
+
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR fixes [ANW-1448](https://archivesspace.atlassian.net/browse/ANW-1448).

Archival object view:

![anw-1448-fix-staff-tree-toolbar-tooltip-acession](https://user-images.githubusercontent.com/3411019/145093511-728ef1d1-a278-4704-85eb-ce79a1a8c2a2.gif)

Resource view:

![anw-1448-fix-staff-tree-toolbar-tooltip-resource](https://user-images.githubusercontent.com/3411019/145093558-fd337576-fd1c-400d-8488-d6efc412677b.gif)

## Description

Fixed the jquery function used in generating the Staff tree toolbar help icon.

## Related JIRA Ticket or GitHub Issue

ANW-1448

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
