### PR TITLE
ANW-996: Add Publish columns to RDE Notes section

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/form.less
+++ b/frontend/app/assets/stylesheets/archivesspace/form.less
@@ -857,6 +857,17 @@ ul.checkbox-list {
   }
 }
 
+// Improve Bootstrap's checkbox focus via their .form-control:focus
+// TODO investigate if the above .checkbox class needs these :focus styles
+input[type='checkbox']:focus {
+  border-color: #1f86db;
+  outline: 0;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075),
+    0 0 8px rgba(31, 134, 219, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075),
+    0 0 8px rgba(31, 134, 219, 0.6);
+}
+
 // hiding form elements for agents light
 
 .subrecord-form-invisible {

--- a/frontend/app/models/mixins/record_children.rb
+++ b/frontend/app/models/mixins/record_children.rb
@@ -41,13 +41,11 @@ module RecordChildren
               end
             end
 
-            child["notes"][i]["publish"] = true
-
             # Multipart and biog/hist notes use a 'text' subnote type for their content.
             if ['note_multipart', 'note_bioghist'].include?(child["notes"][i]["jsonmodel_type"])
               child["notes"][i]["subnotes"] = [{"jsonmodel_type" => "note_text",
                                                 "content" => child["notes"][i]["content"].join(" "),
-                                                "publish" => true}]
+                                                "publish" => child["notes"][i]["publish"]}]
             end
 
           elsif child["notes"][i]["type"].blank? and child["notes"][i]["content"][0].blank?

--- a/frontend/app/views/archival_objects/_rde_templates.html.erb
+++ b/frontend/app/views/archival_objects/_rde_templates.html.erb
@@ -4,7 +4,7 @@
   <th data-id="date" class="section-date" colspan="5" class="conditionally-required"><%= I18n.t("rde.sections.date") %></th>
   <th data-id="extent" class="section-extent" colspan="6" class="conditionally-required"><%= I18n.t("rde.sections.extent") %></th>
   <th data-id="instance" class="section-instance" colspan="6"><%= I18n.t("rde.sections.instance") %></th>
-  <th data-id="note" class="section-note" colspan="18"><%= I18n.t("rde.sections.notes") %></th>
+  <th data-id="note" class="section-note" colspan="21"><%= I18n.t("rde.sections.notes") %></th>
 <% end %>
 
 <% define_template "rde_archival_object_headers" do |form| %>
@@ -36,24 +36,28 @@
   <th id="colCInd2" class="fieldset-label" data-section="instance"><%= I18n.t("sub_container.indicator_2") %></th>
   <th id="colCType3" class="fieldset-label" data-section="instance"><%= I18n.t("sub_container.type_3") %></th>
   <th id="colCInd3" class="fieldset-label" data-section="instance"><%= I18n.t("sub_container.indicator_3") %></th>
+
   <th id="colNType1" class="fieldset-label" data-section="note"><%= I18n.t("note._singular") %> 1</th>
   <th id="colNLabel1" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.label") %> 1</th>
   <th id="colNBeginRestriction1" class="fieldset-label" data-section="note"><%= I18n.t("rights_restriction.begin") %> 1</th>
   <th id="colNEndRestriction1" class="fieldset-label" data-section="note"><%= I18n.t("rights_restriction.end") %> 1</th>
   <th id="colNRestrictionType1" class="fieldset-label" data-section="note"><%= I18n.t("rights_restriction.local_access_restriction_type") %> 1</th>
   <th id="colNCont1" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.content") %> 1</th>
+  <th id="colNPub1" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.publish") %> 1</th>
   <th id="colNType2" class="fieldset-label" data-section="note"><%= I18n.t("note._singular") %> 2</th>
   <th id="colNLabel2" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.label") %> 2</th>
   <th id="colNBeginRestriction2" class="fieldset-label" data-section="note"><%= I18n.t("rights_restriction.begin") %> 2</th>
   <th id="colNEndRestriction2" class="fieldset-label" data-section="note"><%= I18n.t("rights_restriction.end") %> 2</th>
   <th id="colNRestrictionType2" class="fieldset-label" data-section="note"><%= I18n.t("rights_restriction.local_access_restriction_type") %> 2</th>
   <th id="colNCont2" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.content") %> 2</th>
