### PR TITLE
Stricter authentication source check

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -270,6 +270,8 @@ AppConfig[:public_username] = "public_anonymous"
 AppConfig[:staff_username] = "staff_system"
 
 AppConfig[:authentication_sources] = []
+# When 'true' restrict authentication attempts to only the source already set for the user
+AppConfig[:authentication_restricted_by_source] = false # default: allow any source
 
 AppConfig[:realtime_index_backlog_ms] = 60000
 

--- a/common/schemas/user.rb
+++ b/common/schemas/user.rb
@@ -9,6 +9,7 @@
 
       "username" => {"type" => "string", "maxLength" => 255, "ifmissing" => "error", "minLength" => 1},
       "name" => {"type" => "string", "maxLength" => 255, "ifmissing" => "error", "minLength" => 1},
+      "source" => {"type" => "string", "readonly" => true},
 
       "is_system_user" => {"type" => "boolean", "readonly" => true},
 

--- a/frontend/app/views/users/_form.html.erb
+++ b/frontend/app/views/users/_form.html.erb
@@ -14,6 +14,7 @@
 
    <hr/>
 
+   <%= form.label_and_textfield "source", { :field_opts => { :readonly => true } } %>
    <%= form.label_and_password "password", {:field_opts => {:size => 30, :class => "input-large"}, :required => @user.id ? :conditionally : true} %>
    <%= form.label_and_password "confirm_password", {:field_opts => {:size => 30, :class => "input-large"}, :required => @user.id ? :conditionally : true} %>
 

--- a/frontend/app/views/users/index.html.erb
+++ b/frontend/app/views/users/index.html.erb
@@ -1,8 +1,7 @@
 <%= setup_context :title => @manage_access ? I18n.t("user._frontend.section.manage_access") : I18n.t("user._plural") %>
 
 <div class="row">
-   <div class="col-md-3"></div>
-   <div class="col-md-9">
+   <div class="col-md-12">
      <div class="record-toolbar">
        <div class="btn-group pull-right">
          <% unless @manage_access %>
@@ -44,6 +43,7 @@
                </th>
                <th><%= I18n.t("user.admin") %></th>
                <th><%= I18n.t("user.is_active_user") %></th>
+               <th><%= I18n.t("user.source") %></th>
              <% end %>
              <th width="70px"><span class="sr-only"><%= I18n.t('search_results.actions') %></span></th>
            </tr>
@@ -65,14 +65,13 @@
                  <td><%= Time.parse(user.create_time).getlocal %></td>
                  <td><%= Time.parse(user.user_mtime).getlocal %></td>
                  <td><%= user.is_admin %></td>
-                 <td>
-                   <%= active %>
-                 </td>
+                 <td><%= active %></td>
+                 <td><%= user.source %></td>
                <% end %>
                <td>
                  <div class="btn-group" style="float: right">
                 <div class="btn-group" style="float: right">
-                   <% disabled = (user.is_admin || user.is_system_user) ? " disabled" : "" %> 
+                   <% disabled = (user.is_admin || user.is_system_user) ? " disabled" : "" %>
 
                    <% if @manage_access %>
                      <%= link_to I18n.t("actions.edit_groups"), {:controller => :users, :action => :edit_groups, :id => user.id}, :class => "btn btn-xs btn-default".concat(disabled) %>
@@ -86,12 +85,9 @@
                        <%= link_to I18n.t("user._frontend.action.deactivate_user"), user_deactivate_path(user.id), :confirm => "Are you sure?", :class => "btn btn-xs btn-danger".concat(disabled), :id => "deactivate_#{user.username}" %>
                      <% end %>
                    <% end %>
-
-      
-                  
                  </div>
                </td>
-             </tr>           
+             </tr>
            <% end %>
          </tbody>
        </table>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1275,6 +1275,7 @@ en:
     is_active_user: Active
     active: "true"
     inactive: "false"
+    source: Authentication
     _frontend:
       messages:
         access_denied: Access denied. Login as the admin user to perform this action.


### PR DESCRIPTION
Option to restrict existing users to only attempt authentication
against their set source. Without this there are loopholes for
bypassing the "intended" authentication backend if only a single
source of authentication is expected.

Also:
Use more screen real estate for users table
Display source in users table
Display source in user record

## How Has This Been Tested?
Development server confirms single source restriction when config
applied.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
