### PR TITLE
Fix for inability to suppress controlled value list values if the enumeration has no relationships to records

### DIFF
--- a/frontend/app/views/enumerations/_list.html.erb
+++ b/frontend/app/views/enumerations/_list.html.erb
@@ -69,6 +69,8 @@
               <% end%>
               <% if enum_value['suppressed']  %>
                 <%= link_to I18n.t("actions.unsuppress"), {:controller => :enumerations, :action => :update_value, :id => JSONModel(:enumeration).id_for(@enumeration["uri"]), :enumeration_value_id => enum_value["id"], :suppressed => 0 }, :method => :post, :class=> "btn btn-xs btn-warning"%>
+              <% elsif @enumeration['relationships'].length == 0 %>
+                  <%= link_to I18n.t("actions.suppress"), {:controller => :enumerations, :action => :update_value, :id => JSONModel(:enumeration).id_for(@enumeration["uri"]), :enumeration_value_id => enum_value["id"], :suppressed => 1 }, :method => :post, :class=> "btn btn-xs btn-warning"%>
               <% else %>
                 <%= link_to I18n.t("actions.suppress"), {:controller => :enumerations, :action => :update_value, :id => JSONModel(:enumeration).id_for(@enumeration["uri"]), :enumeration_value_id => enum_value["id"], :suppressed => 1 }, :method => :post, :class=> "btn btn-xs btn-warning", :disabled => 'disabled'  %>
               <% end%>


### PR DESCRIPTION
## Description
In the staff interface, in _System > Manage Controlled Value Lists_, if the enumeration being displayed has no relationships, then it won't be possible to suppress individual values in that list. The reason is that, since 4efc80f4e51c88f01383b16d1fb6e34f5c0ac772, the "Suppress" buttons are initially disabled, and then JavaScript in _enumerations.index.js.erb_ re-enables them for values that aren't used in any records. But that won't work if the enumeration has no relationship (i.e. isn't used to populate drop-downs in any records.) So this pull request adds an extra condition so that the "Suppress" buttons aren't disabled in the first place for such enumerations.

Admittedly, this is a very niche issue, as I think all the stock enumerations do have relationships. It only really affects enumerations created by plug-ins. For example, I've created enumerations to give archivists control the display of certain links and buttons in the PUI, by comparing values in records to an array of allowed values in an enumeration.

## Related JIRA Ticket or GitHub Issue
N/A

## How Has This Been Tested?
On a development system. It does not interfere with the disabling of "Suppress" buttons when values have been used.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
