### PR TITLE
[WIP] ANW-1531: Display representative file version in PUI

### DIFF
--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -357,6 +357,12 @@ class IndexerCommon
     end
   end
 
+  def add_representative_file_uri(doc, record)
+    if rep = record['record']['representative_file_version']
+      doc['representative_file_uri'] = record['record']['representative_file_version']['file_uri' ]
+    end
+  end
+
 
   def configure_doc_rules
 
@@ -408,6 +414,7 @@ class IndexerCommon
       add_summary(doc, record)
       add_extents(doc, record)
       add_arks(doc, record)
+      add_representative_file_uri(doc, record)
     }
 
     add_document_prepare_hook {|doc, record|
@@ -1131,7 +1138,7 @@ class IndexerCommon
   end
 
   # ANW-1065
-  # iterate through the do_not_index list and scrub out that part of the JSON tree 
+  # iterate through the do_not_index list and scrub out that part of the JSON tree
   def sanitize_json(json)
     IndexerCommonConfig::do_not_index.each do |k, v|
       if json["jsonmodel_type"] == k

--- a/public/app/controllers/objects_controller.rb
+++ b/public/app/controllers/objects_controller.rb
@@ -104,7 +104,6 @@ class ObjectsController < ApplicationController
       fill_request_info
       if @result['primary_type'] == 'digital_object' || @result['primary_type'] == 'digital_object_component'
         @dig = process_digital(@result['json'])
-        @rep_fv = @result['json']['representative_file_version']
       else
         @dig = process_digital_instance(@result['json']['instances'])
         process_extents(@result['json'])

--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -160,7 +160,6 @@ class ResourcesController < ApplicationController
       fill_request_info
       if @result['primary_type'] == 'digital_object' || @result['primary_type'] == 'digital_object_component'
         @dig = process_digital(@result['json'])
-        @rep_fv = @result['json']['representative_file_version']
       else
         @dig = process_digital_instance(@result['json']['instances'])
         process_extents(@result['json'])

--- a/public/app/models/record.rb
+++ b/public/app/models/record.rb
@@ -10,7 +10,7 @@ class Record
               :resolved_resource, :resolved_top_container, :primary_type, :uri,
               :subjects, :agents, :extents, :repository_information,
               :identifier, :classifications, :level, :other_level, :linked_digital_objects,
-              :container_titles_and_uris
+              :container_titles_and_uris, :representative_file_uri
 
   attr_accessor :criteria
 
@@ -51,6 +51,8 @@ class Record
     @classifications = parse_classifications
     @agents = parse_agents(subjects)
     @extents = parse_extents
+
+    @representative_file_uri = raw['representative_file_uri']
   end
 
   def [](k)

--- a/public/app/views/accessions/show.html.erb
+++ b/public/app/views/accessions/show.html.erb
@@ -12,6 +12,7 @@
   <%= render partial: 'shared/breadcrumbs' %>
 
   <div class="col-sm-9">
+  <%= render partial: 'shared/digital', locals: {:rep_file_uri => @result.representative_file_uri, :rep_file_caption => 'TODO'} %>
 
   <br/>
 

--- a/public/app/views/objects/show.html.erb
+++ b/public/app/views/objects/show.html.erb
@@ -16,7 +16,7 @@
     <% if  defined?(comp_id) && !comp_id && !@result['json']['ref_id'].blank? %>
       <span class='ref_id'>[<%=  t('archival_object._public.header.ref_id') %>: <%= @result['json']['ref_id'] %>]</span>
     <% end %>
-    <%= render partial: 'shared/digital', locals: {:rep_fv => @rep_fv} %>
+    <%= render partial: 'shared/digital', locals: {:rep_file_uri => @result.representative_file_uri, :rep_file_caption => 'TODO'} %>
     <%= render partial: 'shared/record_innards' %>
    </div>
 

--- a/public/app/views/resources/show.html.erb
+++ b/public/app/views/resources/show.html.erb
@@ -20,7 +20,7 @@
 
 <div class="row" id="notes_row">
   <div class="col-sm-9">
-    <%= render partial: 'shared/digital', locals: {:rep_fv => @rep_fv} %>
+    <%= render partial: 'shared/digital', locals: {:rep_file_uri => @result.representative_file_uri, :rep_file_caption => 'TODO'} %>
     <%= render partial: 'shared/record_innards' %>
   </div>
   <div id="sidebar" class="col-sm-3 sidebar sidebar-container resizable-sidebar" <% unless @has_children %>style="display: none"<% end %>>

--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -1,10 +1,8 @@
-<%# expects 'rep_fv' as a file_version hash %>
-
-<% unless rep_fv.blank? %>
+<% unless rep_file_uri.blank? %>
 <div class="images">
   <div class="objectimage">
     <div class="panel panel-default">
-      <%= render partial: 'shared/representative_file_version', locals: {:uri => rep_fv['file_uri'], :caption => rep_fv['caption']} %>
+      <%= render partial: 'shared/representative_file_version', locals: {:uri => rep_file_uri, :caption => rep_file_caption} %>
     </div>
   </div>
 </div>

--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -97,6 +97,11 @@
        <div class="classification-subgroups-tree largetree-container" style="display: none;"></div>
      </div>
      <% end %>
+     <% if result.representative_file_uri %>
+       <div class="representative">
+         <img src="<%= result.representative_file_uri %>">
+       </div>
+     <% end %>
    </div>
 
 <% if !props.fetch(:full,false) %>

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -137,6 +137,7 @@
     <field name="files" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="job_data" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="queue_position" type="int" indexed="true" stored="true" multiValued="false" />
+    <field name="representative_file_uri" type="string" indexed="false" stored="true" multiValued="false" />
     <dynamicField name="*_enum_s" type="string" indexed="true" stored="true" multiValued="true" />
     <dynamicField name="*_u_ustr" type="string" indexed="true" stored="false" multiValued="true" />
     <dynamicField name="*_u_uint" type="int" indexed="true" stored="false" multiValued="true" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR renders the representative file version in resource, accession, and object views.

<!---- Add `@representative_file_version` to record model,
- Remove `@rep_fv` from resources and objects controllers,
- Use `@representative_file_version` in resource, accession and object views-->

## Limitation

Currently only works for resources/accessions/archival objects when a linked digital object that contains a representative file version has been marked as representative of the resource/accession/archival object.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
[ANW-1531](https://archivesspace.atlassian.net/browse/ANW-1531)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
