### PR TITLE
skip orphaned notes when remediating note persistent ids

### DIFF
--- a/common/db/migrations/160_persistent_ids_for_notes_created_during_migrations.rb
+++ b/common/db/migrations/160_persistent_ids_for_notes_created_during_migrations.rb
@@ -23,6 +23,7 @@ Sequel.migration do
       notes = JSON.parse(row[:notes].to_s)
       next unless notes["persistent_id"]
       row.reject! { |k, v| v.nil? }
+      next unless row.keys.last.to_s =~ /_id$/
       parent_type = row.keys.last.to_s.sub(/_id$/, '')
       parent_id = row.values.last
       self[:note_persistent_id].insert(note_id: row[:id], persistent_id: notes["persistent_id"], parent_type: parent_type, parent_id: parent_id)


### PR DESCRIPTION
Upon testing of v3.3.0-RC1 a flaw was discovered in [migration 160](https://github.com/archivesspace/archivesspace/commit/281cb0377f7e164a3668d4135c98c2da3b9cfe64).
It seems that in the wild there are orphaned notes which exist entirely free of context. 
This remedy will make sure that the last populated column in the row looks like a foreign key before attempting to update the persistent id table.