### PR TITLE
ANW-1637: Update release workflow `set-output` env vars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
 
       - name: Get the version
         id: version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: echo 'VERSION=$(echo $GITHUB_REF | cut -d / -f 3)' >> $GITHUB_OUTPUT
 
       - name: Get the release name
         id: release_name
-        run: echo ::set-output name=RELEASE_NAME::$(echo $GITHUB_REF | cut -d / -f 3 | sed 's/v/V/')
+        run: echo 'RELEASE_NAME=$(echo $GITHUB_REF | cut -d / -f 3 | sed 's/v/V/')' >> $GITHUB_OUTPUT
 
       - name: Build Dist
         run: ./build/run build-dist -Dversion=${{ steps.version.outputs.VERSION }}


### PR DESCRIPTION
This PR updates the releases.yml CI workflow file to make use of the latest workflow syntax and to get rid of deprecation warnings we keep getting in our CI tests.

Warning message:

> The set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.

This PR replaces #2863 which experienced merge conflicts after #2879.
