### PR TITLE
ANW-1019: display location info in PUI if user is logged into staff interface

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -743,3 +743,7 @@ AppConfig[:max_linked_events_to_resolve] = 100
 # and the rest discarded.
 # Use with caution and test thoroughly.
 AppConfig[:prune_ark_name_table] = false
+
+# Displays container location in PUI to users logged into the staff interface.
+# Be aware that this data will be visible in the page source to all users, even if not logged in!
+AppConfig[:display_container_location_in_PUI] = false

--- a/frontend/app/controllers/session_controller.rb
+++ b/frontend/app/controllers/session_controller.rb
@@ -49,11 +49,6 @@ class SessionController < ApplicationController
     response.headers['Access-Control-Allow-Origin'] = AppConfig[:public_proxy_url]
     response.headers['Access-Control-Allow-Credentials'] = 'true'
 
-    STDERR.puts "++++++++++++++++++++++++++++++"
-    STDERR.puts params.inspect
-    STDERR.puts session[:session]
-    STDERR.puts user_can_edit?(params)
-
     if session[:session] && params[:uri]
       render json: user_can_edit?(params)
     else

--- a/frontend/app/controllers/session_controller.rb
+++ b/frontend/app/controllers/session_controller.rb
@@ -49,6 +49,11 @@ class SessionController < ApplicationController
     response.headers['Access-Control-Allow-Origin'] = AppConfig[:public_proxy_url]
     response.headers['Access-Control-Allow-Credentials'] = 'true'
 
+    STDERR.puts "++++++++++++++++++++++++++++++"
+    STDERR.puts params.inspect
+    STDERR.puts session[:session]
+    STDERR.puts user_can_edit?(params)
+
     if session[:session] && params[:uri]
       render json: user_can_edit?(params)
     else

