### PR TITLE
Migration 158 Legacy Data Issues

### DIFF
--- a/common/db/db_migrator.rb
+++ b/common/db/db_migrator.rb
@@ -223,9 +223,12 @@ class DBMigrator
     !!                                                                                                !!
     !!                                                                                                !!
     !!                                                Error:                                          !!
-    !!  #{e.inspect}                                                                                  !!
-    !!  #{e.message}                                                                                  !!
-    !!  #{e.backtrace.join("\n")}                                                                     !!
+EOF
+      e.message.split("\n").each do |line|
+        $stderr.puts "    !! #{line}"
+      end
+      $stderr.puts <<EOF
+    !!                                                                                                !!
     !!                                                                                                !!
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -254,40 +257,40 @@ EOF
 
     if current_version && current_version > 0 && current_version < CONTAINER_MIGRATION_NUMBER
       $stderr.puts <<~EOM
-        
+
         =======================================================================
         Important migration issue
         =======================================================================
-        
+
         Hello!
-        
+
         It appears that you are upgrading ArchivesSpace from version 1.4.2 or prior.  To
         complete this upgrade, there are some additional steps to follow.
-        
+
         The 1.5 series of ArchivesSpace introduced a new data model for containers,
         along with a compatibility layer to provide a seamless transition between the
         old and new container models.  In ArchivesSpace version 2.1, this compatibility
         layer was removed in the interest of long-term maintainability and system
         performance.
-        
+
         To upgrade your ArchivesSpace installation, you will first need to upgrade to
         version 2.0.1.  This will upgrade your containers to the new model and clear the
         path for future upgrades.  Once you have done this, you can upgrade to the
         latest ArchivesSpace version as normal.
-        
+
         For more information on upgrading to ArchivesSpace 2.0.1, please see the upgrade
         guide:
-        
+
           https://archivesspace.github.io/tech-docs/administration/upgrading.html
-        
+
         The upgrade guide for version 1.5.0 also contains specific instructions for
         the container upgrade that you will be performing, and the steps in this guide
         apply equally to version 2.0.1.  You can find that guide here:
-        
+
           https://github.com/archivesspace/archivesspace/blob/master/UPGRADING_1.5.0.md
-        
+
         =======================================================================
-        
+
       EOM
 
       raise ContainerMigrationError.new


### PR DESCRIPTION
Adds 2 small modifications to the ARK migration adopted here: https://github.com/archivesspace/archivesspace/pull/2472

1. Ensure that duplicate "zombie" rows are deleted before and after the first big transaction.
2. Ensure that the user is warned and the migration is aborted if legacy data contains a one-to-many ARK-to-Resource relation.


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
