### PR TITLE
Upgrade Uglifier / Fix Docker Build

### DIFF
--- a/frontend/Gemfile
+++ b/frontend/Gemfile
@@ -18,7 +18,7 @@ gem 'coffee-script'
 gem 'coffee-script-source'
 gem 'sass-rails', '~> 5.0', '>= 5.0.6'
 gem 'therubyrhino'
-gem 'uglifier', '3.0.4'
+gem 'uglifier'
 
 gem 'less-rails-bootstrap'
 

--- a/frontend/Gemfile.lock
+++ b/frontend/Gemfile.lock
@@ -297,7 +297,7 @@ GEM
       thread_safe (~> 0.1)
     tzinfo-data (1.2022.3)
       tzinfo (>= 1.0.0)
-    uglifier (3.0.4)
+    uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4-java)
     virtus (2.0.0)
@@ -364,7 +364,7 @@ DEPENDENCIES
   sprockets-rails (= 2.3.3)
   therubyrhino
   tzinfo-data
-  uglifier (= 3.0.4)
+  uglifier
   web-console
   zip-zip (= 0.3)
 

--- a/public/Gemfile
+++ b/public/Gemfile
@@ -22,7 +22,7 @@ gem 'bootstrap-sass', '= 3.3.7'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0', '>= 5.0.6'
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '3.0.4'
+gem 'uglifier'
 # Use font-awesome icons
 gem 'font-awesome-sass', '4.7.0'
 

--- a/public/Gemfile.lock
+++ b/public/Gemfile.lock
@@ -269,7 +269,7 @@ GEM
       thread_safe (~> 0.1)
     tzinfo-data (1.2022.3)
       tzinfo (>= 1.0.0)
-    uglifier (3.0.4)
+    uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     virtus (2.0.0)
       axiom-types (~> 0.1)
@@ -325,7 +325,7 @@ DEPENDENCIES
   therubyrhino
   turbolinks (~> 5)
   tzinfo-data
-  uglifier (= 3.0.4)
+  uglifier
 
 BUNDLED WITH
    2.1.4

--- a/public/config/environments/production.rb
+++ b/public/config/environments/production.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
   config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Upgrade uglifier so ES6 syntax will not break asset precompilation in the public app. 
