### PR TITLE
Add run_serialize_step hook to digital objects

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -585,6 +585,7 @@ class EADSerializer < ASpaceExport::Serializer
         end
       }
     end
+    EADSerializer.run_serialize_step(digital_object, xml, fragments, :dao)
   end
 
 

--- a/backend/app/exporters/serializers/ead3.rb
+++ b/backend/app/exporters/serializers/ead3.rb
@@ -1443,6 +1443,7 @@ class EAD3Serializer < EADSerializer
         }
       end
     end
+    EAD3Serializer.run_serialize_step(digital_object, xml, fragments, :dao)
   end
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds a hook to the digital objects serializer method to allow plugins to hook in with run_serialize_step.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Digital objects map to a somewhat more complex EAD/EAD3 structure than other data (e.g. extents) and may require additional data added to the EAD or EAD3 exports. This change allows plugins to hook into the digital object serializer step without overriding the core method. This follows the convention in https://github.com/archivesspace/archivesspace/pull/2785 where EAD & EAD3 use different hooks.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://github.com/archivesspace/archivesspace/pull/2785

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally tested with a custom plugin being developed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
