### PR TITLE
ANW-1565 MARCXML import conditionally add 264$c

### DIFF
--- a/backend/app/converters/lib/marcxml_bib_base_map.rb
+++ b/backend/app/converters/lib/marcxml_bib_base_map.rb
@@ -872,9 +872,22 @@ module MarcXMLBibBaseMap
                                                date.expression = node.xpath("subfield[@code='c']")
                                                resource.dates << date
                                              end
+                                           else
+                                             resource['_needs_date'] = true
                                            end
                                          }
                                        }),
+
+        "datafield[@tag='264']/subfield[@code='c']" => -> resource, node {
+                                          if resource['_needs_date']
+                                            make(:date) do |date|
+                                              date.label = 'publication'
+                                              date.date_type = 'single'
+                                              date.expression = node.inner_text
+                                              resource.dates << date
+                                            end
+                                          end
+                                        },
 
         # 300s
         # EXTENTS

--- a/backend/spec/lib_marcxml_bib_converter_spec.rb
+++ b/backend/spec/lib_marcxml_bib_converter_spec.rb
@@ -147,7 +147,36 @@ describe 'MARCXML Bib converter' do
       end
     end
 
+    context 'when controlfield positions 7-10, 245$f, 245$g, and 260$c are not present' do
+      let (:test_doc) {
+        src = <<~MARC
+          <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+          <collection xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd" xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <record>
+                  <leader>00000npc a2200000 u 4500</leader>
+                  <controlfield tag="008">130109         xx                  eng d</controlfield>
+                  <datafield tag="245" ind1="1" ind2="0">
+                      <subfield code="a">Resource with Publication Date</subfield>
+                  </datafield>
+                  <datafield tag="300" ind1=" " ind2=" ">
+                      <subfield code="a">1 item</subfield>
+                  </datafield>
+                  <datafield tag="264" ind2=" " ind1=" ">
+                      <subfield code="c">264$c date expression</subfield>
+                  </datafield>
+              </record>
+          </collection>
+        MARC
+        get_tempfile_path(src)
+      }
+      let(:resource) { (convert(test_doc)).last }
 
+      it "maps datafield[@tag='264']/subfield[@code='c'] to resources.dates[]" do
+        expect(resource['dates'][0]['expression']).to eq("264$c date expression")
+        expect(resource['dates'][0]['label']).to eq("publication")
+        expect(resource['dates'][0]['date_type']).to eq("single")
+      end
+    end
 
     describe "MARC import mappings" do
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adds 264$c to MARC XML bib importer map as requested by Metadata Standards subgroup of TAC, when the following are absent:
- controlfield position 6 is not 'i', 'k', or 's' (not in JIRA, but a necessary condition);
- 245$f;
- 245$g; and
- 260$c.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
**Note**: In working on this, I noticed that one of the assumptions inherent in the ticket and that seems to be [attempted in the code](https://github.com/archivesspace/archivesspace/blob/master/backend/app/converters/lib/marcxml_bib_base_map.rb#L867-L875), currently does not work.  If you attempt to upload a MARCXML file that contains no dates in:
- controlfield;
- 245$f; and
- 245$g
a date subrecord **does not** get created from the value in 260$c.  (In fact, if the only place date content is available is 260$c the import will fail with the error that a date is a required field.)  

Happy to file a ticket and/or add a comment in this code if wanted, but wanted to note it here and confirm my reading of the ticket/code is correct first.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1565

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test added.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
