### PR TITLE
ANW-1564 further refactoring of admin-defined subrecord requirements

### DIFF
--- a/backend/spec/controller_required_fields_spec.rb
+++ b/backend/spec/controller_required_fields_spec.rb
@@ -1,0 +1,35 @@
+require_relative 'spec_helper'
+require_relative 'spec_slugs_helper'
+
+describe 'Required Fields' do
+
+  it "lets you post and fetch a requirements definition for a repository and record type" do
+   uri = "/repositories/#{$repo_id}/required_fields/agent_person"
+   url = URI("#{JSONModel::HTTP.backend_url}#{uri}")
+   required_fields = JSONModel(:required_fields).from_hash(
+     {
+       repo_id: $repo_id,
+       record_type: "agent_person",
+       subrecord_requirements: [
+         {
+           record_type: "metadata_rights_declaration",
+           property: "metadata_rights_declarations",
+           required: true,
+           required_fields: ["xlink_title_attribute", "xlink_role_attribute"]
+         }
+       ]
+     })
+   response = JSONModel::HTTP.post_json(url, ASUtils.to_json(required_fields))
+   expect(response.status).to eq(200)
+   required_fields = JSONModel(:required_fields).fetch(uri)
+
+    # requirements apply to this type of subrecord
+   expect(required_fields["subrecord_requirements"].first["record_type"]).to eq("metadata_rights_declaration")
+    # when it is occupying this property on the top-level record
+   expect(required_fields["subrecord_requirements"].first["property"]).to eq("metadata_rights_declarations")
+    # the top-level record requires that subrecords of this type have these fields
+   expect(required_fields["subrecord_requirements"].first["required_fields"]).to eq(["xlink_title_attribute", "xlink_role_attribute"])
+    # at least one subrecord is required
+   expect(required_fields["subrecord_requirements"].first["required"]).to be true
+ end
+end

--- a/common/db/migrations/164_refactor_required_fields.rb
+++ b/common/db/migrations/164_refactor_required_fields.rb
@@ -1,0 +1,31 @@
+require_relative 'utils'
+require 'json'
+
+def convert_blob(old_blob, record_type)
+  new_blob = {'lock_version' => 1}
+  new_blob['record_type'] = record_type
+  new_blob['subrecord_requirements'] = []
+  old_blob.each do |property, defn|
+    next unless defn.is_a?(Array)
+    sr = {'property' => property}
+    defn.each do |requirement|
+      requirement.each do |field, value|
+        next unless value == "REQ"
+        sr['required_fields'] ||= []
+        sr['required_fields'] << field
+      end
+    end
+    new_blob['subrecord_requirements'] << sr
+  end
+  new_blob
+end
+
+Sequel.migration do
+  up do
+    self[:required_fields].each do |row|
+      old_required_blob = JSON.parse(row[:blob])
+      new_blob = convert_blob(old_required_blob['required'], row[:record_type])
+      self[:required_fields].filter(:id => row[:id]).update(:blob => blobify(self, JSON.generate(new_blob)))
+    end
+  end
+end

--- a/common/jsonmodel_client.rb
+++ b/common/jsonmodel_client.rb
@@ -185,8 +185,12 @@ module JSONModel
 
       if response.is_a?(Net::HTTPSuccess) || response.code == '200'
         ASUtils.json_parse(response.body)
+      elsif response.code == '403'
+        raise AccessDeniedException.new
+      elsif response.code == '404'
+        raise RecordNotFound.new
       else
-        nil
+        raise response.body
       end
     end
 
@@ -491,6 +495,10 @@ module JSONModel
         end
       end
 
+      def fetch(uri)
+        hash = JSONModel::HTTP.get_json(uri)
+        self.new(hash)
+      end
     end
 
 

--- a/common/schemas/required_fields.rb
+++ b/common/schemas/required_fields.rb
@@ -7,7 +7,10 @@
     "properties" => {
       "uri" => {"type" => "string", "required" => false},
       "record_type" => {"type" => "string", "ifmissing" => "error", "enum" => ['archival_object', 'digital_object_component', 'resource', 'accession', 'subject', 'digital_object', 'agent_person', 'agent_family', 'agent_software', 'agent_corporate_entity', 'event', 'location', 'classification', 'classification_term']},
-      "required" => {"type" => "object"},
+      "subrecord_requirements" => {
+        "type" => "array",
+        "items" => {"type" => "JSONModel(:subrecord_requirement) object"},
+      },
     },
   },
 }

--- a/common/schemas/subrecord_requirement.rb
+++ b/common/schemas/subrecord_requirement.rb
@@ -1,0 +1,21 @@
+{
+  :schema => {
+    "$schema" => "http://www.archivesspace.org/archivesspace.json",
+    "version" => 1,
+    "type" => "object",
+    "properties" => {
+      "property" => {
+        "type" => "string",
+        "ifmissing" => "error"
+      },
+      "record_type" => {
+        "type" => "string"
+      },
+      "required_fields" => {
+        "type" => "array",
+        "items" => {"type" => "string"},
+      },
+      "required" => {"type" => "boolean", "default" => false}
+    },
+  },
+}

--- a/common/spec/lib/factory_bot_helpers.rb
+++ b/common/spec/lib/factory_bot_helpers.rb
@@ -1262,11 +1262,6 @@ FactoryBot.define do
     country { 'US' }
   end
 