+  <th id="colNPub2" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.publish") %> 2</th>
   <th id="colNType3" class="fieldset-label" data-section="note"><%= I18n.t("note._singular") %> 3</th>
   <th id="colNLabel3" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.label") %> 3</th>
   <th id="colNBeginRestriction3" class="fieldset-label" data-section="note"><%= I18n.t("rights_restriction.begin") %> 3</th>
   <th id="colNEndRestriction3" class="fieldset-label" data-section="note"><%= I18n.t("rights_restriction.end") %> 3</th>
   <th id="colNRestrictionType3" class="fieldset-label" data-section="note"><%= I18n.t("rights_restriction.local_access_restriction_type") %> 3</th>
   <th id="colNCont3" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.content") %> 3</th>
+  <th id="colNPub3" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.publish") %> 3</th>
 <% end %>
 
 <% define_template "rde_archival_object_cols" do |form| %>
@@ -87,20 +91,21 @@
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
+  <col class="fieldset-col" data-default-width='90' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
+  <col class="fieldset-col" data-default-width='90' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
-  <col class="fieldset-col" data-default-width='150' />
-  <col class="fieldset-col" data-default-width='150' />
+  <col class="fieldset-col" data-default-width='90' />
 <% end %>
 
 <% define_template "rde_archival_object_row", jsonmodel_definition(:archival_object) do |form, archival_object| %>
@@ -298,6 +303,11 @@
         <% end %>
       <% end %>
     </td>
+    <td data-col="colNPub1" class="form-group">
+      <% form.push(form.set_index("notes[]", 0), begin archival_object["notes"][0] || {} rescue {} end) do %>
+        <%= form.checkbox "publish", {}, false %>
+      <% end %>
+    </td>
     <td data-col="colNType2" class="form-group">
       <% form.push(form.set_index("notes[]", 1), begin archival_object["notes"][1] || {} rescue {} end) do %>
         <%= form.select("type", [""].concat(note_types_for(:archival_object).map {|value, hash| [hash[:i18n], value]}.sort{|a, b| a[0] <=> b[0]})) %>
@@ -349,6 +359,11 @@
         <% end %>
       <% end %>
     </td>
+    <td data-col="colNPub2" class="form-group">
+      <% form.push(form.set_index("notes[]", 1), begin archival_object["notes"][1] || {} rescue {} end) do %>
+        <%= form.checkbox "publish", {}, false %>
+      <% end %>
+    </td>
     <td data-col="colNType3" class="form-group">
       <% form.push(form.set_index("notes[]", 2), begin archival_object["notes"][2] || {} rescue {} end) do %>
         <%= form.select("type", [""].concat(note_types_for(:archival_object).map {|value, hash| [hash[:i18n], value]}.sort{|a, b| a[0] <=> b[0]})) %>
@@ -398,6 +413,11 @@
         <% form.push(form.set_index("subnotes[]", 0), []) do %>
           <span id="<%= form.id_for("content") %>"></span>
         <% end %>
+      <% end %>
+    </td>
+    <td data-col="colNPub3" class="form-group">
+      <% form.push(form.set_index("notes[]", 2), begin archival_object["notes"][2] || {} rescue {} end) do %>
+        <%= form.checkbox "publish", {}, false %>
       <% end %>
     </td>
     <td data-col="actions" class="form-group">

--- a/frontend/app/views/digital_object_components/_rde_templates.html.erb
+++ b/frontend/app/views/digital_object_components/_rde_templates.html.erb
@@ -4,7 +4,7 @@
   <th data-id="date" class="section-date" colspan="5" class="conditionally-required"><%= I18n.t("rde.sections.date") %></th>
   <th data-id="extent" class="section-extent" colspan="6" class="conditionally-required"><%= I18n.t("rde.sections.extent") %></th>
   <th data-id="file" class="section-file" colspan="10"><%= I18n.t("rde.sections.file_version") %></th>
-  <th data-id="note" class="section-note" colspan="9"><%= I18n.t("rde.sections.notes") %></th>
+  <th data-id="note" class="section-note" colspan="12"><%= I18n.t("rde.sections.notes") %></th>
 <% end %>
 
 <% define_template "rde_digital_object_component_headers" do |form| %>
@@ -43,12 +43,15 @@
   <th id="colNType1" class="fieldset-label" data-section="note"><%= I18n.t("note._singular") %> 1</th>
   <th id="colNLabel1" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.label") %> 1</th>
   <th id="colNCont1" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.content") %> 1</th>
+  <th id="colNPub1" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.publish") %> 1</th>
   <th id="colNType2" class="fieldset-label" data-section="note"><%= I18n.t("note._singular") %> 2</th>
   <th id="colNLabel2" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.label") %> 2</th>
   <th id="colNCont2" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.content") %> 2</th>
