### PR TITLE
Proxy default conf will always be https enabled

### DIFF
--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -32,7 +32,7 @@ server {
   proxy_set_header        X-Forwarded-For    $proxy_add_x_forwarded_for;
   proxy_set_header        X-Forwarded-Host   $host;
   proxy_set_header        X-Forwarded-Server $host;
-  proxy_set_header        X-Forwarded-Proto  $scheme;
+  proxy_set_header        X-Forwarded-Proto  https;
   proxy_set_header        X-Real-IP          $remote_addr;
 
   location / {


### PR DESCRIPTION
Need this tip-off when nginx itself is behind an SSL terminating access point.