### PR TITLE
cope with hyphens in 4-part IDs and titles

### DIFF
--- a/backend/app/model/solr.rb
+++ b/backend/app/model/solr.rb
@@ -355,7 +355,7 @@ class Solr
       if @query_type == :edismax
         add_solr_param(:defType, "edismax")
         add_solr_param(:pf, "four_part_id^4")
-        add_solr_param(:qf, "four_part_id^3 title^2 finding_aid_filing_title^2 fullrecord")
+        add_solr_param(:qf, "identifier_ws^3 title_ws^2 finding_aid_filing_title^2 fullrecord")
       end
 
       # do it here so instance variables can be resolved

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -7,6 +7,8 @@
     <field name="pui_parent_id" type="string" indexed="true" stored="true" required="false" multiValued="false" />
     <field name="four_part_id" type="text_general" indexed="true" stored="true" multiValued="false" />
     <field name="title" type="text_general" indexed="true" stored="true" multiValued="false" />
+    <field name="title_ws" type="text_ws" indexed="true" stored="true" multiValued="false" />
+    <copyField source="title" dest="title_ws" />
     <field name="types" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="primary_type" type="string" indexed="true" stored="true" multiValued="false" />
     <field name="repository" type="string" indexed="true" stored="true" multiValued="false" />
@@ -39,6 +41,8 @@
     <field name="langcode" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="accession_date_year" type="int" indexed="true" stored="true" multiValued="false" />
     <field name="identifier" type="sort_icu" indexed="true" stored="true" multiValued="false" />
+    <field name="identifier_ws" type="text_ws" indexed="true" stored="true" multiValued="false" />
+    <copyField source="identifier" dest="identifier_ws" />
     <field name="acquisition_type" type="string" indexed="true" stored="true" multiValued="false" />
     <field name="accession_date" type="string" indexed="true" stored="true" multiValued="false" />
     <field name="resource_type" type="string" indexed="true" stored="true" multiValued="false" />
@@ -176,6 +180,7 @@
     <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
         <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.LowerCaseFilterFactory" />
       </analyzer>
     </fieldType>
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">


### PR DESCRIPTION
Copies the `identifier` field (the 4-part ID with hyphens) and the `title` field into additional fields to be indexed using the whitespace tokenizer (`text_ws` field type) instead of the standard tokenizer. The standard tokenizer splits hyphenated strings into separate terms, making it impossible to search using the hyphens. Also adds the lowercase filter to the `text_ws` field type, which is important.