### PR TITLE
Update id_lookup_controller.rb API Examples

### DIFF
--- a/backend/app/controllers/id_lookup_controller.rb
+++ b/backend/app/controllers/id_lookup_controller.rb
@@ -15,6 +15,50 @@ class ArchivesSpaceService < Sinatra::Base
 
   Endpoint.get('/repositories/:repo_id/find_by_id/archival_objects')
     .description("Find Archival Objects by ref_id or component_id")
+    .example("shell") do
+      <<~SHELL
+        curl -s -F password="admin" "http://localhost:8089/users/admin/login"
+        # Replace "admin" with your password and "http://localhost:8089/users/admin/login" with your ASpace API URL
+        # followed by "/users/{your_username}/login"
+    
+        set SESSION="session_id"
+        # If using Git Bash, replace set with export
+    
+        curl -H "X-ArchivesSpace-Session: $SESSION" //
+        "http://localhost:8089/repositories/2/find_by_id/archival_objects?component_id[]=hello_im_a_component_id"
+        # Replace "http://localhost:8089" with your ASpace API URL, "2" with the repository ID, and 
+        # "hello_im_a_component_id" with the component ID you are searching for
+
+        curl -H "X-ArchivesSpace-Session: $SESSION" //
+        "http://localhost:8089/repositories/2/find_by_id/archival_objects?ref_id[]=hello_im_a_ref_id"
+        # Replace "http://localhost:8089" with your ASpace API URL, "2" with the repository ID, and 
+        # "hello_im_a_ref_id" with the ref ID you are searching for
+      SHELL
+    end
+    .example("python") do
+      <<~PYTHON
+        from asnake.client import ASnakeClient  # import the ArchivesSnake client
+        
+        client = ASnakeClient(baseurl="http://localhost:8089", username="admin", password="admin")
+        # Replace "http://localhost:8089" with your ArchivesSpace API URL and "admin" for your username and password
+        
+        client.authorize()  # authorizes the client
+        
+        find_ao_compid = client.get("repositories/2/find_by_id/archival_objects", params={"component_id[]": 
+                                                                                          "hello_im_a_component_id"})
+        # Replace "2" with the repository ID and "hello_im_a_component_id" with the component ID you are searching for
+
+        print(find_ao_compid.json())
+        # Output (dict): {'archival_objects': [{'ref': '/repositories/2/archival_objects/708425'}]}
+
+        find_ao_refid = client.get("repositories/2/find_by_id/archival_objects", params={"ref_id[]": 
+                                                                                         "hello_im_a_ref_id"})
+        # Replace "2" with the repository ID and "hello_im_a_ref_id" with the ref ID you are searching for
+        
+        print(find_ao_refid.json())
+        # Output (dict): {'archival_objects': [{'ref': '/repositories/2/archival_objects/708425'}]}
+      PYTHON
+    end
     .params(["repo_id", :repo_id],
             ["ref_id", [String], "An archival object's Ref ID (param may be repeated)", :optional => true],
             ["component_id", [String], "An archival object's component ID (param may be repeated)", :optional => true],
@@ -29,6 +73,38 @@ class ArchivesSpaceService < Sinatra::Base
 
   Endpoint.get('/repositories/:repo_id/find_by_id/digital_object_components')
     .description("Find Digital Object Components by component_id")
+    .example("shell") do
+      <<~SHELL
+        curl -s -F password="admin" "http://localhost:8089/users/admin/login"
+        # Replace "admin" with your password and "http://localhost:8089/users/admin/login" with your ASpace API URL
+        # followed by "/users/{your_username}/login"
+    
+        set SESSION="session_id"
+        # If using Git Bash, replace set with export
+    
+        curl -H "X-ArchivesSpace-Session: $SESSION" //
+        "http://localhost:8089/repositories/2/find_by_id/digital_object_components?component_id[]=im_a_do_component_id"
+        # Replace "http://localhost:8089" with your ASpace API URL, "2" with the repository ID, and 
+        # "im_a_do_component_id" with the component ID you are searching for
+      SHELL
+    end
+    .example("python") do
+      <<~PYTHON
+        from asnake.client import ASnakeClient  # import the ArchivesSnake client
+        
+        client = ASnakeClient(baseurl="http://localhost:8089", username="admin", password="admin")
+        # Replace "http://localhost:8089" with your ArchivesSpace API URL and "admin" for your username and password
+        
+        client.authorize()  # authorizes the client
+        
+        find_do_comp = client.get("repositories/2/find_by_id/digital_object_components", 
+                                  params={"component_id[]": "im_a_do_component_id"})
+        # Replace "2" with the repository ID and "im_a_do_component_id" with the component ID you are searching for
+  
+        print(find_do_comp.json())
+        # Output (dict): {'digital_object_components': [{'ref': '/repositories/2/digital_object_components/1'}]}
+      PYTHON
+    end
     .params(["repo_id", :repo_id],
             ["component_id", [String], "A digital object component's component ID (param may be repeated)", :optional => true],
             ["resolve", :resolve])

--- a/backend/app/controllers/id_lookup_controller.rb
+++ b/backend/app/controllers/id_lookup_controller.rb
@@ -117,6 +117,38 @@ class ArchivesSpaceService < Sinatra::Base
 
   Endpoint.get('/repositories/:repo_id/find_by_id/digital_objects')
     .description("Find Digital Objects by digital_object_id")
+    .example("shell") do
+      <<~SHELL
+        curl -s -F password="admin" "http://localhost:8089/users/admin/login"
+        # Replace "admin" with your password and "http://localhost:8089/users/admin/login" with your ASpace API URL
+        # followed by "/users/{your_username}/login"
+    
+        set SESSION="session_id"
+        # If using Git Bash, replace set with export
+    
+        curl -H "X-ArchivesSpace-Session: $SESSION" //
+        "http://localhost:8089/repositories/2/find_by_id/digital_objects?digital_object_id[]=hello_im_a_digobj_id"
+        # Replace "http://localhost:8089" with your ASpace API URL, "2" with the repository ID, and 
+        # "hello_im_a_digobj_id" with the digital object ID you are searching for
+      SHELL
+    end
+    .example("python") do
+      <<~PYTHON
+        from asnake.client import ASnakeClient  # import the ArchivesSnake client
+        
+        client = ASnakeClient(baseurl="http://localhost:8089", username="admin", password="admin")
+        # Replace "http://localhost:8089" with your ArchivesSpace API URL and "admin" for your username and password
+        
+        client.authorize()  # authorizes the client
+        
+        find_do = client.get("repositories/2/find_by_id/digital_objects", 
+                             params={"digital_object_id[]": "hello_im_a_digobj_id"})
+        # Replace "2" with the repository ID and "im_a_digobj_id" with the digital object ID you are searching for
+  
+        print(find_do.json())
+        # Output (dict): {'digital_objects': [{'ref': '/repositories/2/digital_objects/1'}]}
+      PYTHON
+    end
     .params(["repo_id", :repo_id],
             ["digital_object_id", [String], "A digital object's digital object ID (param may be repeated)", :optional => true],
             ["resolve", :resolve])

--- a/backend/app/controllers/id_lookup_controller.rb
+++ b/backend/app/controllers/id_lookup_controller.rb
@@ -2,10 +2,42 @@ class ArchivesSpaceService < Sinatra::Base
 
   Endpoint.get('/repositories/:repo_id/find_by_id/resources')
     .description("Find Resources by their identifiers")
+    .example("python") do
+      <<~PYTHON
+        from asnake.client import ASnakeClient  # import the ArchivesSnake client
+        import urllib.parse  # import the urllib.parse package for parsing the URL passed to the API
+        
+        client = ASnakeClient(baseurl="http://localhost:8089", username="admin", password="admin")
+        # Replace "http://localhost:8089" with your ArchivesSpace API URL and "admin" for your username and password
+        
+        client.authorize()  # authorizes the client
+        
+        # Finding resources with one identifier field
+        resource_id = urllib.parse.quote("my_resource_id")  # replace "my_resource_id" with the ID you're searching for
+        find_res_id = client.get(f'repositories/:repo_id:/find_by_id/resources?identifier[]=["{identifier}"];resolve[]=resources')
+        # Replace :repo_id: with the repository ID the resource is in and only add ";resolve[]=resources" if you want
+        # the JSON for the returned record - otherwise, it will return the record URI only
+
+        print(find_res_id.json())
+        # Output (dict): {'resources': [{'ref': '/repositories/2/resources/407', '_resolved':  {'lock_version': 0,...}
+    
+        # Finding resources with multiple identifier fields
+        id_0 = urllib.parse.quote("test")  # replace "test" with the first identifier value
+        id_1 = urllib.parse.quote("1234")  # replace "1234" with the second identifier value
+        id_2 = urllib.parse.quote("abcd")  # replace "abcd" with the third identifier value
+        id_3 = urllib.parse.quote("5678")  # replace "5678" with the fourth identifier value
+        find_mult_res_id = client.get(f'repositories/:repo_id:/find_by_id/resources?identifier[]=["{id_0}", "{id_1}", "{id_2}", "{id_3}"];resolve[]=resources')
+        # Replace :repo_id: with the repository ID the resource is in and only add ";resolve[]=resources" if you want
+        # the JSON for the returned record - otherwise, it will return the record URI only
+
+        print(find_mult_res_id.json())
+        # Output (dict): {'resources': [{'ref': '/repositories/2/resources/407', '_resolved':  {'lock_version': 0,...}
+      PYTHON
+    end
     .params(["repo_id", :repo_id],
             ["identifier", [String], "A 4-part identifier expressed as a JSON array (of up to 4 strings) comprised of the id_0 to id_3 fields (though empty fields will be handled if not provided)", :optional => true],
             ["ark", [String], "An ARK attached to a resource record (param may be repeated)", :optional => true],
-            ["resolve", :resolve])
+            ["resolve", :resolve, "The type of record you are resolving, returns the full JSON for linked record. Example: 'resolve[]': 'resources'", :optional => true])
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \
   do
