### PR TITLE
ANW-1589: Change staff help tooltip default location to underneath icon

### DIFF
--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -130,7 +130,7 @@ module ApplicationHelper
               :target => "_blank",
               :title => title,
               :class => "context-help has-tooltip",
-              "data-placement" => "left",
+              "data-placement" => "bottom",
             }.merge(opts[:link_opts] || {})
            )
   end

--- a/frontend/app/views/shared/_header_global.html.erb
+++ b/frontend/app/views/shared/_header_global.html.erb
@@ -10,7 +10,7 @@
         <ul class="nav pull-right navbar-nav navbar-login">
           <%= render "shared/header_user" %>
           <% if ArchivesSpaceHelp.enabled? %>
-            <li class="xs-py15px"><%= link_to_help :link_opts => {"data-placement" => (session[:user] ? "left" : "bottom")} %></li>
+            <li class="xs-py15px"><%= link_to_help %></li>
           <% end %>
         </ul>
       </div><!-- nav-collapse -->

--- a/frontend/app/views/shared/_header_repository.html.erb
+++ b/frontend/app/views/shared/_header_repository.html.erb
@@ -194,7 +194,7 @@
                 </div>
               </li>
               <% if ArchivesSpaceHelp.enabled? %>
-                <li><%= link_to_help :link_opts => {"data-placement" => (session[:user] ? "left" : "bottom")} %></li>
+                <li><%= link_to_help %></li>
               <% end %>
             </ul>
           </li>

--- a/frontend/spec/features/help_tooltip_default_placement_spec.rb
+++ b/frontend/spec/features/help_tooltip_default_placement_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Help tooltip default placement', js: true do
+  it 'should be set to bottom' do
+    login_admin
+    visit '/resources/new'
+    page.should have_css('.global-header a.context-help.has-tooltip.initialised[data-placement="bottom"]')
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes [ANW-1589](https://archivesspace.atlassian.net/browse/ANW-1589) by moving the default placement of the help tooltip from left of to underneath the help icon.

<img width="1512" alt="ANW-1589-1" src="https://user-images.githubusercontent.com/3411019/206768839-b438ce4d-c7ab-4561-b652-d8139353d802.png">

<img width="1512" alt="ANW-1589-2" src="https://user-images.githubusercontent.com/3411019/206768849-bac90b9f-a4a6-4643-aa9c-e4ab54a57ed9.png">

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
