### PR TITLE
ANW-1567 fix mapping for marc xml datafield 583

### DIFF
--- a/backend/app/converters/lib/marcxml_bib_base_map.rb
+++ b/backend/app/converters/lib/marcxml_bib_base_map.rb
@@ -596,9 +596,8 @@ module MarcXMLBibBaseMap
   # can be produced. A chain of sketcky substitutions at
   # the end attempts to keep the punctuation normal.
   def subfield_template(template, node, map=nil)
-    result = template.clone
+    result = template.dup
     section = /\{([^@${]*)([@$])(ind[0-9]|\S{1})([^}]*)\}/
-
     while result.match(section)
       if $2 == '@'
         val = node.attr("#{$3}")
@@ -1242,10 +1241,10 @@ module MarcXMLBibBaseMap
 
         "datafield[@tag='583']" => multipart_note('processinfo', 'Processing Note', %q|
                                             {Action: $a}{--Action Identification: $b}{--Time/Date of Action: $c}{--Action interval: $d}
-                                            {--Action interval: $d}{--Contingency for Action: $e}{--Authorization: $f}{--Jurisdiction: $h}
+                                            {--Contingency for Action: $e}{--Authorization: $f}{--Jurisdiction: $h}
                                             {--Method of action: $i}{--Site of Action: $j}{--Action agent: $k}{--Status: $l}{--Extent: $n}
                                             {--Type of unit: $o}{--URI: $u}{--Non-public note: $x}{--Public note: $z}{--Materials specified: $3}
-                                            {--Institution: $5}.|),
+                                            {--Institution: $5}|.split(/\n+/).map {|l| l.strip }.reject {|l| l.empty? }.join),
 
         "datafield[@tag='584']" => multipart_note('accruals', 'Accruals', %q|
                                             {Accumulation: $a}{--Frequency of use: $b}{--Materials specified: $3}{--Institution: $5}.|),

--- a/backend/spec/examples/marc/at-tracer-marc-1.xml
+++ b/backend/spec/examples/marc/at-tracer-marc-1.xml
@@ -184,7 +184,25 @@ Here is an example of a wrap-in tag using ref, targeting the Abstract note in th
             <subfield code="a">Resource--CustodialHistory-AT</subfield>
         </datafield>
         <datafield tag="583" ind2=" " ind1="1">
-            <subfield code="a">Resource-Appraisal-AT</subfield>
+            <subfield code="a">condition reviewed</subfield>
+            <subfield code="b">classification</subfield>
+            <subfield code="c">19980207</subfield>
+            <subfield code="d">quinquennial</subfield>
+            <subfield code="e">at conclusion of court case</subfield>
+            <subfield code="f">Title IIC project</subfield>
+            <subfield code="h">Joe Smith</subfield>
+            <subfield code="i">microfilm</subfield>
+            <subfield code="j">Museum of Fine Arts</subfield>
+            <subfield code="k">AFD</subfield>
+            <subfield code="l">pages missing</subfield>
+            <subfield code="3">student case files</subfield>
+            <subfield code="n">2</subfield>
+            <subfield code="o">Linear Feet</subfield>
+            <subfield code="u">http://www.uflib.ufl.edu/pres/repro/db</subfield>
+            <subfield code="x">from secret FRD to confidential NSI</subfield>
+            <subfield code="2">Institute for Museum and Library Services grant</subfield>
+            <subfield code="5">DLC</subfield>
+            <subfield code="z">subfield z</subfield>
         </datafield>
         <datafield tag="584" ind2=" " ind1=" ">
             <subfield code="a">Resource-Accruals-AT</subfield>

--- a/backend/spec/lib_marcxml_bib_converter_spec.rb
+++ b/backend/spec/lib_marcxml_bib_converter_spec.rb
@@ -481,7 +481,11 @@ describe 'MARCXML Bib converter' do
          --Time/Date of Action: $c--Action interval: $d--Contingency for Action: $e--Authorization: $f--Jurisdiction: $h
          --Method of action: $j--Site of Action: $j--Action agent: $k--Status: $l--Extent: $n--Type of unit: $o--URI: $u
          --Non-public note: $x--Public note: $z--Materials specified: $3--Institution: $5.'" do
-        expect(@notes).to include('Action: Resource-Appraisal-AT.')
+        expect(@notes[27]).to eq("Action: condition reviewed--Action Identification: classification--Time/Date of Action: 19980207\
+--Action interval: quinquennial--Contingency for Action: at conclusion of court case--Authorization: Title IIC project--Jurisdiction: Joe Smith\
+--Method of action: microfilm--Site of Action: Museum of Fine Arts--Action agent: AFD--Status: pages missing--Extent: 2\
+--Type of unit: Linear Feet--URI: http://www.uflib.ufl.edu/pres/repro/db--Non-public note: from secret FRD to confidential NSI--Public note: subfield z\
+--Materials specified: student case files--Institution: DLC")
       end
 
       it "maps datafield[@tag='584'] to resource.notes[] using template 'Accumulation: $a--Frequency of use: $b--Materials specified: $3--Institution: $5'" do
@@ -1024,4 +1028,36 @@ describe 'MARCXML Bib converter' do
 
     end
   end
+
+  describe "inner workings" do
+
+    class Subnode
+      def initialize(xpath)
+        @xpath = xpath
+      end
+
+      def inner_text
+        @xpath.gsub(/[\[\]@\']/, '_')
+      end
+    end
+
+    class Node
+      def xpath(xpath)
+        [Subnode.new(xpath)]
+      end
+    end
+
+    it "can pass a nokogiri node through a template" do
+      template = %q|{Action: $a}{--Action Identification: $b}{--Time/Date of Action: $c}{--Action interval: $d}
+                    {--Action interval: $d}{--Contingency for Action: $e}{--Authorization: $f}{--Jurisdiction: $h}
+                    {--Method of action: $i}{--Site of Action: $j}{--Action agent: $k}{--Status: $l}{--Extent: $n}
+                    {--Type of unit: $o}{--URI: $u}{--Non-public note: $x}{--Public note: $z}{--Materials specified: $3}
+                    {--Institution: $5}.|
+
+      node = Node.new
+      result = my_converter.subfield_template(template, node)
+      expect(result).to eq "Action: subfield__code=_a__--Action Identification: subfield__code=_b__--Time/Date of Action: subfield__code=_c__--Action interval: subfield__code=_d__ --Action interval: subfield__code=_d__--Contingency for Action: subfield__code=_e__--Authorization: subfield__code=_f__--Jurisdiction: subfield__code=_h__ --Method of action: subfield__code=_i__--Site of Action: subfield__code=_j__--Action agent: subfield__code=_k__--Status: subfield__code=_l__--Extent: subfield__code=_n__ --Type of unit: subfield__code=_o__--URI: subfield__code=_u__--Non-public note: subfield__code=_x__--Public note: subfield__code=_z__--Materials specified: subfield__code=_3__ --Institution: subfield__code=_5__."
+    end
+  end
+
 end


### PR DESCRIPTION
Fixed the mapping for MARC XML `datafield[@tag='583']` and added a test to document the `subfield_template` functionality of the XML converters.