### PR TITLE
API login request with expiring=false now returns feedback

### DIFF
--- a/backend/app/controllers/users.rb
+++ b/backend/app/controllers/users.rb
@@ -193,7 +193,11 @@ class ArchivesSpaceService < Sinatra::Base
       session = create_session_for(username, params[:expiring])
       json_user = User.to_jsonmodel(user)
       json_user.permissions = user.permissions
-      json_response({:session => session.id, :user => json_user})
+      if params[:expiring] == false
+        json_response({:session => session.id, :user => json_user, :expire_after_seconds => AppConfig[:session_nonexpirable_force_expire_after_seconds]})
+      else
+        json_response({:session => session.id, :user => json_user})
+      end
     else
       json_response({:error => "Login failed"}, 403)
     end


### PR DESCRIPTION
## Description
Previously, if you tried to send a curl request with expiring=false, it would return successful regardless of if the param was successful. For example `curl -s -F password="admin" expiring=false "http://localhost:8089/users/admin/login"` would return successfully, but the token would expire because it should be `curl -s -F password="admin" "http://localhost:8089/users/admin/login?expiring=false"

Now, when you send the expiring param the correct way, the response will include a expire_after_seconds field which shows the number of seconds until the token expires. This is set by `AppConfig[:session_nonexpirable_force_expire_after_seconds]`

## Related JIRA Ticket or GitHub Issue
N/A

## How Has This Been Tested?
ran it in devserver mode and gave it curl requests to the backend.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Not sure if there should tests for this, but just let me know if so and I'll try to include them.