--- a/public/app/assets/javascripts/smart_staff_links.js
+++ b/public/app/assets/javascripts/smart_staff_links.js
@@ -32,7 +32,7 @@ $(function () {
           '&autoselect_repo=true';
         staff.attr('href', link);
         staff.removeClass('hide');
-        
+
         var staff_hidden = $('.staff-hidden');
         staff_hidden.removeClass('hide');
       }

--- a/public/app/assets/javascripts/smart_staff_links.js
+++ b/public/app/assets/javascripts/smart_staff_links.js
@@ -21,6 +21,7 @@ $(function () {
     },
   })
     .done(function (data) {
+      console.log(data);
       if (data === true) {
         var staff = $('#staff-link');
         link =

--- a/public/app/assets/javascripts/smart_staff_links.js
+++ b/public/app/assets/javascripts/smart_staff_links.js
@@ -21,7 +21,6 @@ $(function () {
     },
   })
     .done(function (data) {
-      console.log(data);
       if (data === true) {
         var staff = $('#staff-link');
         link =

--- a/public/app/assets/javascripts/smart_staff_links.js
+++ b/public/app/assets/javascripts/smart_staff_links.js
@@ -32,6 +32,9 @@ $(function () {
           '&autoselect_repo=true';
         staff.attr('href', link);
         staff.removeClass('hide');
+        
+        var staff_hidden = $('.staff-hidden');
+        staff_hidden.removeClass('hide');
       }
     })
     .fail(function () {

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -466,6 +466,11 @@ h4,
   font-family: $serif-font;
 }
 
+h4.restricted {
+  color: #f00;
+}
+
+
 h5,
 .h5 {
   font-weight: bold;

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -470,7 +470,6 @@ h4.restricted {
   color: #f00;
 }
 
-
 h5,
 .h5 {
   font-weight: bold;

--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -313,8 +313,6 @@ class ResourcesController < ApplicationController
   def staff_access?(uri)
     staff_interface = URI(AppConfig[:frontend_url] + "/check_session?uri=#{uri}")
     response = Net::HTTP.get(staff_interface)
-    STDERR.puts "++++++++++++++++++++++++++++++"
-    STDERR.puts response.inspect
   end
 
 end

--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -243,6 +243,7 @@ class ResourcesController < ApplicationController
 
   def inventory
     uri = "/repositories/#{params[:rid]}/resources/#{params[:id]}"
+    staff_access?(uri)
     tree_root = archivesspace.get_raw_record(uri + '/tree/root') rescue nil
     @has_children = tree_root && tree_root['child_count'] > 0
     # stuff for the collection bits
@@ -307,6 +308,13 @@ class ResourcesController < ApplicationController
     else
       @results = []
     end
+  end
+
+  def staff_access?(uri)
+    staff_interface = URI(AppConfig[:frontend_url] + "/check_session?uri=#{uri}")
+    response = Net::HTTP.get(staff_interface)
+    STDERR.puts "++++++++++++++++++++++++++++++"
+    STDERR.puts response.inspect
   end
 
 end

--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -53,21 +53,23 @@
       </div>
     <% end %>
 
-    <div class="staff-hidden hide">
-      <% if result['json'].has_key?('container_locations') %>
-        <% result['json']['container_locations'].each do |cl| %>
+    <% if AppConfig[:display_container_location_in_PUI] %>
+      <div class="staff-hidden hide">
+        <% if result['json'].has_key?('container_locations') %>
+          <% result['json']['container_locations'].each do |cl| %>
 
-          <% if result['json']['restricted'] %>
-            <p><h4 class='restricted'><%= I18n.t('top_container.restricted') %></h4></p>
+            <% if result['json']['restricted'] %>
+              <p><h4 class='restricted'><%= I18n.t('top_container.restricted') %></h4></p>
+            <% end %>
+            <p><h4><%= cl["_resolved"]['title'] %></h4></p>
           <% end %>
-          <p><h4><%= cl["_resolved"]['title'] %></h4></p>
         <% end %>
-      <% end %>
 
-      <% if result['json'].has_key?('container_profile') %>
-        <p><h4><%= result['json']['container_profile']["_resolved"]['name'] %></h4></p>
-      <% end %>
-    </div>
+        <% if result['json'].has_key?('container_profile') %>
+          <p><h4><%= result['json']['container_profile']["_resolved"]['name'] %></h4></p>
+        <% end %>
+      </div>
+    <% end %>
 
     <% if result.resolved_repository %>
       <div class="result_context">

--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -53,6 +53,18 @@
       </div>
     <% end %>
 
+    <div class="staff-hidden hide">
+      <% if result['json'].has_key?('container_locations') %>
+        <% result['json']['container_locations'].each do |cl| %>
+          <p><h4><%= cl["_resolved"]['title'] %></h4></p>
+        <% end %>
+      <% end %>
+
+      <% if result['json'].has_key?('container_profile') %>
+        <p><h4><%= result['json']['container_profile']["_resolved"]['name'] %></h4></p>
+      <% end %>
+    </div>
+
     <% if result.resolved_repository %>
       <div class="result_context">
         <strong><%= t('context') %>: </strong>

--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -56,6 +56,10 @@
     <div class="staff-hidden hide">
       <% if result['json'].has_key?('container_locations') %>
         <% result['json']['container_locations'].each do |cl| %>
+
+          <% if result['json']['restricted'] %>
+            <p><h4 class='restricted'><%= I18n.t('top_container.restricted') %></h4></p>
+          <% end %>
           <p><h4><%= cl["_resolved"]['title'] %></h4></p>
         <% end %>
       <% end %>

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -331,6 +331,7 @@ en:
   top_container:
     _singular: Container
     _plural: Containers
+    restricted: Restricted
 
   digital_object:
     _singular: Digital Record


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
displays location and container profile info in the PUI container inventory if user is simultaneously logged into the staff interface

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1019

## How Has This Been Tested?
manual testing

## Screenshots (if appropriate):
![Screenshot_2022-04-13_16-23-09](https://user-images.githubusercontent.com/130926/163281009-7664b03b-0b8c-4ae4-9fee-309a04776a73.jpg)
![Screenshot_2022-04-20_15-41-46](https://user-images.githubusercontent.com/130926/164327755-4f3a908c-d50b-4bce-a95e-d2c3e4d40754.jpg)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
