### PR TITLE
Enable plug-ins to customize EAD3 export differently to EAD 2002

### DIFF
--- a/backend/app/exporters/serializers/ead3.rb
+++ b/backend/app/exporters/serializers/ead3.rb
@@ -518,7 +518,7 @@ class EAD3Serializer < EADSerializer
                 end
               end
 
-              EADSerializer.run_serialize_step(data, xml, @fragments, :did)
+              EAD3Serializer.run_serialize_step(data, xml, @fragments, :did)
 
               # Change from EAD 2002: dao must be children of did in EAD3, not archdesc
               data.digital_objects.each do |dob|
@@ -535,7 +535,7 @@ class EAD3Serializer < EADSerializer
 
             serialize_controlaccess(data, xml, @fragments)
 
-            EADSerializer.run_serialize_step(data, xml, @fragments, :archdesc)
+            EAD3Serializer.run_serialize_step(data, xml, @fragments, :archdesc)
 
             xml.dsc {
 
@@ -1183,7 +1183,7 @@ class EAD3Serializer < EADSerializer
             serialize_languages(languages, xml, fragments)
           end
 
-          EADSerializer.run_serialize_step(data, xml, fragments, :did)
+          EAD3Serializer.run_serialize_step(data, xml, fragments, :did)
 
           data.instances_with_sub_containers.each do |instance|
             serialize_container(instance, xml, @fragments)
@@ -1200,7 +1200,7 @@ class EAD3Serializer < EADSerializer
         serialize_bibliographies(data, xml, fragments)
         serialize_indexes(data, xml, fragments)
         serialize_controlaccess(data, xml, fragments)
-        EADSerializer.run_serialize_step(data, xml, fragments, :archdesc)
+        EAD3Serializer.run_serialize_step(data, xml, fragments, :archdesc)
 
         data.children_indexes.each do |i|
           xml.text(


### PR DESCRIPTION
## Description
The `EAD3Serializer` class [defines its own](https://github.com/archivesspace/archivesspace/blob/4940708b2f2fc64669acef4689a87e196661f011/backend/app/exporters/serializers/ead3.rb#L127-L141) `add_serialize_step` and `run_serialize_step` methods, but when it comes to actually running the export, it calls the `EADSerializer` parent class's version of `run_serialize_step`. Hence, currently, if a plug-ins sets up different hooks to output EAD3 versions of whatever elements they are adding, those will never be called.  To fix this, I have searched and replaced `EADSerializer` with `EAD3Serializer` in ead3.rb.

It is possible there are plug-ins that have been created to add an element that is unchanged between EAD 2002 and EAD3, which haven't added a specific EAD3 hook, hence this change will remove that element from their EAD3 exports. But I think it is necessary to be able to produce valid EAD3 in all but the simplest cases. Even in elements that are essentially unchanged, there are attributes that have been renamed (e.g. the `type` attribute is invalid in EAD3, having been replaced with `localtype`.)

## Related JIRA Ticket or GitHub Issue
None

## How Has This Been Tested?
On a development system, with a plug-in that I am currently developing. This change allows _backend/plugin_init.rb_ to call both `EADSerializer.add_serialize_step(NameOfClass)` and `EAD3Serializer.add_serialize_step(NameOfDifferentClass)`, and then those class can be defined with different `call` methods to output different syntax for EAD3 versus EAD 2002.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
