### PR TITLE
ANW-950: Show See more text and hide borders for PUI print

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/print.css
+++ b/public/app/assets/stylesheets/archivesspace/print.css
@@ -185,17 +185,33 @@
     overflow: initial !important;
   }
 
-  /* Expand accordion panels, via Bodleian */
+  /* Expand accordion panels */
   .collapse {
     display: initial !important;
   }
 
-  /* Show all infinite records, via Bodleian */
+  /* Hide panel borders */
+  .panel,
+  .panel-default,
+  .panel-heading,
+  .panel-body {
+    border-color: white !important;
+  }
+
+  /* Expand 'See more' sections, hide expander */
+  .readmore .more {
+    visibility: visible !important;
+    display: inline !important;
+  }
+  .readmore span.elipses,
+  .readmore a.expander {
+    display: none;
+  }
+
+  /* Show all infinite records, tighten whitespace */
   .infinite-record-wrapper {
     height: auto !important;
   }
-
-  /* Decrease whitespace between repo details and infinite records */
   .infinite-record-wrapper div.infinite-record-record:first-of-type h3 {
     margin-top: 0 !important;
   }
@@ -203,7 +219,6 @@
   /* Applied by print.js */
   .page-location-for-printing {
     padding: 2px;
-    border: 1px dashed black;
     font-size: 10px;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR follows up on [QA feedback](https://archivesspace.atlassian.net/browse/ANW-950?focusedCommentId=38584) on [previous work](https://github.com/archivesspace/archivesspace/pull/2683) on PUI print styles.

- 'See more' text is expanded, and the associated ellipses are removed
- More borders have been hidden

In the screenshots below, the 'See more' expander has been removed, and the content has been expanded under Scope and Content, and the Finding Aid borders have been removed.

<img width="503" alt="ANW-950 1" src="https://user-images.githubusercontent.com/3411019/195087985-946db927-da37-430b-ac85-6779db706cdd.png">

<img width="499" alt="ANW-950 2" src="https://user-images.githubusercontent.com/3411019/195088008-d345feba-60be-430b-8680-a57410e411bb.png">

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
