### PR TITLE
Fix for PDF failure when predefined XML entities are unescaped

### DIFF
--- a/public/app/lib/xml_cleaner.rb
+++ b/public/app/lib/xml_cleaner.rb
@@ -38,11 +38,12 @@ class XMLCleaner
     File.open(file_path + ".tmp", "w") do |outfile|
       File.open(file_path) do |infile|
         infile.each_with_index do |line, index|
+          # The decode() method used below turns the five predefined XML entities into unescaped characters. That can
+          # create non-well-formed XHTML, which will break PDF generation, so first replace them with something that
+          # can be converted back safely afterwards.
+          line.gsub!(/&(amp|lt|gt|quot|apos);/, '~~\1~~')
           line = HTMLEntities.new.decode(line)
-          # decode turns &amp; into & so need to undo that here for PDF to work
-          if line.match(/&\s+/) || line.match(/&[A-Za-z]+[^;]/)
-            line.gsub!('&', '&amp;')
-          end
+          line.gsub!(/~~(amp|lt|gt|quot|apos)~~/, '&\1;')
           outfile.puts(line)
         end
       end


### PR DESCRIPTION
## Description
Since #1745, the HTML which is generated in order to be converted into a PDF has been run through a [third-party library](https://github.com/threedaymonk/htmlentities) which converts most entity references (but maybe not all) into UTF-8 characters. That is fine for numerical entities like `&#246;` and named entities like `&nbsp;` defined by the HTML schema (although the latter would be invalid if exported to EAD, but that's a different matter). But it also converts the five [predefined entities in XML](https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Predefined_entities_in_XML), which can create non-well-formed XHTML, which will break PDF generation. The case of `&amp;` has been handled by regex searching for unescaped-& in the strings returned by the _HTMLEntities.new.decode()_ method, and replacing them with `&amp;` but, as they may be some entity references remaining, it cannot replace all, and so could only do so for lines that contained something that didn't look like an entity reference. That's difficult, if not impossible, to get 100% right.

One case which wasn't anticipated was an ampersand followed by a digit. That has caused complaints from end users here at the Bodleian, that they couldn't get a PDF version of a collection containing, for example, a reference to something like `pages 1&amp;2`. Further testing revealed that is it also possible to break PDF generation by use of `&lt;`, which is converted to `<`, and that then won't be parsed as a less-than symbol but the start of a broken HTML tag. These are all rare cases, but they are difficult to trace, because the original description is using correct encoding. It is only after it has been converted to HTML does it become invalid.

So, instead of adding more special cases to the regex, this fix converts the five predefined XML entities into another form before the _decode_ method is run, so it can safely transform them all back again afterwards.

## Related JIRA Ticket or GitHub Issue
This is essentially a more general fix for https://archivesspace.atlassian.net/browse/ANW-1111 than #1985.

## How Has This Been Tested?
On local development system and QA system running 2.8.1 (in a plugin which overrides the _replace_html_entities_ def.)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
