### PR TITLE
ANW-1519: bugfix for non-repo records not linking properly when imported

### DIFF
--- a/frontend/app/views/jobs/_job_records.html.erb
+++ b/frontend/app/views/jobs/_job_records.html.erb
@@ -13,13 +13,19 @@
         <span class="asicon icon-<%= result["record"]["_resolved"]["jsonmodel_type"] %>"
               title="<%= I18n.t("#{result["record"]["_resolved"]["jsonmodel_type"]}._singular") %>">
         </span>
-        <% if result["record"]["ref"].include?(current_repo.uri) %>
-         <%= resolve_readonly_link_to record_title, result["record"]["ref"] %>
+        <%# ANW-1519: for agents and subjects, we don't need to check what repo they belong in %>
+        <% if result["record"]["_resolved"]["jsonmodel_type"] =~ /agent/ ||
+              result["record"]["_resolved"]["jsonmodel_type"] =~ /subject/ %>
+          <%= resolve_readonly_link_to record_title, result["record"]["ref"] %>
         <% else %>
-          <%= resolve_readonly_link_to "#{record_title} (#{result["record"]["ref"]})", result["record"]["ref"], false %>
-          <span class="label label-warning">
-            <%= I18n.t("job._frontend.external_repo") %>
-          </span>
+          <% if result["record"]["ref"].include?(current_repo.uri) %>
+            <%= resolve_readonly_link_to record_title, result["record"]["ref"] %>
+          <% else %>
+            <%= resolve_readonly_link_to "#{record_title} (#{result["record"]["ref"]})", result["record"]["ref"], false %>
+            <span class="label label-warning">
+             <%= I18n.t("job._frontend.external_repo") %>
+            </span>
+          <% end %>
         <% end %>
       </div>
     <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
bugfix for non-repo records not linking properly when imported

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1519

## How Has This Been Tested?
Manual, in browser testing. Did a MARC import of the following files:
backend/spec/examples/marc/at-tracer-marc-1.xml
backend/spec/examples/marc/authority_john_davis.xml 

And confirmed that the subjects and agents imported were created properly and directly linked to after import

## Screenshots (if appropriate):
![Screenshot_2022-04-26_17-45-47](https://user-images.githubusercontent.com/130926/165410530-1e846286-299d-4987-b73c-ac81f4908408.jpg)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