+  <th id="colNPub2" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.publish") %> 2</th>
   <th id="colNType3" class="fieldset-label" data-section="note"><%= I18n.t("note._singular") %> 3</th>
   <th id="colNLabel3" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.label") %> 3</th>
   <th id="colNCont3" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.content") %> 3</th>
+  <th id="colNPub3" class="fieldset-label" data-section="note"><%= I18n.t("note_attributes.publish") %> 3</th>
 <% end %>
 
 <% define_template "rde_digital_object_component_cols" do |form| %>
@@ -56,19 +59,23 @@
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='70' />
+
+  <col class="fieldset-col" data-default-width='150' />
+  <col class="fieldset-col" data-default-width='150' />
+
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
-  <col class="fieldset-col" data-default-width='150' />
-  <col class="fieldset-col" data-default-width='150' />
+
   <col class="fieldset-col" data-default-width='70' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
+
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
@@ -79,15 +86,19 @@
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
+
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
+  <col class="fieldset-col" data-default-width='90' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
+  <col class="fieldset-col" data-default-width='90' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
   <col class="fieldset-col" data-default-width='150' />
+  <col class="fieldset-col" data-default-width='90' />
 <% end %>
 
 <% define_template "rde_digital_object_component_row", jsonmodel_definition(:digital_object_component) do |form, digital_object_component| %>
@@ -266,6 +277,11 @@
         <% end %>
       <% end %>
     </td>
+    <td data-col="colNPub1" class="form-group">
+      <% form.push(form.set_index("notes[]", 0), begin digital_object_component["notes"][0] || {} rescue {} end) do %>
+          <%= form.checkbox "publish", {}, false %>
+      <% end %>
+    </td>
     <td data-col="colNType2" class="form-group">
       <% form.push(form.set_index("notes[]", 1), begin digital_object_component["notes"][1] || {} rescue {} end) do %>
         <%= form.select("type", [""].concat(note_types_for("digital_object_component").map {|value, hash| [hash[:i18n], value]}.sort{|a, b| a[0] <=> b[0]})) %>
@@ -290,6 +306,11 @@
         <% form.push(form.set_index("subnotes[]", 0), []) do %>
           <span id="<%= form.id_for("content") %>"></span>
         <% end %>
+      <% end %>
+    </td>
+    <td data-col="colNPub2" class="form-group">
+      <% form.push(form.set_index("notes[]", 1), begin digital_object_component["notes"][1] || {} rescue {} end) do %>
+          <%= form.checkbox "publish", {}, false %>
       <% end %>
     </td>
     <td data-col="colNType3" class="form-group">
@@ -318,9 +339,13 @@
         <% end %>
       <% end %>
     </td>
+    <td data-col="colNPub3" class="form-group">
+      <% form.push(form.set_index("notes[]", 2), begin digital_object_component["notes"][2] || {} rescue {} end) do %>
+          <%= form.checkbox "publish", {}, false %>
+      <% end %>
+    </td>
 
-
-    <td data-col="" class="form-group">
+    <td data-col="actions" class="form-group">
       <div class="btn-group">
         <button class="btn btn-success add-row"><span class="glyphicon glyphicon-plus icon-white"></span></button>
         <% if !first_row %><button class="btn remove-row"><span class="glyphicon glyphicon-remove"></span></button><% end %>

--- a/frontend/spec/selenium/spec/rde_templates_spec.rb
+++ b/frontend/spec/selenium/spec/rde_templates_spec.rb
@@ -107,7 +107,7 @@ describe 'RDE Templates' do
     @driver.wait_for_ajax
 
     multiselector_selected_cols = @driver.execute_script('return $("#rde_hidden_columns").data("multiselect").getSelected().length;')
-    expect(multiselector_selected_cols).to eq 42
+    expect(multiselector_selected_cols).to eq 45
 
     @driver.find_element(css: "button[data-id='rde_select_template']").click
     @driver.wait_for_ajax


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR adds 3 new columns to both the Archival Object and Digital Object Component RDE forms for staff to explicitly set the publish status for each of the 3 notes.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Here is the Archival Objects RDE:

![ANW-996 Add Publish column to RDE Notes](https://user-images.githubusercontent.com/3411019/188275636-8159d79a-4bc6-40ff-9b2f-3d88a5e011a8.gif)

Here is the Digital Objects RDE:

![ANW-996 Digital Objects RDE](https://user-images.githubusercontent.com/3411019/188307630-830f03d9-73a3-4b99-8683-2a726d826a80.gif)