-  factory :json_required_fields, class: JSONModel(:required_fields) do
-    record_type { ['archival_object', 'digital_object_component', 'resource', 'accession', 'subject', 'digital_object', 'agent_person', 'agent_family', 'agent_software', 'agent_corporate_entity', 'event', 'location', 'classification', 'classification_term'].sample }
-    required {}
-  end
-
   factory :json_resource_ordered_records, class: JSONModel(:resource_ordered_records) do
     uris { [{
       'ref' => create(:json_resource).uri
@@ -1735,5 +1730,17 @@ FactoryBot.define do
   factory :json_sub_list_job, class: JSONModel(:report_job) do
     report_type { 'SubjectListReport' }
     format { 'json' }
+  end
+
+  factory :json_subrecord_requirement, class: JSONModel(:subrecord_requirement) do
+    property { 'metadata_rights_declarations' }
+    record_type { 'metadata_rights_declaration' }
+    required_fields { %w(descriptive_note) }
+    required { true }
+  end
+
+  factory :json_required_fields, class: JSONModel(:required_fields) do
+    record_type { 'archival_object' }
+    subrecord_requirements { build(:json_subrecord_requirement) }
   end
 end

--- a/frontend/app/helpers/aspace_form_helper.rb
+++ b/frontend/app/helpers/aspace_form_helper.rb
@@ -737,6 +737,17 @@ module AspaceFormHelper
         required = required?(name)
       end
 
+      # additional admin-defined requirements
+      unless required || @required_fields.nil?
+        type = @record_type || @context.last[1]["jsonmodel_type"]
+        # ideally we would send along the property as well,
+        # and be really sure that this field is required on
+        # this type of record in such and such context. A possible
+        # refactor would be to have all or some of  the marking up
+        # of required fields happen on demand (in JavaScript).
+        required = @required_fields.required?(nil, type, name)
+      end
+
       control_group_classes << "required" if required == true
 
       control_group_classes << "conditionally-required" if required == :conditionally
@@ -750,7 +761,6 @@ module AspaceFormHelper
 
       # ANW-429: add JS classes to structured date fields
       control_group_classes << "js-structured_date_select" if name == "date_type_structured"
-
 
       controls_classes << "#{opts[:controls_class]}" if opts.has_key? :controls_class
 
@@ -982,6 +992,15 @@ module AspaceFormHelper
 
     env = self.request.env
     env['form_context_depth'] ||= 0
+    context.instance_variable_set(:@form_context_depth, env['form_context_depth'])
+    # Only fetch required values at the top-level
+    if env['form_context_depth'] == 0
+      begin
+        required_fields = RequiredFields.get(values_from.jsonmodel_type)
+        context.instance_variable_set(:@required_fields, required_fields)
+      rescue
+      end
+    end
 
     s = "<div class=\"form-context\" id=\"form_#{name}\">".html_safe
     s << context.hidden_input("lock_version", values_from["lock_version"])
@@ -1014,6 +1033,10 @@ module AspaceFormHelper
   class BaseDefinition
     def required?(name)
       false
+    end
+
+    def record_type
+      nil
     end
   end
 
@@ -1096,6 +1119,9 @@ module AspaceFormHelper
       options
     end
 
+    def record_type
+      @jsonmodel.record_type
+    end
 
     private
 
@@ -1141,12 +1167,16 @@ module AspaceFormHelper
 
   end
 
-
+  # we expect the template to be defined in a view context
+  # that will have the @required_fields object if applicable.
+  # We add it to the template hash because the object will
+  # be out of scope when the JS templates are emitted.
   def define_template(name, definition = nil, &block)
     @templates ||= {}
     @templates[name] = {
       :block => block,
       :definition => (definition || BaseDefinition.new),
+      :requirements => @required_fields
     }
   end
 
@@ -1162,7 +1192,6 @@ module AspaceFormHelper
 
     templates_to_process = @templates.clone
     templates_processed = []
-
     # As processing a template may register further templates that hadn't been
     # registered previously, keep looping until we have no more templates to
     # process.
@@ -1182,6 +1211,8 @@ module AspaceFormHelper
 
         context.instance_eval do
           @active_template = name
+          @record_type = template[:definition].record_type
+          @required_fields = template[:requirements]
         end
 
         result << "<div id=\"template_#{name}\"><!--"
@@ -1297,22 +1328,6 @@ module AspaceFormHelper
     {
       :"data-form-errors" => (exceptions && exceptions.keys[0])
     }
-  end
-
-  # ANW-429: returns true if an admin has specified field_name as a custom require in record_name.
-  # This code is run inside the templates to ensure that these fields are required no matter how many copies of record_name are added to a form.
-  # required_values is generally queried from the DB once in the controller, and then passed in here from the view preventing multiple queries.
-  def is_required_by_admin?(required_values, record_name, field_name)
-    return false if required_values == [] || required_values.nil? || required_values[record_name].nil?
-
-    # need to call #first because it's possible to specify requires for multiple subrecords, so required_values[record_name] contains an array of hashes.
-    required_list_for_record = required_values[record_name].first
-
-    if required_list_for_record
-      required_list_for_record[field_name] == "REQ"
-    else
-      false
-    end
   end
 
   def custom_report_template_limit_options

--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -326,7 +326,13 @@ module SearchHelper
   end
 
   def get_ancestor_title(field)
-    field_json = JSONModel::HTTP.get_json(field)
+    begin
+      field_json = JSONModel::HTTP.get_json(field)
+    # one record might be "found in" another that is suppressed
+    # so we will just ignore the error.
+    rescue RecordNotFound
+      return nil
+    end
     unless field_json.nil?
       if field.include?('resources') || field.include?('digital_objects')
         clean_mixed_content(field_json['title'])
@@ -409,7 +415,7 @@ module SearchHelper
       @sort_by
     end
 
-
+    # let's rename this method?
     def class
       @classes << " sortable" if sortable?
       @classes << " sort-#{@search_data.current_sort_direction}" if sortable? && @search_data.sorted_by === @sort_by

--- a/frontend/app/models/required_fields.rb
+++ b/frontend/app/models/required_fields.rb
@@ -2,38 +2,25 @@ class RequiredFields
 
   def self.get(record_type)
     uri = "/repositories/#{JSONModel.repository}/required_fields/#{record_type}"
-    result = JSONModel::HTTP.get_json(uri)
-    if result
+    begin
+      result = JSONModel::HTTP.get_json(uri)
       self.new(JSONModel(:required_fields).from_hash(result))
-    else
+    rescue RecordNotFound => e
       self.new(JSONModel(:required_fields).from_hash(record_type: record_type))
     end
   end
-
 
   def self.from_hash(hash)
     self.new(JSONModel(:required_fields).from_hash(hash))
   end
 
-
   def initialize(json)
-    json.required ||= {}
     @json = json
   end
 
-
-  # We kind of cheat here: the form thinks 'lock_version' applies
-  # to the archival record, but it's really for the required_fields
-  # object
-  def form_values
-    values.merge({:lock_version => @json.lock_version})
+  def method_missing(meth, *args)
+    @json.send(meth, *args)
   end
-
-  # confusing to return a hash from :values method in ruby
-  def values
-    @json.required || {}
-  end
-
 
   def save
     uri = "/repositories/#{JSONModel.repository}/required_fields/#{@json.record_type}"
@@ -48,13 +35,59 @@ class RequiredFields
     response
   end
 
+  # this is limited to checking for subrecord presence and checking presence of fields
+  # of subrecords that are immediately attached to a property of the top-level record
+  # as an array, but could be expanded to cover other parts of the record
+  def add_errors(obj)
+    unless obj.jsonmodel_type == @json.record_type
+      raise "Cannot validate a #{obj.jsonmodel_type} with these #{@json.record_type} requirements!"
+    end
+    @json.subrecord_requirements.each do |requirements|
+      property = requirements["property"]
+      type = requirements["record_type"]
+
+      # see comment below
+      if obj[property].present?
+        obj[property].each_with_index do |subrecord, i|
+          next unless subrecord.is_a?(Hash)
+          next if subrecord['jsonmodel_type'] && subrecord['jsonmodel_type'].to_s != requirements['record_type']
+          requirements['required_fields'].each do |required_field|
+            unless subrecord[required_field].present?
+              obj.add_error("#{property}/#{i}/#{required_field}", :missing_required_property)
+            end
+          end
+        end
+      elsif requirements["required"]
+        obj.add_error(property, :missing_required_subrecord)
+      end
+    end
+  end
+
+  # Ideally a subrecord field requirement should probably involve:
+  #  1) a property of the parent schema;
+  #  2) the type of subrecord;
+  #  3) the field name
+  # But since form data carried through an invalid create attempt is missing #2,
+  # and javascript templates lack #1, and furthermore migrated requirements don't
+  # have record types; and since in practice there is generally
+  # only one model type that will satisfy a property (e.g.,
+  # "metadata_rights_declarations / metadata_rights_declaration"), we
+  # will accept nil for either property or type (on either side for type),
+  # and assume it's a match. caveat validator.
   def required?(property, type, field = nil)
-    if field.nil?
-      @json.required.has_key?(property) && @json.required[property].any? { |hash| hash["jsonmodel_type"] == type.to_s }
-    else
-      @json.required.has_key?(property) && @json.required[property].any? {
-        |hash| hash.has_key?(field) && (hash[field] == "REQ" || hash[field] == type.to_s)
-      }
+    @json.subrecord_requirements.each do |requirements|
+      next unless type.nil? || requirements['record_type'].nil? || requirements['record_type'] == type.to_s
+      next unless property.nil? || requirements['property'] == property.to_s
+      return true if property && type && field.nil? && requirements['required']
+      return true if requirements['required_fields'].include?(field.to_s) && field.present?
+    end
+    false
+  end
+
+  def each_required_subrecord
+    @json.subrecord_requirements.each do |requirements|
+      next unless requirements['required']
+      yield requirements['property'], { 'jsonmodel_type' => requirements['record_type'] }
     end
   end
 end

--- a/frontend/app/views/agent_alternate_sets/_template.html.erb
+++ b/frontend/app/views/agent_alternate_sets/_template.html.erb
@@ -1,42 +1,31 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "agent_alternate_set", jsonmodel_definition(:agent_alternate_set) do |form| %>
   <div class="subrecord-form-fields">
     <div class="agent-record-control-container">
-      <%= form.label_and_textfield "set_component",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_alternate_sets", "set_component") }%>
+      <%= form.label_and_textfield "set_component",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textarea "descriptive_note",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_alternate_sets", "descriptive_note") }%>
+      <%= form.label_and_textarea "descriptive_note",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textfield "file_uri",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_alternate_sets", "file_uri") }%>
+      <%= form.label_and_textfield "file_uri",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_select "file_version_xlink_actuate_attribute", 
-        [""] + form.possible_options_for("file_version_xlink_actuate_attribute", false),
-        :required => is_required_by_admin?(r, "agent_alternate_sets", "file_version_xlink_actuate_attribute") %>
+      <%= form.label_and_select "file_version_xlink_actuate_attribute",
+        [""] + form.possible_options_for("file_version_xlink_actuate_attribute", false) %>
 
-      <%= form.label_and_select "file_version_xlink_show_attribute", 
-        [""] + form.possible_options_for("file_version_xlink_show_attribute", false),
-        :required => is_required_by_admin?(r, "agent_alternate_sets", "file_version_xlink_show_attribute") %>
+      <%= form.label_and_select "file_version_xlink_show_attribute",
+        [""] + form.possible_options_for("file_version_xlink_show_attribute", false) %>
 
-      <%= form.label_and_textfield "xlink_title_attribute",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_alternate_sets", "xlink_title_attribute") }%>
+      <%= form.label_and_textfield "xlink_title_attribute",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textfield "xlink_role_attribute",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_alternate_sets", "xlink_role_attribute") }%>
+      <%= form.label_and_textfield "xlink_role_attribute",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textfield "xlink_arcrole_attribute",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_alternate_sets", "xlink_arcrole_attribute") }%>
+      <%= form.label_and_textfield "xlink_arcrole_attribute",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_date "last_verified_date",
-      :required => is_required_by_admin?(r, "agent_alternate_sets", "last_verified_date") %>
+      <%= form.label_and_date "last_verified_date" %>
     </div>
   </div>
 <% end %>

--- a/frontend/app/views/agent_conventions_declarations/_template.html.erb
+++ b/frontend/app/views/agent_conventions_declarations/_template.html.erb
@@ -1,44 +1,33 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "agent_conventions_declaration", jsonmodel_definition(:agent_conventions_declaration) do |form| %>
   <div class="subrecord-form-fields">
     <div class="agent-record-control-container">
       <%= form.label_and_select "name_rule", [""] + form.possible_options_for("name_rule", false) %>
 
-      <%= form.label_and_textfield "citation",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_conventions_declarations", "citation") }%>
+      <%= form.label_and_textfield "citation",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textarea "descriptive_note",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_conventions_declarations", "descriptive_note") }%>
+      <%= form.label_and_textarea "descriptive_note",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textfield "file_uri",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_conventions_declarations", "file_uri") }%>
+      <%= form.label_and_textfield "file_uri",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_select "file_version_xlink_actuate_attribute", 
-        [""] + form.possible_options_for("file_version_xlink_actuate_attribute", false),
-        :required => is_required_by_admin?(r, "agent_conventions_declarations", "file_version_xlink_actuate_attribute") %>
+      <%= form.label_and_select "file_version_xlink_actuate_attribute",
+        [""] + form.possible_options_for("file_version_xlink_actuate_attribute", false) %>
 
-      <%= form.label_and_select "file_version_xlink_show_attribute", 
-        [""] + form.possible_options_for("file_version_xlink_show_attribute", false),
-        :required => is_required_by_admin?(r, "agent_conventions_declarations", "file_version_xlink_show_attribute") %>
+      <%= form.label_and_select "file_version_xlink_show_attribute",
+        [""] + form.possible_options_for("file_version_xlink_show_attribute", false) %>
 
-      <%= form.label_and_textfield "xlink_title_attribute",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_conventions_declarations", "xlink_title_attribute") }%>
+      <%= form.label_and_textfield "xlink_title_attribute",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textfield "xlink_role_attribute",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_conventions_declarations", "xlink_role_attribute") }%>
+      <%= form.label_and_textfield "xlink_role_attribute",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textfield "xlink_arcrole_attribute",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_conventions_declarations", "xlink_arcrole_attribute") }%>
+      <%= form.label_and_textfield "xlink_arcrole_attribute",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_date "last_verified_date",
-        :required => is_required_by_admin?(r, "agent_conventions_declarations", "last_verified_date") %>
+      <%= form.label_and_date "last_verified_date" %>
     </div>
   </div>
 <% end %>
@@ -54,7 +43,7 @@
 <% end %>
 
 <% define_template "agent_conventions_declaration_merge_victim", jsonmodel_definition(:agent_conventions_declaration) do |form| %>
- 
+
   <% disable_replace = false %>
 
   <%= form.record_level_merge_controls(form, "agent_conventions_declaration", true, !disable_replace) %>

--- a/frontend/app/views/agent_identifiers/_template.html.erb
+++ b/frontend/app/views/agent_identifiers/_template.html.erb
@@ -1,14 +1,11 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "agent_identifiers", jsonmodel_definition(:agent_identifier) do |form| %>
   <div class="subrecord-form-fields">
     <div class="agent-record-control-container">
 
       <%= form.label_and_textfield "entity_identifier",  {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_select "identifier_type", 
-        [""] + form.possible_options_for("identifier_type", false),
-        :required => is_required_by_admin?(r, "agent_identifiers", "identifier_type") %>
+      <%= form.label_and_select "identifier_type",
+        [""] + form.possible_options_for("identifier_type", false) %>
     </div>
   </div>
 <% end %>
@@ -28,8 +25,8 @@
   <% disable_replace = true %>
 
   <%= form.record_level_merge_controls(form, "agent_identifier", true, !disable_replace) %>
-  
+
   <%= form.label_and_readonly "entity_identifier" %>
   <%= form.label_and_readonly "identifier_type" %>
-  
+
 <% end %>

--- a/frontend/app/views/agent_maintenance_histories/_template.html.erb
+++ b/frontend/app/views/agent_maintenance_histories/_template.html.erb
@@ -1,16 +1,13 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "agent_maintenance_histories", jsonmodel_definition(:agent_maintenance_history) do |form| %>
   <div class="subrecord-form-fields">
     <div class="agent-record-control-container">
       <%= form.label_and_select "maintenance_event_type", [""] + form.possible_options_for("maintenance_event_type", false) %>
       <%= form.label_and_date "event_date" %>
-      <%= form.label_and_textfield "agent",  
+      <%= form.label_and_textfield "agent",
         {:field_opts => {:size => 30, :class => "form-control"} }%>
       <%= form.label_and_select "maintenance_agent_type", form.possible_options_for("maintenance_agent_type", false) %>
-      <%= form.label_and_textarea "descriptive_note",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_maintenance_histories", "descriptive_note") }%>
+      <%= form.label_and_textarea "descriptive_note",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
     </div>
   </div>
 <% end %>

--- a/frontend/app/views/agent_other_agency_codes/_template.html.erb
+++ b/frontend/app/views/agent_other_agency_codes/_template.html.erb
@@ -1,12 +1,9 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "agent_other_agency_codes", jsonmodel_definition(:agent_other_agency_codes) do |form| %>
   <div class="subrecord-form-fields">
     <div class="agent-record-control-container">
       <%= form.label_and_textfield "maintenance_agency",  {:field_opts => {:size => 30, :class => "form-control"} }%>
-      <%= form.label_and_select "agency_code_type", 
-        [""] + form.possible_options_for("agency_code_type", false), 
-        :required => is_required_by_admin?(r, "agent_other_agency_codes", "agency_code_type")%>
+      <%= form.label_and_select "agency_code_type",
+        [""] + form.possible_options_for("agency_code_type", false) %>
     </div>
   </div>
 <% end %>

--- a/frontend/app/views/agent_places/_template.html.erb
+++ b/frontend/app/views/agent_places/_template.html.erb
@@ -1,12 +1,9 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "agent_place", jsonmodel_definition(:agent_place) do |form| %>
   <div class="subrecord-form-fields">
     <div class="agent-record-control-container">
 
       <%= form.label_and_select "place_role",
-        [""] + form.possible_options_for("place_role", false),
-        :required => is_required_by_admin?(r, "agent_places", "place_role") %>
+        [""] + form.possible_options_for("place_role", false) %>
 
       <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "subjects", :template_erb => "subjects/template", :template => "subrecord_subject_agent_place", :heading_text => I18n.t("name._frontend.section.place_subject"), :heading_size => "h4"} %>
 

--- a/frontend/app/views/agent_record_controls/_template.html.erb
+++ b/frontend/app/views/agent_record_controls/_template.html.erb
@@ -1,66 +1,51 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "agent_record_control", jsonmodel_definition(:agent_record_control) do |form| %>
-  <div class="subrecord-form-fields">
+
+    <div class="subrecord-form-fields">
     <div class="agent-record-control-container">
       <%= form.label_and_select "maintenance_status",
         form.possible_options_for("maintenance_status", false) %>
 
       <%= form.label_and_select "publication_status",
-        [""] + form.possible_options_for("publication_status", false),
-        :required => is_required_by_admin?(r, "agent_record_controls", "publication_status")%>
+        [""] + form.possible_options_for("publication_status", false) %>
 
       <%= form.label_and_textfield "maintenance_agency",
-        {:field_opts => {:size => 30, :class => "form-control"}, 
-        :required => is_required_by_admin?(r, "agent_record_controls", "maintenance_agency") } %>
+        {:field_opts => {:size => 30, :class => "form-control"} } %>
 
       <%= form.label_and_textfield "agency_name",
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_record_controls", "agency_name") }%>
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
       <%= form.label_and_textarea "maintenance_agency_note",
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_record_controls", "maintenance_agency_note") }%>
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
       <%= form.label_and_select "language",
-        [""] + form.possible_options_for("language", false), 
-        :required => is_required_by_admin?(r, "agent_record_controls", "language") %>
+        [""] + form.possible_options_for("language", false) %>
 
-      <%= form.label_and_select "script", 
-        [""] + form.possible_options_for("script", false),
-        :required => is_required_by_admin?(r, "agent_record_controls", "script") %>
+      <%= form.label_and_select "script",
+        [""] + form.possible_options_for("script", false) %>
 
-      <%= form.label_and_textarea "language_note",  
-        {:field_opts => {:size => 30, :class => "form-control"}, 
-        :required => is_required_by_admin?(r, "agent_record_controls", "language_note") }%>
+      <%= form.label_and_textarea "language_note",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_select "romanization", 
-        [""] + form.possible_options_for("romanization", false),
-        :required => is_required_by_admin?(r, "agent_record_controls", "romanization") %>
+      <%= form.label_and_select "romanization",
+        [""] + form.possible_options_for("romanization", false) %>
 
-      <%= form.label_and_select "government_agency_type", 
-        [""] + form.possible_options_for("government_agency_type", false),
-        :required => is_required_by_admin?(r, "agent_record_controls", "government_agency_type") %>
+      <%= form.label_and_select "government_agency_type",
+        [""] + form.possible_options_for("government_agency_type", false) %>
 
-      <%= form.label_and_select "reference_evaluation", 
-        [""] + form.possible_options_for("reference_evaluation", false),
-        :required => is_required_by_admin?(r, "agent_record_controls", "reference_evaluation") %>
+      <%= form.label_and_select "reference_evaluation",
+        [""] + form.possible_options_for("reference_evaluation", false) %>
 
-      <%= form.label_and_select "name_type", 
-        [""] + form.possible_options_for("name_type", false),
-        :required => is_required_by_admin?(r, "agent_record_controls", "name_type") %>
+      <%= form.label_and_select "name_type",
+        [""] + form.possible_options_for("name_type", false) %>
 
-      <%= form.label_and_select "level_of_detail", 
-        [""] + form.possible_options_for("level_of_detail", false),
-        :required => is_required_by_admin?(r, "agent_record_controls", "level_of_detail") %>
+      <%= form.label_and_select "level_of_detail",
+        [""] + form.possible_options_for("level_of_detail", false) %>
 
-      <%= form.label_and_select "modified_record", 
-        [""] + form.possible_options_for("modified_record", false),
-        :required => is_required_by_admin?(r, "agent_record_controls", "modified_record") %>
+      <%= form.label_and_select "modified_record",
+        [""] + form.possible_options_for("modified_record", false) %>
 
-      <%= form.label_and_select "cataloging_source", 
-        [""] + form.possible_options_for("cataloging_source", false),
-        :required => is_required_by_admin?(r, "agent_record_controls", "cataloging_source") %>
+      <%= form.label_and_select "cataloging_source",
+        [""] + form.possible_options_for("cataloging_source", false) %>
     </div>
   </div>
 <% end %>
@@ -79,7 +64,7 @@
 
   <% disable_replace = false %>
   <% disable_append = !(@agent.agent_record_controls.length > 0) %>
-  
+
   <%= form.record_level_merge_controls(form, "agent_record_control", true, !disable_replace, disable_append) %>
 
   <%= form.label_and_merge_select("maintenance_status", "", {:disable_replace => disable_replace}) %>
@@ -97,6 +82,6 @@
   <%= form.label_and_merge_select("level_of_detail", "", {:disable_replace => disable_replace}) %>
   <%= form.label_and_merge_select("modified_record", "", {:disable_replace => disable_replace}) %>
   <%= form.label_and_merge_select("cataloging_source", "", {:disable_replace => disable_replace}) %>
-  
+
   <%= form.hidden_input "id", form.obj["id"] %>
 <% end %>

--- a/frontend/app/views/agent_record_identifiers/_template.html.erb
+++ b/frontend/app/views/agent_record_identifiers/_template.html.erb
@@ -1,5 +1,3 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "agent_record_identifiers", jsonmodel_definition(:agent_record_identifier) do |form| %>
   <div class="subrecord-form-fields agent_record_identifier_form">
     <h3 class="subrecord-form-heading">
@@ -9,13 +7,12 @@
 
       <%= form.hidden_input "primary_identifier", form["primary_identifier"] ? 1 : 0 %>
     </h3>
- 
+
     <div class="agent-record-control-container">
       <%= form.label_and_textfield "record_identifier",  {:field_opts => {:size => 30, :class => "form-control"} }%>
       <%= form.label_and_select "source", [""] + form.possible_options_for("source", false) %>
-      <%= form.label_and_select "identifier_type", 
-          [""] + form.possible_options_for("identifier_type", false),
-          :required => is_required_by_admin?(r, "agent_record_identifiers", "identifier_type") %>
+      <%= form.label_and_select "identifier_type",
+          [""] + form.possible_options_for("identifier_type", false) %>
     </div>
   </div>
 <% end %>
@@ -23,7 +20,7 @@
 <% define_template "agent_record_identifier_merge_target", jsonmodel_definition(:agent_record_identifier) do |form| %>
 
   <%= form.record_level_merge_controls(form, "agent_record_identifier", false) %>
-  
+
   <% if form.obj['primary_identifier'] %><span class="badge"><%= I18n.t("agent_record_identifier.primary") %></span><% end %>
 
   <% field_names = ["record_identifier", "source", "identifier_type"] %>

--- a/frontend/app/views/agent_resources/_template.html.erb
+++ b/frontend/app/views/agent_resources/_template.html.erb
@@ -1,5 +1,3 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "agent_resource", jsonmodel_definition(:agent_resource) do |form| %>
   <div class="subrecord-form-fields">
     <div class="agent-record-control-container">
@@ -7,39 +5,28 @@
 
       <%= form.label_and_textfield "linked_resource",  {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textarea "linked_resource_description",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-         :required => is_required_by_admin?(r, "agent_resources", "linked_resource_description")
-        }%>
+      <%= form.label_and_textarea "linked_resource_description",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textfield "file_uri",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-         :required => is_required_by_admin?(r, "agent_resources", "file_uri") }%>
+      <%= form.label_and_textfield "file_uri",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_select "file_version_xlink_actuate_attribute", 
-        [""] + form.possible_options_for("file_version_xlink_actuate_attribute", false),
-        :required => is_required_by_admin?(r, "agent_resources", "file_version_xlink_actuate_attribute") %>
+      <%= form.label_and_select "file_version_xlink_actuate_attribute",
+        [""] + form.possible_options_for("file_version_xlink_actuate_attribute", false) %>
 
-      <%= form.label_and_select "file_version_xlink_show_attribute", 
-        [""] + form.possible_options_for("file_version_xlink_show_attribute", false),
-        :required => is_required_by_admin?(r, "agent_resources", "file_version_xlink_show_attribute") %>
+      <%= form.label_and_select "file_version_xlink_show_attribute",
+        [""] + form.possible_options_for("file_version_xlink_show_attribute", false) %>
 
-      <%= form.label_and_textfield "xlink_title_attribute",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-         :required => is_required_by_admin?(r, "agent_resources", "xlink_title_attribute") }%>
+      <%= form.label_and_textfield "xlink_title_attribute",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textfield "xlink_role_attribute",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-         :required => is_required_by_admin?(r, "agent_resources", "xlink_role_attribute") 
-         }%>
-         
-      <%= form.label_and_textfield "xlink_arcrole_attribute",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-         :required => is_required_by_admin?(r, "agent_resources", "xlink_arcrole_attribute") 
-         }%>
+      <%= form.label_and_textfield "xlink_role_attribute",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_date "last_verified_date",
-        :required => is_required_by_admin?(r, "agent_resources", "last_verified_date") %>
+      <%= form.label_and_textfield "xlink_arcrole_attribute",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
+
+      <%= form.label_and_date "last_verified_date" %>
 
       <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "places", :template_erb => "subjects/template", :template => "subrecord_subject_agent_resource_place", :heading_text => I18n.t("name._frontend.section.place_subject"), :heading_size => "h4"} %>
 
