### PR TITLE
ANW-1503: bugfix for identifier value not appearing in CSV download

### DIFF
--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -644,6 +644,7 @@ class IndexerCommon
         doc['has_classification_terms'] = record['record']['has_classification_terms']
         doc['slug'] = record['record']['slug']
         doc['is_slug_auto'] = record['record']['is_slug_auto']
+        doc['identifier'] = record['record']['identifier']
       end
     }
 


### PR DESCRIPTION
The cause of the missing identifier value was simply that it was not
being indexed.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Include the "identifier" value for classification records in the indexer. The value not being indexed is the cause of it being missing from CSV exports.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1503

## How Has This Been Tested?
manual in browser testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
