### PR TITLE
ANW-1521: support for tooltips in subrecord header buttons

### DIFF
--- a/frontend/app/assets/javascripts/agents.crud.js
+++ b/frontend/app/assets/javascripts/agents.crud.js
@@ -106,6 +106,7 @@ $(function () {
 
     $('.btn-authoritive-name-toggle', $subform).click(function (event) {
       event.preventDefault();
+      $(this).parent().off('click');
 
       $section.triggerHandler('newauthorizedname.aspace', [$subform]);
     });
@@ -119,6 +120,7 @@ $(function () {
 
     $('.btn-display-name-toggle', $subform).click(function (event) {
       event.preventDefault();
+      $(this).parent().off('click');
 
       $section.triggerHandler('newdisplayname.aspace', [$subform]);
     });

--- a/frontend/app/assets/javascripts/representativemembers.js
+++ b/frontend/app/assets/javascripts/representativemembers.js
@@ -64,6 +64,7 @@ $(function () {
 
         $('.is-representative-toggle', $subform).click(function (e) {
           e.preventDefault();
+          $(this).parent().off('click');
 
           $section.triggerHandler(eventName, [$subform]);
         });
@@ -73,6 +74,7 @@ $(function () {
             $subform,
             representative_subform == $subform
           );
+          $('.tooltip').tooltip('hide');
         });
       }
     }

--- a/frontend/app/assets/javascripts/utils.js
+++ b/frontend/app/assets/javascripts/utils.js
@@ -301,7 +301,8 @@ $(function () {
       var helpTooltips =
         $this.data('trigger') === 'manual' &&
         ($this.is('label.control-label') ||
-          $this.is('.subrecord-form-heading-label'));
+         $this.is('.btn-with-tooltip') ||
+         $this.is('.subrecord-form-heading-label'));
 
       // ANW-1325: Ensure tooltip content is focusable/hoverable by inserting in the DOM
       // right after the triggering element.  Skipping `helpTooltips`, since those are

--- a/frontend/app/assets/javascripts/utils.js
+++ b/frontend/app/assets/javascripts/utils.js
@@ -301,8 +301,8 @@ $(function () {
       var helpTooltips =
         $this.data('trigger') === 'manual' &&
         ($this.is('label.control-label') ||
-         $this.is('.btn-with-tooltip') ||
-         $this.is('.subrecord-form-heading-label'));
+          $this.is('.btn-with-tooltip') ||
+          $this.is('.subrecord-form-heading-label'));
 
       // ANW-1325: Ensure tooltip content is focusable/hoverable by inserting in the DOM
       // right after the triggering element.  Skipping `helpTooltips`, since those are

--- a/frontend/app/assets/stylesheets/archivesspace/form.less
+++ b/frontend/app/assets/stylesheets/archivesspace/form.less
@@ -909,3 +909,8 @@ input[type='checkbox']:focus {
   border-top: 6px solid transparent;
   border-right: 6px solid transparent;
 }
+
+div.btn-with-tooltip {
+  max-width: fit-content;
+  display: inline;
+}

--- a/frontend/app/helpers/aspace_form_helper.rb
+++ b/frontend/app/helpers/aspace_form_helper.rb
@@ -553,6 +553,19 @@ module AspaceFormHelper
       options
     end
 
+    def button_with_tooltip(tooltip, content, classes = [])
+      classes = classes + ["btn", "btn-small", "btn-with-tooltip"]
+
+      options = {:class => classes.join(' ')}
+      add_tooltip_options(tooltip, options)
+
+      attr_string = options.map {|k, v| '%s="%s"' % [CGI::escapeHTML(k.to_s),
+                                                     CGI::escapeHTML(v.to_s)]}
+                           .join(' ')
+
+      "<button #{attr_string}>#{content}</button>".html_safe
+    end
+
     def tooltip(name, prefix = '')
       I18n.t_raw("#{prefix}#{i18n_for(name)}_tooltip", :default => '')
     end

--- a/frontend/app/helpers/aspace_form_helper.rb
+++ b/frontend/app/helpers/aspace_form_helper.rb
@@ -553,17 +553,24 @@ module AspaceFormHelper
       options
     end
 
-    def button_with_tooltip(tooltip, content, classes = [])
-      classes = classes + ["btn", "btn-small", "btn-with-tooltip"]
+    def button_with_tooltip(tooltip, content, div_classes = [], button_classes = [])
+      div_classes    = div_classes + ["btn-with-tooltip"]
+      button_classes = button_classes + ["btn", "btn-small"]
 
-      options = {:class => classes.join(' ')}
-      add_tooltip_options(tooltip, options)
+      div_options = {:class => div_classes.join(' ')}
+      add_tooltip_options(tooltip, div_options)
 
-      attr_string = options.map {|k, v| '%s="%s"' % [CGI::escapeHTML(k.to_s),
+      button_options = {:class => button_classes.join(' ')}
+
+      div_attr_string = div_options.map {|k, v| '%s="%s"' % [CGI::escapeHTML(k.to_s),
                                                      CGI::escapeHTML(v.to_s)]}
                            .join(' ')
 
-      "<button #{attr_string}>#{content}</button>".html_safe
+      button_attr_string = button_options.map {|k, v| '%s="%s"' % [CGI::escapeHTML(k.to_s),
+                                                     CGI::escapeHTML(v.to_s)]}
+                           .join(' ')
+
+      "<div #{div_attr_string}><button #{button_attr_string}>#{content}</button></div>".html_safe
     end
 
     def tooltip(name, prefix = '')

--- a/frontend/app/views/agents/name_forms/_agent_corporate_entity.html.erb
+++ b/frontend/app/views/agents/name_forms/_agent_corporate_entity.html.erb
@@ -2,9 +2,9 @@
   <div class="subrecord-form-fields">
     <h3 class="subrecord-form-heading">
       <span class="badge badge-info is-authoritive-label"><%= I18n.t("name_corporate_entity.authorized") %></span>
-      <button class="btn btn-small btn-authoritive-name-toggle"><%= I18n.t("name._frontend.action.make_authorized") %></button>
+      <%= form.button_with_tooltip(I18n.t("name._frontend.action.make_authorized_tooltip"), I18n.t("name._frontend.action.make_authorized"), [], ["btn-authoritive-name-toggle"]) %>
       <span class="badge badge-info is-display-name-label"><%= I18n.t("name_corporate_entity.is_display_name") %></span>
-      <button class="btn btn-small btn-display-name-toggle"><%= I18n.t("name._frontend.action.make_display_name") %></button>
+      <%= form.button_with_tooltip(I18n.t("name._frontend.action.make_display_name_tooltip"), I18n.t("name._frontend.action.make_display_name"), [], ["btn-display-name-toggle"]) %>
     </h3>
 
     <%= render_aspace_partial :partial => "agents/name_forms/authority_fields", :locals => {:form => form} %>

--- a/frontend/app/views/agents/name_forms/_agent_family.html.erb
+++ b/frontend/app/views/agents/name_forms/_agent_family.html.erb
@@ -2,9 +2,9 @@
   <div class="subrecord-form-fields">
     <h3 class="subrecord-form-heading">
       <span class="badge badge-info is-authoritive-label"><%= I18n.t("name_family.authorized") %></span>
-      <button class="btn btn-small btn-authoritive-name-toggle"><%= I18n.t("name._frontend.action.make_authorized") %></button>
+      <%= form.button_with_tooltip(I18n.t("name._frontend.action.make_authorized_tooltip"), I18n.t("name._frontend.action.make_authorized"), [], ["btn-authoritive-name-toggle"]) %>
       <span class="badge badge-info is-display-name-label"><%= I18n.t("name_family.is_display_name") %></span>
-      <button class="btn btn-small btn-display-name-toggle"><%= I18n.t("name._frontend.action.make_display_name") %></button>
+      <%= form.button_with_tooltip(I18n.t("name._frontend.action.make_display_name_tooltip"), I18n.t("name._frontend.action.make_display_name"), [], ["btn-display-name-toggle"]) %>
     </h3>
 
     <%= render_aspace_partial :partial => "agents/name_forms/authority_fields", :locals => {:form => form} %>

--- a/frontend/app/views/agents/name_forms/_agent_person.html.erb
+++ b/frontend/app/views/agents/name_forms/_agent_person.html.erb
@@ -2,9 +2,9 @@
   <div class="subrecord-form-fields agent-name-form">
     <h3 class="subrecord-form-heading">
       <span class="badge badge-info is-authoritive-label"><%= I18n.t("name_person.authorized") %></span>
-      <button class="btn btn-small btn-authoritive-name-toggle"><%= I18n.t("name._frontend.action.make_authorized") %></button>
+      <%= form.button_with_tooltip(I18n.t("name._frontend.action.make_authorized"), I18n.t("name._frontend.action.make_authorized"), ["btn-authoritive-name-toggle"]) %>
       <span class="badge badge-info is-display-name-label"><%= I18n.t("name_person.is_display_name") %></span>
-      <button class="btn btn-small btn-display-name-toggle"><%= I18n.t("name._frontend.action.make_display_name") %></button>
+      <%= form.button_with_tooltip(I18n.t("name._frontend.action.make_display_name"), I18n.t("name._frontend.action.make_display_name"), ["btn-display-name-toggle"]) %>
     </h3>
 
     <%= render_aspace_partial :partial => "agents/name_forms/authority_fields", :locals => {:form => form} %>

--- a/frontend/app/views/agents/name_forms/_agent_person.html.erb
+++ b/frontend/app/views/agents/name_forms/_agent_person.html.erb
@@ -2,9 +2,9 @@
   <div class="subrecord-form-fields agent-name-form">
     <h3 class="subrecord-form-heading">
       <span class="badge badge-info is-authoritive-label"><%= I18n.t("name_person.authorized") %></span>
-      <%= form.button_with_tooltip(I18n.t("name._frontend.action.make_authorized"), I18n.t("name._frontend.action.make_authorized"), ["btn-authoritive-name-toggle"]) %>
+      <%= form.button_with_tooltip(I18n.t("name._frontend.action.make_authorized_tooltip"), I18n.t("name._frontend.action.make_authorized"), [], ["btn-authoritive-name-toggle"]) %>
       <span class="badge badge-info is-display-name-label"><%= I18n.t("name_person.is_display_name") %></span>
-      <%= form.button_with_tooltip(I18n.t("name._frontend.action.make_display_name"), I18n.t("name._frontend.action.make_display_name"), ["btn-display-name-toggle"]) %>
+      <%= form.button_with_tooltip(I18n.t("name._frontend.action.make_display_name_tooltip"), I18n.t("name._frontend.action.make_display_name"), [], ["btn-display-name-toggle"]) %>
     </h3>
 
     <%= render_aspace_partial :partial => "agents/name_forms/authority_fields", :locals => {:form => form} %>

--- a/frontend/app/views/agents/name_forms/_agent_software.html.erb
+++ b/frontend/app/views/agents/name_forms/_agent_software.html.erb
@@ -2,9 +2,9 @@
   <div class="subrecord-form-fields">
     <h3 class="subrecord-form-heading">
       <span class="badge badge-info is-authoritive-label"><%= I18n.t("name_software.authorized") %></span>
-      <button class="btn btn-small btn-authoritive-name-toggle"><%= I18n.t("name._frontend.action.make_authorized") %></button>
+      <%= form.button_with_tooltip(I18n.t("name._frontend.action.make_authorized_tooltip"), I18n.t("name._frontend.action.make_authorized"), [], ["btn-authoritive-name-toggle"]) %>
       <span class="badge badge-info is-display-name-label"><%= I18n.t("name_software.is_display_name") %></span>
-      <button class="btn btn-small btn-display-name-toggle"><%= I18n.t("name._frontend.action.make_display_name") %></button>
+      <%= form.button_with_tooltip(I18n.t("name._frontend.action.make_display_name_tooltip"), I18n.t("name._frontend.action.make_display_name"), [], ["btn-display-name-toggle"]) %>
     </h3>
 
     <%= render_aspace_partial :partial => "agents/name_forms/authority_fields", :locals => {:form => form} %>

--- a/frontend/app/views/file_versions/_template.html.erb
+++ b/frontend/app/views/file_versions/_template.html.erb
@@ -2,7 +2,7 @@
   <div class="subrecord-form-fields">
     <h3 class="subrecord-form-heading">
       <span class="badge badge-info is-representative-label"><%= I18n.t("file_version.is_representative") %></span>
-      <button class="btn btn-small is-representative-toggle"><%= I18n.t("file_version._frontend.action.make_representative") %></button>
+      <%= form.button_with_tooltip(I18n.t("file_version._frontend.action.make_representative"), I18n.t("file_version._frontend.action.make_representative"), ["is-representative-toggle"]) %>
     </h3>
     <%= form.label_and_textarea("file_uri") %>
     <%= form.label_and_boolean("publish", {:class => "js-file-version-publish"}, user_prefs["publish"]) %>

--- a/frontend/app/views/file_versions/_template.html.erb
+++ b/frontend/app/views/file_versions/_template.html.erb
@@ -2,7 +2,7 @@
   <div class="subrecord-form-fields">
     <h3 class="subrecord-form-heading">
       <span class="badge badge-info is-representative-label"><%= I18n.t("file_version.is_representative") %></span>
-      <%= form.button_with_tooltip(I18n.t("file_version._frontend.action.make_representative"), I18n.t("file_version._frontend.action.make_representative"), ["is-representative-toggle"]) %>
+      <%= form.button_with_tooltip(I18n.t("file_version._frontend.action.make_representative_tooltip"), I18n.t("file_version._frontend.action.make_representative"), [], ["is-representative-toggle"]) %>
     </h3>
     <%= form.label_and_textarea("file_uri") %>
     <%= form.label_and_boolean("publish", {:class => "js-file-version-publish"}, user_prefs["publish"]) %>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1061,7 +1061,7 @@ en:
       action:
         add: Add File Version
         make_representative: Make Representative
-        make_representative_tooltip: Make Representative Tooltip
+        make_representative_tooltip: Use to indicate that this image should be displayed when there are multiple file versions associated with the record.
 
   group:
     _frontend:
@@ -1148,9 +1148,9 @@ en:
       action:
         add: Add Name Form
         make_authorized: Make Authoritive Name
-        make_authorized_tooltip: Make Authoritive Name Tooltip
+        make_authorized_tooltip: Use to indicate the name form is the authoritative version of the name.
         make_display_name: Make Display Name
-        make_display_name_tooltip: Make Display Name Tooltip
+        make_display_name_tooltip: Use to indicate that this form of the name should be used for displays when there are multiple name forms associated with the agent record.
         make_primary: Make Primary
 
   note:

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1061,6 +1061,7 @@ en:
       action:
         add: Add File Version
         make_representative: Make Representative
+        make_representative_tooltip: Make Representative Tooltip
 
   group:
     _frontend:
@@ -1147,7 +1148,9 @@ en:
       action:
         add: Add Name Form
         make_authorized: Make Authoritive Name
+        make_authorized_tooltip: Make Authoritive Name Tooltip
         make_display_name: Make Display Name
+        make_display_name_tooltip: Make Display Name Tooltip
         make_primary: Make Primary
 
   note:


### PR DESCRIPTION


## Description
Adds tooltips to action buttons at the top of some subrecords in ASpace frontend forms to aid in adding user documentation

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1521

## How Has This Been Tested?
manual in browser testing

## Screenshots (if appropriate):
![Screenshot_2022-03-31_09-39-55](https://user-images.githubusercontent.com/130926/161095342-8fd0701c-b69f-4d7b-b93a-407c145344ac.jpg)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
