### PR TITLE
ANW-1448: Refactor staff tree load-via-spreadsheet help-tooltip to fix reorder render bug

### DIFF
--- a/frontend/app/assets/javascripts/tree_toolbar.js.erb
+++ b/frontend/app/assets/javascripts/tree_toolbar.js.erb
@@ -322,10 +322,18 @@ var TreeToolbarConfiguration = {
             },
             onToolbarRendered: function(btn, toolbarRenderer) {
                 $(btn).addClass('disabled');
-                $(btn).after(AS.renderTemplate('template_load_via_spreadsheet_help_icon'));
-                $(btn).next("a").hover(function() {
-                    $('#tt_load_via_spreadsheet').toggle();
-                })
+
+                const inReorderMode = $('#tree-container').hasClass('drag-enabled');
+
+                if (!inReorderMode) {
+                  $(btn).after(AS.renderTemplate('template_load_via_spreadsheet_help_icon'));
+
+                  const helpLinkID = '#load_via_spreadsheet_help_icon';
+                  $(helpLinkID).hover(
+                    () => $(helpLinkID).tooltip('show'),
+                    () => $(helpLinkID).tooltip('hide')
+                  );
+                }
             },
         },
         // RDE
@@ -409,10 +417,18 @@ var TreeToolbarConfiguration = {
             },
             onToolbarRendered: function(btn, toolbarRenderer) {
                 $(btn).addClass('disabled');
-                $(btn).after(AS.renderTemplate('template_load_via_spreadsheet_help_icon'));
-                $(btn).next("a").hover(function() {
-                    $('#tt_load_via_spreadsheet').toggle();
-                })
+
+                const inReorderMode = $('#tree-container').hasClass('drag-enabled');
+
+                if (!inReorderMode) {
+                  $(btn).after(AS.renderTemplate('template_load_via_spreadsheet_help_icon'));
+
+                  const helpLinkID = '#load_via_spreadsheet_help_icon';
+                  $(helpLinkID).hover(
+                    () => $(helpLinkID).tooltip('show'),
+                    () => $(helpLinkID).tooltip('hide')
+                  );
+                }
             },
         }
         ],

--- a/frontend/app/views/shared/_templates.html.erb
+++ b/frontend/app/views/shared/_templates.html.erb
@@ -315,10 +315,7 @@
 --></div>
 
 <div id="template_load_via_spreadsheet_help_icon"><!--
-  <a target='_blank' aria-describedby='tt_load_via_spreadsheet' class='has-tooltip initialised' id='load_via_spreadsheet_help_icon' href="<%= ArchivesSpaceHelp.url_for_topic('resource_load_via_spreadsheet') %>">
+  <a target='_blank' class='has-tooltip initialised' id='load_via_spreadsheet_help_icon' href="<%= ArchivesSpaceHelp.url_for_topic('resource_load_via_spreadsheet') %>" data-toggle="tooltip" data-placement="top" title="<%= I18n.t("help.topics.resource_load_via_spreadsheet")%>" data-container="body">
     <span class='context-help-icon glyphicon glyphicon-question-sign'></span>
-    <div class='js-tooltip' id='tt_load_via_spreadsheet'>
-      <%= I18n.t("help.topics.resource_load_via_spreadsheet")%>
-    </div><div class='tooltip-arrow'></div>
   </a>
 --></div>

--- a/frontend/spec/features/tree_toolbar_import_help_link_spec.rb
+++ b/frontend/spec/features/tree_toolbar_import_help_link_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 require 'rails_helper'
 
-describe 'Largetree toolbar tooltip', js: true do
+$help_link_id = '#load_via_spreadsheet_help_icon'
+
+describe 'Tree toolbar import help link', js: true do
   before(:each) do
     visit '/'
     page.has_xpath? '//input[@id="login"]'
@@ -14,42 +16,34 @@ describe 'Largetree toolbar tooltip', js: true do
     page.has_no_xpath? '//input[@id="login"]'
   end
 
-  it 'should be hidden on edit resource page load' do
+  it 'should be visible on edit resource page load' do
     click_link 'Browse'
     click_link 'Resources'
     find("#tabledSearchResults .btn-primary", match: :first).click
 
-    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+    expect(page).to have_css($help_link_id, visible: true)
   end
 
