### PR TITLE
ANW-1532 add representative @role attributes to EAD and EAD3 exports

### DIFF
--- a/backend/app/exporters/lib/export_helpers.rb
+++ b/backend/app/exporters/lib/export_helpers.rb
@@ -153,6 +153,21 @@ module ASpaceExport
 
       @archdesc_dates
     end
+
+    def instances_with_digital_objects
+      instances = self.instances.select { |inst| inst['digital_object']}.compact
+      instances.each do |inst|
+        inst['digital_object']['_resolved']['_is_in_representative_instance'] = inst['is_representative']
+      end
+    end
+
+    def digital_objects
+      self.instances_with_digital_objects.map { |instance| instance['digital_object']['_resolved'] }
+    end
+
+    def instances_with_sub_containers
+      self.instances.select {|inst| inst['sub_container']}.compact
+    end
   end
 
 

--- a/backend/app/exporters/models/ead.rb
+++ b/backend/app/exporters/models/ead.rb
@@ -105,7 +105,6 @@ class EADModel < ASpaceExport::ExportModel
 
     def initialize(tree, repo_id, prefetched_rec = nil)
       @repo_id = repo_id
-      # @tree = tree
       @children = tree ? tree['children'] : []
       @child_class = self.class
       @json = nil
@@ -128,15 +127,6 @@ class EADModel < ASpaceExport::ExportModel
       self.linked_agents.select {|link| ['creator', 'source'].include?(link['role']) }
     end
 
-
-    def instances_with_sub_containers
-      self.instances.select {|inst| inst['sub_container']}.compact
-    end
-
-
-    def instances_with_digital_objects
-      self.instances.select {|inst| inst['digital_object']}.compact
-    end
   end
 
 
@@ -290,28 +280,10 @@ class EADModel < ASpaceExport::ExportModel
   end
 
 
-  def instances_with_sub_containers
-    self.instances.select {|inst| inst['sub_container']}.compact
-  end
-
-
-  def instances_with_digital_objects
-    self.instances.select {|inst| inst['digital_object']}.compact
-  end
-
-
   def creators_and_sources
     self.linked_agents.select {|link| ['creator', 'source'].include?(link['role']) }
   end
 
-
-  def digital_objects
-    if @include_daos
-      self.instances.select {|inst| inst['digital_object']}.compact.map {|inst| inst['digital_object']['_resolved'] }.compact
-    else
-      []
-    end
-  end
 
   def metadata_rights_declaration_in_publicationstmt
     must_be_empty = %w(file_uri)

--- a/backend/spec/custom_matchers.rb
+++ b/backend/spec/custom_matchers.rb
@@ -43,15 +43,19 @@ end
 
 RSpec::Matchers.define :have_attribute do |att, val|
   match do |node|
-    if val
+    if node && val
       node.attr(att) && node.attr(att) == val
-    else
+    elsif node
       node.attr(att)
+    else
+      false
     end
   end
 
   failure_message do |node|
-    if val and node.attr(att)
+    if node.nil?
+      "Ooops - looks like we tried to check `nil` for an XML attribute! Check your XPath?"
+    elsif val and node.attr(att)
       "Expected '#{node.name}/@#{att}' to be '#{val}', not '#{node.attr(att)}'."
     else
       "Expected the node '#{node.name}' to have the attribute '#{att}'."

