### PR TITLE
ANW-1456 Sort templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/solr_backups/*
 build/gems
 derby.log
 frontend/doc
+frontend/docs
 backend/doc
 config/config.rb
 *.swp

--- a/frontend/app/controllers/bulk_import_templates_controller.rb
+++ b/frontend/app/controllers/bulk_import_templates_controller.rb
@@ -36,7 +36,7 @@ class BulkImportTemplatesController < ApplicationController
         :name => I18n.t('import_job.import_type_assessment_csv'),
         :filename => "aspace_assessment_import_template.csv"
       },
-    ]
+    ].sort_by { |template| template[:name] }
   end
 
   def download

--- a/frontend/app/controllers/custom_report_templates_controller.rb
+++ b/frontend/app/controllers/custom_report_templates_controller.rb
@@ -20,7 +20,12 @@ class CustomReportTemplatesController < ApplicationController
   end
 
   def index
-    @search_data = JSONModel(:custom_report_template).all(:page => selected_page)
+    @search_data = JSONModel(:custom_report_template).all(
+      page: selected_page,
+      page_size: 50,
+      sort_field: params.fetch(:sort, :name),
+      sort_direction: params.fetch(:direction, :asc)
+    )
   end
 
   def copy

--- a/frontend/app/views/custom_report_templates/_listing.html.erb
+++ b/frontend/app/views/custom_report_templates/_listing.html.erb
@@ -4,7 +4,10 @@
 	<table class="table table-striped table-bordered table-condensed">
 		<thead>
 			<tr>
-				<th><%= I18n.t("custom_report_template._singular") %></th>
+				<th>
+					<%= link_to I18n.t("custom_report_template._singular"), sort: :name, direction: sort_direction(:name, params, 'asc') %>
+					<%= sort_pointer(:name, params, '&#x25B2;').html_safe %>
+				</th>
 				<th><%= I18n.t("custom_report_template.description") %></th>
 				<th width="70px"><span class="sr-only"><%= I18n.t('search_results.actions') %></span></th>
 			</tr>


### PR DESCRIPTION
Use JSONModel sort functionality for custom report templates.
Sort bulk import templates by name.

Also smuggled in .gitignore on frontend/docs.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
