### PR TITLE
ANW-901: Update full record exclusions

### DIFF
--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -121,8 +121,6 @@ class IndexerCommon
   end
 
 
-  EXCLUDED_STRING_VALUE_PROPERTIES = Set.new(%w(created_by last_modified_by system_mtime user_mtime json types create_time date_type jsonmodel_type publish extent_type language script system_generated suppressed source rules name_order))
-
   def self.extract_string_values(doc)
     queue = [doc]
     strings = []
@@ -131,8 +129,8 @@ class IndexerCommon
       doc = queue.pop
 
       doc.each do |key, val|
-        if EXCLUDED_STRING_VALUE_PROPERTIES.include?(key) || key =~ /_enum_s$/
-          # ignored
+        if IndexerCommonConfig.fullrecord_excludes.include?(key) || key =~ /_enum_s$/
+          next # ignored
         elsif val.is_a?(String)
           strings.push(val)
         elsif val.is_a?(Hash)
@@ -1138,9 +1136,9 @@ class IndexerCommon
   end
 
   # ANW-1065
-  # iterate through the do_not_index list and scrub out that part of the JSON tree 
+  # iterate through the do_not_index list and scrub out that part of the JSON tree
   def sanitize_json(json)
-    IndexerCommonConfig::do_not_index.each do |k, v|
+    IndexerCommonConfig.do_not_index.each do |k, v|
       if json["jsonmodel_type"] == k
         # subrec is a reference used to navigate inside of the JSON as specified by the v[:location] to find the part of the tree to sanitize
         subrec = json

--- a/indexer/app/lib/indexer_common_config.rb
+++ b/indexer/app/lib/indexer_common_config.rb
@@ -77,9 +77,39 @@ class IndexerCommonConfig
     ]
   end
 
+  # #build_fullrecord uses this to exclude indexing of the record property from the fullrecord field
+  # this means these properties (including any embedded / sub properties) do not influence search via
+  # fullrecord for the record that is being indexed
+  def self.fullrecord_excludes
+    [
+      "created_by",
+      "last_modified_by",
+      "system_mtime",
+      "user_mtime",
+      "json",
+      "types",
+      "create_time",
+      "date_type",
+      "jsonmodel_type",
+      "publish",
+      "extent_type",
+      "language",
+      "script",
+      "system_generated",
+      "suppressed",
+      "source",
+      "rules",
+      "name_order",
+      "repository",
+      "top_container"
+    ]
+  end
+
   def self.do_not_index
     # ANW-1065
-    # #sanitize_json uses this hash to clean up sensitive data, preventing it from being indexed in the json field in the indexer doc.
+    # #sanitize_json uses this hash to clean up sensitive data, preventing it from being indexed.
+    # It does this by mutating the record being indexed, removing the data so it is not available
+    # in the json field or to the fullrecord field when that is built
     {
         "agent_person"           => {:location => [],
                                      :to_clean => "agent_contacts"},


### PR DESCRIPTION
Resolves: repository address is indexed in all searches (SUI and PUI) skewing search results.

Skip indexing of repository and top_container record properties in the fullrecord field for all record types.

This results in repository and top container (including location) data not influening search for other record types.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-901

## How Has This Been Tested?
Using the dev data set perform a general SUI search:

http://localhost:3000/search?utf8=%E2%9C%93&q=Your+Name+Here+Special+Collections+%28YNHSC%29
Before:
448 results, ~10 record types
After:
10 results, 6 record types

http://localhost:3000/search?utf8=%E2%9C%93&q=Overly+Gothic+Library
Before:
614 results, ~11 record types
After:
172 results, 3 record types: location, top container, repository

The repository / location fields are not being found in the Solr doc for the other record types.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
