### PR TITLE
ANW-1506 Display representative file version in PUI

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -771,7 +771,7 @@ i.giant {
 
 /* record details */
 .objectimage {
-  width: 50%;
+  max-width: 50%;
   float: right;
   margin: 0 0 1em 1em;
 }
@@ -779,6 +779,12 @@ i.giant {
   margin: 0 auto;
   display: block;
   max-width: 100%;
+  border-top-right-radius: var(--bootstrap-rounded-corner-radius);
+  border-top-left-radius: var(--bootstrap-rounded-corner-radius);
+}
+
+.objectimage figcaption {
+  padding: 0.5rem;
 }
 
 .objectimage button[type='submit'] {

--- a/public/app/assets/stylesheets/archivesspace/helpers.scss
+++ b/public/app/assets/stylesheets/archivesspace/helpers.scss
@@ -3,6 +3,7 @@
  */
 :root {
   --bootstrap-horizontal-white-space-unit: 15px;
+  --bootstrap-rounded-corner-radius: 4px;
 }
 
 .flex {

--- a/public/app/controllers/objects_controller.rb
+++ b/public/app/controllers/objects_controller.rb
@@ -104,6 +104,7 @@ class ObjectsController < ApplicationController
       fill_request_info
       if @result['primary_type'] == 'digital_object' || @result['primary_type'] == 'digital_object_component'
         @dig = process_digital(@result['json'])
+        @rep_fv = @result['json']['representative_file_version']
       else
         @dig = process_digital_instance(@result['json']['instances'])
         process_extents(@result['json'])

--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -160,6 +160,7 @@ class ResourcesController < ApplicationController
       fill_request_info
       if @result['primary_type'] == 'digital_object' || @result['primary_type'] == 'digital_object_component'
         @dig = process_digital(@result['json'])
+        @rep_fv = @result['json']['representative_file_version']
       else
         @dig = process_digital_instance(@result['json']['instances'])
         process_extents(@result['json'])

--- a/public/app/views/objects/show.html.erb
+++ b/public/app/views/objects/show.html.erb
@@ -16,8 +16,7 @@
     <% if  defined?(comp_id) && !comp_id && !@result['json']['ref_id'].blank? %>
       <span class='ref_id'>[<%=  t('archival_object._public.header.ref_id') %>: <%= @result['json']['ref_id'] %>]</span>
     <% end %>
-    <%= render partial: 'shared/digital', locals: {:dig_objs => @dig} %>
-
+    <%= render partial: 'shared/digital', locals: {:rep_fv => @rep_fv} %>
     <%= render partial: 'shared/record_innards' %>
    </div>
 

--- a/public/app/views/resources/show.html.erb
+++ b/public/app/views/resources/show.html.erb
@@ -20,7 +20,7 @@
 
 <div class="row" id="notes_row">
   <div class="col-sm-9">
-    <%= render partial: 'shared/digital', locals: {:dig_objs => @dig} %>
+    <%= render partial: 'shared/digital', locals: {:rep_fv => @rep_fv} %>
     <%= render partial: 'shared/record_innards' %>
   </div>
   <div id="sidebar" class="col-sm-3 sidebar sidebar-container resizable-sidebar" <% unless @has_children %>style="display: none"<% end %>>

--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -1,42 +1,11 @@
-<%# expects 'dig_objs' as an array of hashes %>
+<%# expects 'rep_fv' as a file_version hash %>
 
-<% unless dig_objs.blank? %>
+<% unless rep_fv.blank? %>
 <div class="images">
-  <% dig_objs.each do |d_file| %>
-    <% if !d_file['out'].blank? %>
-      <% if d_file['thumb'].blank? %>
-        <div class="objectimage">
-          <div class="panel panel-default">
-            <a class="btn btn-default record-type-badge digital_object" style="width: 100%" href="<%= d_file['out'] %>" target="new" title="<%= t('digital_object._public.link')%>">
-              <i class="fa <%= { '(moving_image)' => 'fa-file-video-o' ,
-                          '(sound_recording)' => 'fa-file-audio-o',
-                          '(sound_recording_musical)' => 'fa-file-audio-o',
-                          '(sound_recording_nonmusical)' => 'fa-file-audio-o' ,
-                          '(still_image)' => 'fa-file-image-o' ,
-                          '(text)' =>  'fa-file-text'}.fetch( d_file['material'], 'fa-file-o' ) %> fa-4x"></i><br/>
-              <div class="panel-heading">
-                <%= d_file['caption'].blank? ? "#{t('enumerations.instance_instance_type.digital_object')} #{d_file['material']}" : d_file['caption'].html_safe %>
-              </div>
-            </a>
-          </div>
-        </div>
-      <% else %>
-        <div class="objectimage">
-          <div class="panel panel-default">
-            <a class="thumbnail" href="<%= d_file['out'] %>" target="new" title="<%= t('digital_object._public.link')%>">
-              <img src="<%= d_file['thumb'] %>" alt="<%= strip_mixed_content(d_file['caption'] || t('enumerations.instance_instance_type.digital_object')) %>" />
-            </a>
-	          <div class="panel-heading">
-	            <%= (d_file['caption'] || t('enumerations.instance_instance_type.digital_object')).html_safe %>
-	          </div>
-          </div>
-        </div>
-      <% end %>
-    <% elsif !d_file['thumb'].blank? %>
-      <div class="objectimage">
-        <img src="<%= d_file['thumb'] %>" alt="<%=  strip_mixed_content(d_file['caption'] || t('digital_object._public.thumbnail')) %>" />
-      </div>
-    <% end %>
-  <% end %>
+  <div class="objectimage">
+    <div class="panel panel-default">
+      <%= render partial: 'shared/representative_file_version', locals: {:uri => rep_fv['file_uri'], :caption => rep_fv['caption']} %>
+    </div>
+  </div>
 </div>
 <% end %>

--- a/public/app/views/shared/_representative_file_version.erb
+++ b/public/app/views/shared/_representative_file_version.erb
@@ -1,0 +1,8 @@
+<figure>
+  <a href="<%= uri %>" target="new" title="<%= t('digital_object._public.link')%>">
+    <img src="<%= uri %>" alt="<%= caption.blank? ? '' : caption %>">
+  </a>
+  <% unless caption.blank? %>
+    <figcaption><%= caption %></figcaption>
+  <% end %>
+</figure>

--- a/public/spec/controllers/digital_objects_controller_spec.rb
+++ b/public/spec/controllers/digital_objects_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+img_uri = 'http://foo.com/image.jpg'
+
 describe DigitalObjectsController, type: :controller do
   before(:all) do
     @repo = create(:repo, repo_code: "do_test_#{Time.now.to_i}",
@@ -82,4 +84,33 @@ describe DigitalObjectsController, type: :controller do
       expect(response.status).to eq(404)
     end
   end
+
+  describe "Digital Object" do
+    render_views
+
+    before(:all) do
+      @do2 = create(:digital_object, publish: true, :file_versions => [
+        build(:file_version, {
+          :publish => true,
+          :is_representative => true,
+          :file_uri => img_uri,
+          :use_statement => 'image-service'
+        })
+      ])
+
+      run_indexers
+    end
+
+    it 'should have a representative file version image when one is set' do
+      expect(JSONModel(:digital_object).find(@do2.id)["representative_file_version"]["file_uri"]).to eq(img_uri)
+    end
+
+    it 'should render the representative file version image when one is set' do
+      get(:tree_root, params: { rid: @repo.id, id: @do2.id })
+
+      expect(response.body).to match(img_uri)
+    end
+
+  end
+
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR closes [ANW-1506](https://archivesspace.atlassian.net/browse/ANW-1506) by displaying a digital object's representative file version in the public interface.

![ANW-1506 render digital object representative file version image](https://user-images.githubusercontent.com/3411019/158439860-dcb62536-b1d5-4633-b62f-ecafc7439a60.png)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

- Render image file uri in PUI digital object record
- Add representative_file_verson to objects controller
- Update locals passed to digital partial in objects show template
- Add representative_file_version template
- Refactor digital template around new rep fv template
- Add representative fv helper to resource controller
- Pass representative fv local in resource show view
- Add tests to digital_objects_controller_spec.rb
