### PR TITLE
ANW-1453-improve-typeahead-behavior

### DIFF
--- a/backend/app/model/search.rb
+++ b/backend/app/model/search.rb
@@ -6,7 +6,7 @@ class Search
     show_suppressed = !RequestContext.get(:enforce_suppression)
     show_published_only = RequestContext.get(:current_username) === User.PUBLIC_USERNAME
 
-    Log.debug(params.inspect)
+    Log.debug("backend search received params: #{params.inspect}")
 
     query = if params[:q]
               Solr::Query.create_keyword_search(params[:q])

--- a/frontend/app/controllers/search_controller.rb
+++ b/frontend/app/controllers/search_controller.rb
@@ -56,6 +56,12 @@ class SearchController < ApplicationController
 
   def do_search
     criteria = params_for_backend_search.merge({"facet[]" => SearchResultData.BASE_FACETS.concat(params[:facets]||[]).uniq})
+
+    # linker typeaheads should only search title (maybe)
+    if params['linker']
+      criteria['q'] = "title:#{criteria['q']}"
+    end
+
     context_criteria = params["context_filter_term"] ? {"filter_term[]" => params["context_filter_term"]} : {}
     @search_data = Search.all(session[:repo_id], criteria, context_criteria)
     @hide_sort_options = params[:hide_sort_options] == "true"

--- a/frontend/app/controllers/search_controller.rb
+++ b/frontend/app/controllers/search_controller.rb
@@ -57,13 +57,11 @@ class SearchController < ApplicationController
   def do_search
     criteria = params_for_backend_search.merge({"facet[]" => SearchResultData.BASE_FACETS.concat(params[:facets]||[]).uniq})
 
-    # linker typeaheads should only search title (maybe)
-    if params['linker']
-      criteria['q'] = "title:#{criteria['q']}"
-    end
+    # linker typeaheads should always sort by score
+    sorting = params['linker'] ? "score desc" : nil
 
     context_criteria = params["context_filter_term"] ? {"filter_term[]" => params["context_filter_term"]} : {}
-    @search_data = Search.all(session[:repo_id], criteria, context_criteria)
+    @search_data = Search.all(session[:repo_id], criteria, context_criteria, sorting)
     @hide_sort_options = params[:hide_sort_options] == "true"
     @hide_csv_download = params[:hide_csv_download] == "true"
 

--- a/frontend/app/views/agents/_linker.html.erb
+++ b/frontend/app/views/agents/_linker.html.erb
@@ -44,7 +44,7 @@
              data-label_create_and_link="<%= I18n.t("linker.create_and_link") %>"
              data-name="ref"
              data-path="<%= form.path %>"
-             data-url="<%= url_for :controller => :search, :action => :do_search, :format => :json %>"
+             data-url="<%= url_for :controller => :search, :action => :do_search, :format => :json, :linker => true %>"
              data-browse-url="<%= url_for :controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.AGENT_FACETS, :sort => "title_sort asc" %>"
              data-selected="<%= selected_json %>"
              data-multiplicity="<%= multiplicity %>"

--- a/frontend/app/views/resources/_linker.html.erb
+++ b/frontend/app/views/resources/_linker.html.erb
@@ -34,7 +34,7 @@
             data-label_create_and_link="<%= I18n.t("linker.create_and_link") %>"
             data-path="<%= form.path %>"
             data-name="ref"
-            data-url="<%= url_for :controller => :search, :action => :do_search, :format => :json %>"
+            data-url="<%= url_for :controller => :search, :action => :do_search, :format => :json, :linker => true %>"
             data-browse-url="<%= url_for :controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.RESOURCE_FACETS, :exclude => exclude_ids %>"
             data-selected="<%= selected_json %>"
             data-format_property="title"


### PR DESCRIPTION
This is a change to allow the linker typeahead for agents and resources to force search results to be sorted by score instead of the repo's sort preferences being used. The resources and agents linkers now identify themselves to the frontend `SearchController` by way of a `linker` request parameter. An optional parameter `sorting` is added to the `Search::all` method to skip the preferences check and propagate the desired string as the sort.

The resources linker is used in the `related_resources` view, the `largetree` view, and several background job views. The agents linker is used for several `related_agents`, `linked_agents`, and `classifications` views. I checked a couple of them and nothing unintended seems to occur, but we should probably go through them all and make sure. 