### PR TITLE
ANW-1518: Fix alt text logic for staff Digital Object Component file version image

### DIFF
--- a/frontend/app/views/digital_object_components/_show_inline.html.erb
+++ b/frontend/app/views/digital_object_components/_show_inline.html.erb
@@ -33,7 +33,7 @@
         </section>
 
         <% if digital_object_component.file_versions.length > 0 %>
-          <%= render_aspace_partial :partial => "file_versions/show", :locals => { :file_versions => digital_object_component.file_versions, :section_id => "digital_object_component_file_versions_" } %>
+          <%= render_aspace_partial :partial => "file_versions/show", :locals => { :file_versions => digital_object_component.file_versions, :section_id => "digital_object_component_file_versions_", :title => digital_object_component.display_string } %>
         <% end %>
 
         <% if digital_object_component.lang_materials.length > 0 %>

--- a/frontend/app/views/digital_objects/_show_inline.html.erb
+++ b/frontend/app/views/digital_objects/_show_inline.html.erb
@@ -35,7 +35,7 @@
         </section>
 
         <% if digital_object.file_versions.length > 0 %>
-          <%= render_aspace_partial :partial => "file_versions/show", :locals => { :file_versions => digital_object.file_versions, :section_id => "digital_object_file_versions_" } %>
+          <%= render_aspace_partial :partial => "file_versions/show", :locals => { :file_versions => digital_object.file_versions, :section_id => "digital_object_file_versions_", :title => digital_object.title } %>
         <% end %>
 
         <% if digital_object.lang_materials.length > 0 %>

--- a/frontend/app/views/file_versions/_image.html.erb
+++ b/frontend/app/views/file_versions/_image.html.erb
@@ -2,7 +2,7 @@
   <div class="control-label col-sm-2"><%= I18n.t("file_version.file") %></div>
   <div class="controls label-only">
     <div class="image-container">
-      <img class="image-responsive" src="<%= file['file_uri'] %>" alt="<%= file['caption'] ? file['caption'] : @digital_object['title'] %>"/>
+      <img class="image-responsive" src="<%= file['file_uri'] %>" alt="<%= alt_text %>" />
     </div>
   </div>
 </div>

--- a/frontend/app/views/file_versions/_show.html.erb
+++ b/frontend/app/views/file_versions/_show.html.erb
@@ -20,7 +20,8 @@
         <div id="<%= section_id %>_file_version_<%= index %>" class="accordion-body collapse">
           <div class="form-horizontal">
             <% if can_embed?(file_version) %>
-              <%= render_aspace_partial :partial => "file_versions/image", :locals => {:file => file_version} %>
+              <% alt_text = file_version['caption'] ? file_version['caption'] : title %>
+              <%= render_aspace_partial :partial => "file_versions/image", :locals => {:file => file_version, :alt_text => alt_text } %>
             <% end %>
             <%= render_aspace_partial :partial => "file_versions/file_uri", :locals => {:file_uri => uri_or_string( file_version['file_uri'] ) } %>
           </div>

--- a/frontend/spec/selenium/spec/digital_objects_spec.rb
+++ b/frontend/spec/selenium/spec/digital_objects_spec.rb
@@ -214,4 +214,53 @@ describe 'Digital Objects' do
     @driver.click_and_wait_until_gone(css: "form .record-pane button[type='submit']")
     @driver.find_element(css: '#digital_object_classifications__0_')
   end
+
+  it 'provides alt text for Digital Object and Digital Object Component file version images with and without captions' do
+    alt_do_title = 'File version alt text test'
+    alt_doc_title = 'Child of file version alt text test'
+    alt_uri = 'https://www.archivesspace.org/demos/Congreave%20E-2/ms292_003_page002.jpg'
+    alt_format = 'jpeg'
+    alt_caption = 'This is the caption'
+
+    @alt_do = create(
+      :digital_object,
+      title: alt_do_title,
+      file_versions: [
+        {
+          file_uri: alt_uri,
+          file_format_name: alt_format,
+          caption: alt_caption
+        },
+        {
+          file_uri: alt_uri,
+          file_format_name: alt_format
+        }
+      ]
+    )
+    @alt_doc = create(
+      :digital_object_component,
+      digital_object: { ref: @alt_do.uri },
+      title: alt_doc_title,
+      file_versions: [
+        {
+          file_uri: alt_uri,
+          file_format_name: alt_format,
+          caption: alt_caption
+        },
+        {
+          file_uri: alt_uri,
+          file_format_name: alt_format
+        }
+      ]
+    )
+    run_all_indexers
+
+    @driver.get_view_page(@alt_do)
+    expect(@driver.find_hidden_element(css: "section#digital_object_file_versions_ #digital_object_file_versions__file_version_0 img[alt='#{alt_caption}']"))
+    expect(@driver.find_hidden_element(css: "section#digital_object_file_versions_ #digital_object_file_versions__file_version_1 img[alt='#{alt_do_title}']"))
+
+    @driver.find_element(:link, alt_doc_title).click
+    expect(@driver.find_hidden_element(css: "section#digital_object_component_file_versions_ #digital_object_component_file_versions__file_version_0 img[alt='#{alt_caption}']"))
+    expect(@driver.find_hidden_element(css: "section#digital_object_component_file_versions_ #digital_object_component_file_versions__file_version_1 img[alt='#{alt_doc_title}']"))
+  end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR addresses [ANW-1518](https://archivesspace.atlassian.net/browse/ANW-1518) by fixing a bug in the logic for computing the `alt` text of a Digital Object Component's file version image. DO and DOC file version images use the file version caption to populate the `alt` attribute text on the corresponding `<img>` element in the object's view page. When a DOC file version had no caption set, the attempt was made to derive the alt text from data that was only available to DO.

### Before

<img width="1504" alt="ANW-1518-before" src="https://user-images.githubusercontent.com/3411019/197609785-1e7f65b4-11fb-4a6b-9f31-4249470228e4.png">

### After

<img width="1504" alt="ANW-1518-after" src="https://user-images.githubusercontent.com/3411019/197609813-6c851d00-4eb8-4c62-b78e-a98c1a7580c3.png">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See frontend/spec/selenium/spec/digital_objects_spec.rb

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
