### PR TITLE
ANW-1498: Allow staff is-representative buttons to be toggled off on click

### DIFF
--- a/frontend/app/assets/javascripts/representativemembers.js
+++ b/frontend/app/assets/javascripts/representativemembers.js
@@ -22,51 +22,55 @@ $(function () {
         object_name === 'instance' ||
         object_name == 'agent_contact'
       ) {
-        var $subform = $(subform);
-        var $section = $subform.closest('section.subrecord-form');
-        var isRepresentative =
+        const $subform = $(subform);
+        const $section = $subform.closest('section.subrecord-form');
+        const isRepresentative =
           $(':input[name$="[is_representative]"]', $subform).val() === '1';
-        var local_publish_button = $subform.find('.js-file-version-publish');
-        var local_make_rep_button = $subform.find('.is-representative-toggle');
-
-        var eventName =
+        const $labelBtn = $subform.find('.is-representative-label');
+        const $repBtn = $subform.find('.is-representative-toggle');
+        const eventName =
           'newrepresentative' + object_name.replace(/_/, '') + '.aspace';
 
-        if (local_publish_button.prop('checked') == false) {
-          local_make_rep_button.prop('disabled', true);
-        } else {
-          local_make_rep_button.prop('disabled', false);
-        }
+        if (object_name === 'file_version') {
+          const $pubBox = $subform.find('.js-file-version-publish');
 
-        $subform.find('.js-file-version-publish').click(function (e) {
-          if (
-            $subform.hasClass('is-representative') &&
-            $(this).prop('checked', true)
-          ) {
-            handleRepresentativeChange($subform, false);
-            $(this).prop('checked', false);
-          }
-
-          if ($(this).prop('checked') == false) {
-            local_make_rep_button.prop('disabled', true);
+          if ($pubBox.prop('checked') == false) {
+            $repBtn.prop('disabled', true);
           } else {
-            local_make_rep_button.prop('disabled', false);
+            $repBtn.prop('disabled', false);
           }
-        });
 
-        $subform.find('.is-representative-toggle').click(function (e) {
-          local_publish_button.prop('checked', true);
-        });
+          $pubBox.click(function () {
+            if (
+              $subform.hasClass('is-representative') &&
+              $(this).prop('checked', true)
+            ) {
+              handleRepresentativeChange($subform, false);
+              $(this).prop('checked', false);
+            }
+
+            if ($(this).prop('checked') == false) {
+              $repBtn.prop('disabled', true);
+            } else {
+              $repBtn.prop('disabled', false);
+            }
+          });
+        }
 
         if (isRepresentative) {
           $subform.addClass('is-representative');
         }
 
-        $('.is-representative-toggle', $subform).click(function (e) {
+        $repBtn.click(function (e) {
           e.preventDefault();
           $(this).parent().off('click');
-
           $section.triggerHandler(eventName, [$subform]);
+        });
+
+        $labelBtn.click(function (e) {
+          e.preventDefault();
+          $(this).parent().off('click');
+          handleRepresentativeChange($subform, false);
         });
 
         $section.on(eventName, function (e, representative_subform) {

--- a/frontend/app/assets/stylesheets/archivesspace/form.less
+++ b/frontend/app/assets/stylesheets/archivesspace/form.less
@@ -819,9 +819,16 @@ label {
   }
 }
 
+.is-representative-toggle {
+  border-style: outset;
+  border-color: #878787;
+}
 .is-representative {
   .is-representative-label {
     display: inline;
+    border-style: outset;
+    border-color: #337ab7;
+    cursor: pointer;
   }
   .is-representative-toggle {
     display: none;

--- a/frontend/app/helpers/aspace_form_helper.rb
+++ b/frontend/app/helpers/aspace_form_helper.rb
@@ -553,9 +553,10 @@ module AspaceFormHelper
       options
     end
 
-    def button_with_tooltip(tooltip, content, div_classes = [], button_classes = [])
-      div_classes    = div_classes + ["btn-with-tooltip"]
-      button_classes = button_classes + ["btn", "btn-small"]
+    def button_with_tooltip(tooltip, content, div_classes = [], button_classes = [], use_default_btn_classes = true)
+      div_classes = div_classes + ["btn-with-tooltip"]
+
+      button_classes = use_default_btn_classes ? button_classes + ["btn", "btn-small"] : button_classes
 
       div_options = {:class => div_classes.join(' ')}
       add_tooltip_options(tooltip, div_options)

--- a/frontend/app/views/agents/_contact_details.html.erb
+++ b/frontend/app/views/agents/_contact_details.html.erb
@@ -6,8 +6,8 @@
   <div class="subrecord-form-fields" <%= 'style="display: none;"'.html_safe if @repository && !form['is_representative'] %>>
     <% unless @repository %>
     <h3 class="subrecord-form-heading">
-      <span class="badge badge-info is-representative-label"><%= I18n.t("agent_contact.is_representative") %></span>
-      <button class="btn btn-small is-representative-toggle"><%= I18n.t("agent_contact._frontend.action.make_representative") %></button>
+      <button type="button" class="badge badge-info is-representative-label"><%= I18n.t("agent_contact.is_representative") %></span>
+      <button type="button" class="btn btn-small is-representative-toggle"><%= I18n.t("agent_contact._frontend.action.make_representative") %></button>
     </h3>
     <% end %>
 

--- a/frontend/app/views/file_versions/_template.html.erb
+++ b/frontend/app/views/file_versions/_template.html.erb
@@ -1,7 +1,7 @@
 <% define_template "file_version", jsonmodel_definition(:file_version) do |form| %>
   <div class="subrecord-form-fields">
     <h3 class="subrecord-form-heading">
-      <span class="badge badge-info is-representative-label"><%= I18n.t("file_version.is_representative") %></span>
+      <%= form.button_with_tooltip(I18n.t("file_version._frontend.action.make_representative_tooltip"), I18n.t("file_version.is_representative"), [], ["badge badge-info is-representative-label"], false) %>
       <%= form.button_with_tooltip(I18n.t("file_version._frontend.action.make_representative_tooltip"), I18n.t("file_version._frontend.action.make_representative"), [], ["is-representative-toggle"]) %>
     </h3>
     <%= form.label_and_textarea("file_uri") %>

--- a/frontend/app/views/instances/_template.html.erb
+++ b/frontend/app/views/instances/_template.html.erb
@@ -23,8 +23,8 @@
 <% define_template "instance_digital_object", jsonmodel_definition(:instance) do |form| %>
   <div class="subrecord-form-fields">
     <h3 class="subrecord-form-heading">
-      <span class="badge badge-info is-representative-label"><%= I18n.t("file_version.is_representative") %></span>
-      <button class="btn btn-small is-representative-toggle"><%= I18n.t("file_version._frontend.action.make_representative") %></button>
+      <button type="button" class="badge badge-info is-representative-label"><%= I18n.t("file_version.is_representative") %></button>
+      <button type="button" class="btn btn-small is-representative-toggle"><%= I18n.t("file_version._frontend.action.make_representative") %></button>
     </h3>
     <div class="subrecord-form-container">
       <%= form.hidden_input "instance_type", "digital_object" %>

--- a/frontend/spec/features/is_representative_toggle_spec.rb
+++ b/frontend/spec/features/is_representative_toggle_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Is Representative Toggle', js: true do
+  def toggle_expectations(make_rep_css, make_rep_text, is_rep_css, is_rep_text)
+    expect(page).to have_css(is_rep_css, visible: :hidden )
+    expect(page).to have_css(make_rep_css, visible: true )
+
+    click_on make_rep_text
+
+    expect(page).to have_css(is_rep_css, visible: true )
+    expect(page).to have_css(make_rep_css, visible: :hidden )
+
+    click_on is_rep_text
+
+    expect(page).to have_css(is_rep_css, visible: :hidden )
+    expect(page).to have_css(make_rep_css, visible: true )
+  end
+
+  before(:all) do
+    @make_rep_css = 'button.is-representative-toggle'
+    @make_rep_text = 'Make Representative'
+    @is_rep_css = 'button.is-representative-label'
+    @is_rep_text = 'Representative'
+  end
+
+  before(:each) do
+    login_admin
+  end
+
+  it 'can be toggled on and off for resource instances' do
+    subform = '#resource_instances_ .subrecord-form-list > li[data-index="0"]'
+
+    visit '/resources/new'
+    click_on 'Add Digital Object'
+
+    within subform do
+      toggle_expectations(@make_rep_css, @make_rep_text, @is_rep_css, @is_rep_text)
+    end
+  end
+
+  it 'can be toggled on and off for digital object file versions' do
+    subform = '#digital_object_file_versions_ .subrecord-form-list > li[data-index="0"]'
+
+    visit '/digital_objects/new'
+    click_on 'Add File Version'
+
+    within subform do
+      check 'Publish?'
+      toggle_expectations(@make_rep_css, @make_rep_text, @is_rep_css, @is_rep_text)
+    end
+  end
+
+  it 'can be toggled on and off for agent contact details' do
+    subform = '#agent_person_contact_details .subrecord-form-list > li[data-index="0"]'
+
+    visit '/agents/agent_person/new'
+    click_on 'Add Contact'
+
+    within subform do
+      toggle_expectations(
+        @make_rep_css,
+        'Make preferred contact',
+        @is_rep_css,
+        'Preferred'
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses [ANW-1498](https://archivesspace.atlassian.net/browse/ANW-1498). It allows the 'make representative' button found in the staff app to be toggled on and off on click. (Previously the button only turned the 'is-representative' state on but not off.) The button is found in the resource instances form, digital object file versions form, and agent contact details form.

This PR maintains the status quo of how this feature works -- using two buttons (to do the work of one) in conjunction with JavaScript and a hidden `<input type="text">`, thus recreating the native HTML `<input type="radio">` . In the future this feature should be refactored into a radio button input group, as the nature of the is-representative data model maps well to the radio button use case.

![ANW-1498-make-rep-btn](https://user-images.githubusercontent.com/3411019/214830163-334e4eb5-c90d-4596-b948-3d532b54126a.gif)

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See frontend/spec/features/is_representative_toggle_spec.rb.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[ANW-1498]: https://archivesspace.atlassian.net/browse/ANW-1498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