@@ -67,9 +54,9 @@
   <% disable_replace = false %>
 
   <%= form.record_level_merge_controls(form, "agent_resource", true, !disable_replace) %>
-  
+
   <%= form.hidden_input "id", form.obj["id"] %>
- 
+
   <% field_names = ["linked_agent_role", "linked_resource", "linked_resource_description","file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute",  "last_verified_date"] %>
   <% field_names.each do |field_name| %>
     <%= form.label_and_readonly field_name %>

--- a/frontend/app/views/agent_sources/_template.html.erb
+++ b/frontend/app/views/agent_sources/_template.html.erb
@@ -1,42 +1,31 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "agent_sources", jsonmodel_definition(:agent_sources) do |form| %>
   <div class="subrecord-form-fields">
     <div class="agent-record-control-container">
-      <%= form.label_and_textfield "source_entry",  
-      {:field_opts => {:size => 30, :class => "form-control"},
-      :required => is_required_by_admin?(r, "agent_sources", "source_entry") }%>
+      <%= form.label_and_textfield "source_entry",
+      {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textarea "descriptive_note",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_sources", "descriptive_note") }%>
+      <%= form.label_and_textarea "descriptive_note",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textfield "file_uri",  
-        {:field_opts => {:size => 30, :class => "form-control"}, 
-        :required => is_required_by_admin?(r, "agent_sources", "file_uri")}%>
+      <%= form.label_and_textfield "file_uri",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_select "file_version_xlink_actuate_attribute", 
-        [""] + form.possible_options_for("file_version_xlink_actuate_attribute", false),
-        :required => is_required_by_admin?(r, "agent_sources", "file_version_xlink_actuate_attribute") %>
+      <%= form.label_and_select "file_version_xlink_actuate_attribute",
+        [""] + form.possible_options_for("file_version_xlink_actuate_attribute", false) %>
 
-      <%= form.label_and_select "file_version_xlink_show_attribute", 
-        [""] + form.possible_options_for("file_version_xlink_show_attribute", false),
-        :required => is_required_by_admin?(r, "agent_sources", "file_version_xlink_show_attribute") %>
+      <%= form.label_and_select "file_version_xlink_show_attribute",
+        [""] + form.possible_options_for("file_version_xlink_show_attribute", false) %>
 
-      <%= form.label_and_textfield "xlink_title_attribute",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_sources", "xlink_title_attribute") }%>
+      <%= form.label_and_textfield "xlink_title_attribute",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textfield "xlink_role_attribute",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_sources", "xlink_role_attribute") }%>
+      <%= form.label_and_textfield "xlink_role_attribute",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_textfield "xlink_arcrole_attribute",  
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "agent_sources", "xlink_arcrole_attribute") }%>
+      <%= form.label_and_textfield "xlink_arcrole_attribute",
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_date "last_verified_date",
-        :required => is_required_by_admin?(r, "agent_sources", "last_verified_date") %>
+      <%= form.label_and_date "last_verified_date" %>
     </div>
   </div>
 <% end %>

