### PR TITLE
Some small fixes to SUI permissions

### DIFF
--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -96,7 +96,7 @@ module SearchHelper
 
     return user_can?('update_container_record', record['id']) if record['primary_type'] === "top_container"
     return user_can?('update_container_profile_record') if record['primary_type'] === "container_profile"
-    return user_can?('manage_repository', record['id']) if record['primary_type'] === "repository"
+    return user_can?('create_repository', record['id']) if record['primary_type'] === "repository"
     return user_can?('update_location_record') if record['primary_type'] === "location"
     return user_can?('update_subject_record') if record['primary_type'] === "subject"
     return user_can?('update_classification_record') if ["classification", "classification_term"].include?(record['primary_type'])

--- a/frontend/app/views/repositories/index.html.erb
+++ b/frontend/app/views/repositories/index.html.erb
@@ -7,7 +7,7 @@
     </div>
   </div>
   <div class="col-md-9">
-    <% if user_can?('manage_repository') %>
+    <% if user_can?('create_repository') %>
       <div class="record-toolbar">
         <div class="btn-group pull-right">
           <%= link_to I18n.t("repository._frontend.action.create"), {:controller => :repositories, :action => :new}, :class => "btn btn-sm btn-default" %>

--- a/frontend/app/views/shared/_header_repository.html.erb
+++ b/frontend/app/views/shared/_header_repository.html.erb
@@ -36,7 +36,7 @@
           </li>
           <% if ['update_accession_record', 'update_resource_record', 'update_digital_object_record',
                  'update_subject_record', 'update_event_record',
-                 'update_agent_record', 'update_location_record', 'update_container_profile'].find {|p| user_can?(p)} %>
+                 'update_agent_record', 'update_location_record', 'update_container_profile', 'create_job'].find {|p| user_can?(p)} %>
             <li class="dropdown create-container">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= I18n.t("navbar.create") %> <b class="caret"></b></a>
               <ul class="dropdown-menu">


### PR DESCRIPTION
## Description
I've noticed a few small discrepancies between the permissions on endpoints in the backend and permissions controlling whether corresponding menus/buttons are displayed in the frontend:

- The backend API requires the "create_repository" global permission to create new repositories or edit the details (name, publish y/n, OAI settings, etc) of an existing one. Whereas "manage_repository" is a repository-level permission for controlling access to the current repository. This pull request hides buttons in the staff interface which lead to the form for editing a repository, but unless the user is a system admin they'll get a error if they try to save changes.
- In the staff interface, non-admin users can only see the Create menu if they have permissions to create records (resources, accessions, agents, etc.) This pull request means they'll see it if they have the "create_job" as well (if that is all they have then they'll only get the Background Job sub-menu.)

## Related JIRA Ticket or GitHub Issue
None

## How Has This Been Tested?
On a development system only.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
