### PR TITLE
ANW-340: adding support for sorting facets in alpha order

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -646,6 +646,7 @@ AppConfig[:pui_page_custom_actions] = []
 #   'erb_partial' => 'shared/my_special_action',
 # }
 
+AppConfig[:pui_display_facets_alpha] = false
 
 # Human-Readable URLs options
 # use_human_readable_urls: determines whether fields and options related to human-readable URLs appear in the staff interface

--- a/public/app/views/shared/_only_facets.html.erb
+++ b/public/app/views/shared/_only_facets.html.erb
@@ -19,6 +19,25 @@
 
   <% ordered_facet_types.each do |type| %>
     <% h = @facets.fetch(type, false) %>
+
+    <%# ANW-340: If we are sorting facets in alphabetical order, do the re-sort and facet name translation %>
+    <% if AppConfig[:pui_display_facets_alpha] %>
+      <% alpha_order = {} %>
+      <% h.each do |k, v| %>
+        <% alpha_order[get_pretty_facet_value(type, k)] = v %>
+      <% end %>
+
+      <% h = alpha_order.sort_by {|k, v| k}.to_h %>
+
+    <%# If not, just do the translation %>
+    <% else %>
+      <% translated = {} %>
+      <% h.each do |k, v| %>
+        <% translated[get_pretty_facet_value(type, k)] = v %>
+      <% end %>
+      <% h = translated %>
+    <% end %>
+
     <% next unless h %>
     <dt><%= t("search_results.filter.#{type}") %></dt>
     <% facet_count = 0 %>
@@ -32,8 +51,8 @@
       <dd>
         <a href="<%= app_prefix("#{@page_search}&filter_fields[]=#{type}&filter_values[]=#{CGI.escape(v)}") %>"
            rel="nofollow"
-           title="<%= t('search_results.filter_by')%> '<%= get_pretty_facet_value(type,v) %>'">
-          <%= get_pretty_facet_value(type,v) %>
+           title="<%= t('search_results.filter_by')%> '<%= v %>'">
+          <%= v %>
         </a>
         <span class="recordnumber"><%= ct %></span>
       </dd>

--- a/public/spec/features/resources_spec.rb
+++ b/public/spec/features/resources_spec.rb
@@ -54,4 +54,21 @@ describe 'Resources', js: true do
     click_link 'Resource with Accession'
     expect(page).to have_content('Related Unprocessed Material')
   end
+
+  it 'can display facets in alphabetical order' do
+    visit('/')
+    click_link 'Collections'
+
+    prev = ""
+    page.all('dl#facets dd').each do |dd|
+      next if dd.find("a").text =~ /Term/
+
+      unless prev == ""
+        content = dd.find("a").text
+        expect(prev <=> content).to eq(-1)
+      end
+
+      prev = dd.find("a").text
+    end
+  end
 end

--- a/public/spec/spec_helper.rb
+++ b/public/spec/spec_helper.rb
@@ -32,6 +32,7 @@ $expire = 30000
 AppConfig[:backend_url] = $backend
 AppConfig[:pui_hide][:record_badge] = false # we want this for testing
 AppConfig[:arks_enabled] = true # ARKs have to be enabled to be able to test them
+AppConfig[:pui_display_facets_alpha] = true
 
 $backend_start_fn = proc {
   TestUtils::start_backend($backend_port,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow administrator to choose to display facet lists in PUI in alphabetical order instead of relevance order

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-340

## How Has This Been Tested?
manual in browser testing, unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
