### PR TITLE
Allow the light mode toggle to appear when creating new Agents

### DIFF
--- a/frontend/app/views/shared/_toolbar_new_records.html.erb
+++ b/frontend/app/views/shared/_toolbar_new_records.html.erb
@@ -2,5 +2,12 @@
   <div class="pull-left save-changes">
     <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
   </div>
+  <% if controller_name == "agents" && full_mode? %>
+    <div class="btn-toolbar pull-right">
+      <div class="btn-group">
+        <%= render_aspace_partial :partial => "shared/lightmode_toggle", :locals => {:type => 'agents'} %>
+      </div>
+    </div>
+  <% end %>
   <br style="clear:both" />
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This simple PR causes the lightmode toggle button to appear when creating new Agent records. It does this by adding the button code to the new records toolbar, conditionally scoping it to the `agents` controller.
<!--- Why is this change required? What problem does it solve? -->
I have submitted this PR because it was a change requested by our archivists; having added it to our local plugin, they thought it likely that other institutions could make use of it too.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
N/A

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing carried out in a development environment, frontend test suite run. Identical code currently running in a plugin with no apparent issues in our production system.

## Screenshots (if appropriate):

![Screenshot from 2022-06-17 11-55-21](https://user-images.githubusercontent.com/56871330/174285137-1b44a006-a294-4289-b44d-2039a7c67033.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
