### PR TITLE
ANW-1242: bugfix for lost formatting when expanding notes in PUI

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -76,7 +76,7 @@ a img {
 }
 .readmore.expanded .more {
   visibility: visible;
-  display: inline;
+  display: block;
 }
 .readmore.expanded .elipses {
   visibility: hidden;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
CSS fix for block paragraph tags being converted to inline when expanding/contracting with the show less/more function in the PUI. CSS fix also solves the carriage return issue in the same request.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1242

## How Has This Been Tested?
Manual in browser testing

## Screenshots (if appropriate):
![Screenshot_2022-01-12_15-18-24](https://user-images.githubusercontent.com/130926/149232315-8e9d00ac-9204-4811-9e1c-4013b7c97ae5.jpg)
![Screenshot_2022-01-12_15-17-49](https://user-images.githubusercontent.com/130926/149232320-399e5428-a67d-45cd-a307-0a33f7249481.jpg)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
