### PR TITLE
ANW-1526: Fix for file version URIs not appearing when linked in file version and custom report where FV is linked

### DIFF
--- a/reports/digital_objects/digital_object_file_versions_list_subreport/digital_object_file_versions_list_subreport.rb
+++ b/reports/digital_objects/digital_object_file_versions_list_subreport/digital_object_file_versions_list_subreport.rb
@@ -9,9 +9,9 @@ class DigitalObjectFileVersionsListSubreport < AbstractSubreport
 
   def query_string
     "select
-      file_uri as uri,
-      digital_object.title as digital_object_title,
-      digital_object_component.title as digital_object_component_title
+      file_uri as 'file_uri',
+      digital_object.title as 'digital_object_title',
+      digital_object_component.title as 'digital_object_component_title'
     from file_version 
     left outer join digital_object
       on file_version.digital_object_id = digital_object.id

--- a/reports/digital_objects/digital_object_file_versions_list_subreport/digital_object_file_versions_list_subreport.rb
+++ b/reports/digital_objects/digital_object_file_versions_list_subreport/digital_object_file_versions_list_subreport.rb
@@ -10,14 +10,14 @@ class DigitalObjectFileVersionsListSubreport < AbstractSubreport
   def query_string
     "select
       file_uri as uri,
-      value as use_statement,
-      component_id as component_identifier,
-      ifnull(title, display_string) as component_title
-    from file_version left outer join digital_object_component
-      on digital_object_component_id = digital_object_component.id
-      join enumeration_value on use_statement_id = enumeration_value.id
-    where digital_object_id = #{db.literal(@digital_object_id)}
-      or root_record_id = #{db.literal(@digital_object_id)}"
+      digital_object.title as digital_object_title,
+      digital_object_component.title as digital_object_component_title
+    from file_version 
+    left outer join digital_object
+      on file_version.digital_object_id = digital_object.id
+    left outer join digital_object_component on file_version.digital_object_component_id = digital_object_component.id
+    where digital_object.id = #{db.literal(@digital_object_id)}
+    or root_record_id = #{db.literal(@digital_object_id)}"
   end
 
   def self.field_name

--- a/reports/digital_objects/digital_object_file_versions_report/digital_object_file_versions_report.rb
+++ b/reports/digital_objects/digital_object_file_versions_report/digital_object_file_versions_report.rb
@@ -8,11 +8,7 @@ class DigitalObjectFileVersionsReport < AbstractReport
   end
 
   def query_string
-    "select 
-      id,
-      digital_object_id as identifier,
-      title as record_title
-    from digital_object where repo_id = #{db.literal(@repo_id)}"
+    "select digital_object.id, digital_object.digital_object_id as identifier, title as record_title, file_uri as uri from digital_object join file_version on digital_object.id = file_version.digital_object_id where repo_id = #{db.literal(@repo_id)}"
   end
 
   def fix_row(row)

--- a/reports/digital_objects/digital_object_file_versions_report/digital_object_file_versions_report.rb
+++ b/reports/digital_objects/digital_object_file_versions_report/digital_object_file_versions_report.rb
@@ -8,7 +8,14 @@ class DigitalObjectFileVersionsReport < AbstractReport
   end
 
   def query_string
-    "select digital_object.id, digital_object.digital_object_id as identifier, title as record_title, file_uri as uri from digital_object join file_version on digital_object.id = file_version.digital_object_id where repo_id = #{db.literal(@repo_id)} and file_uri is not null"
+    "select 
+      digital_object.id as 'digital_object_id', 
+      digital_object.digital_object_id as 'digital_object_identifier', 
+      title as 'digital_object_title', 
+      file_uri as 'digital_object_uri' 
+      from digital_object 
+      join file_version on digital_object.id = file_version.digital_object_id 
+      where repo_id = #{db.literal(@repo_id)} and file_uri is not null"
   end
 
   def fix_row(row)

--- a/reports/digital_objects/digital_object_file_versions_report/digital_object_file_versions_report.rb
+++ b/reports/digital_objects/digital_object_file_versions_report/digital_object_file_versions_report.rb
@@ -8,7 +8,7 @@ class DigitalObjectFileVersionsReport < AbstractReport
   end
 
   def query_string
-    "select digital_object.id, digital_object.digital_object_id as identifier, title as record_title, file_uri as uri from digital_object join file_version on digital_object.id = file_version.digital_object_id where repo_id = #{db.literal(@repo_id)}"
+    "select digital_object.id, digital_object.digital_object_id as identifier, title as record_title, file_uri as uri from digital_object join file_version on digital_object.id = file_version.digital_object_id where repo_id = #{db.literal(@repo_id)} and file_uri is not null"
   end
 
   def fix_row(row)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Rewrote report queries to show file version information

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1526

## How Has This Been Tested?
Manual testing:

Created 3 digital object records:
- one with no subrecords at all
- one with a date subrecord
- one with a file_version subrecord and a digital object component with a file_version subrecords, both with different file version URLs

Created a Digital Object custom report linking file versions and date subrecords

The result of the custom report is that all 3 digital object records show in report, with the URIs for both file versions (for the DO and it's DOC child that have one) and the date subrecord data for the DO that has that. Screenshot below.

The result of the file version report is that only rows for the DO and it's DOC child with file versions appear in the report. Screenshot below.

## Screenshots (if appropriate):
![custom_report](https://user-images.githubusercontent.com/130926/172491899-5492b7dd-59f1-4d56-a246-e8c996ad32e2.jpg)
![file_version_report](https://user-images.githubusercontent.com/130926/172491915-6089d26c-9070-4d2a-be15-e6217e2bae0b.jpg)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
