### PR TITLE
ANW-287 move HM accession / component link plugin to core

### DIFF
--- a/backend/app/model/accession.rb
+++ b/backend/app/model/accession.rb
@@ -37,6 +37,11 @@ class Accession < Sequel::Model(:accession)
                       :json_property => 'related_resources',
                       :contains_references_to_types => proc {[Resource]})
 
+  define_relationship(:name => :accession_component_links,
+                      :json_property => 'component_links',
+                      :contains_references_to_types => proc {[ArchivalObject]},
+                      :is_array => true)
+
 
   define_directional_relationship(:name => :related_accession,
                                   :json_property => 'related_accessions',

--- a/backend/app/model/archival_object.rb
+++ b/backend/app/model/archival_object.rb
@@ -61,6 +61,10 @@ class ArchivalObject < Sequel::Model(:archival_object)
                   end
                 }
 
+  define_relationship(:name => :accession_component_links,
+                      :json_property => 'accession_links',
+                      :contains_references_to_types => proc {[Accession]},
+                      :is_array => true)
 
   def self.produce_display_string(json)
     display_string = json['title'] || ""

--- a/backend/spec/model_accession_spec.rb
+++ b/backend/spec/model_accession_spec.rb
@@ -366,6 +366,13 @@ describe 'Accession model' do
     expect(Accession.to_jsonmodel(bert.id)['related_accessions'].first['ref']).to eq(ernie.uri)
   end
 
+  it "can link an accession and a resource component (archival object)" do
+    linked_component = create(:json_archival_object)
+    accession = create(:json_accession, component_links: [{'ref' => linked_component.uri}])
+    linked_component = ArchivalObject.to_jsonmodel(linked_component.id)
+    expect(linked_component['accession_links'][0]['ref']).to eq(accession.uri)
+  end
+
   describe "slug tests" do
     before(:all) do
       AppConfig[:use_human_readable_urls] = true

--- a/common/db/migrations/163_accession_component_links.rb
+++ b/common/db/migrations/163_accession_component_links.rb
@@ -1,0 +1,27 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    # users of the as_accession_links plugin will already
+    # have this table. See https://github.com/hudmol/as_accession_links
+    unless tables.include?(:accession_component_links_rlshp)
+      create_table(:accession_component_links_rlshp) do
+        primary_key :id
+
+        Integer :accession_id
+        Integer :archival_object_id
+
+        Integer :suppressed, :default => 0
+        Integer :aspace_relationship_position
+
+        apply_mtime_columns(false)
+      end
+
+      alter_table(:accession_component_links_rlshp) do
+        add_foreign_key([:accession_id], :accession, :key => :id)
+        add_foreign_key([:archival_object_id], :archival_object, :key => :id)
+      end
+    end
+  end
+end

--- a/common/schemas/accession.rb
+++ b/common/schemas/accession.rb
@@ -115,7 +115,25 @@
           "properties" => {
             "ref" => {
               "type" => [{"type" => "JSONModel(:resource) uri"}],
-                      "ifmissing" => "error"
+              "ifmissing" => "error"
+            },
+            "_resolved" => {
+              "type" => "object",
+              "readonly" => "true"
+            }
+          }
+        }
+      },
+
+      "component_links" => {
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "subtype" => "ref",
+          "properties" => {
+            "ref" => {
+              "type" => [{"type" => "JSONModel(:archival_object) uri"}],
+              "ifmissing" => "error"
             },
             "_resolved" => {
               "type" => "object",

--- a/common/schemas/archival_object.rb
+++ b/common/schemas/archival_object.rb
@@ -106,8 +106,25 @@
         "type" => "JSONModel(:ark_name) object",
         "readonly" => true,
         "required" => false
-      }
+      },
 
+      "accession_links" => {
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "subtype" => "ref",
+          "properties" => {
+            "ref" => {
+              "type" => [{"type" => "JSONModel(:accession) uri"}],
+              "ifmissing" => "error"
+            },
+            "_resolved" => {
+              "type" => "object",
+              "readonly" => "true"
+            }
+          }
+        }
+      }
     },
   },
 }

--- a/frontend/app/assets/javascripts/archival_objects.crud.js
+++ b/frontend/app/assets/javascripts/archival_objects.crud.js
@@ -27,6 +27,9 @@ function SimpleLinkingModal(config) {
     this
   );
   self.$container = $('.linker-container', self.$modal);