--- a/frontend/app/views/agents/_contact_details.html.erb
+++ b/frontend/app/views/agents/_contact_details.html.erb
@@ -1,5 +1,3 @@
-<% r = @required ? @required.values : [] %>
-
 <%= render_aspace_partial :partial => "telephones/template" %>
 
 
@@ -18,32 +16,23 @@
     <%= form.label_and_textfield "name", :required => @repository ? :conditionally : true %>
 
     <%= form.label_and_select "salutation",
-         form.possible_options_for('salutation', true),
-         :required => is_required_by_admin?(r, "agent_contacts", "salutation") %>
+         form.possible_options_for('salutation', true) %>
 
-    <%= form.label_and_textfield "address_1",
-        :required => is_required_by_admin?(r, "agent_contacts", "address_1") %>
+    <%= form.label_and_textfield "address_1" %>
 
-    <%= form.label_and_textfield "address_2",
-        :required => is_required_by_admin?(r, "agent_contacts", "address_2") %>
+    <%= form.label_and_textfield "address_2" %>
 
-    <%= form.label_and_textfield "address_3",
-        :required => is_required_by_admin?(r, "agent_contacts", "address_3") %>
+    <%= form.label_and_textfield "address_3" %>
 
-    <%= form.label_and_textfield "city",
-        :required => is_required_by_admin?(r, "agent_contacts", "city") %>
+    <%= form.label_and_textfield "city" %>
 
