### PR TITLE
ANW-699: moving 'add item' button to bottom for defined lists

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/notes.less
+++ b/frontend/app/assets/stylesheets/archivesspace/notes.less
@@ -70,3 +70,7 @@
     }
   }
 }
+
+.add-item-btn-bottom {
+  margin: 5px;
+}

--- a/frontend/app/views/notes/_template.html.erb
+++ b/frontend/app/views/notes/_template.html.erb
@@ -700,15 +700,15 @@
       <section class="subrecord-form">
         <h4 class="subrecord-form-heading">
           <%= I18n.t("note_definedlist.items") %>
-          <% if not form.readonly? %>
-            <button class="btn btn-xs btn-default pull-right add-item-btn"><%= I18n.t("note._frontend.action.note_definedlist_item") %></button>
-          <% end %>
         </h4>
         <div class="subrecord-form-container">
           <%= form.list_for(form["items"], "items[]") do |item| %>
             <% form.emit_template("definedlist_item", item) %>
           <% end %>
         </div>
+        <% if not form.readonly? %>
+          <button class="btn btn-xs btn-default add-item-btn add-item-btn-bottom"><%= I18n.t("note._frontend.action.note_definedlist_item") %></button>
+        <% end %>
       </section>
     </div>
   </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ease of use, so that adding more items doesn't require scrolling up so much.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-699

## How Has This Been Tested?
manual in browser testing

## Screenshots (if appropriate):
![Screenshot_2022-01-11_15-05-21](https://user-images.githubusercontent.com/130926/149029238-72fc88f5-7008-4e26-a880-e0c1a09cfc34.jpg)
![Screenshot_2022-01-11_15-05-37](https://user-images.githubusercontent.com/130926/149029264-43660219-a9db-44d6-b1b9-29ad92f5a0d4.jpg)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
