### PR TITLE
ANW-1478: prevent create custom template button for showing unless permissions

### DIFF
--- a/frontend/app/views/jobs/_form.html.erb
+++ b/frontend/app/views/jobs/_form.html.erb
@@ -158,7 +158,7 @@
             <%= I18n.t("reports.translation_defaults.select") %>
           </button>
           <div class="btn-group pull-right">
-            <% if code === "custom_report" %>
+            <% if code === "custom_report" && user_can?('manage_custom_report_templates') %>
               <%= link_to I18n.t("custom_report_template._frontend.action.create"), {:controller => :custom_report_templates, :action => :new}, :class => "btn btn-default create-report-template" %>
             <% end %>
             <button class="pull-right btn btn-primary unselect-report" for="<%= code %>" type="button">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
prevent create custom template button for showing unless permissions

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1478

## How Has This Been Tested?
manual, in browser testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