-    <%= form.label_and_textfield "region",
-        :required => is_required_by_admin?(r, "agent_contacts", "region") %>
+    <%= form.label_and_textfield "region" %>
 
-    <%= form.label_and_textfield "country",
-        :required => is_required_by_admin?(r, "agent_contacts", "country") %>
+    <%= form.label_and_textfield "country" %>
 
-    <%= form.label_and_textfield "post_code",
-        :required => is_required_by_admin?(r, "agent_contacts", "post_code") %>
+    <%= form.label_and_textfield "post_code" %>
 
-    <%= form.label_and_textfield "email",
-        :required => is_required_by_admin?(r, "agent_contacts", "email") %>
+    <%= form.label_and_textfield "email" %>
 
     <% if @repository %>
       <%= form.label_and_textfield "email_signature" %>

--- a/frontend/app/views/agents/name_forms/_agent_corporate_entity.html.erb
+++ b/frontend/app/views/agents/name_forms/_agent_corporate_entity.html.erb
@@ -1,5 +1,3 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "name_corporate_entity", jsonmodel_definition(:name_corporate_entity) do |form| %>
   <div class="subrecord-form-fields">
     <h3 class="subrecord-form-heading">
@@ -13,48 +11,37 @@
 
     <%= form.label_and_textfield "primary_name" %>
 
-    <%= form.label_and_textfield "subordinate_name_1",
-        :required => is_required_by_admin?(r, "names", "subordinate_name_1") %>
+    <%= form.label_and_textfield "subordinate_name_1" %>
 
-    <%= form.label_and_textfield "subordinate_name_2",
-        :required => is_required_by_admin?(r, "names", "subordinate_name_2") %>
+    <%= form.label_and_textfield "subordinate_name_2" %>
 
-    <%= form.label_and_textfield "number",
-        :required => is_required_by_admin?(r, "names", "number") %>
+    <%= form.label_and_textfield "number" %>
 
-    <%= form.label_and_textfield "dates",
-        :required => is_required_by_admin?(r, "names", "dates") %>
+    <%= form.label_and_textfield "dates" %>
 
     <hr/>
-    <%= form.label_and_textfield "location",
-        :required => is_required_by_admin?(r, "names", "location") %>
+    <%= form.label_and_textfield "location" %>
 
-    <%= form.label_and_boolean "conference_meeting",
-        :required => is_required_by_admin?(r, "names", "conference_meeting") %>
+    <%= form.label_and_boolean "conference_meeting" %>
 
-    <%= form.label_and_boolean "jurisdiction",
-        :required => is_required_by_admin?(r, "names", "jurisdiction") %>
+    <%= form.label_and_boolean "jurisdiction" %>
 
     <hr/>
     <%= form.label_and_select "language",
-         [""] + form.possible_options_for("language", false),
-         :required => is_required_by_admin?(r, "names", "language") %>
+         [""] + form.possible_options_for("language", false) %>
 
-    <%= form.label_and_select "script", 
-        [""] + form.possible_options_for("script", false),
-        :required => is_required_by_admin?(r, "names", "script") %>
+    <%= form.label_and_select "script",
+        [""] + form.possible_options_for("script", false) %>
 
-    <%= form.label_and_select "transliteration", 
-        [""] + form.possible_options_for("transliteration", false),
-        :required => is_required_by_admin?(r, "names", "transliteration") %>
+    <%= form.label_and_select "transliteration",
+        [""] + form.possible_options_for("transliteration", false) %>
 
     <hr/>
-    <%= form.label_and_textfield "qualifier",
-        :required => is_required_by_admin?(r, "names", "qualifier") %>
+    <%= form.label_and_textfield "qualifier" %>
 
     <%= form.label_and_textfield "sort_name", {:field_opts => {:automatable => true}, :required => :conditionally}%>
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "use_dates", :template_erb => "dates/template", :template => "structured_date_label_usage", :heading_text => I18n.t("name._frontend.section.use_date"), :heading_size => "h4", :template_overrides => "agents/name_forms/date_labels"} %>
-    
+
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "parallel_names", :template => "parallel_name_corporate_entity", :template_erb => "agents/name_forms/agent_corporate_entity", :heading_text => I18n.t("name._frontend.section.parallel_names"), :heading_size => "h4"} %>
   </div>
 <% end %>

--- a/frontend/app/views/agents/name_forms/_agent_family.html.erb
+++ b/frontend/app/views/agents/name_forms/_agent_family.html.erb
@@ -1,5 +1,3 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "name_family", jsonmodel_definition(:name_family) do |form| %>
   <div class="subrecord-form-fields">
     <h3 class="subrecord-form-heading">
@@ -11,47 +9,39 @@
 
     <%= render_aspace_partial :partial => "agents/name_forms/authority_fields", :locals => {:form => form} %>
 
-    <%= form.label_and_textfield "prefix",
-        :required => is_required_by_admin?(r, "names", "prefix")%>
+    <%= form.label_and_textfield "prefix" %>
 
     <%= form.label_and_textfield "family_name" %>
 
-    <%= form.label_and_textfield "dates",
-        :required => is_required_by_admin?(r, "names", "dates") %>
+    <%= form.label_and_textfield "dates" %>
 
     <hr/>
-    <%= form.label_and_textfield "family_type",
-        :required => is_required_by_admin?(r, "names", "family_type") %>
+    <%= form.label_and_textfield "family_type" %>
 
-    <%= form.label_and_textfield "location",
-        :required => is_required_by_admin?(r, "names", "location") %>
+    <%= form.label_and_textfield "location" %>
 
     <hr/>
-    <%= form.label_and_select "language", 
-        [""] + form.possible_options_for("language", false),
-        :required => is_required_by_admin?(r, "names", "language") %>
+    <%= form.label_and_select "language",
+        [""] + form.possible_options_for("language", false) %>
 
-    <%= form.label_and_select "script", 
-        [""] + form.possible_options_for("script", false),
-        :required => is_required_by_admin?(r, "names", "script") %>
+    <%= form.label_and_select "script",
+        [""] + form.possible_options_for("script", false) %>
 
-    <%= form.label_and_select "transliteration", 
-        [""] + form.possible_options_for("transliteration", false),
-        :required => is_required_by_admin?(r, "names", "transliteration") %>
+    <%= form.label_and_select "transliteration",
+        [""] + form.possible_options_for("transliteration", false) %>
     <hr/>
- 
-    <%= form.label_and_textfield "qualifier",
-        :required => is_required_by_admin?(r, "names", "qualifier") %>
+
+    <%= form.label_and_textfield "qualifier" %>
     <%= form.label_and_textfield "sort_name", {:field_opts => {:automatable => true}, :required => :conditionally}%>
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "use_dates", :template_erb => "dates/template", :template => "structured_date_label_usage", :heading_text => I18n.t("name._frontend.section.use_date"), :heading_size => "h4", :template_overrides => "agents/name_forms/date_labels"} %>
-    
+
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "parallel_names", :template => "parallel_name_family", :template_erb => "agents/name_forms/agent_family", :heading_text => I18n.t("name._frontend.section.parallel_names"), :heading_size => "h4"} %>
   </div>
 <% end %>
 
 <% define_template "parallel_name_family", jsonmodel_definition(:parallel_name_family) do |form| %>
   <div class="subrecord-form-fields">
- 
+
     <%= form.label_and_textfield "prefix" %>
     <%= form.label_and_textfield "family_name" %>
     <%= form.label_and_textfield "dates" %>