--- a/backend/spec/export_ead_representative_file_version_spec.rb
+++ b/backend/spec/export_ead_representative_file_version_spec.rb
@@ -1,0 +1,112 @@
+require 'nokogiri'
+require 'spec_helper'
+require_relative 'export_spec_helper'
+
+# See https://archivesspace.atlassian.net/browse/ANW-1209
+describe "Representative File Version EAD Export Rules" do
+
+  let(:digital_object_for_resource) {
+    create(:json_digital_object,
+           title: "dig_obj_for_resource",
+           publish: true,
+           file_versions: [
+             build(:json_file_version,
+                   is_representative: true,
+                   use_statement: "image-service")
+           ]
+          )
+  }
+
+  let(:digital_object_for_archival_object) {
+    create(:json_digital_object,
+           title: "dig_obj_for_archival_object",
+           publish: true,
+           file_versions: [
+             build(:json_file_version,
+                   is_representative: true,
+                   use_statement: "image-service")
+           ]
+          )
+  }
+
+
+  let(:resource) {
+    resource = create(:json_resource,
+                      instances: [
+                        build(:json_instance_digital,
+                              instance_type: 'digital_object',
+                              is_representative: true,
+                              digital_object: {
+                                ref: digital_object_for_resource.uri
+                              })
+                      ]
+                     )
+
+    create(:json_archival_object,
+           resource: {ref: resource.uri},
+           instances: [
+             build(:json_instance_digital,
+                   instance_type: 'digital_object',
+                   is_representative: true,
+                   digital_object: {
+                     ref: digital_object_for_archival_object.uri
+                   })
+           ]
+          )
+    resource
+  }
+
+  let(:ead) {
+    get_ead(resource)
+  }
+
+  let(:ead3) {
+    get_ead(resource, ead3: true)
+  }
+
+  # REQ 9.1 from ANW-1209 linked doc
+  # If a Digital Object record with a single file version is linked as the “Representative” Digital Object instance in a Resource
+  # or Archival Object record, then the EAD 2002 export for that record shall include a \"representative\" value in the <dao> element's
+  # @role attribute.
+  it "adds 'representative' to the @role attribute of the <dao> tag" do
+    expect(ead.at_xpath("//xmlns:dao[@xlink:title='dig_obj_for_resource']")).to have_attribute("xlink:role", "image-service representative")
+    expect(ead.at_xpath("//xmlns:dao[@xlink:title='dig_obj_for_archival_object']")).to have_attribute("xlink:role", "image-service representative")
+  end
+
+  # REQ 9.2 from ANW-1209 linked doc
+  # If a Digital Object record with multiple file versions is linked as the \"Representative\" Digital Object instance in a Resource
+  # or Archival Object record, then the EAD 2002 export for that record shall include a \"representative\" value in the <daogrp> element's
+  # @role attribute.
+  it "adds 'representative' to the @role attribute of the <daogrp> tag" do
+    digital_object_for_resource.file_versions.push(build(:json_file_version))
+    digital_object_for_resource.save
+    digital_object_for_archival_object.file_versions.push(build(:json_file_version))
+    digital_object_for_archival_object.save
+
+    expect(ead.at_xpath("//xmlns:daogrp[@xlink:title='dig_obj_for_resource']")).to have_attribute("xlink:role", "representative")
+    expect(ead.at_xpath("//xmlns:daogrp[@xlink:title='dig_obj_for_archival_object']")).to have_attribute("xlink:role", "representative")
+  end
+
+  # REQ 10.1 from ANW-1209 linked doc
+  # If a Digital Object record with a single published File Version is linked as the “Representative” Digital Object instance in a Resource
+  # or Archival Object record, then the EAD3 export for that record shall include a "representative" value in the <dao> element's @linkrole attribute.
+  it "adds 'representative' to the @linkerole attribute of the <dao> tag" do
+    expect(ead3.at_xpath("//xmlns:dao[@linktitle='dig_obj_for_resource']")).to have_attribute("linkrole", "image-service representative")
+    expect(ead3.at_xpath("//xmlns:dao[@linktitle='dig_obj_for_archival_object']")).to have_attribute("linkrole", "image-service representative")
+  end
+
+  # REQ 10.1 from ANW-1209 linked doc
+  # If a Digital Object record with multiple published File Versions is linked as the "Representative" Digital Object instance in a Resource or
+  # Archival Object record, then the EAD3 export for that record shall include a "representative" value in the <daoset> element's @localtype attribute.
+  # File versions marked in the Digital Object record as "Representative"  shall also include a "representative" value in the <dao> element's @linkrole
+  # attribute.
+  it "adds 'representative' to the @linkrole attribute of the <daoset> tag" do
+    digital_object_for_resource.file_versions.push(build(:json_file_version))
+    digital_object_for_resource.save
+    digital_object_for_archival_object.file_versions.push(build(:json_file_version))
+    digital_object_for_archival_object.save
+
+    expect(ead3.at_xpath("//xmlns:daoset")).to have_attribute("linkrole", "representative")
+    expect(ead3.at_xpath("//xmlns:dsc//xmlns:daoset")).to have_attribute("linkrole", "representative")
+  end
+end

--- a/backend/spec/export_spec_helper.rb
+++ b/backend/spec/export_spec_helper.rb
@@ -91,6 +91,12 @@ def get_eac(rec, repo_id = $repo_id)
   end
 end
 
+def get_ead(rec, opts={})
+  opts[:include_unpublished] ||= true
+  opts[:include_daos] ||= true
+  get_xml("/repositories/#{$repo_id}/resource_descriptions/#{rec.id}.xml?#{URI.encode_www_form(opts)}")
+end
+
 def multipart_note_set(publish = true)
   ['accruals', 'appraisal', 'arrangement', 'bioghist', 'accessrestrict', 'userestrict', 'custodhist', 'dimensions', 'altformavail', 'originalsloc', 'fileplan', 'odd', 'acqinfo', 'legalstatus', 'otherfindaid', 'phystech', 'prefercite', 'processinfo', 'relatedmaterial', 'scopecontent', 'separatedmaterial'].map do |type|
     build(:json_note_multipart, {


### PR DESCRIPTION
Adds `Xlink:role` and `linkrole` attributes to EAD and EAD3 export respectively when representative digital object instances are attached to resources and archival objects per specification in ANW-1209.