### PR TITLE
ANW-1557 MARCXML import add 852$j

### DIFF
--- a/backend/app/converters/lib/marcxml_bib_base_map.rb
+++ b/backend/app/converters/lib/marcxml_bib_base_map.rb
@@ -752,7 +752,7 @@ module MarcXMLBibBaseMap
 
         # ID_0, ID_1, ID_2, ID_3
         "datafield[@tag='852']" => -> resource, node {
-          id = concatenate_subfields(%w(k h i m), node, '_')
+          id = concatenate_subfields(%w(k h i j m), node, '_')
           resource.id_0 = id unless id.empty?
         },
 

--- a/backend/spec/lib_marcxml_bib_converter_spec.rb
+++ b/backend/spec/lib_marcxml_bib_converter_spec.rb
@@ -75,6 +75,13 @@ describe 'MARCXML Bib converter' do
                         <subfield code="c">711_sub_c</subfield>
                         <subfield code="q">711_sub_q</subfield>
                       </datafield>
+                      <datafield ind1="1" ind2=" " tag="852">
+                        <subfield code="k">Call number prefix</subfield>
+                        <subfield code="h">Classification part</subfield>
+                        <subfield code="i">Item part</subfield>
+                        <subfield code="j">Shelving control number</subfield>
+                        <subfield code="m">Call number suffix</subfield>
+                      </datafield>
                   </record>
              </collection>
       END
@@ -147,6 +154,9 @@ describe 'MARCXML Bib converter' do
       end
     end
 
+    it "maps datafield[@tag='852'] $k, $h, $i, $j, $m to id_0" do
+      expect(@resource['id_0']).to eq("Call number prefix_Classification part_Item part_Shelving control number_Call number suffix")
+    end
 
 
     describe "MARC import mappings" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adds 852$j to MARC XML bib importer map as requested by Metadata Standards subgroup of TAC.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1557

## How Has This Been Tested?
New test added to `backend/spec/lib_marcxml_bib_converter_spec.rb`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