+  if (self.config.url_html == undefined) {
+    throw 'Cannot load linking modal because the modal config is missing a url';
+  }
   self.reload_modal(self.config.url_html);
   self.init_click_handlers();
   self.init_radio_handlers();

--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -262,7 +262,7 @@ class ApplicationController < ActionController::Base
                       "linked_events", "linked_events::linked_records",
                       "linked_events::linked_agents",
                       "top_container", "container_profile", "location_profile",
-                      "owner_repo", "places"] + Plugins.fields_to_resolve
+                      "owner_repo", "places", "component_links", "accession_links"] + Plugins.fields_to_resolve
     }
   end
 

--- a/frontend/app/models/archival_object.rb
+++ b/frontend/app/models/archival_object.rb
@@ -33,7 +33,7 @@ class ArchivalObject < JSONModel(:archival_object)
                                                      :content => [accession.condition_description])
     end
 
-    # self.related_accessions = [{'ref' => accession.uri, '_resolved' => accession}]
+    self.accession_links = [{'ref' => accession.uri, '_resolved' => accession}]
 
     self.notes = notes
 

--- a/frontend/app/views/accession_links/_accession_linker.html.erb
+++ b/frontend/app/views/accession_links/_accession_linker.html.erb
@@ -1,0 +1,39 @@
+<%
+  if form.obj.empty?
+    selected_json = "{}"
+  else
+    selected_json = ASUtils.to_json(form.obj['_resolved'])
+  end
+
+  field_label ||= I18n.t("accession._singular")
+  linker_id ||= "accession_links_"
+%>
+<div class="form-group required">
+  <label class="control-label col-sm-2"><%= field_label %></label>
+  <div class="controls col-sm-8">
+    <div class="input-group linker-wrapper">
+      <input type="text" class="linker"
+             id="<%= linker_id %>"
+             data-label="<%= I18n.t "archival_object.accession_link" %>"
+             data-label_plural="<%= I18n.t "archival_object.accession_links" %>"
+             data-path="<%= form.path %>"
+             data-name="ref"
+             data-url="<%= url_for :controller => :search, :action => :do_search, :format => :json %>"
+             data-browse-url="<%= url_for :controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.BASE_FACETS %>"
+             data-selected="<%= selected_json %>"
+             data-format_property="display_string"
+             data-multiplicity="one"
+             data-sortable="true"
+             data-types='["accession"]'
+             aria-label="Link to accession"
+      />
+
+      <div class="input-group-btn">
+        <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="Link to record"><span class="caret"></span></a>
+        <ul class="dropdown-menu">
+          <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/app/views/accession_links/_show.html.erb
+++ b/frontend/app/views/accession_links/_show.html.erb
@@ -1,0 +1,34 @@
+<%
+   section_id = "archival_object_accession_links" if section_id.blank?
+%>
+
+<section id="<%= section_id %>" class="subrecord-form-dummy">
+  <h3><%= I18n.t("accession_link._plural") %></h3>
+
+  <div class="subrecord-form-container">
+    <div class="subrecord-form-fields">
+      <table class="table table-striped table-bordered table-condensed table-hover token-list">
+        <thead>
+          <tr>
+            <td><%= I18n.t("accession.id_0") %></td>
+            <td><%= I18n.t("accession.title") %></td>
+          </tr>
+        </thead>
+        <tbody>
+          <% accession_links.each_with_index do | acc, index | %>
+            <tr>
+              <td><%= (0..3).map{|i| acc["_resolved"]["id_#{i}"]}.compact.join("-") %></td>
+              <td>
+                <%= render_token :object => acc["_resolved"],
+                                 :label => acc["_resolved"]["display_string"],
+                                 :type => "accession",
+                                 :uri => acc["ref"] %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+</section>

--- a/frontend/app/views/accession_links/_template.html.erb
+++ b/frontend/app/views/accession_links/_template.html.erb
@@ -1,0 +1,5 @@
+<% define_template("component_accession_links",  jsonmodel_definition(:archival_object)) do |form| %>
+  <div class="subrecord-form-fields">
+    <%= render_aspace_partial :partial => "accession_links/accession_linker", :locals => { :form => form }%>
+  </div>
+<% end %>

