### PR TITLE
ANW-1566 MARCXML import add 555

### DIFF
--- a/backend/app/converters/lib/marcxml_bib_base_map.rb
+++ b/backend/app/converters/lib/marcxml_bib_base_map.rb
@@ -1132,6 +1132,8 @@ module MarcXMLBibBaseMap
 
         },
 
+        "datafield[@tag='555']" => multipart_note('otherfindaid', 'Other Finding Aid', "{$a}{; $b}{; $c}{; $d}{; $u}{; $3}."),
+
         "datafield[@tag='561']" => multipart_note('custodhist', 'Ownership and Custodial History', "{$3: }{$a}."),
 
         "datafield[@tag='562']" => multipart_note('relatedmaterial', 'Copy and Version Identification', %q|

--- a/backend/spec/lib_marcxml_bib_converter_spec.rb
+++ b/backend/spec/lib_marcxml_bib_converter_spec.rb
@@ -387,6 +387,10 @@ describe 'MARCXML Bib converter' do
         expect(@lang_materials_notes).to include('Resource-LanguageMaterials-AT.')
       end
 
+      it "maps datafield[@tag='555'] to resource.notes[] using template '$a; $b; $c; $d; $u; $3.'" do
+        expect(@notes).to include('Finding Aid Available Online:; Resource-EAD-Location-AT.')
+      end
+
       it "maps datafield[@tag='561'] to resource.notes[] using template '$3: $a.'" do
         expect(@notes).to include('Resource--CustodialHistory-AT.')
       end


### PR DESCRIPTION
Adds 555 to MARC XML bib importer map as requested by Metadata Standards subgroup of TAC

## Description
Maps 555 $a, b, c, d, u, 3 to object note_multipart; note_type=”otherfindaid”; label= Other Finding Aid with a format of:
`$a; $b; $c; $d; $u; $3`

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1566

## How Has This Been Tested?
New test added.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