@@ -25,14 +57,18 @@ class ArchivesSpaceService < Sinatra::Base
         # If using Git Bash, replace set with export
     
         curl -H "X-ArchivesSpace-Session: $SESSION" //
-        "http://localhost:8089/repositories/2/find_by_id/archival_objects?component_id[]=hello_im_a_component_id"
-        # Replace "http://localhost:8089" with your ASpace API URL, "2" with the repository ID, and 
-        # "hello_im_a_component_id" with the component ID you are searching for
+        "http://localhost:8089/repositories/:repo_id:/find_by_id/archival_objects?component_id[]=hello_im_a_component_id;resolve[]=archival_objects"
+        # Replace "http://localhost:8089" with your ASpace API URL, :repo_id: with the repository ID, 
+        # "hello_im_a_component_id" with the component ID you are searching for, and only add 
+        # "resolve[]=archival_objects" if you want the JSON for the returned record - otherwise, it will return the 
+        # record URI only
 
         curl -H "X-ArchivesSpace-Session: $SESSION" //
-        "http://localhost:8089/repositories/2/find_by_id/archival_objects?ref_id[]=hello_im_a_ref_id"
-        # Replace "http://localhost:8089" with your ASpace API URL, "2" with the repository ID, and 
-        # "hello_im_a_ref_id" with the ref ID you are searching for
+        "http://localhost:8089/repositories/:repo_id:/find_by_id/archival_objects?ref_id[]=hello_im_a_ref_id;resolve[]=archival_objects"
+        # Replace "http://localhost:8089" with your ASpace API URL, :repo_id: with the repository ID, 
+        # "hello_im_a_ref_id" with the ref ID you are searching for, and only add 
+        # "resolve[]=archival_objects" if you want the JSON for the returned record - otherwise, it will return the 
+        # record URI only
       SHELL
     end
     .example("python") do
