### PR TITLE
ANW-1296: add missing values for instance_type when running a bulk import

### DIFF
--- a/backend/app/lib/bulk_import/bulk_import_mixins.rb
+++ b/backend/app/lib/bulk_import/bulk_import_mixins.rb
@@ -208,28 +208,28 @@ module BulkImportMixins
   end
 
   def value_check(cvlist, value, errs)
+    # reload cvlist in case it has been modified by processing a previous row
+    cvlist_reloaded = CvList.new(cvlist.which, @current_user)
+    list_name = cvlist_reloaded.which.to_s
+
     ret_val = nil
+
     begin
-      ret_val = cvlist.value(value)
-      STDERR.puts "++++++++++++++++++++++++++++++"
-      STDERR.puts "++++++++++++++++++++++++++++++"
-      STDERR.puts "++++++++++++++++++++++++++++++"
-      STDERR.puts "++++++++++++++++++++++++++++++"
-      STDERR.puts "WHAT"
-      STDERR.puts ret_val.to_s
+      ret_val = cvlist_reloaded.value(value)
 
-      # ANW-1296: if the enum is editable, but value being checked is not present, add it
+      # ANW-1296: for instance_instance_type enums, add value to list if it's not present
+      if CvList::CREATE_NEW_VALUES_FOR.include?(list_name)
+        if ret_val != value
+          enum = Enumeration.find(:name => cvlist_reloaded.which)
 
-      if ret_val != value
-        enum = Enumeration.find(:name => cvlist.which)
+          if enum.editable === 1 || enum.editable == true
+            unless @validate_only
+              new_position = enum.enumeration_value.length + 1
+              enum.add_enumeration_value(:value => value, :position => new_position)
+            end
 
-        if enum.editable === 1 || enum.editable == true
-          unless @validate_only
-            new_position = enum.enumeration_value.length + 1
-            enum.add_enumeration_value(:value => value, :position => new_position)
+            ret_val = value
           end
-
-          ret_val = value
         end
       end
     rescue Exception => ex

--- a/backend/app/lib/bulk_import/bulk_import_mixins.rb
+++ b/backend/app/lib/bulk_import/bulk_import_mixins.rb
@@ -211,6 +211,27 @@ module BulkImportMixins
     ret_val = nil
     begin
       ret_val = cvlist.value(value)
+      STDERR.puts "++++++++++++++++++++++++++++++"
+      STDERR.puts "++++++++++++++++++++++++++++++"
+      STDERR.puts "++++++++++++++++++++++++++++++"
+      STDERR.puts "++++++++++++++++++++++++++++++"
+      STDERR.puts "WHAT"
+      STDERR.puts ret_val.to_s
+
+      # ANW-1296: if the enum is editable, but value being checked is not present, add it
+
+      if ret_val != value
+        enum = Enumeration.find(:name => cvlist.which)
+
+        if enum.editable === 1 || enum.editable == true
+          unless @validate_only
+            new_position = enum.enumeration_value.length + 1
+            enum.add_enumeration_value(:value => value, :position => new_position)
+          end
+
+          ret_val = value
+        end
+      end
     rescue Exception => ex
       errs << ex.message
     end

--- a/backend/app/lib/bulk_import/cv_list.rb
+++ b/backend/app/lib/bulk_import/cv_list.rb
@@ -5,6 +5,7 @@ require_relative "bulk_import_mixins"
 class CvList
   include CrudHelpers
 
+
   # for these enums, don't throw an error if values are referenced
   CREATE_NEW_VALUES_FOR = ["instance_instance_type"]
 

--- a/backend/app/lib/bulk_import/cv_list.rb
+++ b/backend/app/lib/bulk_import/cv_list.rb
@@ -10,6 +10,8 @@ class CvList
   @which = ""
   @current_user
 
+  attr_reader :which
+
   def initialize(which, current_user)
     @which = which
     @current_user = current_user
@@ -22,7 +24,7 @@ class CvList
     elsif @list.index(label)
       v = label
     end
-    raise Exception.new(I18n.t("bulk_import.error.enum", :label => label, :which => @which)) if !v
+    #raise Exception.new(I18n.t("bulk_import.error.enum", :label => label, :which => @which)) if !v
     v
   end
 

--- a/backend/app/lib/bulk_import/cv_list.rb
+++ b/backend/app/lib/bulk_import/cv_list.rb
@@ -5,6 +5,9 @@ require_relative "bulk_import_mixins"
 class CvList
   include CrudHelpers
 
+  # for these enums, don't throw an error if values are referenced
+  CREATE_NEW_VALUES_FOR = ["instance_instance_type"]
+
   @list = []
   @list_hash = {}
   @which = ""
@@ -24,7 +27,7 @@ class CvList
     elsif @list.index(label)
       v = label
     end
-    #raise Exception.new(I18n.t("bulk_import.error.enum", :label => label, :which => @which)) if !v
+    raise Exception.new(I18n.t("bulk_import.error.enum", :label => label, :which => @which)) if !v and !CvList::CREATE_NEW_VALUES_FOR.include?(@which)
     v
   end
 

--- a/backend/app/lib/bulk_import/cv_list.rb
+++ b/backend/app/lib/bulk_import/cv_list.rb
@@ -7,7 +7,7 @@ class CvList
 
 
   # for these enums, don't throw an error if values are referenced
-  CREATE_NEW_VALUES_FOR = ["instance_instance_type"]
+  CREATE_NEW_VALUES_FOR = ["instance_instance_type", "container_type"]
 
   @list = []
   @list_hash = {}

--- a/backend/spec/lib_bulk_import_container_instance_handler_spec.rb
+++ b/backend/spec/lib_bulk_import_container_instance_handler_spec.rb
@@ -41,10 +41,10 @@ describe "Container Instance Handler" do
     expect(results).to eq(teststruct)
   end
 
-  it "rejects a bad container type" do
+  it "allows new container_type values " do
     expect {
       results = @cih.build("Boxes", "1", "2342")
-    }.to raise_error("NOT FOUND: 'Boxes' not found in list container_type")
+    }.to_not raise_error
   end
   it "creates an instance, first by creating it in the database" do
     create_top
@@ -52,12 +52,12 @@ describe "Container Instance Handler" do
     hsh = hash_it(results)
     expect(hsh["long_display_string"]).to eq("Box 1 [Barcode: 2342]")
     instances = @cih.create_container_instance("Audio", "Box", "1", "2342", @res_uri, @report)
-    expect(instances.instance_type).to eq("audio")
+    expect(instances.instance_type).to eq("Audio")
   end
-  it "tries to create an instance with an invalid instance type" do
+  it "allows new instance_instance_type values" do
     create_top
     expect {
       instances = @cih.create_container_instance("Phonograph", "Box", "1", "2342", @res_uri, @report)
-    }.to raise_error("NOT FOUND: 'Phonograph' not found in list instance_instance_type")
+    }.to_not raise_error
   end
 end

--- a/backend/spec/lib_bulk_import_cvlist_spec.rb
+++ b/backend/spec/lib_bulk_import_cvlist_spec.rb
@@ -28,4 +28,12 @@ describe "Controlled Value List" do
       value = subject_sources.value("Universal sources")
     }.to raise_error(Exception)
   end
+
+  it "should not throw an exception for missing values for enums where new values should be created" do
+    expect {
+      current_user = User.find(:username => "admin")
+      subject_sources = CvList.new("instance_instance_type", current_user)
+      value = subject_sources.value("Bank Vault")
+    }.to_not raise_error(Exception)
+  end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
add missing values for instance_type when running a bulk import

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1296

## How Has This Been Tested?
Manual and unit testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