@@ -65,7 +55,7 @@
     <%= form.label_and_select "script", [""] + form.possible_options_for("script", false) %>
     <%= form.label_and_select "transliteration", [""] + form.possible_options_for("transliteration", false) %>
     <hr/>
- 
+
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "use_dates", :template_erb => "dates/template", :template => "structured_date_label_usage", :heading_text => I18n.t("name._frontend.section.use_date"), :heading_size => "h4", :template_overrides => "agents/name_forms/date_labels"} %>
   </div>
 <% end %>

--- a/frontend/app/views/agents/name_forms/_agent_person.html.erb
+++ b/frontend/app/views/agents/name_forms/_agent_person.html.erb
@@ -1,5 +1,3 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "name_person", jsonmodel_definition(:name_person) do |form| %>
   <div class="subrecord-form-fields agent-name-form">
     <h3 class="subrecord-form-heading">
@@ -11,51 +9,39 @@
 
     <%= render_aspace_partial :partial => "agents/name_forms/authority_fields", :locals => {:form => form} %>
 
-    <%= form.label_and_select "name_order", 
+    <%= form.label_and_select "name_order",
         form.possible_options_for("name_order") %>
 
-    <%= form.label_and_textfield "prefix",
-        :required => is_required_by_admin?(r, "names", "prefix") %>
+    <%= form.label_and_textfield "prefix" %>
 
-    <%= form.label_and_textfield "title",
-        :required => is_required_by_admin?(r, "names", "title") %>
+    <%= form.label_and_textfield "title" %>
 
     <%= form.label_and_textfield "primary_name" %>
 
-    <%= form.label_and_textfield "rest_of_name",
-        :required => is_required_by_admin?(r, "names", "rest_of_name") 
-        %>
+    <%= form.label_and_textfield "rest_of_name" %>
 
-    <%= form.label_and_textfield "suffix",
-        :required => is_required_by_admin?(r, "names", "suffix") %>
+    <%= form.label_and_textfield "suffix" %>
 
-    <%= form.label_and_textfield "fuller_form",
-        :required => is_required_by_admin?(r, "names", "fuller_form") %>
+    <%= form.label_and_textfield "fuller_form" %>
 
-    <%= form.label_and_textfield "number",
-        :required => is_required_by_admin?(r, "names", "number") %>
+    <%= form.label_and_textfield "number" %>
 
-    <%= form.label_and_textfield "dates",
-        :required => is_required_by_admin?(r, "names", "dates") %>
+    <%= form.label_and_textfield "dates" %>
 
     <hr/>
     <%= form.label_and_select "language",
-     [""] + form.possible_options_for("language", false),
-     :required => is_required_by_admin?(r, "names", "language") %>
+     [""] + form.possible_options_for("language", false) %>
 
-    <%= form.label_and_select "script", 
-        [""] + form.possible_options_for("script", false),
-        :required => is_required_by_admin?(r, "names", "script") %>
+    <%= form.label_and_select "script",
+        [""] + form.possible_options_for("script", false) %>
 
 
-    <%= form.label_and_select "transliteration", 
-        [""] + form.possible_options_for("transliteration", false),
-        :required => is_required_by_admin?(r, "names", "transliteration") %>
+    <%= form.label_and_select "transliteration",
+        [""] + form.possible_options_for("transliteration", false) %>
 
     <hr/>
- 
-    <%= form.label_and_textfield "qualifier",
-        :required => is_required_by_admin?(r, "names", "qualifier") %>
+
+    <%= form.label_and_textfield "qualifier" %>
 
     <%= form.label_and_textfield "sort_name", {:field_opts => {:automatable => true}, :required => :conditionally}%>
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "use_dates", :template_erb => "dates/template", :template => "structured_date_label_usage", :heading_text => I18n.t("name._frontend.section.use_date"), :heading_size => "h4", :template_overrides => {"date_label" => "agents/name_forms/date_labels"}} %>
@@ -81,7 +67,7 @@
     <%= form.label_and_select "script", [""] + form.possible_options_for("script", false) %>
     <%= form.label_and_select "transliteration", [""] + form.possible_options_for("transliteration", false) %>
     <hr/>
- 
+
     <%= form.label_and_textfield "qualifier" %>
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "use_dates", :template_erb => "dates/template", :template => "structured_date_label_usage", :heading_text => I18n.t("name._frontend.section.use_date"), :heading_size => "h4", :template_overrides => {"date_label" => "agents/name_forms/date_labels"}} %>
   </div>

--- a/frontend/app/views/agents/name_forms/_agent_software.html.erb
+++ b/frontend/app/views/agents/name_forms/_agent_software.html.erb
@@ -1,5 +1,3 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "name_software", jsonmodel_definition(:name_software) do |form| %>
   <div class="subrecord-form-fields">
     <h3 class="subrecord-form-heading">
@@ -13,34 +11,27 @@
 
     <%= form.label_and_textfield "software_name" %>
 
-    <%= form.label_and_textfield "version",
-      :required => is_required_by_admin?(r, "names", "version")%>
+    <%= form.label_and_textfield "version" %>
 
-    <%= form.label_and_textfield "manufacturer",
-      :required => is_required_by_admin?(r, "names", "manufacturer") %>
+    <%= form.label_and_textfield "manufacturer" %>
 
-    <%= form.label_and_textfield "dates",
-      :required => is_required_by_admin?(r, "names", "dates")%>
+    <%= form.label_and_textfield "dates" %>
     <hr/>
     <%= form.label_and_select "language",
-         [""] + form.possible_options_for("language", false),
-         :required => is_required_by_admin?(r, "names", "language") %>
+         [""] + form.possible_options_for("language", false) %>
 
-    <%= form.label_and_select "script", 
-        [""] + form.possible_options_for("script", false),
-        :required => is_required_by_admin?(r, "names", "script") %>
+    <%= form.label_and_select "script",
+        [""] + form.possible_options_for("script", false) %>
 
-    <%= form.label_and_select "transliteration", 
-        [""] + form.possible_options_for("transliteration", false),
-        :required => is_required_by_admin?(r, "names", "transliteration") %>
+    <%= form.label_and_select "transliteration",
+        [""] + form.possible_options_for("transliteration", false) %>
     <hr/>
- 
-    <%= form.label_and_textfield "qualifier",
-      :required => is_required_by_admin?(r, "names", "qualifier") %>
+
+    <%= form.label_and_textfield "qualifier" %>
 
     <%= form.label_and_textfield "sort_name", {:field_opts => {:automatable => true}, :required => :conditionally}%>
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "use_dates", :template_erb => "dates/template", :template => "structured_date_label_usage", :heading_text => I18n.t("name._frontend.section.use_date"), :heading_size => "h4", :template_overrides => "agents/name_forms/date_labels"} %>
-    
+
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "parallel_names", :template => "parallel_name_software", :template_erb => "agents/name_forms/agent_software", :heading_text => I18n.t("name._frontend.section.parallel_names"), :heading_size => "h4"} %>
   </div>
 <% end %>
@@ -56,7 +47,7 @@
     <%= form.label_and_select "script", [""] + form.possible_options_for("script", false) %>
     <%= form.label_and_select "transliteration", [""] + form.possible_options_for("transliteration", false) %>
     <hr/>
- 
+
     <%= form.label_and_textfield "qualifier" %>
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "use_dates", :template_erb => "dates/template", :template => "structured_date_label_usage", :heading_text => I18n.t("name._frontend.section.use_date"), :heading_size => "h4", :template_overrides => "agents/name_forms/date_labels"} %>
   </div>

--- a/frontend/app/views/agents/name_forms/_authority_fields.html.erb
+++ b/frontend/app/views/agents/name_forms/_authority_fields.html.erb
@@ -1,17 +1,10 @@
-<% r = @required ? @required.values : [] %>
-
 <%= form.hidden_input "is_display_name", form["is_display_name"] ? 1 : 0 %>
 <div class="name-authority-fields">
-  <%= form.label_and_textfield "authority_id",
-  :required => is_required_by_admin?(r, "names", "authority_id") %>
+  <%= form.label_and_textfield "authority_id" %>
 
-  <%= form.label_and_select "source", 
-  	form.possible_options_for('source', true), 
-  	:required => is_required_by_admin?(r, "names", "source") %>
+  <%= form.label_and_select "source", form.possible_options_for('source', true) %>
 
-  <%= form.label_and_select "rules", 
-  	form.possible_options_for('rules', true), 
-  	:required => is_required_by_admin?(r, "names", "rules") %>
+  <%= form.label_and_select "rules", form.possible_options_for('rules', true) %>
 
   <%= form.hidden_input "authorized", form["authorized"] ? 1 : 0 %>
   <hr/>

--- a/frontend/app/views/metadata_rights_declarations/_template.html.erb
+++ b/frontend/app/views/metadata_rights_declarations/_template.html.erb
@@ -1,40 +1,31 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "metadata_rights_declaration", jsonmodel_definition(:metadata_rights_declaration) do |form| %>
   <div class="subrecord-form-fields">
     <div class="agent-record-control-container">
