### PR TITLE
ANW-1410: Support ind1 = 1 for corp names in MARC importer

### DIFF
--- a/backend/app/converters/lib/marcxml_bib_base_map.rb
+++ b/backend/app/converters/lib/marcxml_bib_base_map.rb
@@ -494,19 +494,18 @@ module MarcXMLBibBaseMap
     }
   end
 
-
-  def sets_name_order_from_ind1
+  def sets_jurisdiction_from_ind1
     -> name, node {
       name['jurisdiction'] = case node.value
-                           when '1'
-                             true
-                           when '0'
-                             false
-                           end
+                             when '1'
+                               true
+                             when '0'
+                               false
+                             end
     }
   end
 
-  def sets_jurisdiction_from_ind1
+  def sets_name_order_from_ind1
     -> name, node {
       name['name_order'] = case node.value
                            when '1'

--- a/backend/app/converters/lib/marcxml_bib_base_map.rb
+++ b/backend/app/converters/lib/marcxml_bib_base_map.rb
@@ -271,6 +271,7 @@ module MarcXMLBibBaseMap
       "subfield[@code='s']" => adds_prefixed_qualifier('Version'),
       "subfield[@code='t']" => adds_prefixed_qualifier('Title of work'),
       "subfield[@code='u']" => adds_prefixed_qualifier('Affiliation'),
+      "@ind1" => sets_jurisdiction_from_ind1,
     }
   end
 
@@ -496,6 +497,17 @@ module MarcXMLBibBaseMap
 
   def sets_name_order_from_ind1
     -> name, node {
+      name['jurisdiction'] = case node.value
+                           when '1'
+                             true
+                           when '0'
+                             false
+                           end
+    }
+  end
+
+  def sets_jurisdiction_from_ind1
+    -> name, node {
       name['name_order'] = case node.value
                            when '1'
                              'inverted'
@@ -504,7 +516,6 @@ module MarcXMLBibBaseMap
                            end
     }
   end
-
 
   def sets_name_source_from_code
     -> name, node {

--- a/backend/spec/lib_marcxml_bib_converter_spec.rb
+++ b/backend/spec/lib_marcxml_bib_converter_spec.rb
@@ -129,6 +129,15 @@ describe 'MARCXML Bib converter' do
       end
     end
 
+    it "sets jurisdiction = true based on ind1" do
+      @corps.each do |c|
+        c['names'].each do |n|
+          expect(n['jurisdiction']).to eq(true)
+        end
+      end
+    end
+
+
 
     describe "MARC import mappings" do
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Support ind1 = 1 for corp names in MARC importer

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1410

## How Has This Been Tested?
Manual and unit testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
