### PR TITLE
ANW-1342: adding default value for extent type in deaccession show page

### DIFF
--- a/frontend/app/views/deaccessions/_show.html.erb
+++ b/frontend/app/views/deaccessions/_show.html.erb
@@ -29,7 +29,7 @@
             <div class="col-md-7">
               <% if !deaccession["extents"].blank? %>
                 <%= deaccession["extents"][0]['number'] %>
-                <%= I18n.t('enumerations.extent_extent_type.'+deaccession["extents"][0]['extent_type']) %>
+                <%= I18n.t('enumerations.extent_extent_type.'+deaccession["extents"][0]['extent_type'], :default => deaccession["extents"][0]['extent_type']) %>
               <% end %>
             </div>
           </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
adding default value for extent type in deaccession show page

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1342

## How Has This Been Tested?
manual in browser testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
