### PR TITLE
Do not set up PUI route for handling ARK URLs if arks_enabled is false

### DIFF
--- a/public/config/routes.rb
+++ b/public/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
 
     get '/welcome', to: 'welcome#show'
 
-    get '/ark:/*ark_id' => 'ark_name#show'
+    if AppConfig[:arks_enabled]
+      get '/ark:/*ark_id' => 'ark_name#show'
+    end
 
     # I don't think this is used anywhere...
     post '/cite', to: 'cite#show'


### PR DESCRIPTION
Re-implemention of #2436 because the change in public/config/routes.rb was lost when #2437 was merged.