--- a/frontend/app/views/accessions/_form.html.erb
+++ b/frontend/app/views/accessions/_form.html.erb
@@ -50,6 +50,7 @@
 
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "linked_agents", :template => "accession_linked_agent"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "related_resources", :template => "accession_related_resource"} %>
+<%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "component_links", :template => "accession_component_links"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "related_accessions", :template_erb => "interrelated_accessions/template", :template => "interrelated_accessions"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "subjects", :template => "subrecord_subject"} %>
 

--- a/frontend/app/views/accessions/_sidebar.html.erb
+++ b/frontend/app/views/accessions/_sidebar.html.erb
@@ -9,6 +9,7 @@
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'extent', :property => 'extents') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'linked_agent', :property => 'linked_agents') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'related_resource', :property => 'related_resources') %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'component_link', :property => 'component_links') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'interrelated_accession', :property => 'related_accessions') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'subject', :property => 'subjects') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_document', :property => 'external_documents') %>

--- a/frontend/app/views/accessions/show.html.erb
+++ b/frontend/app/views/accessions/show.html.erb
@@ -57,7 +57,7 @@
           <% end %>
 
           <% readonly.emit_template("accession") %>
-          
+
           <% if @accession.lang_materials.length > 0 %>
             <%= render_aspace_partial :partial => "lang_materials/show", :locals => { :lang_materials => @accession.lang_materials, :section_id => "accession_lang_materials_" } %>
           <% end %>
@@ -76,6 +76,10 @@
 
          <% if @accession.related_resources.length > 0 %>
            <%= render_aspace_partial :partial => "related_resources/show", :locals => { :related_resources => @accession.related_resources, :section_id => "accession_related_resources_" } %>
+         <% end %>
+
+         <% if @accession.component_links.length > 0 %>
+             <%= render_aspace_partial :partial => "component_links/show", :locals => { :component_links => @accession.component_links, :section_id => "accession_component_links_" } %>
          <% end %>
 
          <% if @accession.related_accessions.length > 0 %>

--- a/frontend/app/views/archival_objects/_form_container.html.erb
+++ b/frontend/app/views/archival_objects/_form_container.html.erb
@@ -72,6 +72,7 @@
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "extents"} %>
 
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "linked_agents", :template => "archival_object_linked_agent"} %>
+  <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "accession_links", :template => "component_accession_links"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "subjects", :template => "subrecord_subject"} %>
 
   <%= render_aspace_partial :partial => "notes/form", :locals => {:form => form, :all_note_types => note_types_for(form['jsonmodel_type'])} %>

--- a/frontend/app/views/archival_objects/_show_inline.html.erb
+++ b/frontend/app/views/archival_objects/_show_inline.html.erb
@@ -50,6 +50,10 @@
           <%= render_aspace_partial :partial => "linked_agents/show", :locals => { :linked_agents => archival_object.linked_agents, :section_id => "archival_object_linked_agents_" } %>
         <% end %>
 
+        <% if archival_object.accession_links.length > 0 %>
+            <%= render_aspace_partial :partial => "accession_links/show", :locals => { :accession_links => archival_object.accession_links, :section_id => "archival_object_accession_links_" } %>
+        <% end %>
+
         <% if not archival_object.subjects.blank? %>
           <%= render_aspace_partial :partial => "subjects/show_inline", :locals => {:subjects => archival_object.subjects, :section_id => "archival_object_subjects_"} %>
         <% end %>

--- a/frontend/app/views/archival_objects/_sidebar.html.erb
+++ b/frontend/app/views/archival_objects/_sidebar.html.erb
@@ -9,6 +9,7 @@
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'date', :property => 'dates') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'extent', :property => 'extents') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'linked_agent', :property => 'linked_agents') %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'accession_link', :property => 'accession_links') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'subject', :property => 'subjects') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'note', :property => 'notes', :anchor => 'notes') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_document', :property => 'external_documents') %>

