### PR TITLE
Print more diagnostic information on a DB connection failure

### DIFF
--- a/backend/app/model/db.rb
+++ b/backend/app/model/db.rb
@@ -52,6 +52,18 @@ class DB
           end
 
           @pool = pool
+        rescue Sequel::DatabaseConnectionError
+          Log.error("DB connection failed: #{$!}")
+
+          exceptions = [$!.wrapped_exception].compact
+
+          while !exceptions.empty?
+            exception = exceptions.shift
+            Log.error("Additional DB info: #{exception.inspect}: #{exception}")
+            exceptions << exception.get_cause if exception.get_cause
+          end
+
+          raise
         rescue
           Log.error("DB connection failed: #{$!}")
           raise


### PR DESCRIPTION
Sometimes the real content of a MySQL connection failure is several wrapped exceptions deep.  For example, socket-level errors like Connection Refused/Reset and SSL version errors report a fairly bland "Communications link failure", without giving any real clues about the problem.

This commit walks the nested exceptions on a DB connection failure and logs them all out.
