### PR TITLE
ANW-1568 MARCXML import add 584

### DIFF
--- a/backend/app/converters/lib/marcxml_bib_base_map.rb
+++ b/backend/app/converters/lib/marcxml_bib_base_map.rb
@@ -1146,6 +1146,9 @@ module MarcXMLBibBaseMap
 
         "datafield[@tag='581']" => bibliography_note_template('Publications About Described Materials', "{$3: }{$a }{($z)}."),
 
+        "datafield[@tag='584']" => multipart_note('accruals', 'Accruals', %q|
+                                            {Accumulation: $a}{--Frequency of use: $b}{--Materials specified: $3}{--Institution: $5}.|),
+
         "datafield[starts-with(@tag, '59')]" => multipart_note('odd', 'Local Note'),
 
         # LINKED AGENTS (PERSON)

--- a/backend/app/converters/lib/marcxml_bib_base_map.rb
+++ b/backend/app/converters/lib/marcxml_bib_base_map.rb
@@ -1152,7 +1152,7 @@ module MarcXMLBibBaseMap
                                             {--Method of action: $i}{--Site of Action: $j}{--Action agent: $k}{--Status: $l}{--Extent: $n}
                                             {--Type of unit: $o}{--URI: $u}{--Non-public note: $x}{--Public note: $z}{--Materials specified: $3}
                                             {--Institution: $5}.|),
-                                            
+
         "datafield[@tag='584']" => multipart_note('accruals', 'Accruals', %q|
                                             {Accumulation: $a}{--Frequency of use: $b}{--Materials specified: $3}{--Institution: $5}.|),
 

--- a/backend/spec/lib_marcxml_bib_converter_spec.rb
+++ b/backend/spec/lib_marcxml_bib_converter_spec.rb
@@ -391,6 +391,10 @@ describe 'MARCXML Bib converter' do
         expect(@notes).to include('Resource--CustodialHistory-AT.')
       end
 
+      it "maps datafield[@tag='584'] to resource.notes[] using template 'Accumulation: $a--Frequency of use: $b--Materials specified: $3--Institution: $5'" do
+        expect(@notes).to include('Accumulation: Resource-Accruals-AT.')
+      end
+
       it "maps datafield[@tag='630'] to subject" do
         s = @subjects.select {|s| s['terms'][0]['term'] == 'Subjects--Uniform Title--AT'}
         expect(s.count).to eq(1)

--- a/backend/spec/lib_marcxml_bib_converter_spec.rb
+++ b/backend/spec/lib_marcxml_bib_converter_spec.rb
@@ -397,7 +397,7 @@ describe 'MARCXML Bib converter' do
          --Non-public note: $x--Public note: $z--Materials specified: $3--Institution: $5.'" do
         expect(@notes).to include('Action: Resource-Appraisal-AT.')
       end
-      
+
       it "maps datafield[@tag='584'] to resource.notes[] using template 'Accumulation: $a--Frequency of use: $b--Materials specified: $3--Institution: $5'" do
         expect(@notes).to include('Accumulation: Resource-Accruals-AT.')
       end


### PR DESCRIPTION
Adds 584 to MARC XML bib importer map as requested by Metadata Standards subgroup of TAC.

## Description
Maps 584 $a, b, 3, 5 to note_multipart; note_type='accruals'; label='Accruals' with a format of (if subfield exists): `Accumulation: $a--Frequency of use: $b--Materials specified: $3--Institution: $5`.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1568

## How Has This Been Tested?
New test added.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
