### PR TITLE
ANW-1506: Add additional file versions accordion to PUI digital object and digital object component pages

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -783,19 +783,31 @@ i.giant {
   display: block;
   margin: 0 0 1em 1em;
 }
-.objectimage img {
+.objectimage img,
+.additional-file-version img {
   margin: 0 auto;
   display: block;
   max-width: 100%;
   border-top-right-radius: var(--bootstrap-rounded-corner-radius);
   border-top-left-radius: var(--bootstrap-rounded-corner-radius);
 }
-.objectimage figcaption {
+.objectimage figcaption,
+.additional-file-version figcaption {
   padding: 0.5rem;
 }
 .objectimage button[type='submit'] {
   width: 100%;
   white-space: normal;
+}
+
+@media (min-width: 500px) {
+  .additional-file-version {
+    display: block;
+    max-width: 500px;
+  }
+}
+.additional-file-version + .additional-file-version {
+  margin-top: 1rem !important;
 }
 
 .record-type-badge.digital_object.external-digital-object__link {

--- a/public/app/views/digital_objects/_additional_file_versions.html.erb
+++ b/public/app/views/digital_objects/_additional_file_versions.html.erb
@@ -1,0 +1,7 @@
+<ol class="list-unstyled mb0">
+  <% fvs.each do |fv| %>
+    <li class="panel panel-default additional-file-version">
+      <%= render partial: 'shared/representative_file_version', locals: {:uri => fv['file_uri'], :caption => fv['caption']} %>
+    </li>
+  <% end %>
+</ol>

--- a/public/app/views/shared/_record_innards.html.erb
+++ b/public/app/views/shared/_record_innards.html.erb
@@ -66,6 +66,17 @@
 	<%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('resource._public.additional'),
 	      :p_id => 'add_desc', :p_body => x } %>
 	<% end %>
+  <% if @rep_fv.present? && @result.json['file_versions'].length > 1 %>
+    <%
+      additional_file_versions = @result.json['file_versions'].select { |fv| fv['file_uri'] != @rep_fv['file_uri'] }
+      x = render partial: 'digital_objects/additional_file_versions', locals: { :fvs => additional_file_versions }
+    %>
+    <%= render partial: 'shared/accordion_panel', locals: {
+      :p_title => t('digital_object._public.additional'),
+      :p_id => 'additional_file_versions_list',
+      :p_body => x
+    } %>
+  <% end %>
     <% unless @result.agents.blank? %>
   <%# ANW-1095: don't show creators in related names section since it is redundant %>
   <% not_creators = @result.agents.except("creator") %>

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -350,6 +350,7 @@ en:
       link: Link to digital object
       badge_label: Digital %{level}
       go: Go to file
+      additional: Additional File Versions
 
   subject:
     _singular: Subject

--- a/public/spec/controllers/digital_objects_controller_spec.rb
+++ b/public/spec/controllers/digital_objects_controller_spec.rb
@@ -1,7 +1,5 @@
 require 'spec_helper'
 
-img_uri = 'http://foo.com/image.jpg'
-
 describe DigitalObjectsController, type: :controller do
   before(:all) do
     @repo = create(:repo, repo_code: "do_test_#{Time.now.to_i}",
@@ -88,6 +86,8 @@ describe DigitalObjectsController, type: :controller do
   describe "Digital Object" do
     render_views
 
+    img_uri = 'http://foo.com/image.jpg'
+
     before(:all) do
       @do2 = create(:digital_object, publish: true, :file_versions => [
         build(:file_version, {
@@ -101,11 +101,7 @@ describe DigitalObjectsController, type: :controller do
       run_indexers
     end
 
-    xit 'should have a representative file version image when one is set' do
-      expect(JSONModel(:digital_object).find(@do2.id)["representative_file_version"]["file_uri"]).to eq(img_uri)
-    end
-
-    xit 'should render the representative file version image when one is set' do
+    it 'should render the representative file version image when one is set' do
       get(:tree_root, params: { rid: @repo.id, id: @do2.id })
 
       expect(response.body).to match(img_uri)

--- a/public/spec/controllers/objects_controller_spec.rb
+++ b/public/spec/controllers/objects_controller_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+
+describe ObjectsController, type: :controller do
+  img_uri1 = 'http://foo.com/image.jpg'
+  img_uri2 = 'http://foo.com/image2.jpg'
+  img_uri3 = 'http://foo.com/image3.jpg'
+
+  before(:all) do
+    @repo = create(:repo, repo_code: "do_test_#{Time.now.to_i}",
+                          publish: true)
+    set_repo @repo
+    run_indexers
+  end
+
+  describe 'Digital Objects' do
+    render_views
+
+    before(:all) do
+      @do1 = create(:digital_object, publish: true, :file_versions => [
+        build(:file_version, {
+          :publish => true,
+          :is_representative => false,
+          :file_uri => img_uri1,
+          :use_statement => 'image-service'
+        }),
+        build(:file_version, {
+          :publish => true,
+          :is_representative => true,
+          :file_uri => img_uri2,
+          :use_statement => 'image-service'
+        }),
+        build(:file_version, {
+          :publish => true,
+          :is_representative => false,
+          :file_uri => img_uri3,
+          :use_statement => 'image-service'
+        })
+      ])
+
+      run_indexers
+    end
+
+    it 'should display additional published File Versions not designated as representative in an Additional File Versions accordion' do
+      get(:show, params: { rid: @repo.id, obj_type: 'digital_objects', id: @do1.id })
+
+      page = response.body
+
+      additional_file_versions_accordion_css = '#res_accordion > .panel.panel-default > #additional_file_versions_list'
+      additional_file_version_css = '#additional_file_versions_list li.additional-file-version'
+      additional_file_version_1_src = "#{additional_file_version_css} img[src='#{img_uri1}']"
+      additional_file_version_2_src = "#{additional_file_version_css} img[src='#{img_uri3}']"
+
+      expect(page).to have_css(additional_file_versions_accordion_css)
+      expect(page).to have_css(additional_file_version_css, :count => 2)
+      expect(page).to have_css(additional_file_version_1_src)
+      expect(page).to have_css(additional_file_version_2_src)
+    end
+
+  end
+
+  describe 'Digital Object Components' do
+    render_views
+
+    before(:all) do
+      @do2 = create(:digital_object, publish: true)
+
+      @doc = create(
+        :digital_object_component,
+        publish: true,
+        digital_object: { ref: @do2.uri },
+        :file_versions => [
+          build(:file_version, {
+            :publish => true,
+            :is_representative => false,
+            :file_uri => img_uri1,
+            :use_statement => 'image-service'
+          }),
+          build(:file_version, {
+            :publish => true,
+            :is_representative => true,
+            :file_uri => img_uri2,
+            :use_statement => 'image-service'
+          }),
+          build(:file_version, {
+            :publish => true,
+            :is_representative => false,
+            :file_uri => img_uri3,
+            :use_statement => 'image-service'
+          })
+        ]
+      )
+
+      run_indexers
+    end
+
+    it 'should display additional published File Versions not designated as representative in an Additional File Versions accordion' do
+      get(:show, params: { rid: @repo.id, obj_type: 'digital_object_components', id: @doc.id })
+
+      page = response.body
+
+      additional_file_versions_accordion_css = '#res_accordion > .panel.panel-default > #additional_file_versions_list'
+      additional_file_version_css = '#additional_file_versions_list li.additional-file-version'
+      additional_file_version_1_src = "#{additional_file_version_css} img[src='#{img_uri1}']"
+      additional_file_version_2_src = "#{additional_file_version_css} img[src='#{img_uri3}']"
+
+      expect(page).to have_css(additional_file_versions_accordion_css)
+      expect(page).to have_css(additional_file_version_css, :count => 2)
+      expect(page).to have_css(additional_file_version_1_src)
+      expect(page).to have_css(additional_file_version_2_src)
+    end
+
+  end
+
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR solves [ANW-1506](https://archivesspace.atlassian.net/browse/ANW-1506) which correlates to Req3.3 of [ANW-1209](https://archivesspace.atlassian.net/browse/ANW-1209).

It adds an "Additional File Versions" accordion to digital object and digital object component pages in the PUI if there are additional file versions not marked as representative.

![ANW-1506-digital-object](https://user-images.githubusercontent.com/3411019/209207207-ccb07c31-3573-4f48-b800-d1eaff9288e6.png)

![ANW-1506-digital-object-component](https://user-images.githubusercontent.com/3411019/209207229-93999b29-0c4a-4fc9-85b5-5367d9e573bd.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See public/spec/controllers/objects_controller_spec.rb.
