### PR TITLE
Performance improvement for loading of linked event records in SUI

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -717,3 +717,8 @@ AppConfig[:export_eac_agency_code] = false
 # Disable logged warnings when changing config settings that have already been set
 # This might be useful when running tests that need to fiddle with config
 AppConfig[:disable_config_changed_warning] = false
+
+# Resolving linked events can have a big impact on performance. If the number of linked
+# events surpasses the max then the events will not be resolved and a more abridged
+# record will be displayed to keep memory usage under control as the no. of events grows
+AppConfig[:max_linked_events_to_resolve] = 100

--- a/frontend/app/views/linked_events/_show.html.erb
+++ b/frontend/app/views/linked_events/_show.html.erb
@@ -28,9 +28,10 @@
               </td>
               <td>
                 <% record['linked_records'].each do |link| %>
-                  <div><%= I18n.t("enumerations.linked_event_archival_record_roles.#{link['role']}", :default => link['role']) %>:
-                    <%= link['_resolved']['display_string'] || link['_resolved']['title'] %>
-                  </div>
+                  <div>
+                    <%= I18n.t("enumerations.linked_event_archival_record_roles.#{link['role']}", :default => link['role']) %><% if link['_resolved'] %>:
+                    <%= link['_resolved']['display_string'] || link['_resolved']['title'] %><% end %>
+                  <div>
                 <% end %>
               </td>
               <td><%= display_audit_info(record, :format => 'compact') %></td>


### PR DESCRIPTION
Implements the fetch_resolved refactoring mentioned in the comment,
by consolidating the method in application controller.

Also adds an excludes option to the method signature which allows for
an optimized way of loading accession & resource records by being more
selective about the data that is retrieved (vs. everything in find_opts).

Applies an exclusion for linked events (and their linked records) in
edit & update mode as that data is not required and can have a large
impact on performance when many linked event records are associated.

Adds an AppConfig setting for max_linked_events_to_resolve. When
the max is exceeded (> no. of linked events) then the events and
linked records are not resolved in view mode and a simplified
display is presented (excludes titles). This keeps memory usage
under control as the no. of linked events grows.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
