### PR TITLE
ANW-1430: changing shortcut key from space to control for infinite scroll library

### DIFF
--- a/public/app/assets/javascripts/infinite_scroll.js
+++ b/public/app/assets/javascripts/infinite_scroll.js
@@ -70,7 +70,7 @@
 
     var PGUP = 33;
     var PGDN = 34;
-    var SPC = 32;
+    var CTRL = 17;
 
     var DOWN = 40;
     var UP = 38;
@@ -78,10 +78,10 @@
     $(document).on('keydown', function (e) {
       var viewportHeight = self.wrapper.height();
 
-      if (e.keyCode == PGDN || (e.keyCode == SPC && !e.shiftKey)) {
+      if (e.keyCode == PGDN || (e.keyCode == CTRL && !e.shiftKey)) {
         self.scrollBy(viewportHeight);
         e.preventDefault();
-      } else if (e.keyCode == PGUP || (e.keyCode == SPC && e.shiftKey)) {
+      } else if (e.keyCode == PGUP || (e.keyCode == CTRL && e.shiftKey)) {
         self.scrollBy(0 - viewportHeight);
         e.preventDefault();
       } else if (e.keyCode == DOWN) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Javascript code in the InfiniteScroll js library is breaking search on the collection organization page of the PUI. Spacebar keypress events are being intercepted. This changes code to use CTRL key instead of spacebar.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1430

## How Has This Been Tested?
Manual, in browser testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
