### PR TITLE
ANW-1530 show representative image as thumbnail in staff search results

### DIFF
--- a/common/config/search_browse_column_config.rb
+++ b/common/config/search_browse_column_config.rb
@@ -60,7 +60,8 @@ module SearchAndBrowseColumnConfig
       "create_time" => {:field => "create_time", :sortable => true},
       "user_mtime" => {:field => "user_mtime", :sortable => true},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]},
-      "uri" => {:field => "uri", :sortable => true}
+      "uri" => {:field => "uri", :sortable => true},
+      "representative_file_version" => {:field => "representative_file_version", :sortable => false}
     },
     "resource" => {
       "title" => {:field => "title", :sortable => true, :sort_by => "title_sort"},
@@ -79,7 +80,8 @@ module SearchAndBrowseColumnConfig
       "create_time" => {:field => "create_time", :sortable => true},
       "user_mtime" => {:field => "user_mtime", :sortable => true},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]},
-      "uri" => {:field => "uri", :sortable => true}
+      "uri" => {:field => "uri", :sortable => true},
+      "representative_file_version" => {:field => "representative_file_version", :sortable => false}
     },
     "digital_object" => {
       "title" => {:field => "title", :sortable => true, :sort_by => "title_sort"},
@@ -94,7 +96,8 @@ module SearchAndBrowseColumnConfig
       "create_time" => {:field => "create_time", :sortable => true},
       "user_mtime" => {:field => "user_mtime", :sortable => true},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]},
-      "uri" => {:field => "uri", :sortable => true}
+      "uri" => {:field => "uri", :sortable => true},
+      "representative_file_version" => {:field => "representative_file_version", :sortable => false}
     },
     "multi" => {
       "primary_type" => {:field => "primary_type", :sortable => true},
@@ -145,7 +148,8 @@ module SearchAndBrowseColumnConfig
       "extents" => {:field => "extents"},
       "langcode" => {:field => "langcode", :sortable => false},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]},
-      "uri" => {:field => "uri", :sortable => true}
+      "uri" => {:field => "uri", :sortable => true},
+      "representative_file_version" => {:field => "representative_file_version", :sortable => false}
     },
     "assessment" => {
       "assessment_id" => {:field => "assessment_id", :sortable => true},
@@ -201,7 +205,8 @@ module SearchAndBrowseColumnConfig
       "extents" => {:field => "extents"},
       "langcode" => {:field => "langcode", :sortable => false},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]},
-      "uri" => {:field => "uri", :sortable => true}
+      "uri" => {:field => "uri", :sortable => true},
+      "representative_file_version" => {:field => "representative_file_version", :sortable => false}
     },
     "event" => {
       "agents" => {:field => "agents"},

--- a/frontend/app/assets/stylesheets/archivesspace/search.less
+++ b/frontend/app/assets/stylesheets/archivesspace/search.less
@@ -55,3 +55,11 @@
     width: 70%;
   }
 }
+
+.table-search-results {
+  .col {
+    img {
+      max-width: 125px;
+    }
+  }
+}

--- a/frontend/app/views/search/_representative_file_version_cell.html.erb
+++ b/frontend/app/views/search/_representative_file_version_cell.html.erb
@@ -1,0 +1,8 @@
+<%
+  json = ASUtils.json_parse(record["json"])
+  file_uri = json['representative_file_version'] ? json['representative_file_version']['file_uri'] : nil
+%>
+
+<% if file_uri %>
+<img src="<%= file_uri %>"/>
+<% end %>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -226,6 +226,7 @@ en:
       asc: Ascending
       desc: Descending
       uri: URI
+      representative_file_version: Thumbnail Image
     resource:
       score: Relevance
       title: Title
@@ -249,6 +250,7 @@ en:
       asc: Ascending
       desc: Descending
       uri: URI
+      representative_file_version: Thumbnail Image
     archival_object:
       score: Relevance
       title: Title
@@ -266,6 +268,7 @@ en:
       asc: Ascending
       desc: Descending
       uri: URI
+      representative_file_version: Thumbnail Image
     subject:
       score: Relevance
       source: Source
@@ -296,6 +299,7 @@ en:
       asc: Ascending
       desc: Descending
       uri: URI
+      representative_file_version: Thumbnail Image
     digital_object_component:
       score: Relevance
       title: Title
@@ -310,6 +314,7 @@ en:
       asc: Ascending
       desc: Descending
       uri: URI
+      representative_file_version: Thumbnail Image
     agent:
       score: Relevance
       title: Name


### PR DESCRIPTION
Use the `representative_file_version` data to construct a thumbnail image for search results in the staff ui:

<img width="1282" alt="image" src="https://user-images.githubusercontent.com/1626547/208721973-18af3bcb-c1a2-43a5-9d1f-2f5885b7f03c.png">

Note: to test this you will need to go to your repository or global preferences and select "Thumbnail image" for one of the browse columns for the record type you are going to test. Example:

<img width="1184" alt="image" src="https://user-images.githubusercontent.com/1626547/208722270-e62b0181-c927-42b3-8404-94656cfb5e49.png">