-  it 'should be hidden on edit resource page when help button\'s neighboring buttons are hovered' do
+  it 'should display a tooltip above when hovered on edit resource page' do
     click_link 'Browse'
     click_link 'Resources'
     find("#tabledSearchResults .btn-primary", match: :first).click
 
-    find_link('Enable Reorder Mode').hover
-    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
-
-    find_link('Add Child').hover
-    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
-
-    find_link('Load via Spreadsheet').hover
-    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
-
-    find_link('Rapid Data Entry').hover
-    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+    page.should have_no_css("#$help_link_id[aria-describedby*='tooltip']")
+    page.find($help_link_id).hover
+    page.should have_css("#$help_link_id[aria-describedby*='tooltip'][data-placement='top']")
   end
 
-  it 'should be visible on edit resource page when help button is hovered' do
+  it 'should be hidden when resource tree is in reorder mode' do
     click_link 'Browse'
     click_link 'Resources'
     find("#tabledSearchResults .btn-primary", match: :first).click
 
-    find('#load_via_spreadsheet_help_icon').hover
-    expect(page).to have_css('#tt_load_via_spreadsheet', visible: true)
+    click_on 'Enable Reorder Mode'
+    expect(page).to have_css($help_link_id, visible: :hidden)
   end
 
-  it 'should be hidden on edit archival object page load' do
+  it 'should be visible on edit archival object page load' do
     @resource = create(:json_resource)
     @parent = create(:json_archival_object,
                      :resource => {'ref' => @resource.uri},
@@ -71,10 +65,10 @@ describe 'Largetree toolbar tooltip', js: true do
       find("a.record-title").click
     end
 
-    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+    expect(page).to have_css($help_link_id, visible: true)
   end
 
-  it 'should be hidden on edit archival object page when help button\'s neighboring buttons are hovered' do
+  it 'should display a tooltip above when hovered on edit archival object page' do
     @resource = create(:json_resource)
     @parent = create(:json_archival_object,
                      :resource => {'ref' => @resource.uri},
@@ -96,26 +90,12 @@ describe 'Largetree toolbar tooltip', js: true do
       find("a.record-title").click
     end
 
-    find_link('Enable Reorder Mode').hover
-    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
-
-    find_link('Add Child').hover
-    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
-
-    find_link('Add Sibling').hover
-    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
-
-    find_link('Load via Spreadsheet').hover
-    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
-
-    find_link('Transfer').hover
-    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
-
-    find_link('Rapid Data Entry').hover
-    expect(page).to have_css('#tt_load_via_spreadsheet', visible: :hidden)
+    page.should have_no_css("#$help_link_id[aria-describedby*='tooltip']")
+    page.find($help_link_id).hover
+    page.should have_css("#$help_link_id[aria-describedby*='tooltip'][data-placement='top']")
   end
 
-  it 'should be visible on edit archival object page when help button is hovered' do
+  it 'should be hidden when archival object tree is in reorder mode' do
     @resource = create(:json_resource)
     @parent = create(:json_archival_object,
                      :resource => {'ref' => @resource.uri},
@@ -137,8 +117,8 @@ describe 'Largetree toolbar tooltip', js: true do
       find("a.record-title").click
     end
 
-    find('#load_via_spreadsheet_help_icon').hover
-    expect(page).to have_css('#tt_load_via_spreadsheet', visible: true)
+    click_on 'Enable Reorder Mode'
+    expect(page).to have_css($help_link_id, visible: :hidden)
   end
 
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After #2546 was merged, [user feedback](https://archivesspace.atlassian.net/browse/ANW-1448?focusedCommentId=38035&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-38035) found a pre-existing bug where the 'load via spreadsheet' help button was still showing while in tree reorder mode. This PR solves this by refactoring the help button and tooltip logic. This also fixes the tooltip layout position discrepancies that existed between resource and archival object tree views.

![tree-toolbar-tooltip](https://user-images.githubusercontent.com/3411019/148547646-e9fbbf7a-3094-4dcd-990f-b3fb46170a2f.gif)

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-1448](https://archivesspace.atlassian.net/browse/ANW-1448?focusedCommentId=38035&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-38035)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See frontend/spec/features/largetree_toolbar_import_help_link_spec.rb.

## Screenshots (if appropriate):

See above.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