@@ -44,26 +80,32 @@ class ArchivesSpaceService < Sinatra::Base
         
         client.authorize()  # authorizes the client
         
-        find_ao_compid = client.get("repositories/2/find_by_id/archival_objects", params={"component_id[]": 
-                                                                                          "hello_im_a_component_id"})
-        # Replace "2" with the repository ID and "hello_im_a_component_id" with the component ID you are searching for
+        find_ao_compid = client.get("repositories/:repo_id:/find_by_id/archival_objects", 
+                                    params={"component_id[]": "hello_im_a_component_id",
+                                    "resolve[]": "archival_objects"})
+        # Replace :repo_id: with the repository ID, "hello_im_a_component_id" with the component ID you are searching for, and
+        # only add "resolve[]": "archival_objects" if you want the JSON for the returned record - otherwise, it will 
+        # return the record URI only
 
         print(find_ao_compid.json())
-        # Output (dict): {'archival_objects': [{'ref': '/repositories/2/archival_objects/708425'}]}
+        # Output (dict): {'archival_objects': [{'ref': '/repositories/2/archival_objects/708425', '_resolved':...}]}
 
-        find_ao_refid = client.get("repositories/2/find_by_id/archival_objects", params={"ref_id[]": 
-                                                                                         "hello_im_a_ref_id"})
-        # Replace "2" with the repository ID and "hello_im_a_ref_id" with the ref ID you are searching for
+        find_ao_refid = client.get("repositories/:repo_id:/find_by_id/archival_objects", 
+                                   params={"ref_id[]": "hello_im_a_ref_id"
+                                   "resolve[]": "archival_objects"})
+        # Replace :repo_id: with the repository ID, "hello_im_a_ref_id" with the ref ID you are searching for, and only add 
+        # "resolve[]": "archival_objects" if you want the JSON for the returned record - otherwise, it will return the 
+        # record URI only
         
         print(find_ao_refid.json())
