### PR TITLE
add i18n to frontend and public interface footers

### DIFF
--- a/frontend/app/views/site/_footer.html.erb
+++ b/frontend/app/views/site/_footer.html.erb
@@ -1,7 +1,7 @@
 <div class="container-fluid footer">
    <div class="row">
       <div class="col-md-12">
-        <p><% if AppConfig[:enable_public] %>View <a href="<%= AppConfig[:public_proxy_url] %>">Public Interface</a> | <% end %>Visit <a href='http://archivesspace.org'>ArchivesSpace.org</a> | <%= ASConstants.VERSION %> |<% if AppConfig[:feedback_url] && !AppConfig[:feedback_url].blank? %> <a id='aspaceFeedbackLink' href='https://archivesspace.org/contact' target='_blank'>Send Feedback or Report a Problem</a> <% end %></p>
+        <p><% if AppConfig[:enable_public] %><%= I18n.t("footer.public_interface", :public_url => AppConfig[:public_proxy_url]) %> | <% end %><%= I18n.t("footer.archivesspace_home") %> | <%= ASConstants.VERSION %><% if AppConfig[:feedback_url] && !AppConfig[:feedback_url].blank? %> | <%= I18n.t("footer.feedback", :feedback_url => AppConfig[:feedback_url]) %> <% end %></p>
       </div>
    </div>
 </div>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -556,6 +556,11 @@ en:
   header:
     staff_interface: ArchivesSpace Staff Interface
 
+  footer:
+    public_interface: View <a href="%{public_url}">Public Interface</a>
+    archivesspace_home: Visit <a href='http://archivesspace.org'>ArchivesSpace.org</a>
+    feedback: <a id='aspaceFeedbackLink' href='%{feedback_url}' target='_blank'>Send Feedback or Report a Problem</a>
+
   session:
     gone: Your backend session was not found
     expired: Your session expired due to inactivity

--- a/public/app/views/shared/_footer.html.erb
+++ b/public/app/views/shared/_footer.html.erb
@@ -1,10 +1,10 @@
 <div class="container-fluid panel-footer">
   <div class="row">
      <div class="col-md-12">
-       <p class="footer-items"><a href="<%= AppConfig[:frontend_proxy_url] %>">Staff Interface</a>
-         | Visit <a href="http://archivesspace.org">ArchivesSpace.org</a>
+       <p class="footer-items"><%= I18n.t("footer.staff_interface", staff_url: AppConfig[:frontend_proxy_url]).html_safe %>
+         | <%= I18n.t("footer.archivesspace_home").html_safe %>
          | <%= ASConstants.VERSION %>
-         | <% if AppConfig[:feedback_url] && !AppConfig[:feedback_url].blank? %><a id='aspaceFeedbackLink' href='<%= AppConfig[:feedback_url]%>' target='_blank'>Send Feedback or Report a Problem</a><% end %></p>
+         <% if AppConfig[:feedback_url] && !AppConfig[:feedback_url].blank? %> | <%= I18n.t("footer.feedback", :feedback_url => AppConfig[:feedback_url]).html_safe %><% end %></p>
      </div>
   </div>
 </div>

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -527,3 +527,8 @@ en:
     file_version_xlink_actuate_attribute: Xlink Actuate Attribute
     file_version_xlink_show_attribute: Xlink Show Attribute
     last_verified_date: Last Verified Date
+
+  footer:
+    staff_interface: <a href="%{staff_url}">Staff Interface</a>
+    archivesspace_home: Visit <a href='http://archivesspace.org'>ArchivesSpace.org</a>
+    feedback: <a id='aspaceFeedbackLink' href='%{feedback_url}' target='_blank'>Send Feedback or Report a Problem</a>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Footers of public and frontend interface were not ready for i18n. I have changed that and added three new translation keys each to the `en.yml` files of frontend and public components. They live under `footer`. This was inspired by the already existing `header` in the frontend component.
I'm unsure if relevant keys need to be added to other languages as well. If so, please point this out.
I'm unsure why I had to use the `I18n.t().html_safe` in the public footer. This was not necessary in the frontend footer. If this is a problem, please tell me.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Fixes #2583 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visual testing by running the frontend and public interfaces locally.
Could not run automated tests locally because of `You have already activated nokogiri 1.12.4, but your Gemfile requires nokogiri 1.12.3`. Not sure what I'm doing wrong.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
