### PR TITLE
add a helper so feature specs can await backend job completion

### DIFF
--- a/frontend/spec/features/bulk_import_spec.rb
+++ b/frontend/spec/features/bulk_import_spec.rb
@@ -36,7 +36,9 @@ describe 'Bulk Import', js: true do
     sleep 5
     visit "/jobs"
     expect(page).to have_text "Load via Spreadsheet"
-    click_link "View"
+    first(:link, "View").click
+    wait_for_job_to_complete(page)
+    visit current_path
     expect(page).to have_link "A subseries"
     expect(page).to have_link "The first series"
   end

--- a/frontend/spec/features/jobs_spec.rb
+++ b/frontend/spec/features/jobs_spec.rb
@@ -35,7 +35,7 @@ describe 'Jobs', js: true do
     fill_in('String to find', with: 'abc')
     fill_in('Replacement string', with: 'def')
     click_button('Start Job')
-
+    wait_for_job_to_complete(page)
     expect(page).to have_content('Find and Replace Job')
     click_button('Refresh Page')
     expect(page).to have_content('Completed')
@@ -55,7 +55,7 @@ describe 'Jobs', js: true do
     fill_in('token-input-job_source_', with: resource.title)
     find(:css, 'li.token-input-dropdown-item2').click
     click_button('Start Job')
-
+    wait_for_job_to_complete(page)
     expect(page).to have_content('print_to_pdf_job')
     click_button('Refresh Page')
     sleep 1.seconds
@@ -74,7 +74,7 @@ describe 'Jobs', js: true do
     end
     select('CSV', from: 'Format')
     click_button('Start Job')
-
+    wait_for_job_to_complete(page)
     expect(page).to have_content('report_job')
     click_button('Refresh Page')
     sleep 1.seconds
@@ -91,7 +91,7 @@ describe 'Jobs', js: true do
     end
     click_button('Accession Report')
     click_button('Start Job')
-
+    wait_for_job_to_complete(page)
     expect(page).to have_content('report_job')
     click_button('Refresh Page')
     sleep 1.seconds
@@ -106,7 +106,7 @@ describe 'Jobs', js: true do
 
   it 'can import an accession and display import type' do
     template_file = File.expand_path(
-      '../backend/spec/examples/aspace_accession_import_template.csv')
+      '../../../../backend/spec/examples/aspace_accession_import_template.csv', __FILE__)
 
     click_link('Repository settings')
     click_link('Background Jobs')
@@ -118,7 +118,7 @@ describe 'Jobs', js: true do
     # can this be done without calling the javascript directly?
     execute_script("return $('#job_filenames_ > span > input')[0]").send_keys(template_file)
     click_button('Start Job')
-
+    wait_for_job_to_complete(page)
     expect(page).to have_content('Import Job')
     click_button('Refresh Page')
     sleep 1.seconds

--- a/frontend/spec/rails_helper.rb
+++ b/frontend/spec/rails_helper.rb
@@ -76,3 +76,19 @@ Capybara.default_max_wait_time = 10
 ActionController::Base.logger.level = Logger::ERROR
 Rails.logger.level = Logger::ERROR
 Rails::Controller::Testing.install
+
+def wait_for_job_to_complete(page)
+  job_id = page.current_path.sub(/^[^\d]*/, '')
+  sanity_counter = 0
+  complete = false
+  while (sanity_counter < 100 && !complete) do
+    begin
+      job = JSONModel(:job).find(job_id)
+      complete = ["completed", "failed"].include?(job.status)
+    rescue
+    end
+    return if complete
+    sleep 1
+    sanity_counter += 1
+  end
+end


### PR DESCRIPTION
[Recent work](https://github.com/archivesspace/archivesspace/pull/2776) exposed an existing problem with tests using `sleep` and a bit of hope to check page elements that appear after a backend job completed. This attempts to remove the guesswork and uses the backend API to wait for confirmation the job is in completed status. 