### PR TITLE
ANW-1095: don't show creators in two places on PUI show page

### DIFF
--- a/public/app/views/shared/_record_innards.html.erb
+++ b/public/app/views/shared/_record_innards.html.erb
@@ -81,7 +81,9 @@
                                                            :p_id => 'classifications_list', :p_body => x} %>
   <% end %>
 	<% unless @result.agents.blank? %>
-	  <% x= render partial: 'shared/agents_list', locals: {:list => @result.agents} %>
+  <%# ANW-1095: don't show creators in related names section since it is redundant %>
+  <% not_creators = @result.agents.except("creator") %>
+	  <% x= render partial: 'shared/agents_list', locals: {:list => not_creators} %>
 	   <%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('pui_agent.related'),
 	     :p_id => 'agent_list', :p_body => x} %>
         <% end %>

--- a/public/spec/controllers/resources_controller_spec.rb
+++ b/public/spec/controllers/resources_controller_spec.rb
@@ -41,7 +41,7 @@ describe ResourcesController, type: :controller do
   it 'should show the published resources' do
     expect(get(:index)).to have_http_status(200)
     results = assigns(:results)
-    expect(results['total_hits']).to eq(7)
+    expect(results['total_hits']).to eq(8)
     expect(results.records.first['title']).to eq("Published Resource")
   end
 

--- a/public/spec/controllers/search_controller_spec.rb
+++ b/public/spec/controllers/search_controller_spec.rb
@@ -16,7 +16,7 @@ describe SearchController, type: :controller do
 
     expect(response).to have_http_status(200)
     expect(response).to render_template('search/search_results')
-    expect(result_data['total_hits']).to eq(33)
+    expect(result_data['total_hits']).to eq(34)
   end
 
   it 'should return all digital objects when filtered' do

--- a/public/spec/features/agents_spec.rb
+++ b/public/spec/features/agents_spec.rb
@@ -6,7 +6,7 @@ describe 'Agents', js: true do
     visit('/')
     click_link 'Names'
     within all('.col-sm-12')[0] do
-      expect(page).to have_content("Showing Names: 1 - 1 of 1")
+      expect(page).to have_content("Showing Names: 1 - 3 of 3")
     end
   end
 

--- a/public/spec/features/resources_spec.rb
+++ b/public/spec/features/resources_spec.rb
@@ -7,7 +7,7 @@ describe 'Resources', js: true do
     click_link 'Collections'
     expect(current_path).to eq ('/repositories/resources')
     within all('.col-sm-12')[0] do
-      expect(page).to have_content("Showing Collections: 1 - 6 of 6")
+      expect(page).to have_content("Showing Collections: 1 - 7 of 7")
     end
     within all('.col-sm-12')[1] do
       expect(page.all("a[class='record-title']", text: 'Published Resource').length).to eq 1
@@ -53,5 +53,15 @@ describe 'Resources', js: true do
     click_link 'Collections'
     click_link 'Resource with Accession'
     expect(page).to have_content('Related Unprocessed Material')
+  end
+
+  it 'displays linked agents on show page, with creators in top section but not in related names' do
+    visit('/')
+    click_link 'Collections'
+    click_link 'Resource with Agents'
+
+    expect(page).to have_content('Linked Agent 1')
+    expect(page).to have_css('#agent_list', text: 'Linked Agent 2')
+    expect(page).to_not have_css('#agent_list', text: 'Linked Agent 1')
   end
 end

--- a/public/spec/spec_helper.rb
+++ b/public/spec/spec_helper.rb
@@ -147,6 +147,27 @@ def setup_test_data
   create(:resource, title: "Resource for Phrase Search", publish: true)
   create(:resource, title: "Search as Phrase Resource", publish: true)
 
+
+  linked_agent_1 = create(:agent_person,
+         names: [build(:name_person,
+                       primary_name: "Linked Agent 1",
+                       sort_name: "Linked Agent 1")],
+         publish: true)
+
+  linked_agent_2 = create(:agent_person,
+         names: [build(:name_person,
+                       primary_name: "Linked Agent 2",
+                       sort_name: "Linked Agent 2")],
+         publish: true)
+
+
+  create(:resource, title: "Resource with Agents", publish: true, linked_agents:
+    [
+      {'role' => 'creator', 'ref' => linked_agent_1.uri},
+      {'role' => 'source', 'ref' => linked_agent_2.uri}
+    ]
+  )
+
   resource_with_scope = create(:resource_with_scope, title: "Resource with scope note", publish: true)
   aos = (0..5).map do
     create(:archival_object,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Rework for ANW-1095: don't show creators in two places on PUI show page

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1095

## How Has This Been Tested?
Manual and unit testing

## Screenshots (if appropriate):
![Screenshot_2022-07-13_17-03-09](https://user-images.githubusercontent.com/130926/179006688-d0bed02e-9259-4c6f-b25a-cafd33a1b4a0.jpg)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