+
       <%= form.label_and_select "license", [""] + form.possible_options_for("license", false) %>
 
       <%= form.label_and_textarea "descriptive_note",
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "metadata_rights_declarations", "descriptive_note") }%>
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
       <%= form.label_and_textfield "file_uri",
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "metadata_rights_declarations", "file_uri") }%>
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
       <%= form.label_and_select "file_version_xlink_actuate_attribute",
-        [""] + form.possible_options_for("file_version_xlink_actuate_attribute", false),
-        :required => is_required_by_admin?(r, "metadata_rights_declarations", "file_version_xlink_actuate_attribute") %>
+        [""] + form.possible_options_for("file_version_xlink_actuate_attribute", false) %>
 
       <%= form.label_and_select "file_version_xlink_show_attribute",
-        [""] + form.possible_options_for("file_version_xlink_show_attribute", false),
-        :required => is_required_by_admin?(r, "metadata_rights_declarations", "file_version_xlink_show_attribute") %>
+        [""] + form.possible_options_for("file_version_xlink_show_attribute", false) %>
 
       <%= form.label_and_textfield "xlink_title_attribute",
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "metadata_rights_declarations", "xlink_title_attribute") }%>
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
       <%= form.label_and_textfield "xlink_role_attribute",
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "metadata_rights_declarations", "xlink_role_attribute") }%>
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
       <%= form.label_and_textfield "xlink_arcrole_attribute",
-        {:field_opts => {:size => 30, :class => "form-control"},
-        :required => is_required_by_admin?(r, "metadata_rights_declarations", "xlink_arcrole_attribute") }%>
+        {:field_opts => {:size => 30, :class => "form-control"} }%>
 
-      <%= form.label_and_date "last_verified_date",
-        :required => is_required_by_admin?(r, "metadata_rights_declarations", "last_verified_date") %>
+      <%= form.label_and_date "last_verified_date" %>
     </div>
   </div>
 <% end %>

--- a/frontend/app/views/shared/_form_messages.html.erb
+++ b/frontend/app/views/shared/_form_messages.html.erb
@@ -5,7 +5,6 @@
 
        var setupErrorMessage = function(idx, elt, type) {
          var $matched;
-
          if ($("#" + elt).length) {
            $matched = $("#" + elt);
            $matched.closest(".form-group, td").addClass("has-"+type);
@@ -30,6 +29,8 @@
            // the first element.
            $matched = $("#" + elt + "_0_");
            $matched.closest(".form-group, td").addClass("has-"+type);
+         } else if ($("section." + elt.replace(/_$/, ''))) {
+           $matched = $("section." + elt.replace(/_$/, ''));
          }
          if ($matched && !$("." + type + "[data-target=" + elt + "]").hasClass("linked-to-field")) {
              var matchedTarget = $("." + type + "[data-target=" + elt + "]");

--- a/frontend/app/views/shared/_required_subrecord.html.erb
+++ b/frontend/app/views/shared/_required_subrecord.html.erb
@@ -1,0 +1,12 @@
+<% property = template_opts[:property] %>
+<% type = template_opts[:type] %>
+<% field_names = template_opts[:field_names] %>
+
+<%= render_aspace_partial :partial => "shared/required_subrecord_checkbox", :locals => {form: form, property: property, type: type} %>
+<% field_names.each do |field_name| %>
+  <% if form.required?(field_name) %>
+    <%= form.label_and_readonly field_name %>
+  <% else %>
+    <%= form.label_and_req_boolean field_name %>
+  <% end %>
+<% end %>

--- a/frontend/app/views/shared/_required_subrecord_form.html.erb
+++ b/frontend/app/views/shared/_required_subrecord_form.html.erb
@@ -27,7 +27,8 @@
     <div class="form-group">
       <label class="col-sm-2 control-label"><%= I18n.t("actions.require_subrecord") %></label>
         <div class="col-sm-1 req_checkbox">
-          <input id="required_fields__<%= property %>" type="checkbox" name="<%= form_name %>" value="<%= type %>" <%= @required.required?(property, type) ? " checked=checked" : "" %>>
+          <input id="required_fields__<%= property %>" type="hidden" name="<%= form_name %>" value="<%= type %>" >
+          <input id="required_fields__<%= property %>__required" type="checkbox" name="agent[<%= property %>][0][required]" value="true" <%= @required_fields.required?(property, type) ? " checked=checked" : "" %>>
         </div>
     </div>
     <% field_names.each do |field_name| %>
@@ -36,7 +37,7 @@
       <div class="form-group">
         <label class="col-sm-2 control-label" for="agent_record_identifier_" plugin=""><%=  label %></label>
         <div class="col-sm-9  label-only">
-          <input id="required_fields__<%= field_name %>_" type="checkbox" name="<%= form_name %>" value="<%= type %>" col_size="1" controls_class="req_checkbox"<%= definition.required?(field_name) ? ' disabled checked=checked' : '' %><%= @required.required?(property, type, field_name) ? " checked=checked" : "" %>>
+          <input id="required_fields__<%= field_name %>_" type="checkbox" name="<%= form_name %>" value="<%= type %>" col_size="1" controls_class="req_checkbox"<%= definition.required?(field_name) ? ' disabled checked=checked' : '' %><%= @required_fields.required?(property, type, field_name) ? " checked=checked" : "" %>>
         </div>
       </div>
     <% end  %>

--- a/frontend/app/views/used_languages/_template.html.erb
+++ b/frontend/app/views/used_languages/_template.html.erb
@@ -1,15 +1,11 @@
-<% r = @required ? @required.values : [] %>
-
 <% define_template "used_language", jsonmodel_definition(:used_language) do |form| %>
   <div class="subrecord-form-fields">
     <div class="used-language-container">
-      <%= form.label_and_select "language", 
-        [""] + form.possible_options_for("language", false),
-        :required => is_required_by_admin?(r, "used_languages", "language") %>
+      <%= form.label_and_select "language",
+        [""] + form.possible_options_for("language", false) %>
 
-      <%= form.label_and_select "script", 
-        [""] + form.possible_options_for("script", false),
-        :required => is_required_by_admin?(r, "used_languages", "script") %>
+      <%= form.label_and_select "script",
+        [""] + form.possible_options_for("script", false) %>
 
       <%= render_aspace_partial :partial => "notes/form", :locals => {:form => form, :all_note_types => note_types_for("used_language"), :section_id => "used_language_notes", :nested_note_jsonmodel => "used_language", :header_size => "h4", :show_apply_note_order_action => false} %>
     </div>
@@ -32,7 +28,7 @@
 
   <%= form.record_level_merge_controls(form, "used_language", true, !disable_replace) %>
   <%= form.hidden_input "id", form.obj["id"] %>
- 
+
   <% field_names = ["language", "script"] %>
   <% field_names.each do |field_name| %>
     <%= form.label_and_readonly field_name %>

--- a/frontend/spec/controllers/agents_controller_spec.rb
+++ b/frontend/spec/controllers/agents_controller_spec.rb
@@ -36,10 +36,18 @@ describe AgentsController, type: :controller do
       JSONModel(:required_fields).from_hash(
         {
           record_type: 'agent_person',
-          required: {
-            "metadata_rights_declarations" => [JSONModel(:metadata_rights_declaration).new._always_valid!],
-            "agent_maintenance_histories" => [JSONModel(:agent_maintenance_history).new._always_valid!.update({"descriptive_note"=>"REQ"}).tap {|obj| obj['maintenance_agent_type'] = nil}],
-          }
+          subrecord_requirements: [
+            {
+              property: "metadata_rights_declarations",
+              record_type: "metadata_rights_declaration",
+              required: true
+            },
+            {
+              property: "agent_maintenance_histories",
+              record_type: "agent_maintenance_history",
+              required_fields: ["descriptive_note"]
+            }
+          ]
         })
     }
 
@@ -62,23 +70,18 @@ describe AgentsController, type: :controller do
              agent: agent.to_hash
            }
 
-      assert_equal(json_required_fields.required, assigns(:required).values)
       obj = assigns(:agent)
       expect(obj._exceptions[:errors]).to eq({
                                                "metadata_rights_declarations"=>["Subrecord is required but was missing"],
                                                "agent_maintenance_histories/0/descriptive_note" => ["Property is required but was missing"]
                                              })
+
     end
 
     it "can build a form for viewing and editing user-managed required fields and subrecords" do
       session = User.login('admin', 'admin')
       User.establish_session(controller, session, 'admin')
       controller.session[:repo_id] = JSONModel.repository
-      agent = build(:json_agent_person,
-                    :agent_maintenance_histories => [
-                      build(:json_agent_maintenance_history,
-                            :descriptive_note => nil
-                           )])
 
       allow(RequiredFields).to receive(:get)
                                  .with("agent_person")
@@ -86,34 +89,13 @@ describe AgentsController, type: :controller do
 
       get :required, params: {
              agent_type: "agent_person",
-             agent: agent.to_hash
           }
 
