### PR TITLE
ANW-1168: strip out quotes from the confimration when deleting a repo

### DIFF
--- a/frontend/app/views/repositories/_toolbar.html.erb
+++ b/frontend/app/views/repositories/_toolbar.html.erb
@@ -19,7 +19,7 @@
                 {   :class => "btn btn-sm btn-danger delete-record delete-repository", 
                     :"data-confirm-btn-class" => "btn-danger repo-delete", 
                     :"data-title" => I18n.t("actions.delete_repository_confirm_title", :name => @repository["repository"]["name"]),
-                    :"data-message" => I18n.t("actions.delete_repository_confirm_message", :repository => @repository["repository"]["repo_code"] ) } %>
+                    :"data-message" => I18n.t("actions.delete_repository_confirm_message", :repository => @repository["repository"]["repo_code"].gsub("'", "").gsub('"', '') ) } %>
             </div>
           </div>
         <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Single quotes are not being escaped properly by translations and JS layers, so trying to delete a repo with a single quote in the name leads to an unexpected string in the confirmation. This removes quptes from the confirmation to bypass this issue while still allowing for single quotes in repo names.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1168

## How Has This Been Tested?
Manual in browser and unit testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
