### PR TITLE
revise tree position selection when spawning component

### DIFF
--- a/frontend/app/assets/javascripts/largetree.js.erb
+++ b/frontend/app/assets/javascripts/largetree.js.erb
@@ -457,7 +457,7 @@
                 self.appendWaypoints(row, row.data('uri'), node.waypoints, node.waypoint_size, row.data('level') + 1);
 
                 if (done_callback) {
-                    done_callback();
+                    setTimeout(done_callback, 100);
                 }
             })
             .fail(function () {

--- a/frontend/app/views/archival_objects/_form_container.html.erb
+++ b/frontend/app/views/archival_objects/_form_container.html.erb
@@ -11,7 +11,7 @@
 
 <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:form => form} %>
 
-<%= form.hidden_input "parent", nil, {"data-base-name" => "archival_object[parent]", "class" => "hidden-parent-uri", "data-browse-url-html" => url_for(:controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.ARCHIVAL_OBJECT_FACETS), "data-browse-url-json" => url_for(:controller => :search, :action => :do_search, :format => :json, :facets => SearchResultData.ARCHIVAL_OBJECT_FACETS), "data-modal-title" => I18n.t('archival_object._frontend.action.select_parent'), "data-leave-empty" => I18n.t('archival_object._frontend.action.leave_parent_empty')} %>
+  <%= form.hidden_input "parent", nil, {"data-base-name" => "archival_object[parent]", "class" => "hidden-parent-uri", "data-browse-url-html" => url_for(:controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.ARCHIVAL_OBJECT_FACETS), "data-browse-url-json" => url_for(:controller => :search, :action => :do_search, :format => :json, :facets => SearchResultData.ARCHIVAL_OBJECT_FACETS), "data-modal-title" => I18n.t('archival_object._frontend.action.select_parent_and_position'), "data-leave-empty" => I18n.t('archival_object._frontend.action.leave_parent_empty')} %>
   <%= form.hidden_input "resource", nil, {"data-browse-url-html" => url_for(:controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.RESOURCE_FACETS), "data-browse-url-json" => url_for(:controller => :search, :action => :do_search, :format => :json, :facets => SearchResultData.RESOURCE_FACETS), "data-modal-title" => I18n.t('archival_object._frontend.action.select_resource')} %>
 
   <%= form.hidden_input "position" %>

--- a/frontend/app/views/archival_objects/new.html.erb
+++ b/frontend/app/views/archival_objects/new.html.erb
@@ -1,5 +1,52 @@
 <%= setup_context :object => @archival_object, :controller => :resources %>
 
+
+<script>
+  <%
+    translations = {}
+
+    ['instance_instance_type', 'container_type', 'resource_resource_type',
+     'archival_record_level', 'digital_object_digital_object_type'
+    ].each do |enumeration_name|
+      translations[enumeration_name] ||= {}
+
+      JSONModel.enum_values(enumeration_name).each do |enumeration_value|
+        translations[enumeration_name][enumeration_value] = I18n.t("enumerations.#{enumeration_name}.#{enumeration_value}", :default => enumeration_value)
+      end
+    end
+  %>
+
+  var ENUMERATION_TRANSLATIONS = <%== translations.to_json %>;
+
+  var EnumerationTranslations = {
+    t : function(enumeration, enumeration_value) {
+      if (ENUMERATION_TRANSLATIONS.hasOwnProperty(enumeration)) {
+          if (ENUMERATION_TRANSLATIONS[enumeration].hasOwnProperty(enumeration_value)) {
+              return ENUMERATION_TRANSLATIONS[enumeration][enumeration_value];
+          } else if (enumeration == 'archival_record_level'){
+              return enumeration_value;
+          }
+      }
+      return null;
+    }
+  };
+
+ var SPAWN_PLACEHOLDER_TEXT = <%== I18n.t("archival_object._frontend.messages.spawn_placeholder").to_json %>;
+
+ <%
+ spawn_menu = {
+     before: I18n.t("archival_object._frontend.messages.spawn_menu_before"),
+     child: I18n.t("archival_object._frontend.messages.spawn_menu_child"),
+     after: I18n.t("archival_object._frontend.messages.spawn_menu_after")
+ }
+ %>
+ var SPAWN_MENU_ITEMS = <%== spawn_menu.to_json %>
+
+</script>
+
+
+<%= stylesheet_link_tag "archivesspace/largetree" %>
+
 <div id="object_container">
   <%= form_for @archival_object, :as => "archival_object", :url => {:action => :create}, :html => {:class => 'form-horizontal aspace-record-form', :id => "archival_object_form"} do |f| %>
     <%= form_context :archival_object, @archival_object do |form| %>
@@ -10,7 +57,6 @@
          <div class="col-md-9">
            <%= render_aspace_partial :partial => "archival_objects/toolbar_new_records" %>
            <div class="record-pane">
-
              <%= render_aspace_partial :partial => "archival_objects/form_container", :locals => {:form => form} %>
 
              <div class="form-actions">

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -841,6 +841,10 @@ en:
         has_unpublished_ancestor: Please be aware this record has an ancestor that is unpublished.
         spawned: "This Archival Object has been spawned from Accession <strong>%{accession.display_string}</strong>"
         delete_conflict: "Archival Object could not be deleted: <pre>%{error}</pre>"
+        spawn_placeholder: "<em>Spawned component will be inserted here</em>"
+        spawn_menu_before: Insert spawned component before
+        spawn_menu_child: Insert spawned component as child
+        spawn_menu_after: Insert spawned component after
       section:
         basic_information: Basic Information
       action:
@@ -849,7 +853,7 @@ en:
         save: Save Archival Object
         bulk_import: Load via Spreadsheet
         select_resource: Select Resource
-        select_parent: Select Parent
+        select_parent_and_position: Select Component Position
         leave_parent_empty: Close / Do not Assign Parent
 
       tree:

--- a/frontend/spec/features/spawning_spec.rb
+++ b/frontend/spec/features/spawning_spec.rb
@@ -34,7 +34,8 @@ describe 'Spawning', js: true do
     find("#spawn-dropdown li:nth-of-type(3)").click
     find("input[value='#{@resource.uri}']").click
     find("#addSelectedButton").click
-    find("input[value='#{@parent.uri}']").click
+    click_link find("#archival_object_#{@parent.id} .title").text
+    find("ul.largetree-dropdown-menu li:nth-of-type(2)").click
     find("#addSelectedButton").click
     expect(page.evaluate_script("location.href")).to include("resource_id=#{@resource.id}")
     expect(page.evaluate_script("location.href")).to include("archival_object_id=#{@parent.id}")
@@ -43,6 +44,7 @@ describe 'Spawning', js: true do
     accession_link = find(:css, "form input[name='archival_object[accession_links][0][ref]']", :visible => false)
     expect(accession_link.value).to eq(@accession.uri)
     find(".save-changes button[type='submit']").click
+    sleep 1
     expect(find("div.indent-level-1 div.title")['title']).to eq "Parent"
     expect(find("div.indent-level-2 div.title")['title']).to eq "Spawned Accession"
     ref_id = find(".identifier-display").text


### PR DESCRIPTION
Revised the 2nd modal ("Select Parent") in the spawn resource component from accession workflow. New design uses tree view rather than a search pane, and has a 3 option menu for selecting location (before, child, after) similar to the reorder mode in the resource edit view (but without the drag and drop handles).

<img width="1696" alt="image" src="https://user-images.githubusercontent.com/1626547/180473887-f5738640-4049-4758-8c9f-940008922843.png">

<img width="1702" alt="image" src="https://user-images.githubusercontent.com/1626547/180474062-67c25f2f-d08e-4db9-b9e3-200f9b0fb858.png">


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
