### PR TITLE
ANW-28, ANW-949: Staff print styles

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace.less
+++ b/frontend/app/assets/stylesheets/archivesspace.less
@@ -35,3 +35,5 @@
 @import 'css-spinners/spinner';
 @import 'bootstrap-select/bootstrap-select';
 @import 'tablesorter/bootstrap';
+
+@import 'archivesspace/print';

--- a/frontend/app/assets/stylesheets/archivesspace/print.less
+++ b/frontend/app/assets/stylesheets/archivesspace/print.less
@@ -1,0 +1,176 @@
+@media print {
+  * {
+    margin-top: 0 !important;
+    margin-bottom: 2pt !important;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+  }
+
+  body {
+    font-size: 10pt !important;
+  }
+
+  h1 {
+    font-size: 1.3em !important;
+  }
+
+  h2 {
+    font-size: 1.2em !important;
+  }
+
+  h3 {
+    font-size: 1.1em !important;
+  }
+
+  h4 {
+    font-size: 1em !important;
+  }
+
+  h5 {
+    font-size: 0.9em !important;
+  }
+
+  h6 {
+    font-size: 0.8em !important;
+  }
+
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin-top: 10pt !important;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    break-after: avoid !important;
+  }
+
+  figure,
+  img,
+  ul {
+    break-inside: avoid !important;
+  }
+
+  header,
+  .breadcrumb-row,
+  #archivesSpaceSidebar,
+  .record-toolbar,
+  .panel-default .panel-heading,
+  #accession_classifications_,
+  .sidebar,
+  .actions,
+  .table-record-actions,
+  #linked_assessments > h3 > a.btn,
+  footer {
+    display: none !important;
+  }
+
+  .container-fluid {
+    padding-right: 0 !important;
+    padding-left: 0 !important;
+  }
+
+  .row {
+    margin-right: 0 !important;
+    margin-left: 0 !important;
+  }
+
+  .row > .col-xs-1,
+  .row > .col-sm-1,
+  .row > .col-md-1,
+  .row > .col-lg-1,
+  .row > .col-xs-2,
+  .row > .col-sm-2,
+  .row > .col-md-2,
+  .row > .col-lg-2,
+  .row > .col-xs-3,
+  .row > .col-sm-3,
+  .row > .col-md-3,
+  .row > .col-lg-3,
+  .row > .col-xs-4,
+  .row > .col-sm-4,
+  .row > .col-md-4,
+  .row > .col-lg-4,
+  .row > .col-xs-5,
+  .row > .col-sm-5,
+  .row > .col-md-5,
+  .row > .col-lg-5,
+  .row > .col-xs-6,
+  .row > .col-sm-6,
+  .row > .col-md-6,
+  .row > .col-lg-6,
+  .row > .col-xs-7,
+  .row > .col-sm-7,
+  .row > .col-md-7,
+  .row > .col-lg-7,
+  .row > .col-xs-8,
+  .row > .col-sm-8,
+  .row > .col-md-8,
+  .row > .col-lg-8,
+  .row > .col-xs-9,
+  .row > .col-sm-9,
+  .row > .col-md-9,
+  .row > .col-lg-9,
+  .row > .col-xs-10,
+  .row > .col-sm-10,
+  .row > .col-md-10,
+  .row > .col-lg-10,
+  .row > .col-xs-11,
+  .row > .col-sm-11,
+  .row > .col-md-11,
+  .row > .col-lg-11,
+  .row > .col-xs-12,
+  .row > .col-sm-12,
+  .row > .col-md-12,
+  .row > .col-lg-12 {
+    padding-right: 0 !important;
+    padding-left: 0 !important;
+  }
+
+  .subrecord-form-list,
+  .subrecord-form-dummy,
+  .subrecord-form {
+    padding: 0 !important;
+    margin: 0 !important;
+  }
+
+  .collapse {
+    display: block;
+    width: 100%;
+    visibility: visible;
+  }
+
+  label,
+  .form-group > .control-label {
+    float: left;
+    font-weight: bold;
+  }
+
+  label::after,
+  .form-group > .control-label::after {
+    content: ':';
+  }
+
+  .label-only {
+    float: left;
+  }
+
+  .token,
+  li.token-input-token {
+    border-color: #000;
+  }
+
+  .print-hide {
+    display: none !important;
+  }
+
+  @page {
+    margin: 1cm;
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR closes [ANW-28](https://archivesspace.atlassian.net/browse/ANW-28) and [ANW-949](https://archivesspace.atlassian.net/browse/ANW-949) by adding a print stylesheet for the staff interface.

Screenshots  of PDFs printed from Firefox at 100% scale, not stretched to fit width, then converted to JPG:

![ANW-28-1](https://user-images.githubusercontent.com/3411019/175783109-1ee19e7e-606f-4e10-8f6a-09688b58774b.jpeg)

![ANW-28-2](https://user-images.githubusercontent.com/3411019/175783112-195479d4-f96a-4c5d-a14e-e6fdea5df249.jpeg)

![ANW-28-3](https://user-images.githubusercontent.com/3411019/175783115-8b18c37b-8619-4353-901a-d6114531f824.jpeg)
