### PR TITLE
DO spawn error check was just plain wrong

### DIFF
--- a/frontend/app/controllers/digital_objects_controller.rb
+++ b/frontend/app/controllers/digital_objects_controller.rb
@@ -79,10 +79,11 @@ class DigitalObjectsController < ApplicationController
       elsif params[:spawn_from_archival_object_id]
         copy_from_record = ArchivalObject.find(params[:spawn_from_archival_object_id])
       end
-      raise ArgumentError.new("valid Resource, Resource Component, or Accession not provided") unless copy_from_record
 
-      updates = map_record_fields_to_digital_object(copy_from_record)
-      @digital_object.update(updates)
+      if copy_from_record
+        updates = map_record_fields_to_digital_object(copy_from_record)
+        @digital_object.update(updates)
+      end
     end
 
     return render_aspace_partial :partial => "digital_objects/new" if params[:inline]


### PR DESCRIPTION
Of course, the lack of any record passed in to copy from is not an error; it just means that we don't need to copy anything and should proceed with a blank digital object as usual.

I will look into adding an appropriate test for this case. (The test previously added for this feature only checks the affirmative case where we are creating on top of an resource.)