### PR TITLE
back out of JS backtick template interpolation due to outdated asset …

### DIFF
--- a/public/app/assets/javascripts/print.js
+++ b/public/app/assets/javascripts/print.js
@@ -38,7 +38,7 @@ function addPageLocationMsg() {
   const contentEl = document.querySelector('#content');
   const locationEl = document.createElement('p');
   locationEl.classList.add('page-location-for-printing');
-  locationEl.innerHTML = `<i>Printed from</i> ${location}`;
+  locationEl.innerHTML = '<i>Printed from</i> ' + location;
 
   contentEl.insertAdjacentElement('beforebegin', locationEl);
 }


### PR DESCRIPTION
Back out of newer JS template interpolation introduced here:
https://github.com/archivesspace/archivesspace/pull/2683

Public app's `asset:precompile` task currently chokes on backticks. 

We should revisit as we upgrade Rails and asset pipeline. 