-        # Output (dict): {'archival_objects': [{'ref': '/repositories/2/archival_objects/708425'}]}
+        # Output (dict): {'archival_objects': [{'ref': '/repositories/2/archival_objects/708425', '_resolved':...}]}
       PYTHON
     end
     .params(["repo_id", :repo_id],
             ["ref_id", [String], "An archival object's Ref ID (param may be repeated)", :optional => true],
             ["component_id", [String], "An archival object's component ID (param may be repeated)", :optional => true],
             ["ark", [String], "An ARK attached to an archival object record (param may be repeated)", :optional => true],
-            ["resolve", :resolve])
+            ["resolve", :resolve, "The type of record you are resolving, returns the full JSON for linked record. Example: 'resolve[]': 'archival_object'", :optional => true])
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \
   do
@@ -83,9 +125,11 @@ class ArchivesSpaceService < Sinatra::Base
         # If using Git Bash, replace set with export
     
         curl -H "X-ArchivesSpace-Session: $SESSION" //
-        "http://localhost:8089/repositories/2/find_by_id/digital_object_components?component_id[]=im_a_do_component_id"
-        # Replace "http://localhost:8089" with your ASpace API URL, "2" with the repository ID, and 
-        # "im_a_do_component_id" with the component ID you are searching for
+        "http://localhost:8089/repositories/:repo_id:/find_by_id/digital_object_components?component_id[]=im_a_do_component_id;resolve[]=digital_object_components"
+        # Replace "http://localhost:8089" with your ASpace API URL, :repo_id: with the repository ID, 
+        # "im_a_do_component_id" with the component ID you are searching for, and only add 
+        # "resolve[]=digital_object_components" if you want the JSON for the returned record - otherwise, it will return
+        # the record URI only
       SHELL
     end
     .example("python") do
@@ -97,17 +141,20 @@ class ArchivesSpaceService < Sinatra::Base
         
         client.authorize()  # authorizes the client
         
-        find_do_comp = client.get("repositories/2/find_by_id/digital_object_components", 
-                                  params={"component_id[]": "im_a_do_component_id"})
-        # Replace "2" with the repository ID and "im_a_do_component_id" with the component ID you are searching for
+        find_do_comp = client.get("repositories/:repo_id:/find_by_id/digital_object_components", 
+                                  params={"component_id[]": "im_a_do_component_id"
+                                  "resolve[]": "digital_object_components"})
+        # Replace :repo_id: with the repository ID, "im_a_do_component_id" with the component ID you are searching for, and
+        # only add "resolve[]": "digital_object_components" if you want the JSON for the returned record - otherwise, it
+        # will return the record URI only
   
         print(find_do_comp.json())
