### PR TITLE
ANW-691 Add breadcrumbs to digital objects listing (redo)

### DIFF
--- a/public/app/controllers/objects_controller.rb
+++ b/public/app/controllers/objects_controller.rb
@@ -26,17 +26,18 @@ class ObjectsController < ApplicationController
       params[:limit] = 'digital_object,archival_object' unless params.fetch(:limit, nil)
       params[:op] = ['OR']
     end
-    page = Integer(params.fetch(:page, "1"))
     search_opts = default_search_opts(DEFAULT_OBJ_SEARCH_OPTS)
     search_opts['fq'] = ["repository:\"/repositories/#{repo_id}\""] if repo_id
     @base_search = repo_id ? "/repositories/#{repo_id}/objects?" : '/objects?'
+
+    search_opts['resolve[]'] = ['linked_instance_uris:id'] if params[:limit].include? 'digital_object'
 
     begin
       set_up_and_run_search( params[:limit].split(","), DEFAULT_OBJ_FACET_TYPES, search_opts, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
       redirect_back(fallback_location: '/') and return
-    rescue Exception => error
+    rescue Exception
       flash[:error] = I18n.t('errors.unexpected_error')
       redirect_back(fallback_location: '/objects' ) and return
     end

--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -63,11 +63,16 @@
       <div class="result_context">
         <strong><%= t('context') %>: </strong>
         <span  class="repo_name">
+          <%= badge_for_type('repository') %>
           <%= link_to result.resolved_repository.fetch('name'),
                      app_prefix(repository_base_url(
                       "uri" => result.resolved_repository.fetch('uri'),
                       "slug" => result.resolved_repository.fetch('slug') {|s| nil })) %>
         </span>
+
+        <% if result.is_a?(DigitalObject) && !result.linked_instances.blank? %>
+          <%= render partial: 'digital_objects/linked_instances', locals: {:instances => result.linked_instances} %>
+        <% end %>
 
         <% if result.respond_to?(:ancestors) && result.ancestors %>
           <% result.ancestors.each do |ancestor| %>

--- a/public/spec/features/digital_objects_spec.rb
+++ b/public/spec/features/digital_objects_spec.rb
@@ -35,4 +35,12 @@ describe 'Digital Objects', js: true do
       expect(page).to have_content('Record Groups')
     end
   end
+
+  it 'displays breadcrumbs for items in the Digital Materials listing' do
+    visit '/'
+    click_link 'Digital Materials'
+    within find('div[data-uri="/repositories/2/digital_objects/5"') do
+      expect(page).to have_content('Resource with digital instance')
+    end
+  end
 end


### PR DESCRIPTION
This version ensures that `linked_instances` is populated by the controller, as it should be. It also reuses the existing linked instances partial instead of adding new code.

(Also cleans up a couple of unused variables in the controller code.)