### PR TITLE
ANW-961: Refactor PUI search results breadcrumbs

### DIFF
--- a/public/app/assets/stylesheets/application.scss
+++ b/public/app/assets/stylesheets/application.scss
@@ -33,6 +33,7 @@
 @import 'foundation/_functions.scss';
 @import 'archivesspace/aspace';
 @import 'archivesspace/record-type-badge';
+@import 'archivesspace/result-linked-instances';
 
 @import 'archivesspace/infinite-scroll';
 @import 'archivesspace/largetree';

--- a/public/app/assets/stylesheets/archivesspace/result-linked-instances.scss
+++ b/public/app/assets/stylesheets/archivesspace/result-linked-instances.scss
@@ -1,0 +1,41 @@
+.result_linked_instances_tree {
+  position: relative;
+  margin: 0 0 0 10px;
+  padding: 0;
+  list-style: none;
+}
+
+.result_linked_instances_tree:before {
+  content: "";
+  position: absolute;
+  display: block;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 0;
+  border-left: 1px solid;
+}
+
+.result_linked_instances_tree li {
+  position: relative;
+  margin: 0;
+  padding: 0 1rem;
+}
+
+.result_linked_instances_tree li:before {
+content: "";
+  position: absolute;
+  display: block;
+  top: 1rem;
+  left: 0;
+  width: 10px;
+  height: 0;
+  margin-top: -5px;
+  border-top: 1px solid;
+}
+
+.result_linked_instances_tree li:last-child:before {
+  bottom: 0;
+  height: auto;
+  background: white;
+}

--- a/public/app/views/digital_objects/_search_result_breadcrumbs.html.erb
+++ b/public/app/views/digital_objects/_search_result_breadcrumbs.html.erb
@@ -1,0 +1,64 @@
+<% if result.linked_instances.length == 0 %>
+
+  <div class="result_context">
+    <%= render partial: 'shared/result_breadcrumbs_repo', locals: { :result => result } %>
+  </div>
+
+<% elsif result.linked_instances.length == 1 %>
+
+  <div class="result_context">
+    <%= render partial: 'shared/result_breadcrumbs_repo', locals: { :result => result } %>
+    <% result.linked_instances.each do |uri, instance_record| %>
+      <% if instance_record.primary_type == 'resource' %>
+        <%= render partial: 'shared/result_breadcrumbs_ancestor', locals: {
+        :span_class => 'resource_name',
+        :badge_type => 'resource',
+        :body => instance_record.breadcrumb[0][:crumb],
+        :url => app_prefix(uri) } %>
+      <% elsif instance_record.primary_type == 'archival_object' %>
+        <% num_crumbs = instance_record.breadcrumb.length %>
+        <% instance_record.breadcrumb.each_with_index do |crumb, i| %>
+          <%= render partial: 'shared/result_breadcrumbs_ancestor', locals: {
+            :span_class => "#{crumb[:type]}_name",
+            :badge_type => crumb[:type],
+            :body => crumb[:crumb],
+            :url => i != num_crumbs - 1 ? app_prefix(crumb[:uri]) : app_prefix(uri) } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+
+<% else %>
+
+  <div class="result_context" style="display: flex">
+    <strong style="flex-shrink: 0"><%= t('context') %>: </strong>
+    <div>
+      <%= render partial: 'shared/result_breadcrumbs_repo', locals: { :result => result, :hide_label => true } %>
+      <ol class="result_linked_instances_tree">
+        <% result.linked_instances.each do |uri, instance_record| %>
+          <li>
+            <% if instance_record.primary_type == 'resource' %>
+              <%= render partial: 'shared/result_breadcrumbs_ancestor', locals: {
+                :span_class => 'resource_name',
+                :badge_type => 'resource',
+                :body => instance_record.breadcrumb[0][:crumb],
+                :url => app_prefix(uri),
+                :hide_delimiter => true } %>
+            <% elsif instance_record.primary_type == 'archival_object' %>
+              <% num_crumbs = instance_record.breadcrumb.length %>
+              <% instance_record.breadcrumb.each_with_index do |crumb, i| %>
+                <%= render partial: 'shared/result_breadcrumbs_ancestor', locals: {
+                  :span_class => "#{crumb[:type]}_name",
+                  :badge_type => crumb[:type],
+                  :body => crumb[:crumb],
+                  :url => i != num_crumbs - 1 ? app_prefix(crumb[:uri]) : app_prefix(uri),
+                  :hide_delimiter => i == 0 ? true : false } %>
+              <% end %>
+            <% end %>
+          </li>
+        <% end %>
+      </ol>
+    </div>
+  </div>
+
+<% end %>

--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -60,40 +60,11 @@
     </div>
 
     <% if result.resolved_repository %>