-      expect(assigns(:required).required?("metadata_rights_declarations", "metadata_rights_declaration")).to be true
-      expect(assigns(:required).required?("agent_maintenance_histories", "agent_maintenance_history")).to be true
-      # repurpose jsonmodel_type to set required subrecord state in the form
-      assert_select("input[name='agent[metadata_rights_declarations][0][jsonmodel_type]'][value='metadata_rights_declaration'][checked='checked']")
-      assert_select("input[name='agent[agent_maintenance_histories][0][jsonmodel_type]'][value='agent_maintenance_history'][checked='checked']")
-
+      expect(assigns(:required_fields).required?("metadata_rights_declarations", "metadata_rights_declaration")).to be true
+      assert_select("input[name='agent[metadata_rights_declarations][0][jsonmodel_type]'][value='metadata_rights_declaration']")
+      assert_select("input[name='agent[metadata_rights_declarations][0][required]'][value='true'][checked='checked']")
       # required subform fields are flagged on the schema property with a string that is the subrecord type
       assert_select("input[name='agent[agent_maintenance_histories][0][descriptive_note]'][value='agent_maintenance_history'][checked='checked']")
-    end
-
-    it "makes the subrecord itself required if a field of the subrecord is required" do
-      session = User.login('admin', 'admin')
-      User.establish_session(controller, session, 'admin')
-      controller.session[:repo_id] = JSONModel.repository
-      post :update_required, params: {
-             agent_type: "agent_person",
-             agent: {
-               "agent_record_controls"=>{
-                 "0"=>{"script"=>"agent_record_control"}
-               }
-             }
-           }
-      required = RequiredFields.get("agent_person")
-      expect(required.required?('agent_record_controls', 'agent_record_control', 'script')).to be_truthy
-      expect(required.required?('agent_record_controls', 'agent_record_control')).to be_truthy
     end
   end
 end

--- a/frontend/spec/models/required_fields_spec.rb
+++ b/frontend/spec/models/required_fields_spec.rb
@@ -4,29 +4,88 @@ require 'rails_helper'
 
 describe "RequiredFields model" do
 
-  let(:json_record) {
-    JSONModel(:required_fields).from_hash({
-                                            record_type: 'agent_person',
-                                            required: {
-                                              "agent_record_controls": [
-                                                                         {
-                                                                           "jsonmodel_type": "agent_record_control"
-                                                                         }
-                                                                       ],
-                                            }
-                                          })
+  let(:requirements_model) {
+    RequiredFields.new(
+      JSONModel(:required_fields).from_hash({
+                                              repo_id: JSONModel.repository,
+                                              record_type: "agent_person",
+                                              subrecord_requirements: [
+                                                {
+                                                  record_type: "metadata_rights_declaration",
+                                                  property: "metadata_rights_declarations",
+                                                  required_fields: ["xlink_title_attribute", "xlink_role_attribute"],
+                                                  required: true
+                                                },
+                                                {
+                                                  record_type: "agent_maintenance_history",
+                                                  property: "agent_maintenance_histories",
+                                                  required_fields: ["descriptive_note"] }
+                                              ]
+                                            }))
   }
 
-  it "gives an empty RequiredFields object for any lookup that does not exist" do
-    expect(RequiredFields.get("agent_person").values).to be_empty
+  let(:agent_person_missing_subrecord) {
+    build(:json_agent_person,
+          :metadata_rights_declarations => nil)
+  }
+
+  let(:agent_person_missing_subrecord_fields) {
+    build(:json_agent_person, {
+            :metadata_rights_declarations => [build(:json_metadata_rights_declaration,
+                                                    {
+                                                      :xlink_title_attribute => nil,
+                                                      :xlink_role_attribute => nil
+                                                    })],
+            :agent_maintenance_histories => [build(:json_agent_maintenance_history,
+                                                   :descriptive_note => nil
+                                                  )]
+          })
+  }
+
+  let(:required_fields) { RequiredFields.get("agent_person") }
+
+  it "adds appropriate errors to an object with deficiencies" do
+    allow(RequiredFields).to receive(:get).with("agent_person").and_return(requirements_model)
+    required_fields.add_errors(agent_person_missing_subrecord)
+    expect(agent_person_missing_subrecord._exceptions[:errors]).to eq({
+                                                                        "metadata_rights_declarations"=>["Subrecord is required but was missing"],
+                                                                      })
+
+    required_fields.add_errors(agent_person_missing_subrecord_fields)
+    expect(agent_person_missing_subrecord_fields._exceptions[:errors]).to eq({
+                                                                        "metadata_rights_declarations/0/xlink_title_attribute"=>["Property is required but was missing"],
+                                                                        "metadata_rights_declarations/0/xlink_role_attribute"=>["Property is required but was missing"],
+                                                                        "agent_maintenance_histories/0/descriptive_note"=>["Property is required but was missing"],
+                                                                      })
+
   end
 
-  it "can create, persist, and retrieve a required_fields definition with a key and blob" do
-    session = User.login('admin', 'admin')
-    Thread.current[:backend_session] = session['session']
-    required = RequiredFields.new(json_record)
-    required.save
-    required = RequiredFields.get("agent_person")
-    expect(required.values).to eq({"agent_record_controls"=>[{"jsonmodel_type" => "agent_record_control"}]})
+  it "can tell you if a subrecord is required as a given property" do
+    allow(RequiredFields).to receive(:get).with("agent_person").and_return(requirements_model)
+    expect(required_fields.required?("metadata_rights_declarations", "metadata_rights_declaration", "xlink_title_attribute")).to be true
+    expect(required_fields.required?("agent_maintenance_histories", "agent_maintenance_history", )).not_to be true
+  end
+
+  it "can tell you if a field is required for a given property / record type" do
+    allow(RequiredFields).to receive(:get).with("agent_person").and_return(requirements_model)
+    expect(required_fields.required?("metadata_rights_declarations", "metadata_rights_declaration", "xlink_title_attribute")).to be true
+  end
+
+
+  it "can tell you if a field is required for a given property / record type even if the stored requirements lack types" do
+    requirements_without_types = RequiredFields.new(
+      JSONModel(:required_fields).from_hash({
+                                              repo_id: JSONModel.repository,
+                                              record_type: "agent_person",
+                                              subrecord_requirements: [
+                                                {
+                                                  property: "metadata_rights_declarations",
+                                                  required_fields: ["xlink_title_attribute", "xlink_role_attribute"],
+                                                  required: true
+                                                }
+                                              ]
+                                            }))
+    allow(RequiredFields).to receive(:get).with("agent_person").and_return(requirements_without_types)
+    expect(required_fields.required?("metadata_rights_declarations", "metadata_rights_declaration", "xlink_title_attribute")).to be true
   end
 end


### PR DESCRIPTION
This is a follow up / continuation of https://github.com/archivesspace/archivesspace/pull/2703 and a refactor of https://github.com/archivesspace/archivesspace/pull/1073. 

What's changed:

The API endpoint `repositories/:repo_id/required_fields/:record_type` now returns an object like this:

```json
{
  "lock_version": 0,
  "record_type": "agent_person",
  "subrecord_requirements": [
    {
      "property": "agent_other_agency_codes",
      "required_fields": [
        "agency_code_type"
      ],
      "required": false
    },
   {
      "property": "metadata_rights_declarations",
      "record_type": "metadata_rights_declaration",
      "required": true,
      "required_fields": [
        "license",
        "descriptive_note"
      ]
    },
    {
      "property": "agent_resources",
      "required_fields": [
        "file_version_xlink_show_attribute"
      ],
      "required": false
    }
  ],
  "jsonmodel_type": "required_fields",
  "uri": "/repositories/2/required_fields/agent_person"
}
```
The `record_type` is optional, since legacy datasets will have blobs that look like this:

```json
{
  "record_type": "agent_person",
  "lock_version": 1,
  "required": {
    "agent_type": "agent_person",
    "agent_other_agency_codes": [
      {
        "agency_code_type": "REQ"
      }
    ],
    "metadata_rights_declarations": [
      {
        "xlink_role_attribute": "REQ",
        "xlink_arcrole_attribute": "REQ",
        "last_verified_date": "REQ"
      }
    ],
    "agent_alternate_sets": [
      {
        "descriptive_note": "REQ"
      }
    ],
    "agent_resources": [
      {
        "file_version_xlink_show_attribute": "REQ",
        "publish": false
      }
    ],
    "is_linked_to_published_record": false,
    "system_generated": false,
    "publish": false,
    "is_slug_auto": false
  },
  "jsonmodel_type": "required_fields",
  "uri": "/repositories/2/required_fields/agent_person"
}
```
We probably could have inferred the record type of these legacy entries, since in practice a property and record_type have a 1:1 relationship. But since this is not absolute and the schema structures allow for properties that can take more than one record type, we decided to implement a requirements model in the frontend that can decide if a field is required in cases where: a) the requirements are missing a type; b) the caller doesn't know the type; c) the caller doesn't know the property. It seems to work, since in practice the only area where admin-defined requirements has been implemented  is in Agent records, and these only have properties that allow a single sub record type.

This points to a more general issue with properties and record types that can be matched to them. There seem to be many places in ArchivesSpace, especially in views, where there is a non-explicit dependency on only one type being found as a property (sub record) of another. There is also a lot of repetition in views, repeated property and record type names, which could perhaps be eliminated. 
