### PR TITLE
mizuno-aspace is now a proper rubygem

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -44,7 +44,7 @@ group :development, :test do
   gem 'pry', '~> 0.12.2'
   gem 'pry-debugger-jruby', '>= 1.2.2'
   gem 'pry-nav'
-  gem 'mizuno', git: "https://github.com/archivesspace/mizuno", branch: "master"
+  gem 'mizuno-aspace'
 end
 
 gem 'multi_json', '~> 1.15.0'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/archivesspace/mizuno
-  revision: d5c963a70c3ea6144df941801975179b03dfaa5c
-  branch: master
-  specs:
-    mizuno (9.4.44)
-      childprocess (>= 0.2.6)
-      choice (>= 0.1.0)
-      ffi (>= 1.0.0)
-      rack (>= 1.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -52,6 +41,11 @@ GEM
     ladle (0.2.0-java)
     method_source (0.9.2)
     minitest (5.14.4)
+    mizuno-aspace (9.4.44)
+      childprocess (>= 0.2.6)
+      choice (>= 0.1.0)
+      ffi (>= 1.0.0)
+      rack (>= 1.0.0)
     multi_json (1.15.0)
     multipart-post (1.2.0)
     mustermann (1.1.1)
@@ -163,7 +157,7 @@ DEPENDENCIES
   json (= 2.3.0)
   json-schema (= 1.0.10)
   ladle (= 0.2.0)
-  mizuno!
+  mizuno-aspace
   multi_json (~> 1.15.0)
   multipart-post (= 1.2.0)
   net-http-persistent (= 2.8)

--- a/frontend/Gemfile
+++ b/frontend/Gemfile
@@ -55,7 +55,7 @@ group :development, :test do
   gem 'pry-debugger-jruby', '>= 1.2.2'
   gem 'pry-nav'
   gem 'pry-rails'
-  gem 'mizuno', git: "https://github.com/archivesspace/mizuno", branch: "master"
+  gem 'mizuno-aspace'
 end
 
 group :development do

--- a/frontend/Gemfile.lock
+++ b/frontend/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/archivesspace/mizuno
-  revision: d5c963a70c3ea6144df941801975179b03dfaa5c
-  branch: master
-  specs:
-    mizuno (9.4.44)
-      childprocess (>= 0.2.6)
-      choice (>= 0.1.0)
-      ffi (>= 1.0.0)
-      rack (>= 1.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -161,6 +150,11 @@ GEM
     mime-types-data (3.2021.0704)
     mini_mime (1.1.0)
     minitest (5.14.4)
+    mizuno-aspace (9.4.44)
+      childprocess (>= 0.2.6)
+      choice (>= 0.1.0)
+      ffi (>= 1.0.0)
+      rack (>= 1.0.0)
     multi_json (1.15.0)
     multipart-post (1.2.0)
     net-http-digest_auth (1.4.1)
@@ -331,7 +325,7 @@ DEPENDENCIES
   less-rails-bootstrap
   loofah (>= 2.2.3)
   mechanize
-  mizuno!
+  mizuno-aspace
   multi_json (~> 1.15.0)
   multipart-post (= 1.2.0)
   net-http-persistent (= 2.8)

--- a/public/Gemfile
+++ b/public/Gemfile
@@ -54,7 +54,7 @@ group :development, :test do
   gem 'pry', '~> 0.12.2'
   gem 'pry-nav'
   gem 'pry-rails'
-  gem 'mizuno', git: "https://github.com/archivesspace/mizuno", branch: "master"
+  gem 'mizuno-aspace'
 end
 
 group :test do

--- a/public/Gemfile.lock
+++ b/public/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/archivesspace/mizuno
-  revision: d5c963a70c3ea6144df941801975179b03dfaa5c
-  branch: master
-  specs:
-    mizuno (9.4.44)
-      childprocess (>= 0.2.6)
-      choice (>= 0.1.0)
-      ffi (>= 1.0.0)
-      rack (>= 1.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -158,6 +147,11 @@ GEM
     method_source (0.9.2)
     mini_mime (1.1.0)
     minitest (5.14.4)
+    mizuno-aspace (9.4.44)
+      childprocess (>= 0.2.6)
+      choice (>= 0.1.0)
+      ffi (>= 1.0.0)
+      rack (>= 1.0.0)
     multi_json (1.15.0)
     multipart-post (1.2.0)
     net-http-persistent (2.8)
@@ -314,7 +308,7 @@ DEPENDENCIES
   launchy
   listen
   loofah (>= 2.2.3)
-  mizuno!
+  mizuno-aspace
   multipart-post (= 1.2.0)
   net-http-persistent (= 2.8)
   nokogiri (>= 1.10.8)


### PR DESCRIPTION
As the title says, mizuno now from ruby gems (and free of log4j)

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
