### PR TITLE
Fix digital_object enumeration value on instance_instance_type

### DIFF
--- a/common/db/migrations/160_fix_digital_object_instance_type.rb
+++ b/common/db/migrations/160_fix_digital_object_instance_type.rb
@@ -1,0 +1,38 @@
+require_relative 'utils'
+
+Sequel.migration do
+
+  up do
+    $stderr.puts("Fixing digital_object enumeration value for instance_type - make sure it's there and make it readonly")
+
+    enum_id = self[:enumeration].filter(name: 'instance_instance_type').get(:id)
+
+    if self[:enumeration_value].filter(enumeration_id: enum_id, value: 'digital_object').count == 0
+      # oops, someone deleted it - recreate it!
+      now = Time.now
+
+      pos = self[:enumeration_value].filter(enumeration_id: enum_id).max(:position) + 1
+
+      self[:enumeration_value].insert(
+                                      enumeration_id: enum_id,
+                                      value: 'digital_object',
+                                      readonly: 1,
+                                      position: pos,
+                                      json_schema_version: 1,
+                                      created_by: 'admin',
+                                      create_time: now,
+                                      system_mtime: now,
+                                      user_mtime: now
+                                      )
+    else
+      # phew it lives! - make it readonly
+      self[:enumeration_value].filter(enumeration_id: enum_id, value: 'digital_object').update(readonly: 1)
+    end
+  end
+
+
+  down do
+    # no going back
+  end
+
+end


### PR DESCRIPTION
This value is required for creating digital object instances. This commit
does two things to make this less flaky:

  - Make sure the value exists. If it doesn't then recreate it
  - Set it to readonly to stop future fluff ups
