### PR TITLE
ANW-1459 assign a random identifier to bulk import digital objects

### DIFF
--- a/backend/app/lib/bulk_import/digital_object_handler.rb
+++ b/backend/app/lib/bulk_import/digital_object_handler.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 require_relative "handler"
 require_relative "../../model/digital_object"
 
@@ -28,7 +29,7 @@ class DigitalObjectHandler < Handler
         archival_object.ref_id = "VAL#{rand(1000000)}"
       end
     end
-    osn = id || "#{archival_object.ref_id.to_s}d"
+    osn = id || SecureRandom.hex
     if !check_digital_id(osn)
 =begin
       if @validate_only

--- a/backend/spec/model_bulk_import_job_spec.rb
+++ b/backend/spec/model_bulk_import_job_spec.rb
@@ -30,8 +30,8 @@ describe 'Bulk Import Jobs' do
 
       tmp = ASUtils.tempfile("bulk-import-digital-object-csv-#{Time.now.to_i}")
       tmp.write("ArchivesSpace digital object import field codes, collection_id, ead, ref_id, res_uri, ao_ref_id, ao_uri, digital_object_id, digital_object_title, publish,	digital_object_link, thumbnail,digital_object_link_publish,thumbnail_publish\n")
-      tmp.write(",,#{resource.ead_id},,,#{archival_object.ref_id},,blah,blah blah,t,http://blahblah.com,http://thumbnail.com,1,0\n")
-      tmp.write(",,#{resource.ead_id},,,#{archival_object.ref_id},,hideme,hide me,f,http://hideme.com,http://thumbnail.com,0,1\n")
+      tmp.write(",,#{resource.ead_id},,,#{archival_object.ref_id},,,blah blah,t,http://blahblah.com,http://thumbnail.com,1,0\n")
+      tmp.write(",,#{resource.ead_id},,,#{archival_object.ref_id},,,hide me,f,http://hideme.com,http://thumbnail.com,0,1\n")
       tmp.rewind
       user = create_nobody_user
       job = Job.create_from_json(json,


### PR DESCRIPTION
Assign a random identifier to digital objects rather than using the ref_id of the associated archival object.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
