### PR TITLE
Fix inaccurate API endpoint description

### DIFF
--- a/backend/app/controllers/repository_transfer.rb
+++ b/backend/app/controllers/repository_transfer.rb
@@ -40,7 +40,7 @@ class ArchivesSpaceService < Sinatra::Base
 
 
   Endpoint.post('/repositories/:repo_id/transfer')
-    .description("Transfer this record to a different repository")
+    .description("Transfer all records to a different repository")
     .params(["target_repo", String, "The URI of the target repository"],
             ["repo_id", :repo_id])
     .permissions([:transfer_repository])


### PR DESCRIPTION
## Description
I've been trying to understand how permissions work, and noticed this very small issue, but one that could confuse people searching the API docs. The other "transfer" endpoints move individual records, but this one moves all records in a repository to another repository.

## Related JIRA Ticket or GitHub Issue
N/A

## How Has This Been Tested?
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. _[Presumably this will update the API docs when they're regenerated?]_
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