-      <div class="result_context">
-        <strong><%= t('context') %>: </strong>
-        <span  class="repo_name">
-          <%= badge_for_type('repository') %>
-          <%= link_to result.resolved_repository.fetch('name'),
-                     app_prefix(repository_base_url(
-                      "uri" => result.resolved_repository.fetch('uri'),
-                      "slug" => result.resolved_repository.fetch('slug') {|s| nil })) %>
-        </span>
-
-        <% if result.is_a?(DigitalObject) && !result.linked_instances.blank? %>
-          <%= render partial: 'digital_objects/linked_instances', locals: {:instances => result.linked_instances} %>
-        <% end %>
-
-        <% if result.respond_to?(:ancestors) && result.ancestors %>
-          <% result.ancestors.each do |ancestor| %>
-            <%= t('context_delimiter') %>
-            <span class="ancestor">
-            <% identifier = ancestor.has_key?('id_0') ? (0..3).collect { |i| ancestor["id_#{i}"] }.compact.join('-') : nil %>
-            <% title = process_mixed_content(ancestor.fetch('title', "[#{ ancestor.fetch('level', 'untitled')}]" )).html_safe %>
-            <%= link_to (identifier.blank? ? title : "#{identifier}, #{title}"), app_prefix(ancestor.fetch('uri')) %>
-            </span>
-          <% end %>
-        <% else %>
-          <% unless props.fetch(:no_res, false) || result.resolved_resource.blank? %>
-            <%= t('context_delimiter') %>
-            <span class="resource_name">
-              <%= link_to process_mixed_content(result.resolved_resource.fetch('title')).html_safe, app_prefix(result.resolved_resource.fetch('uri')) %>
-            </span>
-          <% end %>
-        <% end %>
-      </div>
+      <%= render partial: 'shared/result_breadcrumbs', locals: {
+        :result => result,
+        :props => props
+      } %>
     <% end %>
-
 
        <% if !props.fetch(:full,false)  && result['primary_type'] == 'repository' %>
        <div><strong><%= t('number_of', { :type => t('resource._plural') }) %></strong> <%= @counts[result.uri]['resource'] %></div>

--- a/public/app/views/shared/_result_breadcrumbs.html.erb
+++ b/public/app/views/shared/_result_breadcrumbs.html.erb
@@ -1,0 +1,36 @@
+<%
+  top_level_records = [Accession, Classification, Record, Resource]
+  can_have_linked_instances = [DigitalObject]
+  children_records = [ArchivalObject, DigitalObjectComponent]
+%>
+
+<% if top_level_records.include? result.class %>
+
+  <div class="result_context">
+    <%= render partial: 'shared/result_breadcrumbs_repo', locals: { :result => result } %>
+  </div>
+
+<% elsif can_have_linked_instances.include? result.class %>
+
+  <%= render partial: 'digital_objects/search_result_breadcrumbs', locals: {
+    :result => result,
+    :props => props
+  } %>
+
+<% elsif children_records.include? result.class %>
+
+  <div class="result_context">
+    <%= render partial: 'shared/result_breadcrumbs_repo', locals: { :result => result } %>
+    <% if result.respond_to?(:ancestors) && result.ancestors %>
+      <% result.ancestors.each do |ancestor| %>
+        <% ancestor_type = ancestor.fetch('uri').split('/')[3].chop %>
+        <%= render partial: 'shared/result_breadcrumbs_ancestor', locals: {
+          :span_class => "#{ancestor_type}_name",
+          :badge_type => ancestor_type,
+          :body => ancestor.fetch('title'),
+          :url => app_prefix(ancestor.fetch('uri')) } %>
+      <% end %>
+    <% end %>
+  </div>
+
+<% end %>

--- a/public/app/views/shared/_result_breadcrumbs_ancestor.html.erb
+++ b/public/app/views/shared/_result_breadcrumbs_ancestor.html.erb
@@ -1,0 +1,7 @@
+<% if !local_assigns[:hide_delimiter] %>
+  <%= t('context_delimiter') %>
+<% end %>
+<span class="#{span_class}">
+  <%= badge_for_type badge_type %>
+  <%= link_to body, url %>
+</span>

--- a/public/app/views/shared/_result_breadcrumbs_repo.html.erb
+++ b/public/app/views/shared/_result_breadcrumbs_repo.html.erb
@@ -1,0 +1,10 @@
+<% if !local_assigns[:hide_label] %>
+  <strong><%= t('context') %>: </strong>
+<% end %>
+<span class="repo_name">
+  <%= badge_for_type('repository') %>
+  <%= link_to result.resolved_repository.fetch('name'),
+            app_prefix(repository_base_url(
+              "uri" => result.resolved_repository.fetch('uri'),
+              "slug" => result.resolved_repository.fetch('slug') {|s| nil })) %>
+</span>


### PR DESCRIPTION
This PR provides an update to [ANW-961](https://archivesspace.atlassian.net/browse/ANW-961) PR #2877 that:

1. renders breadcrumbs for each linked instance of a digital object in a PUI search result
2. makes consistent the use of icons in breadcrumbs of all PUI search results

### Before

![ANW-961-before](https://user-images.githubusercontent.com/3411019/206730946-f0c3e115-ecfb-4b0c-8d17-017f3ec5f41d.png)

### After

![ANW-961-after](https://user-images.githubusercontent.com/3411019/206730973-62e19131-3401-41ab-9e4d-d505b68032dd.png)
