### PR TITLE
ANW-1134: Avoid resolving top_containers where it's unnecessary

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -157,6 +157,7 @@ AppConfig[:solr_indexing_frequency_seconds] = 30
 AppConfig[:solr_facet_limit] = 100
 
 AppConfig[:default_page_size] = 10
+AppConfig[:max_boolean_queries] = 1024 # ArchivesSpace Solr default
 AppConfig[:max_page_size] = 250
 
 # An option to change the length of the abstracts on the collections overview page

--- a/public/app/controllers/agents_controller.rb
+++ b/public/app/controllers/agents_controller.rb
@@ -11,7 +11,7 @@ class AgentsController < ApplicationController
   DEFAULT_AG_FACET_TYPES = %w{primary_type subjects}
   DEFAULT_AG_SEARCH_OPTS = {
     'sort' => 'title_sort asc',
-    'resolve[]' => ['repository:id', 'resource:id@compact_resource', 'ancestors:id@compact_resource', 'top_container_uri_u_sstr:id'],
+    'resolve[]' => ['repository:id', 'resource:id@compact_resource', 'ancestors:id@compact_resource'],
     'facet.mincount' => 1
   }
 

--- a/public/app/controllers/repositories_controller.rb
+++ b/public/app/controllers/repositories_controller.rb
@@ -10,7 +10,7 @@ class RepositoriesController < ApplicationController
   DEFAULT_SEARCH_FACET_TYPES = ['primary_type', 'subjects', 'published_agents']
   DEFAULT_REPO_SEARCH_OPTS = {
      'sort' => 'title_sort asc',
-    'resolve[]' => ['repository:id', 'resource:id@compact_resource', 'ancestors:id@compact_resource', 'top_container_uri_u_sstr:id'],
+    'resolve[]' => ['repository:id', 'resource:id@compact_resource', 'ancestors:id@compact_resource'],
     'facet.mincount' => 1
   }
   DEFAULT_TYPES = %w{archival_object digital_object agent resource accession}

--- a/public/app/controllers/search_controller.rb
+++ b/public/app/controllers/search_controller.rb
@@ -5,7 +5,7 @@ class SearchController < ApplicationController
   DEFAULT_SEARCH_FACET_TYPES = ['repository', 'primary_type', 'subjects', 'published_agents', 'langcode']
   DEFAULT_SEARCH_OPTS = {
 #    'sort' => 'title_sort asc',
-    'resolve[]' => ['repository:id', 'resource:id@compact_resource', 'ancestors:id@compact_resource', 'top_container_uri_u_sstr:id'],
+    'resolve[]' => ['repository:id', 'resource:id@compact_resource', 'ancestors:id@compact_resource'],
     'facet.mincount' => 1
   }
   DEFAULT_TYPES = %w{archival_object digital_object digital_object_component agent resource repository accession classification subject}


### PR DESCRIPTION
Remove 'top_container_uri_u_sstr:id' from default search opts in
controllers where it isn't required / used.

Not only is it unnecessary but it can wreak havoc in general
searches where the search returns records containing many
instances, resulting in "too many boolean clauses".

For the latter issue we now pre-check for subqueries that
exceed our defined limit (default 1024) and drop the excess
conditions with a warning, equivalent to the max resolve warning.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
