### PR TITLE
ANW-961: add breadcrumbs to digital materials listing

### DIFF
--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -68,7 +68,7 @@
                      app_prefix(repository_base_url(
                       "uri" => result.resolved_repository.fetch('uri'),
                       "slug" => result.resolved_repository.fetch('slug') {|s| nil })) %>
-          <% if result.kind_of?(DigitalObject) %>
+          <% if result.is_a?(DigitalObject) %>
             <% resolved_instances_record = 
                  ArchivesSpaceClient.instance.get_record(result.uri, {'resolve[]' => ['linked_instance_uris:id']}) %>
             <% resolved_instances_record.linked_instances.each do |uri, instance_record| %>

--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -72,8 +72,7 @@
             <% fullrec.linked_instances.each do |uri, instance_record| %>
               <% if instance_record.primary_type == 'archival_object' %>
                   <% instance_record.breadcrumb.each do |crumb| %>
-                    <!-- We just want the containing resource here, not any intermediate archival_objects, right? -->
-                    <% next if crumb[:uri].blank? or crumb[:type] != 'resource' %>
+                    <% next if crumb[:uri].blank? %>
                     <%= t('context_delimiter') %>
                     <%= badge_for_type(crumb[:type]) %> <%= link_to crumb[:crumb], app_prefix(crumb[:uri]) %>
                   <% end %>

--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -67,6 +67,19 @@
                      app_prefix(repository_base_url(
                       "uri" => result.resolved_repository.fetch('uri'),
                       "slug" => result.resolved_repository.fetch('slug') {|s| nil })) %>
+          <% if result.kind_of?(DigitalObject) %>
+            <% fullrec = ArchivesSpaceClient.instance.get_record(result.uri, {'resolve[]' => ['linked_instance_uris:id']}) %>
+            <% fullrec.linked_instances.each do |uri, instance_record| %>
+              <% if instance_record.primary_type == 'archival_object' %>
+                  <% instance_record.breadcrumb.each do |crumb| %>
+                    <!-- We just want the containing resource here, not any intermediate archival_objects, right? -->
+                    <% next if crumb[:uri].blank? or crumb[:type] != 'resource' %>
+                    <%= t('context_delimiter') %>
+                    <%= badge_for_type(crumb[:type]) %> <%= link_to crumb[:crumb], app_prefix(crumb[:uri]) %>
+                  <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
         </span>
 
         <% if result.respond_to?(:ancestors) && result.ancestors %>

--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -63,13 +63,15 @@
       <div class="result_context">
         <strong><%= t('context') %>: </strong>
         <span  class="repo_name">
+          <%= badge_for_type('repository') %>
           <%= link_to result.resolved_repository.fetch('name'),
                      app_prefix(repository_base_url(
                       "uri" => result.resolved_repository.fetch('uri'),
                       "slug" => result.resolved_repository.fetch('slug') {|s| nil })) %>
           <% if result.kind_of?(DigitalObject) %>
-            <% fullrec = ArchivesSpaceClient.instance.get_record(result.uri, {'resolve[]' => ['linked_instance_uris:id']}) %>
-            <% fullrec.linked_instances.each do |uri, instance_record| %>
+            <% resolved_instances_record = 
+                 ArchivesSpaceClient.instance.get_record(result.uri, {'resolve[]' => ['linked_instance_uris:id']}) %>
+            <% resolved_instances_record.linked_instances.each do |uri, instance_record| %>
               <% if instance_record.primary_type == 'archival_object' %>
                   <% instance_record.breadcrumb.each do |crumb| %>
                     <% next if crumb[:uri].blank? %>

--- a/public/spec/features/digital_objects_spec.rb
+++ b/public/spec/features/digital_objects_spec.rb
@@ -35,4 +35,12 @@ describe 'Digital Objects', js: true do
       expect(page).to have_content('Record Groups')
     end
   end
+
+  it 'displays breadcrumbs for items in the Digital Materials listing' do
+    visit '/'
+    click_link 'Digital Materials'
+    within find('div[data-uri="/repositories/2/digital_objects/5"') do
+      expect(page).to have_content('Resource with digital instance')
+    end
+  end
 end


### PR DESCRIPTION
Checks for breadcrumbs in any linked instances for a digital object and displays them in the digital materials listing