### PR TITLE
Hide 'View Published' for published records in unpublished repositories

### DIFF
--- a/frontend/app/views/shared/_view_published_button.html.erb
+++ b/frontend/app/views/shared/_view_published_button.html.erb
@@ -1,22 +1,26 @@
 <% if record.publish %>
 
-  <% record_type = record.jsonmodel_type %>
+  <% if current_repo.publish || !record.repository %>
 
-  <div class="btn-group">
+    <% record_type = record.jsonmodel_type %>
 
-    <% if AppConfig[:use_human_readable_urls] && !record['slug'].nil? && !record['slug'].empty? %>
-      <% if ['agent_person', 'agent_family', 'agent_corporate_entity', 'agent_software'].include?(record_type) %>
-        <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], 'agents', @agent['slug']).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
-      <% elsif AppConfig[:repo_name_in_slugs] %>
-        <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], 'repositories', session[:repo_slug], "#{record_type}" + 's', record['slug']).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
+    <div class="btn-group">
+
+      <% if AppConfig[:use_human_readable_urls] && !record['slug'].nil? && !record['slug'].empty? %>
+        <% if ['agent_person', 'agent_family', 'agent_corporate_entity', 'agent_software'].include?(record_type) %>
+          <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], 'agents', @agent['slug']).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
+        <% elsif AppConfig[:repo_name_in_slugs] %>
+          <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], 'repositories', session[:repo_slug], "#{record_type}" + 's', record['slug']).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
+        <% else %>
+          <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], "#{record_type}" + 's', record['slug']).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
+        <% end %>
       <% else %>
-        <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], "#{record_type}" + 's', record['slug']).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
+        <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], record.uri).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
       <% end %>
-    <% else %>
-      <%= link_to I18n.t("actions.view_published"), File.join(AppConfig[:public_proxy_url], record.uri).to_s, :target => "_blank", :class => "btn btn-sm btn-default" %>
-    <% end %>
 
-  </div>
+    </div>
+
+  <% end %>
 
 <% end %>
 


### PR DESCRIPTION
## Description
Currently, the 'View Published' toolbar button in the staff interface is hidden for unpublished records. However, it is still visible for records (resources, archival objects, digital objects, accessions) which belong to a repository which isn't published. Clicking the button in such cases returns a 404 page, as it should, but the presence of the button could make people incorrectly think they are published. It is a minor issue, but can cause confusion, if using an unpublished repository as a staging area.

This change fixes that, by adding a new condition that must be met for the button to be displayed:
```
if current_repo.publish || !record.repository
```
The second clause is needed to allow global records (e.g. agents) that don't belong to the repository the staff user has currently activated to be previewed.

## Related JIRA Ticket or GitHub Issue
None

## How Has This Been Tested?
On development system (and in a local plug-in on a production system.)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
