### PR TITLE
[Chore] Improve VS Code editor config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,9 +20,10 @@
     "donjayamanne.githistory",
     "eamodio.gitlens",
     "esbenp.prettier-vscode",
-    "misogi.ruby-rubocop",
+    "LoranKloeze.ruby-rubocop-revived",
     "mutantdino.resourcemonitor",
     "rebornix.Ruby",
+    "dbaeumer.vscode-eslint",
     "stylelint.vscode-stylelint",
     "waderyan.gitblame",
     "wingrunr21.vscode-ruby"

--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -1,0 +1,49 @@
+# Using the VS Code editor for local development
+
+The [settings.json](settings.json) file in this directory makes it easy for contributors using VS Code to follow the ArchivesSpace code style. Using this tool chain in your editor helps fix code format and lint errors _before_ committing files or running tests. In many cases such errors will be fixed automatically when the file being worked on is saved. Errors that can't be fixed automatically will be highlighted with squiggly lines. Hovering your mouse over these lines will display a description of the error to help reach a solution.
+
+## Prerequisites
+
+1. [Node.js](https://nodejs.org)
+2. [Ruby](https://www.ruby-lang.org/)
+3. [VS Code](https://code.visualstudio.com/)
+
+## Set up VS Code
+
+### Add system dependencies
+
+1. [ESLint](https://eslint.org/)
+2. [Prettier](https://prettier.io/)
+3. [Rubocop](https://rubocop.org/)
+4. [Stylelint](https://stylelint.io/)
+
+#### Rubocop
+
+```bash
+gem install rubocop
+```
+
+See https://docs.rubocop.org/rubocop/installation.html for further information, including using Bundler instead of Gem.
+
+#### ESLint, Prettier, Stylelint
+
+Run the following command from the ArchivesSpace root directory.
+
+```bash
+npm install
+```
+
+See [package.json](../package.json) for further details on how these tools are used in ArchivesSpace.
+
+### Add VS Code extensions
+
+Add the following extensions via the VS Code command palette or the Extensions panel. (See this [documentation for installing and managing extensions](https://code.visualstudio.com/learn/get-started/extensions)).
+
+1. [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) (dbaeumer.vscode-eslint)
+2. [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) (esbenp.prettier-vscode)
+3. [Ruby Rubocop Revised](https://marketplace.visualstudio.com/items?itemName=LoranKloeze.ruby-rubocop-revived) (LoranKloeze.ruby-rubocop-revived)
+4. [Stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) (stylelint.vscode-stylelint)
+
+It's important to note that since these extensions work in tandem with the [VS Code settings file](settings.json), these settings only impact your ArchivesSpace VS Code Workspace, not your global VS Code User settings.
+
+The extensions should now work out of the box at this point providing error messages and autocorrecting fixable errors on file save!

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,40 @@
 {
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
   "editor.defaultFormatter": null,
+  "editor.formatOnSave": true,
+  "files.insertFinalNewline": true,
+  "prettier.configPath": ".prettierrc",
+  "ruby.rubocop.autocorrectOnSave": true,
+  "stylelint.snippet": [
+    "css",
+    "less",
+    "postcss",
+    "scss"
+  ],
+  "stylelint.validate": [
+    "css",
+    "less",
+    "postcss",
+    "scss"
+  ],
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
   },
-  "prettier.configPath": ".prettierrc",
-  "stylelint.configFile": ".stylelintrc",
+  "[less]": {
+    "editor.defaultFormatter": "stylelint.vscode-stylelint"
+  },
   "[ruby]": {
-    "editor.defaultFormatter": "misogi.ruby-rubocop"
+    "editor.defaultFormatter": "LoranKloeze.ruby-rubocop-revived"
+  },
+  "[scss]": {
+    "editor.defaultFormatter": "stylelint.vscode-stylelint"
   }
 }


### PR DESCRIPTION
This PR isn't related to any existing issue.

It improves the auto-fixing of lint errors for contributors who use VS Code _before_ they push to GitHub. VS Code plugin activity can be hard to debug and inefficient. This PR improves the existing config by being more explicit about which plugin does what. It also turns on a key setting by default that was previously left to the contributor to initiate (`"source.fixAll": true`).

The VS Code settings should probably be added to the @archivesspace/tech-docs , since it's essentially ArchivesSpace's official recommendation for VS Code tooling config, and requires any contributor using VS Code to manually add the related plugins to their editor.

@mark-cooper I wanted to get your OK to change the rubocop plugin. As the name suggests (LoranKloeze.ruby-rubocop-revived), it is a more active fork of the initial rubocop plugin you added. I've been using it locally with success.