-        # Output (dict): {'digital_object_components': [{'ref': '/repositories/2/digital_object_components/1'}]}
+        # Output (dict): {'digital_object_components': [{'ref': '/repositories/2/digital_object_components/1', '_resolved':...}]}
       PYTHON
     end
     .params(["repo_id", :repo_id],
             ["component_id", [String], "A digital object component's component ID (param may be repeated)", :optional => true],
-            ["resolve", :resolve])
+            ["resolve", :resolve, "The type of record you are resolving, returns the full JSON for linked record. Example: 'resolve[]': 'digital_object_components'", :optional => true])
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \
   do
@@ -127,9 +174,11 @@ class ArchivesSpaceService < Sinatra::Base
         # If using Git Bash, replace set with export
     
         curl -H "X-ArchivesSpace-Session: $SESSION" //
-        "http://localhost:8089/repositories/2/find_by_id/digital_objects?digital_object_id[]=hello_im_a_digobj_id"
-        # Replace "http://localhost:8089" with your ASpace API URL, "2" with the repository ID, and 
-        # "hello_im_a_digobj_id" with the digital object ID you are searching for
+        "http://localhost:8089/repositories/:repo_id:/find_by_id/digital_objects?digital_object_id[]=hello_im_a_digobj_id;resolve[]=digital_objects"
+        # Replace "http://localhost:8089" with your ASpace API URL, :repo_id: with the repository ID, 
+        # "hello_im_a_digobj_id" with the digital object ID you are searching for, and only add 
+        # "resolve[]=digital_objects" if you want the JSON for the returned record - otherwise, it will return the 
+        # record URI only
       SHELL
     end
     .example("python") do
@@ -141,17 +190,20 @@ class ArchivesSpaceService < Sinatra::Base
         
         client.authorize()  # authorizes the client
         
-        find_do = client.get("repositories/2/find_by_id/digital_objects", 
-                             params={"digital_object_id[]": "hello_im_a_digobj_id"})
-        # Replace "2" with the repository ID and "im_a_digobj_id" with the digital object ID you are searching for
+        find_do = client.get("repositories/:repo_id:/find_by_id/digital_objects", 
+                             params={"digital_object_id[]": "hello_im_a_digobj_id", 
+                                     "resolve[]": "digital_objects"})
+        # Replace :repo_id: with the repository ID, "im_a_digobj_id" with the digital object ID you are searching for, and
+        # only add "resolve[]=digital_objects" if you want the JSON for the returned record - otherwise, it will return 
+        # the record URI only
   
         print(find_do.json())
-        # Output (dict): {'digital_objects': [{'ref': '/repositories/2/digital_objects/1'}]}
+        # Output (dict): {'digital_objects': [{'ref': '/repositories/2/digital_objects/1', '_resolved':...}]}
       PYTHON
     end
     .params(["repo_id", :repo_id],
             ["digital_object_id", [String], "A digital object's digital object ID (param may be repeated)", :optional => true],
-            ["resolve", :resolve])
+            ["resolve", :resolve, "The type of record you are resolving, returns the full JSON for linked record. Example: 'resolve[]': 'digital_objects'", :optional => true])
     .permissions([:view_repository])
     .returns([200, "JSON array of refs"]) \
   do


### PR DESCRIPTION
Provides shell and python examples for endpoints in the id_lookup_controller.rb file.

## Description
Adds examples to the 4 endpoints in the file, as well as updates the description of the :resolve parameter to better clarify usage. /repositories/:repo_id/find_by_id/resources still needs a shell example and an example searching via ARK for python.

This change is required to help users reference the API for examples when building their own code to access and take advantage of the API.

## Related JIRA Ticket or GitHub Issue
N/A*
* Will add JIRA ticket to add shell and ARK example to /repositories/:repo_id/find_by_id/resources

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
