### PR TITLE
add config option to make migration 158 prune the ark_name table

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -730,3 +730,12 @@ AppConfig[:disable_config_changed_warning] = false
 # events surpasses the max then the events will not be resolved and a more abridged
 # record will be displayed to keep memory usage under control as the no. of events grows
 AppConfig[:max_linked_events_to_resolve] = 100
+
+# Prior to 3.2.0, multiple ARKs may have been created without
+# the user intending to do so. Setting this to true will make
+# database upgrade 158 attempt to clean up unwanted extra ARKs.
+# When multiple rows in the ARK table reference the same resource
+# or archival object, the first one created will be kept
+# and the rest discarded.
+# Use with caution and test thoroughly.
+AppConfig[:prune_ark_name_table] = false


### PR DESCRIPTION
It seems like sometime prior to 3.2.0 ArchivesSpace was creating additional rows in the ark_name table, maybe without the user's knowledge when they edited a resource or archival object. If that is the case, and all ark_names after the first one created for a resource or archival_object should be pruned, app admins can set this before running `setup-database`:

`AppConfig[:prune_ark_name_table] = true`