### PR TITLE
search queries are not html!

### DIFF
--- a/public/app/controllers/concerns/searchable.rb
+++ b/public/app/controllers/concerns/searchable.rb
@@ -10,7 +10,6 @@ module Searchable
 
 
   def set_up_search(default_types = [], default_facets=[], default_search_opts={}, params={}, q='')
-    params = sanitize_params(params)
     @search = Search.new(params)
     limit = params.fetch(:limit, '')
     field = params.fetch(:field, nil)
@@ -78,7 +77,6 @@ module Searchable
   end
 
   def set_up_advanced_search(default_types = [], default_facets=[], default_search_opts={}, params={})
-    params = sanitize_params(params)
     @search = Search.new(params)
     unless @search[:limit].blank?
       default_types = @search[:limit].split(",")
@@ -173,7 +171,6 @@ module Searchable
 
 
   def get_filter_years(params)
-    params = sanitize_params(params)
     years = {}
     from = params.fetch(:filter_from_year, '').strip
     to = params.fetch(:filter_to_year, '').strip
@@ -294,7 +291,6 @@ module Searchable
 
 
   def search_terms(params)
-    params = sanitize_params(params)
     terms = ''
     queries = params.fetch(:q, nil)
     if queries
@@ -406,28 +402,6 @@ module Searchable
 #      type = type.chomp.chop if type.end_with?('s')
     end
     type
-  end
-
-  def sanitize_params(unsanitized)
-    unsanitized.each do |k, v|
-      if v.is_a?(Array)
-        sanitized = []
-        v.each do |val|
-          sanitized << ActionController::Base.helpers.sanitize(val)
-        end
-      elsif v.is_a?(Hash)
-        sanitized = {}
-        v.each do |_key, value|
-          sanitized.merge!(_key: ActionController::Base.helpers.sanitize(value))
-        end
-      elsif v.is_a?(String)
-        sanitized = ActionController::Base.helpers.sanitize(v)
-      elsif v.is_a?(Fixnum)
-        sanitized = v
-      end
-      unsanitized[k.to_sym] = sanitized
-    end
-    return unsanitized
   end
 
   def repositories_sort_by


### PR DESCRIPTION
Removes a method that was running `ActionView::Helpers::SanitizeHelper.sanitize` over search controller params, and garbling search queries with an '&' in the query string.