### PR TITLE
ANW-1518 Refactor test for image alt text for rep file versions

### DIFF
--- a/frontend/spec/selenium/common/driver.rb
+++ b/frontend/spec/selenium/common/driver.rb
@@ -131,14 +131,22 @@ class Driver
 
   def get_edit_page(json_obj)
     if json_obj.jsonmodel_type == 'archival_object'
-      @driver.get("#{@frontend}#{json_obj.resource['ref'].sub(%r{/repositories/\d+}, '')}/edit#tree::archival_object_#{json_obj.uri.sub(%r{.*/}, '')}")
+      @driver.get("#{@frontend}#{json_obj.resource['ref'].sub(%r{/repositories/\d+}, '')}/edit#tree::archival_object_#{json_obj.id}")
+    elsif json_obj.jsonmodel_type == 'digital_object_component'
+      @driver.get("#{@frontend}#{json_obj.digital_object['ref'].sub(%r{/repositories/\d+}, '')}/edit#tree::digital_object_component_#{json_obj.id}")
     else
       @driver.get("#{@frontend}#{json_obj.uri.sub(%r{/repositories/\d+}, '')}/edit")
     end
   end
 
   def get_view_page(json_obj)
-    @driver.get("#{@frontend}#{json_obj.uri.sub(%r{/repositories/\d+}, '')}")
+    if json_obj.jsonmodel_type == 'archival_object'
+      @driver.get("#{@frontend}#{json_obj.resource['ref'].sub(%r{/repositories/\d+}, '')}#tree::archival_object_#{json_obj.id}")
+    elsif json_obj.jsonmodel_type == 'digital_object_component'
+      @driver.get("#{@frontend}#{json_obj.digital_object['ref'].sub(%r{/repositories/\d+}, '')}#tree::digital_object_component_#{json_obj.id}")
+    else
+      @driver.get("#{@frontend}#{json_obj.uri.sub(%r{/repositories/\d+}, '')}")
+    end
   end
 
   def select_repo(code)

--- a/frontend/spec/selenium/spec/digital_objects_spec.rb
+++ b/frontend/spec/selenium/spec/digital_objects_spec.rb
@@ -10,6 +10,44 @@ describe 'Digital Objects' do
     @do = create(:digital_object)
     @cl = create(:classification)
 
+    @alt_do_title = 'File version alt text test'
+    @alt_doc_title = 'Child of file version alt text test'
+    alt_uri = 'https://www.archivesspace.org/demos/Congreave%20E-2/ms292_003_page002.jpg'
+    alt_format = 'jpeg'
+    @alt_caption = 'This is the caption'
+
+    @alt_do = create(
+      :digital_object,
+      title: @alt_do_title,
+      file_versions: [
+        {
+          file_uri: alt_uri,
+          file_format_name: alt_format,
+          caption: @alt_caption
+        },
+        {
+          file_uri: alt_uri,
+          file_format_name: alt_format
+        }
+      ]
+    )
+    @alt_doc = create(
+      :digital_object_component,
+      digital_object: { ref: @alt_do.uri },
+      title: @alt_doc_title,
+      file_versions: [
+        {
+          file_uri: alt_uri,
+          file_format_name: alt_format,
+          caption: @alt_caption
+        },
+        {
+          file_uri: alt_uri,
+          file_format_name: alt_format
+        }
+      ]
+    )
+
     run_all_indexers
 
     @do_child1 = create(:digital_object_component, digital_object: { ref: @do.uri })
@@ -160,7 +198,7 @@ describe 'Digital Objects' do
   end
 
   it 'can drag and drop reorder a Digital Object' do
-    @driver.get("#{$frontend}#{@do.uri.sub(%r{/repositories/\d+}, '')}/edit#tree::digital_object_component_#{@do_child1.id}")
+    @driver.get_edit_page(@do_child1)
     @driver.wait_for_ajax
 
     child = @driver.find_element(:id, "digital_object_component_#{@do_child1.id}")
@@ -215,52 +253,16 @@ describe 'Digital Objects' do
     @driver.find_element(css: '#digital_object_classifications__0_')
   end
 
-  it 'provides alt text for Digital Object and Digital Object Component file version images with and without captions' do
-    alt_do_title = 'File version alt text test'
-    alt_doc_title = 'Child of file version alt text test'
-    alt_uri = 'https://www.archivesspace.org/demos/Congreave%20E-2/ms292_003_page002.jpg'
-    alt_format = 'jpeg'
-    alt_caption = 'This is the caption'
-
-    @alt_do = create(
-      :digital_object,
-      title: alt_do_title,
-      file_versions: [
-        {
-          file_uri: alt_uri,
-          file_format_name: alt_format,
-          caption: alt_caption
-        },
-        {
-          file_uri: alt_uri,
-          file_format_name: alt_format
-        }
-      ]
-    )
-    @alt_doc = create(
-      :digital_object_component,
-      digital_object: { ref: @alt_do.uri },
-      title: alt_doc_title,
-      file_versions: [
-        {
-          file_uri: alt_uri,
-          file_format_name: alt_format,
-          caption: alt_caption
-        },
-        {
-          file_uri: alt_uri,
-          file_format_name: alt_format
-        }
-      ]
-    )
-    run_all_indexers
-
+  it 'provides alt text for Digital Object file version images based on caption or title' do
     @driver.get_view_page(@alt_do)
-    expect(@driver.find_hidden_element(css: "section#digital_object_file_versions_ #digital_object_file_versions__file_version_0 img[alt='#{alt_caption}']"))
-    expect(@driver.find_hidden_element(css: "section#digital_object_file_versions_ #digital_object_file_versions__file_version_1 img[alt='#{alt_do_title}']"))
-
-    @driver.find_element(:link, alt_doc_title).click
-    expect(@driver.find_hidden_element(css: "section#digital_object_component_file_versions_ #digital_object_component_file_versions__file_version_0 img[alt='#{alt_caption}']"))
-    expect(@driver.find_hidden_element(css: "section#digital_object_component_file_versions_ #digital_object_component_file_versions__file_version_1 img[alt='#{alt_doc_title}']"))
+    expect(@driver.find_hidden_element(css: "section#digital_object_file_versions_ #digital_object_file_versions__file_version_0 img[alt='#{@alt_caption}']"))
+    expect(@driver.find_hidden_element(css: "section#digital_object_file_versions_ #digital_object_file_versions__file_version_1 img[alt='#{@alt_do_title}']"))
   end
+
+  it 'provides alt text for Digital Object Component file version images based on caption or title' do
+    @driver.get_view_page(@alt_doc)
+    expect(@driver.find_hidden_element(css: "section#digital_object_component_file_versions_ #digital_object_component_file_versions__file_version_0 img[alt='#{@alt_caption}']"))
+    expect(@driver.find_hidden_element(css: "section#digital_object_component_file_versions_ #digital_object_component_file_versions__file_version_1 img[alt='#{@alt_doc_title}']"))
+  end
+
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This PR improves the test from #2847. It updates the frontend selenium driver helpers `get_view_page()` and `get_edit_page()` to get archival object and digital object component pages.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

[ANW-1518](https://archivesspace.atlassian.net/browse/ANW-1518)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See frontend/spec/selenium/spec/digital_objects_spec.rb.
