### PR TITLE
ANW-907, ANW-1626: Refactor PUI digital object links

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "description": "Check front end files for lint errors during CI",
   "scripts": {
     "eslint:ci": "eslint frontend/ public/",
+    "eslint:fix": "eslint --fix frontend/ public/",
     "stylelint:ci": "stylelint '{frontend,public}/**/*.{css,less,scss}' -f verbose",
-    "prettier:ci": "prettier --check frontend/ public/"
+    "stylelint:fix": "stylelint '{frontend,public}/**/*.{css,less,scss}' -f verbose --fix",
+    "prettier:ci": "prettier --check frontend/ public/",
+    "prettier:fix": "prettier --write frontend/ public/"
   },
   "devDependencies": {
     "eslint": "^8.14.0",

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -774,9 +774,13 @@ i.giant {
 }
 
 /* record details */
-.objectimage {
-  max-width: 50%;
+.available-digital-objects {
   float: right;
+  max-width: 50%;
+}
+
+.objectimage {
+  display: block;
   margin: 0 0 1em 1em;
 }
 .objectimage img {
@@ -786,14 +790,54 @@ i.giant {
   border-top-right-radius: var(--bootstrap-rounded-corner-radius);
   border-top-left-radius: var(--bootstrap-rounded-corner-radius);
 }
-
 .objectimage figcaption {
   padding: 0.5rem;
 }
-
 .objectimage button[type='submit'] {
   width: 100%;
   white-space: normal;
+}
+
+.record-type-badge.digital_object.external-digital-object__link {
+  width: 100%;
+  padding: 0 !important;
+  text-decoration: none;
+}
+
+.external-digital-object__content-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-bottom: 20px;
+  padding: var(--bootstrap-horizontal-white-space-unit);
+  border: 1px solid $digital-object-color;
+  border-radius: var(--bootstrap-rounded-corner-radius);
+  background-color: #fff;
+  text-align: center;
+}
+.external-digital-object__link:hover
+  .external-digital-object__content-container {
+  background-color: var(--bootstrap-default-white-hover);
+}
+
+.external-digital-object__content-btn {
+  /* bootstrap's .btn */
+  display: block;
+  margin-bottom: 0;
+  padding: 6px 12px;
+  border: 1px solid $digital-object-color;
+  border-radius: var(--bootstrap-rounded-corner-radius);
+  font-size: 14px;
+  font-family: var(--bootstrap-sans);
+  font-weight: normal;
+  white-space: nowrap;
+  text-align: center;
+  color: #fff;
+  background-color: $digital-object-color;
+}
+.external-digital-object__link:hover .external-digital-object__content-btn {
+  background-color: var(--bootstrap-danger-red-hover);
+  border-color: var(--bootstrap-danger-red-hover);
 }
 
 span.component {

--- a/public/app/assets/stylesheets/archivesspace/helpers.scss
+++ b/public/app/assets/stylesheets/archivesspace/helpers.scss
@@ -4,14 +4,20 @@
 :root {
   --bootstrap-horizontal-white-space-unit: 15px;
   --bootstrap-rounded-corner-radius: 4px;
+  --bootstrap-sans: 'Helvetica Neue', helvetica, arial, sans-serif;
+  --bootstrap-danger-red: #d9534f;
+  --bootstrap-danger-red-hover: #c9302c;
+  --bootstrap-default-white-hover: #eee;
 }
 
 .flex {
   display: flex;
 }
+
 .align-items-center {
   align-items: center;
 }
+
 .flex-grow-1 {
   flex-grow: 1;
 }
@@ -19,9 +25,11 @@
 .mt15px {
   margin-top: var(--bootstrap-horizontal-white-space-unit);
 }
+
 .mr15px {
   margin-right: var(--bootstrap-horizontal-white-space-unit);
 }
+
 .mb0 {
   margin-bottom: 0;
 }

--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -3,7 +3,7 @@
   otherwise expects to-be-deprecated 'dig_objs' as an array of hashes
 <!-- /comment --><% end  %>
 <% if AppConfig[:enable_representative_file_version] && rep_fv.present? %>
-<div class="images">
+<div class="available-digital-objects">
   <div class="objectimage">
     <div class="panel panel-default">
       <%= render partial: 'shared/representative_file_version', locals: {:uri => rep_fv['file_uri'], :caption => rep_fv['caption']} %>
@@ -11,24 +11,32 @@
   </div>
 </div>
 <% elsif dig_objs.present? %>
-<div class="images">
+<div class="available-digital-objects">
   <% dig_objs.each do |d_file| %>
     <% if !d_file['out'].blank? %>
       <% if d_file['thumb'].blank? %>
         <div class="objectimage">
-          <div class="panel panel-default">
-            <a class="btn btn-default record-type-badge digital_object" style="width: 100%" href="<%= d_file['out'] %>" target="new" title="<%= t('digital_object._public.link')%>">
+          <a
+            class="external-digital-object__link record-type-badge digital_object"
+            href="<%= d_file['out'] %>"
+            target="new"
+            title="<%= t('digital_object._public.link')%>"
+          >
+            <div class="external-digital-object__content-container">
               <i class="fa <%= { '(moving_image)' => 'fa-file-video-o' ,
                           '(sound_recording)' => 'fa-file-audio-o',
                           '(sound_recording_musical)' => 'fa-file-audio-o',
                           '(sound_recording_nonmusical)' => 'fa-file-audio-o' ,
                           '(still_image)' => 'fa-file-image-o' ,
-                          '(text)' =>  'fa-file-text'}.fetch( d_file['material'], 'fa-file-o' ) %> fa-4x"></i><br/>
-              <div class="panel-heading">
+                          '(text)' =>  'fa-file-text-o'}.fetch( d_file['material'], 'fa-file-o' ) %> fa-4x"></i>
+              <h5 class="ws-normal">
                 <%= d_file['caption'].blank? ? "#{t('enumerations.instance_instance_type.digital_object')} #{d_file['material']}" : d_file['caption'].html_safe %>
-              </div>
-            </a>
-          </div>
+              </h5>
+              <p class="external-digital-object__content-btn">
+                <%= t('digital_object._public.go')%> <i class="fa fa-external-link" aria-hidden="true"></i>
+              </p>
+            </div>
+          </a>
         </div>
       <% else %>
         <div class="objectimage">

--- a/public/config/locales/de.yml
+++ b/public/config/locales/de.yml
@@ -294,6 +294,7 @@ de:
       thumbnail: Vorschaubild
       link: Verweis zu digitalem Objekt
       badge_label: Digital %{level}
+      go: Gehen Sie zur Datei
     _plural: Digitales Archivgut
   subject:
     _singular: Thema

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -344,6 +344,7 @@ en:
       thumbnail: thumbnail
       link: Link to digital object
       badge_label: Digital %{level}
+      go: Go to file
 
   subject:
     _singular: Subject

--- a/public/config/locales/es.yml
+++ b/public/config/locales/es.yml
@@ -327,6 +327,7 @@ es:
       thumbnail: Miniatura
       link: Enlace al objeto digital
       badge_label: Digital %{level}
+      go: Ir al archivo
       section: {}
       messages: {}
   digital_object_component:

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -347,6 +347,7 @@ fr:
       thumbnail: miniature
       link: Lien vers objet numérique
       badge_label: Numérique %{level}
+      go: Aller au dossier
       section: {}
       messages: {}
   digital_object_component:

--- a/public/config/locales/ja.yml
+++ b/public/config/locales/ja.yml
@@ -299,6 +299,7 @@ ja:
       thumbnail: サムネイル
       link: デジタルオブジェクトへのリンク
       badge_label: デジタル%{level}
+      go: ファイルに移動
       section: {}
       messages: {}
   digital_object_component:

--- a/public/config/locales/pt.yml
+++ b/public/config/locales/pt.yml
@@ -128,3 +128,12 @@ pt:
     agents: criadores de conteúdo
   search-field: Campo de pesquisa
   searched-field: pesquisando% {campo}
+
+  digital_object:
+    _singular: Registro Digital
+    _plural: Materiais Digitais
+    _public:
+      thumbnail: miniatura
+      link: Link para objeto digital
+      badge_label: Digital %{level}
+      go: Ir para o arquivo

--- a/public/spec/features/file_version_link_spec.rb
+++ b/public/spec/features/file_version_link_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'File Version Link', js: true do
+  def check_uri_css(uri, css)
+    visit(uri)
+    expect(page).to have_css(css)
+  end
+
+  type_map = {
+    'default': '.fa-file-o',
+    'moving_image': '.fa-file-video-o',
+    'sound_recording': '.fa-file-audio-o',
+    'sound_recording_musical': '.fa-file-audio-o',
+    'sound_recording_nonmusical': '.fa-file-audio-o',
+    'still_image': '.fa-file-image-o',
+    'text': '.fa-file-text-o'
+  }
+
+  before(:all) do
+    file_base = 'https://example.com/fv'
+
+    @do1 = create(
+      :digital_object,
+      publish: true,
+      digital_object_type: 'still_image',
+      file_versions: [
+        {
+          publish: true,
+          file_uri: file_base + '0.jpg',
+          file_format_name: 'jpeg'
+        },
+        {
+          publish: true,
+          file_uri: file_base + '1.jpg',
+          file_format_name: 'jpeg'
+        },
+        {
+          publish: false,
+          file_uri: file_base + '2.jpg',
+          file_format_name: 'jpeg'
+        }
+      ]
+    )
+    @do2 = create(
+      :digital_object,
+      publish: true,
+      digital_object_type: 'still_image',
+      file_versions: [
+        {
+          publish: true,
+          file_uri: file_base + '0.gif',
+          file_format_name: 'gif'
+        },
+        {
+          publish: true,
+          file_uri: file_base + '1.gif',
+          file_format_name: 'gif'
+        },
+        {
+          publish: false,
+          file_uri: file_base + '2.gif',
+          file_format_name: 'gif'
+        }
+      ]
+    )
+    @do3 = create(
+      :digital_object,
+      publish: true,
+      digital_object_type: 'sound_recording',
+      file_versions: [
+        {
+          publish: true,
+          file_uri: file_base + '0.mp3',
+          file_format_name: 'mp3'
+        },
+        {
+          publish: true,
+          file_uri: file_base + '1.mp3',
+          file_format_name: 'mp3'
+        },
+        {
+          publish: false,
+          file_uri: file_base + '2.mp3',
+          file_format_name: 'mp3'
+        }
+      ]
+    )
+    @resource = create(:resource, publish: true,
+                       instances: [build(:instance_digital, digital_object: { ref: @do1.uri }), build(:instance_digital, digital_object: { ref: @do2.uri }), build(:instance_digital, digital_object: { ref: @do3.uri })])
+
+    @do_movie = create(:digital_object, publish: true, digital_object_type: 'moving_image', file_versions: [{publish: true, file_uri: file_base + '0.avi', file_format_name: 'avi'}])
+    @do_sound1 = create(:digital_object, publish: true, digital_object_type: 'sound_recording', file_versions: [{publish: true, file_uri: file_base + '0.aiff', file_format_name: 'aiff'}])
+    @do_sound2 = create(:digital_object, publish: true, digital_object_type: 'sound_recording_musical', file_versions: [{publish: true, file_uri: file_base + '0.mp3', file_format_name: 'mp3'}])
+    @do_sound3 = create(:digital_object, publish: true, digital_object_type: 'sound_recording_nonmusical', file_versions: [{publish: true, file_uri: file_base + '0.mp3', file_format_name: 'mp3'}])
+    @do_image = create(:digital_object, publish: true, digital_object_type: 'still_image', file_versions: [{publish: true, file_uri: file_base + '0.tiff', file_format_name: 'tiff'}])
+    @do_text = create(:digital_object, publish: true, digital_object_type: 'text', file_versions: [{publish: true, file_uri: file_base + '0.txt', file_format_name: 'txt'}])
+    @do_default = create(:digital_object, publish: true, file_versions: [{publish: true, file_uri: file_base + '0.pdf', file_format_name: 'pdf'}])
+
+    run_indexers
+  end
+
+  it "shows a link to only the most recently published file version on a digital object's page" do
+    visit(@do1.uri)
+    expect(page.all('.available-digital-objects > .objectimage').length).to eq 1
+    expect(page).to have_css('.available-digital-objects .external-digital-object__link[href="https://example.com/fv1.jpg"]')
+  end
+
+  it "shows links to all linked digital objects' most recently published file versions on a resource's page" do
+    visit(@resource.uri)
+    expect(page.all('.available-digital-objects > .objectimage').length).to eq 3
+    expect(page).to have_css('.available-digital-objects .external-digital-object__link[href="https://example.com/fv1.jpg"]')
+    expect(page).to have_css('.available-digital-objects .external-digital-object__link[href="https://example.com/fv1.gif"]')
+    expect(page).to have_css('.available-digital-objects .external-digital-object__link[href="https://example.com/fv1.mp3"]')
+  end
+
+  it "shows the correct icon for digital_object_type moving_image" do
+    check_uri_css(@do_movie.uri, type_map[:moving_image])
+  end
+
+  it "shows the correct icon for digital_object_type sound_recording" do
+    check_uri_css(@do_sound1.uri, type_map[:sound_recording])
+  end
+
+  it "shows the correct icon for digital_object_type sound_recording_musical" do
+    check_uri_css(@do_sound2.uri, type_map[:sound_recording_musical])
+  end
+
+  it "shows the correct icon for digital_object_type sound_recording_nonmusical" do
+    check_uri_css(@do_sound3.uri, type_map[:sound_recording_nonmusical])
+  end
+
+  it "shows the correct icon for digital_object_type still_image" do
+    check_uri_css(@do_image.uri, type_map[:still_image])
+  end
+
+  it "shows the correct icon for digital_object_type text" do
+    check_uri_css(@do_text.uri, type_map[:text])
+  end
+
+  it "shows the correct icon for digital_object_type default" do
+    check_uri_css(@do_default.uri, type_map[:default])
+  end
+
+end


### PR DESCRIPTION
This PR addresses [ANW-907](https://archivesspace.atlassian.net/browse/ANW-907) and [ANW-1626](https://archivesspace.atlassian.net/browse/ANW-1626).

It also provides npm lint fix scripts for developer convenience.

ANW-907 refers to the digital object links not being recognizable as such. This PR adds a visual button to the object's link box with an icon denoting the link leads to an external resource. This PR builds on [an earlier branch](#2843). In that branch the link color was changed to black, but here I kept the color red which denotes digital objects as defined in the [stylesheets](https://github.com/archivesspace/archivesspace/blob/master/public/app/assets/stylesheets/archivesspace/colors.scss#L44). The color could of course be easily changed if the color for digital objects is arbitrary.

If merged this would close #2843.

ANW-1626 refers to an unintended layout behavior on smaller viewports when a resource has multiple linked digital objects. The behavior occurs because each link component is `float`ed to the right. This PR fixes this by making the links container the floated element instead.

![ANW-1626-external-digital-object-links](https://user-images.githubusercontent.com/3411019/198980754-02b605d7-9233-45f6-8491-92c623371709.gif)

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See public/spec/features/file_version_link_spec.rb.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
