### PR TITLE
ANW-1498: change UI so make representative is disabled unless publish is checked

### DIFF
--- a/frontend/app/assets/javascripts/representativemembers.js
+++ b/frontend/app/assets/javascripts/representativemembers.js
@@ -32,10 +32,10 @@ $(function () {
         var eventName =
           'newrepresentative' + object_name.replace(/_/, '') + '.aspace';
 
-        if(local_publish_button.prop('checked') == false) {
-            local_make_rep_button.prop('disabled', true)
+        if (local_publish_button.prop('checked') == false) {
+          local_make_rep_button.prop('disabled', true);
         } else {
-            local_make_rep_button.prop('disabled', false)
+          local_make_rep_button.prop('disabled', false);
         }
 
         $subform.find('.js-file-version-publish').click(function (e) {
@@ -47,10 +47,10 @@ $(function () {
             $(this).prop('checked', false);
           }
 
-          if($(this).prop('checked') == false) {
-            local_make_rep_button.prop('disabled', true)
+          if ($(this).prop('checked') == false) {
+            local_make_rep_button.prop('disabled', true);
           } else {
-            local_make_rep_button.prop('disabled', false)
+            local_make_rep_button.prop('disabled', false);
           }
         });
 

--- a/frontend/app/assets/javascripts/representativemembers.js
+++ b/frontend/app/assets/javascripts/representativemembers.js
@@ -26,9 +26,17 @@ $(function () {
         var $section = $subform.closest('section.subrecord-form');
         var isRepresentative =
           $(':input[name$="[is_representative]"]', $subform).val() === '1';
+        var local_publish_button = $subform.find('.js-file-version-publish');
+        var local_make_rep_button = $subform.find('.is-representative-toggle');
 
         var eventName =
           'newrepresentative' + object_name.replace(/_/, '') + '.aspace';
+
+        if(local_publish_button.prop('checked') == false) {
+            local_make_rep_button.prop('disabled', true)
+        } else {
+            local_make_rep_button.prop('disabled', false)
+        }
 
         $subform.find('.js-file-version-publish').click(function (e) {
           if (
@@ -38,11 +46,15 @@ $(function () {
             handleRepresentativeChange($subform, false);
             $(this).prop('checked', false);
           }
+
+          if($(this).prop('checked') == false) {
+            local_make_rep_button.prop('disabled', true)
+          } else {
+            local_make_rep_button.prop('disabled', false)
+          }
         });
 
         $subform.find('.is-representative-toggle').click(function (e) {
-          var local_publish_button = $subform.find('.js-file-version-publish');
-
           local_publish_button.prop('checked', true);
         });
 

--- a/frontend/spec/selenium/spec/digital_objects_spec.rb
+++ b/frontend/spec/selenium/spec/digital_objects_spec.rb
@@ -78,7 +78,7 @@ describe 'Digital Objects' do
     @driver.click_and_wait_until_gone(:link, 'Edit')
   end
 
-  it "sets published when make representative is checked, and vice versa" do
+  it "make representative is disabled unless published is checked, and vice versa" do
     @driver.find_element(:link, 'Create').click
     @driver.click_and_wait_until_gone(:link, 'Digital Object')
 
@@ -94,15 +94,13 @@ describe 'Digital Objects' do
 
     @driver.click_and_wait_until_gone(css: "form#new_digital_object button[type='submit']")
 
-    # make sure publish is checked when is representative is checked
-    @driver.find_element(css: '.is-representative-toggle').click
-    publish_box = @driver.find_element(css: '.js-file-version-publish')
-    expect(publish_box.attribute('checked')).to_not be_nil
+    # make sure is representative is disabled with publish is unchecked
+    is_rep_button = @driver.find_element(css: '.is-representative-toggle')
+    expect(is_rep_button.attribute('disabled')).to eq("true")
 
-    # make sure is representative is unchecked with publish is unchecked
-    publish_box.click
-    subform = @driver.find_element(id: 'digital_object_file_versions__0_')
-    expect(subform.attribute('class')).to_not include('is-representative')
+    # make sure is representative is enabled when publish is checked 
+    @driver.find_element(css: '.js-file-version-publish').click
+    expect(is_rep_button.attribute('disabled')).to be_nil
   end
 
   it 'reports errors if adding a child with no title to a Digital Object' do

--- a/frontend/spec/selenium/spec/digital_objects_spec.rb
+++ b/frontend/spec/selenium/spec/digital_objects_spec.rb
@@ -98,7 +98,7 @@ describe 'Digital Objects' do
     is_rep_button = @driver.find_element(css: '.is-representative-toggle')
     expect(is_rep_button.attribute('disabled')).to eq("true")
 
-    # make sure is representative is enabled when publish is checked 
+    # make sure is representative is enabled when publish is checked
     @driver.find_element(css: '.js-file-version-publish').click
     expect(is_rep_button.attribute('disabled')).to be_nil
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Tweaking UI so that make representative is disabled when published is unchecked for file versions

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1498


## How Has This Been Tested?
manual and unit testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
