### PR TITLE
Fixes ANW-1550 - replaces broken XMLCleaner with Nokogiri PushParser

### DIFF
--- a/public/app/lib/xml_cleaner.rb
+++ b/public/app/lib/xml_cleaner.rb
@@ -1,117 +1,44 @@
-class XMLCleaner
-
-  # To ensure we make progress, we'll attempt to fix up to this many errors
-  # before giving up.
-  MAX_ITERATIONS = 10000
-
-  def initialize
-    @log = Rails.logger
+# Document class used to process (potentially flawed) HTML on its way to becoming PDFs
+# handles character entities and namespaces
+class XMLCleaner < Nokogiri::XML::SAX::Document
+  attr_accessor :file
+  def initialize(file)
+    @file = file
   end
 
-  def clean(file_path)
-    factory = javax.xml.parsers.DocumentBuilderFactory.new_instance
-    factory.setValidating(true)
-    factory.setNamespaceAware(true)
-
-    builder = factory.new_document_builder
-    builder.setErrorHandler(NamespaceCorrectingErrorHandler.new(file_path))
-
-    attempt = 0
-    begin
-      attempt += 1
-      replace_html_entities(file_path)
-      builder.parse(java.io.File.new(file_path))
-    rescue NamespaceCorrectingErrorHandler::RetryParse
-      if attempt >= MAX_ITERATIONS
-        raise "Maximum error count (#{attempt}) exceeded for this document.  Giving up!"
-      else
-        @log.info("Corrected error in XML markup.  Parsing again (attempt: #{attempt}).")
-        retry
-      end
-    rescue
-      raise "Failed to clean XML: #{$!}"
-    end
+  # gsub out all potentially problematic chars with entity references
+  def entity_gsub!(chars)
+    mapping = {
+      '&' => '&amp;',
+      '<' => '&lt;',
+      '>' => '&gt;',
+      '"' => '&quot;',
+      "'" => '&apos;'
+    }
+    re = /&(?!amp;)|[<>'"]/
+    chars.gsub!(re, mapping)
+    chars
   end
 
-  # Decode HTML entities so they can be parsed as XML
-  def replace_html_entities(file_path)
-    File.open(file_path + ".tmp", "w") do |outfile|
-      File.open(file_path) do |infile|
-        infile.each_with_index do |line, index|
-          # The decode() method used below turns the five predefined XML entities into unescaped characters. That can
-          # create non-well-formed XHTML, which will break PDF generation, so first replace them with something that
-          # can be converted back safely afterwards.
-          line.gsub!(/&(amp|lt|gt|quot|apos);/, '~~\1~~')
-          line = HTMLEntities.new.decode(line)
-          line.gsub!(/~~(amp|lt|gt|quot|apos)~~/, '&\1;')
-          outfile.puts(line)
-        end
+
+  def start_element_namespace(name, attrs=[], prefix=nil, uri=nil, ns=[])
+    return if name == 'ridiculous_wrapper_element'
+    @file << "<#{name}"
+    unless attrs.empty?
+      attrs.each do |attr|
+        @file << " #{attr.localname}=\"#{entity_gsub!(attr.value)}\""
       end
     end
-    File.rename(file_path + ".tmp", file_path)
+    @file << '>'
   end
 
-  # An error handler that rewrites the underlying XML to resolve missing
-  # namespace errors.
-  class NamespaceCorrectingErrorHandler
+  def characters(chars)
+    @file << entity_gsub!(chars)
+  end
 
-    # Thrown to signal we can try parsing again
-    class RetryParse < StandardError; end
-
-    def initialize(file_path)
-      @file_path = file_path
-    end
-
-    def fatal_error(exception)
-      if exception.getMessage =~ /The prefix "(.*)" for .*? "(\1:.*?)".* is not bound./ &&
-         exception.line_number &&
-         exception.column_number
-
-        # Caused by an undefined namespace such as `ns2:href`.  We can correct these
-        element_to_fix = $2
-        remove_namespace_prefix!(element_to_fix, exception.line_number, exception.column_number)
-
-        raise RetryParse.new
-      else
-        raise exception
-      end
-    end
-
-    def method_missing(*)
-      # All other errors are ignored
-    end
-
-    private
-
-    def remove_namespace_prefix!(element_to_fix, lineno, colno)
-      File.open(@file_path + ".tmp", "w") do |outfile|
-        File.open(@file_path) do |infile|
-          infile.each_with_index do |line, index|
-            if index == (lineno - 1)
-              line = fix_line(line, element_to_fix, colno)
-            end
-
-            outfile.puts(line)
-          end
-        end
-      end
-
-      File.rename(@file_path + ".tmp", @file_path)
-    end
-
-    def fix_line(line, element_to_fix, colno)
-      # Annoyingly, `collno` seems to point past the place that the error
-      # actually happened, so we can't pinpoint the exact position to fix.
-      # We'll just hope that valid text doesn't actually look like a namespace
-
-      prefix, rest = element_to_fix.scan(/\A(.*?):(.*)\z/)[0]
-
-      if prefix && rest
-        line.gsub(element_to_fix, rest)
-      else
-        raise "Unexpected error while cleaning XML document: expected to find '#{element_to_fix}' in line #{line} but could not"
-      end
-    end
+  def end_element_namespace(name, prefix= nil, uri=nil)
+    return if name == 'ridiculous_wrapper_element'
+    @file << '</' << name << '>'
   end
 
 end

--- a/public/app/lib/xml_cleaner.rb
+++ b/public/app/lib/xml_cleaner.rb
@@ -2,6 +2,7 @@
 # handles character entities and namespaces
 class XMLCleaner < Nokogiri::XML::SAX::Document
   attr_accessor :file
+
   def initialize(file)
     @file = file
   end

--- a/public/app/models/finding_aid_pdf.rb
+++ b/public/app/models/finding_aid_pdf.rb
@@ -46,9 +46,12 @@ class FindingAidPDF
     has_children = @ordered_records.entries.length > 1
 
     out_html = Tempfile.new
-    out_html.write(renderer.render_to_string partial: 'header', layout: false, :locals => {:record => @resource})
 
-    out_html.write(renderer.render_to_string partial: 'titlepage', layout: false, :locals => {:record => @resource})
+    # Use a NokogiriPushParser-based
+    writer = Nokogiri::XML::SAX::PushParser.new(XMLCleaner.new(out_html))
+    writer.write(renderer.render_to_string partial: 'header', layout: false, :locals => {:record => @resource})
+
+    writer.write(renderer.render_to_string partial: 'titlepage', layout: false, :locals => {:record => @resource})
 
     # Drop the resource and filter the AOs
     toc_aos = @ordered_records.entries.drop(1).select {|entry|
@@ -61,9 +64,9 @@ class FindingAidPDF
       end
     }
 
-    out_html.write(renderer.render_to_string partial: 'toc', layout: false, :locals => {:resource => @resource, :has_children => has_children, :ordered_aos => toc_aos})
+    writer.write(renderer.render_to_string partial: 'toc', layout: false, :locals => {:resource => @resource, :has_children => has_children, :ordered_aos => toc_aos})
 
-    out_html.write(renderer.render_to_string partial: 'resource', layout: false, :locals => {:record => @resource, :has_children => has_children})
+    writer.write(renderer.render_to_string partial: 'resource', layout: false, :locals => {:record => @resource, :has_children => has_children})
 
     page_size = 50
 
@@ -78,11 +81,11 @@ class FindingAidPDF
       record_set.zip(entry_set).each do |record, entry|
         next unless record.is_a?(ArchivalObject)
 
-        out_html.write(renderer.render_to_string partial: 'archival_object', layout: false, :locals => {:record => record, :level => entry.depth})
+        writer.write(renderer.render_to_string partial: 'archival_object', layout: false, :locals => {:record => record, :level => entry.depth})
       end
     end
 
-    out_html.write(renderer.render_to_string partial: 'footer', layout: false, :locals => {:record => @resource})
+    writer.write(renderer.render_to_string partial: 'footer', layout: false, :locals => {:record => @resource})
     out_html.close
 
     out_html
@@ -90,8 +93,6 @@ class FindingAidPDF
 
   def generate
     out_html = source_file
-
-    XMLCleaner.new.clean(out_html.path)
 
     pdf_file = Tempfile.new
     pdf_file.close


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The existing code, which is run per PDF finding aid generation on the
PUI, will run up to 10,000 times before failing in the face of invalid
XML with an error it doesn't understand, which is most XML errors.
This can take tens of minutes or more on large XML output.

The replacement code fixes all the same issues, and will fail early
and gracefully on the XML issues the previous code groveled over.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1550

## How Has This Been Tested?
Run in production on Harvard's instance for lo these many fortnights now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
