### PR TITLE
ANW-170: Modify datepicker plugin to allow pasting year, month, or day

### DIFF
--- a/frontend/spec/features/datepicker_plugin_spec.rb
+++ b/frontend/spec/features/datepicker_plugin_spec.rb
@@ -1,0 +1,73 @@
+require 'date'
+require 'spec_helper.rb'
+require 'rails_helper.rb'
+
+describe 'DatepickerPlugin', js: true do
+
+  before(:each) do
+    visit '/'
+    page.has_xpath? '//input[@id="login"]'
+
+    within "form.login" do
+      fill_in "username", with: "admin"
+      fill_in "password", with: "admin"
+
+      click_button "Sign In"
+    end
+
+    page.has_no_xpath? '//input[@id="login"]'
+    page.has_css? 'button[title="Show Advanced Search"]'
+    first('button[title="Show Advanced Search"]').click
+    first('.advanced-search-add-row-dropdown').click
+    first('.advanced-search-add-date-row').click
+    page.has_css? 'input#v1.date-field'
+
+    @date_field = find 'input#v1.date-field'
+    @datepicker_toggle = find 'button[title="Toggle the Date Picker"]'
+
+    expect(page).not_to have_css('body > .datepicker')
+    @datepicker_toggle.click
+    expect(page).to have_css('body > .datepicker > .datepicker-years', visible: false)
+    expect(page).to have_css('body > .datepicker > .datepicker-months', visible: false)
+    expect(page).to have_css('body > .datepicker > .datepicker-days', visible: false)
+  end
+
+  it 'accepts a pasted year date in yyyy format' do
+    execute_script("navigator.clipboard.writeText('1999').catch(err => err);")
+
+    @date_field.click
+    if page.driver.browser.capabilities.platform == 'mac'
+      @date_field.send_keys([:command, 'v'])
+    else
+      @date_field.send_keys([:control, 'v'])
+    end
+
+    expect(page).to have_css('body > .datepicker > .datepicker-years', visible: true)
+  end
+
+  it 'accepts a pasted month date in yyyy-mm format' do
+    execute_script("navigator.clipboard.writeText('1999-12').catch(err => err);")
+
+    @date_field.click
+    if page.driver.browser.capabilities.platform == 'mac'
+      @date_field.send_keys([:command, 'v'])
+    else
+      @date_field.send_keys([:control, 'v'])
+    end
+
+    expect(page).to have_css('body > .datepicker > .datepicker-months', visible: true)
+  end
+
+  it 'accepts a pasted day date in yyyy-mm-dd format' do
+    execute_script("navigator.clipboard.writeText('1999-12-31').catch(err => err);")
+
+    @date_field.click
+    if page.driver.browser.capabilities.platform == 'mac'
+      @date_field.send_keys([:command, 'v'])
+    else
+      @date_field.send_keys([:control, 'v'])
+    end
+
+    expect(page).to have_css('body > .datepicker > .datepicker-days', visible: true)
+  end
+end

--- a/frontend/vendor/assets/javascripts/bootstrap-datepicker.js
+++ b/frontend/vendor/assets/javascripts/bootstrap-datepicker.js
@@ -523,10 +523,30 @@
 			else {
 				return;
 			}
-			this.setDate(dateString);
-			this.update();
-			evt.preventDefault();
-		},
+
+      // ANW-170: Allow pasting year, month, or day
+      const inputField = this.inputField['0'];
+      const pastePrecision = dateString.split('-').length;
+      const pasteFormatMap = {
+        1: { format: 'yyyy', minViewMode: 2 },
+        2: { format: 'yyyy-mm', minViewMode: 1 },
+        3: { format: 'yyyy-mm-dd', minViewMode: 0 }
+      };
+
+      const pasteHandler = () => {
+        const format = pasteFormatMap[pastePrecision].format;
+        const minViewMode = pasteFormatMap[pastePrecision].minViewMode;
+
+        $(inputField).datepicker('destroy');
+        $(inputField).datepicker({ format, minViewMode });
+        $(inputField).datepicker('setDate', dateString);
+        $(inputField).datepicker('upDate');
+        $(inputField).datepicker('show');
+      };
+
+      pasteHandler();
+      evt.preventDefault();
+    },
 
 		_utc_to_local: function(utc){
 			return utc && new Date(utc.getTime() + (utc.getTimezoneOffset()*60000));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

⚠️ THIS PR MODIFIES A VENDOR PLUGIN ⚠️

This PR addresses [QA feedback from previous ANW-170 work](https://archivesspace.atlassian.net/browse/ANW-170?focusedCommentId=38512) that was concerned about the datepicker behavior when pasting year or month values with the datepicker toggled on. Previously the datepicker would force year and month values into the current day's date. This PR modifies the datepicker vendor plugin to allow pasting year, month, or day values into a datefield when the datepicker is toggled on.

![ANW-170 Datepicker paste modification](https://user-images.githubusercontent.com/3411019/193810999-2629fc13-8b3d-4ebb-8732-7537cd6e16b4.gif)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

https://archivesspace.atlassian.net/browse/ANW-170

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See frontend/spec/features/datepicker_plugin_spec.rb

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
