### PR TITLE
ANW-1095: display all creators in public interface

### DIFF
--- a/public/app/views/shared/_record_innards.html.erb
+++ b/public/app/views/shared/_record_innards.html.erb
@@ -18,10 +18,7 @@
     <% end %>
 
     <% if @result.agents && Array(@result.agents['creator']).length > 0 %>
-      <% a_direct_creator = @result.agents['creator'].reject{|r| r['_inherited']}.take(1) %>
-      <% unless a_direct_creator.empty? %>
-        <%= render partial: 'shared/agents_list', locals: {:list => {'creator' => a_direct_creator}, :heading_size => 'h2'} %>
-      <% end %>
+      <%= render partial: 'shared/agents_list', locals: {:list => {'creator' => @result.agents['creator']}, :heading_size => 'h2'} %>
     <% end %>
 
     <% non_folder.each do |type| %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
UI tweak to display all creators instead of just one

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1095

## How Has This Been Tested?
manual, in browser testing

## Screenshots (if appropriate):
![Screenshot_2022-02-10_08-58-18](https://user-images.githubusercontent.com/130926/153445927-6fef312b-51e3-4d2c-90d9-d19d4c84484e.jpg)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
