### PR TITLE
Support mixed content on the title fields of major record types

### DIFF
--- a/frontend/app/views/accessions/_form.html.erb
+++ b/frontend/app/views/accessions/_form.html.erb
@@ -11,7 +11,7 @@
                                  :form => form,
                                  :record => @accession) %>
 
-       <%= form.label_and_textarea "title" %>
+       <%= form.label_and_textarea "title", :field_opts => {:class => "form-control mixed-content"} %>
        <%= form.label_and_fourpartid %>
 
        <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @accession} if AppConfig[:use_human_readable_urls] %>

--- a/frontend/app/views/archival_objects/_form_container.html.erb
+++ b/frontend/app/views/archival_objects/_form_container.html.erb
@@ -31,7 +31,7 @@
                                    :form => form,
                                    :record => @archival_object) %>
 
-        <%= form.label_and_textarea("title", :required => :conditionally)%>
+        <%= form.label_and_textarea("title", :required => :conditionally, :field_opts => {:class => "form-control mixed-content"})%>
 
         <% if form.obj["ref_id"].blank? %>
           <%= form.label_and_readonly "ref_id", "<em>#{I18n.t("archival_object.ref_id_auto_generation_message")}</em>" %>

--- a/frontend/app/views/digital_object_components/_form_container.html.erb
+++ b/frontend/app/views/digital_object_components/_form_container.html.erb
@@ -32,7 +32,7 @@
                                  :record => @digital_object_component) %>
 
       <%= form.label_and_textfield "label", :required => :conditionally %>
-      <%= form.label_and_textarea "title", :required => :conditionally %>
+      <%= form.label_and_textarea "title", :required => :conditionally, :field_opts => {:class => "form-control mixed-content"} %>
       <%= form.label_and_textfield "component_id" %>
 
       <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @digital_object_component} if AppConfig[:use_human_readable_urls] %>

--- a/frontend/app/views/digital_objects/_form_container.html.erb
+++ b/frontend/app/views/digital_objects/_form_container.html.erb
@@ -15,7 +15,7 @@
                                  :form => form,
                                  :record => @digital_object) %>
 
-      <%= form.label_and_textarea "title" %>
+      <%= form.label_and_textarea "title", :field_opts => {:class => "form-control mixed-content"} %>
 
       <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @digital_object} if AppConfig[:use_human_readable_urls] %>
 

--- a/frontend/app/views/resources/_form_container.html.erb
+++ b/frontend/app/views/resources/_form_container.html.erb
@@ -23,7 +23,7 @@
                                  :form => form,
                                  :record => @resource) %>
 
-      <%= form.label_and_textarea "title" %>
+      <%= form.label_and_textarea "title", :field_opts => {:class => "form-control mixed-content"} %>
       <%= form.label_and_fourpartid %>
 
       <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @resource} if AppConfig[:use_human_readable_urls] %>
@@ -57,8 +57,10 @@
           <%= form.label_and_textfield "ead_id" %>
           <%= form.label_and_textfield "ead_location" %>
           <hr/>
-          <%= form.label_and_textarea "finding_aid_title" %>
-          <%= form.label_and_textarea "finding_aid_subtitle" %>
+
+          <%= form.label_and_textarea "finding_aid_title", :field_opts => {:class => "mixed-content"} %>
+          <%= form.label_and_textarea "finding_aid_subtitle", :field_opts => {:class => "mixed-content"} %>
+
           <%= form.label_and_textarea "finding_aid_filing_title" %>
           <%= form.label_and_textfield "finding_aid_date" %>
           <%= form.label_and_textarea "finding_aid_author" %>


### PR DESCRIPTION
Hi there,

I'm not sure if others will find this useful, but this is a sister commit to PR #2710.  It adds support for EAD markup to the titles of the major record types.  We developed this for The New School, who use markup in titles pretty heavily, along with the emph-italic feature added by #2710.

Includes:

  * Titles for Resource, Archival Object, Accession, Digital Object, Digital Object Component.

  * Finding Aid Title and Subtitle for Resource records.
