### PR TITLE
ANW-1584: fix for filters being dropped after first page of subject pages on PUI

### DIFF
--- a/public/app/controllers/subjects_controller.rb
+++ b/public/app/controllers/subjects_controller.rb
@@ -89,6 +89,8 @@ class SubjectsController < ApplicationController
     render 'search/search_results'
   end
 
+  RETAINED_PARAMETERS = ['filter_fields', 'filter_values']
+
   def show
     sid = params.require(:id)
     uri = "/subjects/#{sid}"
@@ -98,8 +100,14 @@ class SubjectsController < ApplicationController
       @result =  archivesspace.get_record(uri, @criteria)
       @results = fetch_subject_results(@result['title'], uri, params)
       if !@results.blank?
-        params[:q] = '*'
-        @pager = Pager.new(@base_search, @results['this_page'], @results['last_page'])
+
+        extra_params = Hash[RETAINED_PARAMETERS.map {|f|
+          if params[f]
+            [f, params[f]]
+          end
+        }.compact].to_query
+
+        @pager = Pager.new("#{uri}?#{extra_params}", @results['this_page'], @results['last_page'])
       else
         @pager = nil
       end


### PR DESCRIPTION
## Description
When a subject has been linked to from enough records that its representation in the PUI has multiple pages, any filters which a user applies (e.g. to narrow to a record type) are lost when they navigate to the second page.

This does not happen for agents which have similar numbers of linked records. So, comparing the controller code, I found the same problem had previously been fixed for agents by @marktriggs here:

https://github.com/archivesspace/archivesspace/commit/e51f4e96c11bda594bbb7acf953a7ac650f9a24c

So I have simply replicated exactly the same change in the subjects controller. Which seems to have the desired effect. Filters are now retained as you browse through the multiple pages of records matching both the subject and a filter.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1584

## How Has This Been Tested?
On a development system only.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
