### PR TITLE
ANW-1409: add support for importing $q in 111, 611 and 711 marc tags as qualifier

### DIFF
--- a/backend/app/converters/lib/marcxml_bib_base_map.rb
+++ b/backend/app/converters/lib/marcxml_bib_base_map.rb
@@ -378,7 +378,7 @@ module MarcXMLBibBaseMap
             "subfield[@code='e'][1]" => trim('subordinate_name_2', '.'),
             "subfield[@code='e'][2]" => appends_subordinate_name_2,
             "subfield[@code='e'][3]" => appends_subordinate_name_2,
-            "subfield[@code='q']" => adds_prefixed_qualifier(trim('qualifier', '.'))
+            "subfield[@code='q']" => trim('qualifier', '.')
           },
         }
       }

--- a/backend/app/converters/lib/marcxml_bib_base_map.rb
+++ b/backend/app/converters/lib/marcxml_bib_base_map.rb
@@ -378,6 +378,7 @@ module MarcXMLBibBaseMap
             "subfield[@code='e'][1]" => trim('subordinate_name_2', '.'),
             "subfield[@code='e'][2]" => appends_subordinate_name_2,
             "subfield[@code='e'][3]" => appends_subordinate_name_2,
+            "subfield[@code='q']" => adds_prefixed_qualifier(trim('qualifier', '.'))
           },
         }
       }

--- a/backend/spec/examples/marc/at-tracer-marc-1.xml
+++ b/backend/spec/examples/marc/at-tracer-marc-1.xml
@@ -237,6 +237,10 @@ Here is an example of a wrap-in tag using ref, targeting the Abstract note in th
             <subfield code="a">Subjects--Function-AT</subfield>
             <subfield code="2">Local sources</subfield>
         </datafield>
+        <datafield tag="711" ind2=" " ind1="3">
+            <subfield code="a">Corp Name</subfield>
+            <subfield code="q">Qualifier</subfield>
+        </datafield>
         <datafield tag="700" ind2=" " ind1="3">
             <subfield code="a">FNames-FamilyName-AT</subfield>
             <subfield code="c">FNames-Prefix-AT</subfield>

--- a/backend/spec/lib_marcxml_bib_converter_spec.rb
+++ b/backend/spec/lib_marcxml_bib_converter_spec.rb
@@ -228,11 +228,11 @@ describe 'MARCXML Bib converter' do
       end
 
       it "maps datafield[@tag='110' or @tag='610' or @tag='710'] to agent_corporate_entity" do
-        expect(@corps.count).to eq(4)
+        expect(@corps.count).to eq(5)
       end
 
       it "maps datafield[@tag='110' or @tag='610' or @tag='710'] to agent_corporate_entity with source 'ingest'" do
-        expect(@corps.select {|f| f['names'][0]['source'] == 'ingest'}.count).to eq(3)
+        expect(@corps.select {|f| f['names'][0]['source'] == 'ingest'}.count).to eq(4)
       end
 
       it "maps datafield[@tag='610']/subfield[@code='2'] to agent_corporate_entity.names[].source" do
@@ -246,7 +246,7 @@ describe 'MARCXML Bib converter' do
 
       it "maps datafield[@tag='110'][subfield[@code='e']='Creator (cre)'] and datafield[@tag='710'][subfield[@code='e']='source'] or no $e/$4 to agent_corporate_entity linked as 'creator'" do
         links = @resource['linked_agents'].select {|a| @corps.map {|c| c['uri']}.include?(a['ref'])}
-        expect(links.select {|l| l['role'] == 'creator'}.count).to eq(3)
+        expect(links.select {|l| l['role'] == 'creator'}.count).to eq(4)
       end
 
       it "maps datafield[@tag='610' or @tag='110' or @tag='710']/subfield[@tag='a'] to agent_corporate_entity.names[].primary_name" do
@@ -383,6 +383,17 @@ describe 'MARCXML Bib converter' do
         expect(s.last['terms'][0]['term_type']).to eq('topical')
         expect(s.count).to eq(1)
         expect(s.last['source']).to eq('Local sources')
+      end
+
+      it "maps datafield[@tag='711'] $q to qualifier" do
+        has_qualifier = 0
+        @corps.each do |corp|
+          corp['names'].each do |name|
+            has_qualifier += 1 if name['qualifier'] == "Qualifier"
+          end
+        end
+
+        expect(has_qualifier).to eq(1)
       end
     end
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
add support for importing $q in 111, 611 and 711 marc tags as qualifier

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1409


## How Has This Been Tested?
manual and unit testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