--- a/frontend/app/views/component_links/_component_linker.html.erb
+++ b/frontend/app/views/component_links/_component_linker.html.erb
@@ -1,0 +1,39 @@
+<%
+  if form.obj.empty?
+    selected_json = "{}"
+  else
+    selected_json = ASUtils.to_json(form.obj['_resolved'])
+  end
+
+  field_label ||= I18n.t("archival_object._singular")
+  linker_id ||= "component_links_"
+%>
+<div class="form-group required">
+  <label class="control-label col-sm-2"><%= field_label %></label>
+  <div class="controls col-sm-8">
+    <div class="input-group linker-wrapper">
+      <input type="text" class="linker"
+             id="<%= linker_id %>"
+             data-label="<%= I18n.t "accession.component_link" %>"
+             data-label_plural="<%= I18n.t "accession.component_links" %>"
+             data-path="<%= form.path %>"
+             data-name="ref"
+             data-url="<%= url_for :controller => :search, :action => :do_search, :format => :json %>"
+             data-browse-url="<%= url_for :controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.BASE_FACETS %>"
+             data-selected="<%= selected_json %>"
+             data-format_property="display_string"
+             data-multiplicity="one"
+             data-sortable="true"
+             data-types='["archival_object"]'
+             aria-label="Link to component"
+      />
+
+      <div class="input-group-btn">
+        <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="Link to record"><span class="caret"></span></a>
+        <ul class="dropdown-menu">
+          <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/app/views/component_links/_show.html.erb
+++ b/frontend/app/views/component_links/_show.html.erb
@@ -1,0 +1,35 @@
+<%
+   section_id = "accession_component_links" if section_id.blank?
+%>
+
+<section id="<%= section_id %>" class="subrecord-form-dummy">
+  <h3><%= I18n.t("component_link._plural") %></h3>
+
+
+  <div class="subrecord-form-container">
+    <div class="subrecord-form-fields">
+      <table class="table table-striped table-bordered table-condensed table-hover token-list">
+        <thead>
+          <tr>
+            <td><%= I18n.t("archival_object.ref_id") %></td>
+            <td><%= I18n.t("archival_object.title") %></td>
+          </tr>
+        </thead>
+        <tbody>
+          <% component_links.each_with_index do | ao, index | %>
+            <tr>
+              <td><%= ao["_resolved"]['ref_id'] %></td>
+              <td>
+                <%= render_token :object => ao["_resolved"],
+                                 :label => ao["_resolved"]["display_string"],
+                                 :type => "archival_object",
+                                 :uri => ao["ref"] %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+</section>

--- a/frontend/app/views/component_links/_template.html.erb
+++ b/frontend/app/views/component_links/_template.html.erb
@@ -1,0 +1,5 @@
+<% define_template("accession_component_links",  jsonmodel_definition(:accession)) do |form| %>
+  <div class="subrecord-form-fields">
+    <%= render_aspace_partial :partial => "component_links/component_linker", :locals => { :form => form }%>
+  </div>
+<% end %>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -708,7 +708,23 @@ en:
     linked_to_assessment: Record cannot be deleted as it is linked to an assessment
     cannot_delete_repository_agent: This agent is linked to a repository and can't be removed.
 
+  component_link:
+    _plural: Component Links
+    _singular: Component Link
+    _frontend:
+      action:
+        add: Add Component Link
+
+  accession_link:
+    _plural: Accession Links
+    _singular: Accesssion Link
+    _frontend:
+      action:
+        add: Add Accession Link
+
   accession:
+    component_link: Linked Component
+    component_links: Linked Components
     _frontend:
       messages:
         created: Accession <strong>%{accession.display_string}</strong> created

--- a/frontend/spec/features/spawning_spec.rb
+++ b/frontend/spec/features/spawning_spec.rb
@@ -40,8 +40,14 @@ describe 'Spawning', js: true do
     expect(page.evaluate_script("location.href")).to include("archival_object_id=#{@parent.id}")
     expect(find("#archival_object_title_").value()).to eq "Spawned Accession"
     find("#archival_object_level_ option[value='class']").click
+    accession_link = find(:css, "form input[name='archival_object[accession_links][0][ref]']", :visible => false)
+    expect(accession_link.value).to eq(@accession.uri)
     find(".save-changes button[type='submit']").click
     expect(find("div.indent-level-1 div.title")['title']).to eq "Parent"
     expect(find("div.indent-level-2 div.title")['title']).to eq "Spawned Accession"
+    ref_id = find(".identifier-display").text
+    visit "/accessions/#{@accession.id}"
+    linked_component_ref_id = find("#accession_component_links_ table tbody tr td:nth-child(1)").text
+    expect(linked_component_ref_id).to eq(ref_id)
   end
 end


### PR DESCRIPTION
Porting the [Accession / Component link plugin](https://github.com/hudmol/as_accession_links) into core. 

Added is the auto-population of the linked accession field when a component is spawned from an accession.