### PR TITLE
Assessment View Delete Button Visibility

### DIFF
--- a/frontend/app/views/assessments/_toolbar.html.erb
+++ b/frontend/app/views/assessments/_toolbar.html.erb
@@ -5,14 +5,15 @@
         <%= link_to I18n.t("actions.edit"), {:controller => :assessments, :action => :edit, :id => @assessment.id}, :class => "btn btn-sm btn-primary" %>
       </div>
     <% end %>
-
-    <div class="btn-toolbar pull-right">
-      <div class="btn-group">
-        <div class="btn btn-inline-form">
-          <%= button_delete_action url_for(:controller => :assessments, :action => :delete, :id => @assessment.id), { :"data-title" => I18n.t("actions.delete_confirm_title", :title => @assessment.display_string) } %>
+    <% if user_can?('delete_assessment_record') %>
+      <div class="btn-toolbar pull-right">
+        <div class="btn-group">
+          <div class="btn btn-inline-form">
+            <%= button_delete_action url_for(:controller => :assessments, :action => :delete, :id => @assessment.id), { :"data-title" => I18n.t("actions.delete_confirm_title", :title => @assessment.display_string) } %>
+          </div>
         </div>
       </div>
-    </div>
+    <% end %>
     <div class="clearfix"></div>
   </div>
 <% end %>


### PR DESCRIPTION
Fixes visibility of delete button on assessment views for users without delete permission

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Minor change to view for below issue.
<!--- Why is this change required? What problem does it solve? -->
The delete button on the assessment edit/view was visible to users without the correct permissions (delete_assessment_record)

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manual testing in local dev instance
<!--- Include details of your testing environment, and the tests you ran to -->
Mac O/S running the packaged docker containers with dev db.
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
