### PR TITLE
ensure that solr checksum verification does not obscure 404 responses…

### DIFF
--- a/backend/app/main.rb
+++ b/backend/app/main.rb
@@ -149,7 +149,7 @@ class ArchivesSpaceService < Sinatra::Base
         Solr.verify_checksums!
         Log.info('Solr config checksum verification ok.')
       else
-        Log.warn('Solr config checksum verification disabled.')
+        Log.warn('Solr config checksum verification disabled: Solr may be offline or misconfigured')
       end
 
       ordered_plugin_backend_dirs = ASUtils.order_plugins(ASUtils.find_local_directories('backend'))


### PR DESCRIPTION
… or tcp/http errors

## Description
Distinct startup errors when `AppConfig[:solr_verify_checksums] = true` and a) Solr (or any web server) is online but returns a non 200 response; or b) Solr returns a 200 but the checksum of the body does not pass verification.

## Related JIRA Ticket or GitHub Issue
[Github Issue 2634](https://github.com/archivesspace/archivesspace/issues/2634)

## How Has This Been Tested?
Reworked the backend sole tests to use mock solr responses.

## Screenshots (if appropriate):
```shell
 + NET HTTP ERROR

[java]       ========================================================================
[java]       A trace file has been written to the following location: /var/folders/cf/y6d0x2z11g59hm9zcwbtrsnm0000gn/T/aspace_diagnostic_1647950175.txt
[java]
[java]       This file contains information that will assist developers in diagnosing
[java]       problems with your ArchivesSpace installation.  Please review the file's
[java]       contents for sensitive information (such as passwords) that you might not
[java]       want to share.
[java]       ========================================================================
[java] Errno::ECONNREFUSED: Connection refused - Failed to open TCP connection to localhost:8985 (Connection refused - connect(2) for "localhost" port 8985)

 + SOLR SERVER 404
[java]       ========================================================================
[java]       A trace file has been written to the following location: /var/folders/cf/y6d0x2z11g59hm9zcwbtrsnm0000gn/T/aspace_diagnostic_1647950027.txt
[java]
[java]       This file contains information that will assist developers in diagnosing
[java]       problems with your ArchivesSpace installation.  Please review the file's
[java]       contents for sensitive information (such as passwords) that you might not
[java]       want to share.
[java]       ========================================================================
[java] Solr::NotFound: Status 404 when trying to verify http://localhost:8983/solr/nothereServer response:
[java] <html>
[java] <head>
[java] <meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
[java] <title>Error 404 Not Found</title>
[java] </head>
[java] <body><h2>HTTP ERROR 404 Not Found</h2>
[java] <table>
[java] <tr><th>URI:</th><td>/solr/nothere/admin/file</td></tr>
[java] <tr><th>STATUS:</th><td>404</td></tr>
[java] <tr><th>MESSAGE:</th><td>Not Found</td></tr>
[java] <tr><th>SERVLET:</th><td>default</td></tr>
[java] </table>
[java]
[java] </body>
[java] </html>

 + BAD SCHEMA
[java]       ========================================================================
[java]       A trace file has been written to the following location: /var/folders/cf/y6d0x2z11g59hm9zcwbtrsnm0000gn/T/aspace_diagnostic_1647951569.txt
[java]
[java]       This file contains information that will assist developers in diagnosing
[java]       problems with your ArchivesSpace installation.  Please review the file's
[java]       contents for sensitive information (such as passwords) that you might not
[java]       want to share.
[java]       ========================================================================
[java] Solr::ChecksumMismatchError: Solr checksum verification failed (schema): expected [4d4849771a91d677f255b638cbefa8b8d67a236c56c645bb13c2842480614d78] got [6a6bcb1bb3096ee832a22243992592221740e40821da7e0e1d42a861bbd59313]
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
