### PR TITLE
Fix sorting of records with titles containing non-ASCII characters

### DIFF
--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -1125,7 +1125,7 @@ class IndexerCommon
     return nil if value.nil?
     out = value.gsub(/<[^>]+>/, '')
     out.gsub!(/-/, ' ')
-    out.gsub!(/[^\w\s]/, '')
+    out.gsub!(/[^\p{L}\d\s_]/, '')
     out.gsub!(/\s+/, ' ')
     out.strip
   end


### PR DESCRIPTION
## Description
Nakanoshima Museum of Art couldn't get their Japanese titles to sort correctly. They identified that the primary culprit was `clean_for_sort` stripping out everything which isn't an ASCII world character. It isn't as noticeable in a primarily English-speaking institution, although it does make a small difference when there are accented characters or Greek letters, for example, near the start of a title.

The fix is to replace `\w`, which is equivalent to `[a-zA-z0-9_]`, with `\p{L}`, which should match anything deemed by Unicode to be a letter. This will allow non-English titles to be sorted correctly. Although it might require some adjustment to the Solr schema by individual ArchivesSpace users.

## Related JIRA Ticket or GitHub Issue
http://lyralists.lyrasis.org/pipermail/archivesspace_users_group/2022-May/009290.html

## How Has This Been Tested?
On a development system and on a QA system in a plug-in (overriding the clean_for_sort method.)

`build/run indexer:test` completes successfully.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
