### PR TITLE
make sure not to accidentally set resource as a parent

### DIFF
--- a/frontend/app/assets/javascripts/archival_objects.crud.js
+++ b/frontend/app/assets/javascripts/archival_objects.crud.js
@@ -166,14 +166,9 @@ function TreeLinkingModal(config) {
           menuSelectHandler(self.selected_row.data('level'));
           self.selected_row.before(self.inserted_row);
           if (
-            self.inserted_row.closest('.table-row-group').prev('.root-row')
+            !self.inserted_row.closest('.table-row-group').prev('.root-row')
               .length > 0
           ) {
-            self.parent_uri = self.inserted_row
-              .closest('.table-row-group')
-              .prev('.root-row')
-              .data('uri');
-          } else {
             self.parent_uri = self.inserted_row
               .closest('.table-row-group')
               .prev('.largetree-node')

--- a/frontend/app/assets/javascripts/archival_objects.crud.js
+++ b/frontend/app/assets/javascripts/archival_objects.crud.js
@@ -166,8 +166,8 @@ function TreeLinkingModal(config) {
           menuSelectHandler(self.selected_row.data('level'));
           self.selected_row.before(self.inserted_row);
           if (
-            !self.inserted_row.closest('.table-row-group').prev('.root-row')
-              .length > 0
+            self.inserted_row.closest('.table-row-group').prev('.root-row')
+              .length < 1
           ) {
             self.parent_uri = self.inserted_row
               .closest('.table-row-group')

--- a/frontend/app/controllers/archival_objects_controller.rb
+++ b/frontend/app/controllers/archival_objects_controller.rb
@@ -196,8 +196,11 @@ class ArchivalObjectsController < ApplicationController
   def delete
     archival_object = JSONModel(:archival_object).find(params[:id])
 
-    previous_record = JSONModel::HTTP.get_json("#{archival_object['uri']}/previous")
-
+    previous_record = begin
+      JSONModel::HTTP.get_json("#{archival_object['uri']}/previous")
+    rescue RecordNotFound
+      nil
+    end
     begin
       archival_object.delete
     rescue ConflictException => e


### PR DESCRIPTION
Fix a bug that put the resource uri into the parent param when inserting before a top-level object