### PR TITLE
fix typo for German language select

### DIFF
--- a/common/aspace_i18n.rb
+++ b/common/aspace_i18n.rb
@@ -25,7 +25,7 @@ module I18n
     'es' => 'spa',
     'fr' => 'fre',
     'ja' => 'jpn',
-    'de' => 'gem'
+    'de' => 'ger'
   }.sort_by { |_, v| v }.to_h.freeze
 
   def self.supported_locales


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixing a small typo re German language select. ger = Deutsch while gem = Germanic Languages.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
