### PR TITLE
leave out the field prefix when doing keyword searches so default qf …

### DIFF
--- a/backend/app/model/advanced_query_string.rb
+++ b/backend/app/model/advanced_query_string.rb
@@ -8,8 +8,11 @@ class AdvancedQueryString
 
   def to_solr_s
     return empty_solr_s if empty_search?
-
-    "#{prefix}#{field}:#{value}"
+    if field.nil?
+      "#{prefix}#{value}"
+    else
+      "#{prefix}#{field}:#{value}"
+    end
   end
 
   private

--- a/backend/spec/model_solr_spec.rb
+++ b/backend/spec/model_solr_spec.rb
@@ -155,7 +155,7 @@ describe 'Solr model' do
     it "constructs advanced query containing Boolean NOT without adding a match-all clause" do
       query_string = Solr::Query.construct_advanced_query_string(canned_query)
 
-      expect(query_string).to eq("((-title:(tennis)) AND ((fullrecord:(golf))))")
+      expect(query_string).to eq("((-title:(tennis)) AND (((golf))))")
     end
 
   end

--- a/common/search_definitions.rb
+++ b/common/search_definitions.rb
@@ -1,4 +1,4 @@
-AdvancedSearch.define_field(:name => 'keyword', :type => :text, :visibility => [:staff, :public], :solr_field => 'fullrecord')
+AdvancedSearch.define_field(:name => 'keyword', :type => :text, :visibility => [:staff, :public], :solr_field => nil)
 AdvancedSearch.define_field(:name => 'title', :type => :text, :visibility => [:staff, :public], :solr_field => 'title')
 AdvancedSearch.define_field(:name => 'identifier', :type => :text, :visibility => [:staff, :public], :solr_field => 'identifier')
 AdvancedSearch.define_field(:name => 'creators', :type => :text, :visibility => [:staff, :public], :solr_field => 'creators_text')


### PR DESCRIPTION
The defaults for the `'/select` edismax handler have this value for `qf`:

```xml
      <str name="qf">title^25 four_part_id^50 fullrecord</str>
```

But the backend `Solr` model renders ASpace `advanced_query` schema objects into field-prefixed query strings, which will make the `qf` field irrelevant. For example, a solr query like `q=foo&qf=title^20record^10` will search both fields and weight them as specified, but a search like `?q=(title:foo)&qf=title^20record^10` will only search the `title` field. 

So rather than attempt to majorly rework things, this change just modifies the translation from AS query schema to Solr syntax such that AS's `keyword` no longer maps to `fullrecord` but instead uniquely produces a prefixless query. I tested this a bit with the negations and it seems non-disruptive.




