### PR TITLE
ANW-1615: account for LargeTree client-side interactions

### DIFF
--- a/common/config/preference_defaults.rb
+++ b/common/config/preference_defaults.rb
@@ -9,7 +9,7 @@ module PreferenceConfig
       'publish' => false,
       'rde_sort_alpha' => true,
       'include_unpublished' => false,
-      'digital_object_spawn_description' => false,
+      'digital_object_spawn' => false,
       'accession_browse_column_1' => 'title',
       'accession_browse_column_2' => 'identifier',
       'accession_browse_column_3' => 'accession_date',

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -2386,7 +2386,7 @@ en:
     publish_tooltip: Whether to publish new records by default.
     default_values: Pre-populate Records?
     default_values_tooltip: Whether to pre-populate new Accession and Resource records with default values.
-    digital_object_spawn_description: Spawn description for Digital Object instances from linked Resource/Accession?
+    digital_object_spawn: Spawn description for Digital Object instances from linked Resource/Accession?
     browse_column: Column %{num}
     browse_column_tooltip: The field to show in column %{num}.
     sort_column: Default Sort Column

--- a/common/locales/ja.yml
+++ b/common/locales/ja.yml
@@ -1435,7 +1435,7 @@ ja:
     publish_tooltip: 既定で新しいレコードを発行するかどうか。
     default_values: レコードの事前入力？
     default_values_tooltip: 新しいAccessionレコードとResourceレコードに既定値をあらかじめ設定するかどうか。
-    digital_object_spawn_description: Resourceからディジタルオブジェクトのデータフィールドを書き込む？
+    digital_object_spawn: Resourceからディジタルオブジェクトのデータフィールドを書き込む？
     browse_column: 列%{num}
     browse_column_tooltip: 列%{num}に表示するフィールド。
     sort_column: デフォルトのソート列

--- a/common/schemas/defaults.rb
+++ b/common/schemas/defaults.rb
@@ -71,7 +71,7 @@ end
         "items" => {"type" => "string"}
       },
 
-      "digital_object_spawn_description" => {
+      "digital_object_spawn" => {
         "type" => "boolean",
         "required" => false,
         "default" => false

--- a/frontend/app/assets/javascripts/digital_object_spawning.js.erb
+++ b/frontend/app/assets/javascripts/digital_object_spawning.js.erb
@@ -1,0 +1,15 @@
+// Since resources and archival objects use the front-end LargeTree for display, the active record
+// on display can change independently of what the backend was last aware. This means we need to
+// maniuplate the target attribute for the Create button so that the data from the correct record
+// is used for spawning, not whatever @resource/@archival_object was initally passed into the view.
+
+const createButton = $('label').filter(function() {
+    return $(this).text().trim() === 'Digital Object'; 
+  }).siblings().find('.linker-create-btn');
+
+createButton.click(function() {
+  const match = tree.large_tree.current_tree_id.match(/(\w+)_(\d+)$/);
+  var data_target = createButton.attr('data-target');
+  data_target += "&spawn_from_" + match[1] + "_id=" + match[2];
+  createButton.attr('data-target', data_target);
+});

--- a/frontend/app/controllers/digital_objects_controller.rb
+++ b/frontend/app/controllers/digital_objects_controller.rb
@@ -71,7 +71,7 @@ class DigitalObjectsController < ApplicationController
       end
     end
 
-    if user_prefs['digital_object_spawn_description']
+    if user_prefs['digital_object_spawn']
       if params[:spawn_from_resource_id]
         copy_from_record = Resource.find(params[:spawn_from_resource_id])
       elsif params[:spawn_from_accession_id]

--- a/frontend/app/helpers/digital_object_helper.rb
+++ b/frontend/app/helpers/digital_object_helper.rb
@@ -18,7 +18,7 @@ module DigitalObjectHelper
     # many resource note types will map exactly
     accept_resource_note_types = note_types_for('digital_object').keys
     # other note types will be mapped to a different digital object note type
-    accept_resource_note_types.concat(['abstract', 'scopecontent', 'materialspec', 'physfacet', 'phystech'])
+    accept_resource_note_types.concat(['abstract', 'scopecontent', 'materialspec', 'physfacet', 'phystech', 'odd'])
 
     if record_hash['notes']
       new_notes = []
@@ -41,6 +41,8 @@ module DigitalObjectHelper
                             'summary'
                           when 'materialspec', 'phystech', 'physfacet'
                             'physdesc'
+                          when 'odd'
+                            'note'
                           else
                             note_record['type']
                           end

--- a/frontend/app/helpers/digital_object_helper.rb
+++ b/frontend/app/helpers/digital_object_helper.rb
@@ -34,7 +34,11 @@ module DigitalObjectHelper
                           when 'note_singlepart'
                             note_record['content']
                           when 'note_multipart'
-                            note_record['subnotes'].map {|sn| sn['content']}.compact
+                            # DO notes are not multipart so just grab any note text and add them
+                            # as content items (important to avoid the other complex types)
+                            note_record['subnotes'].map { |sn|
+                              sn['content'] if sn['jsonmodel_type'] == 'note_text'
+                            }.compact
                           end,
             'type'     => case note_record['type']
                           when 'abstract', 'scopecontent'
@@ -48,8 +52,9 @@ module DigitalObjectHelper
                           end
           }
 
-          # ensure that at least one content item is present
-          new_note_h['content'] = [''] if new_note_h['content'].length == 0
+          # notes with no content are invalid!
+          next unless new_note_h['content'].length > 0
+
           new_note = JSONModel(:note_digital_object).from_hash(new_note_h)
         end
         new_notes << new_note.to_hash

--- a/frontend/app/views/defaults/_template.html.erb
+++ b/frontend/app/views/defaults/_template.html.erb
@@ -7,7 +7,7 @@
       <%= form.label_and_boolean "rde_sort_alpha", {}, form.default_for("rde_sort_alpha") %>
       <%= form.label_and_boolean "include_unpublished", {}, form.default_for("include_unpublished") %>
       <%= form.label_and_boolean "default_values", {}, form.default_for("default_values") %>
-      <%= form.label_and_boolean "digital_object_spawn_description", {}, form.default_for("digital_obect_spawn_description") %>
+      <%= form.label_and_boolean "digital_object_spawn", {}, form.default_for("digital_obect_spawn_description") %>
       <%= form.label_and_select "locale", supported_locales_options, supported_locales_default %>
 
       <h3 id="noteorder"><%= I18n.t "defaults.note_order_section" %></h3>

--- a/frontend/app/views/digital_objects/_linker.html.erb
+++ b/frontend/app/views/digital_objects/_linker.html.erb
@@ -58,12 +58,9 @@
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
           <% if user_can?('update_digital_object_record') %>
             <li>
-            <% if @resource %>
-              <a href="javascript:void(0);" data-target="<%= url_for :controller => :digital_objects, :action => :new, :inline => true, :spawn_from_resource_id => @resource.id %>" class="linker-create-btn"><%= I18n.t("actions.create") %></a>
-            <% elsif @accession %>
-               <a href="javascript:void(0);" data-target="<%= url_for :controller => :digital_objects, :action => :new, :inline => true, :spawn_from_accession_id => @accession.id %>" class="linker-create-btn"><%= I18n.t("actions.create") %></a>           
-            <% elsif @archival_object %>
-               <a href="javascript:void(0);" data-target="<%= url_for :controller => :digital_objects, :action => :new, :inline => true, :spawn_from_archival_object_id => @archival_object.id %>" class="linker-create-btn"><%= I18n.t("actions.create") %></a>           
+            <% if (user_prefs['digital_object_spawn'] && @accession) %>
+              <%# accessions can spawn DOs directly via backend %>
+              <a href="javascript:void(0);" data-target="<%= url_for :controller => :digital_objects, :action => :new, :inline => true, :spawn_from_accession_id => @accession.id %>" class="linker-create-btn"><%= I18n.t("actions.create") %></a>
             <% else %>
               <a href="javascript:void(0);" data-target="<%= url_for :controller => :digital_objects, :action => :new, :inline => true %>" class="linker-create-btn"><%= I18n.t("actions.create") %></a>
             <% end %>
@@ -74,3 +71,8 @@
     </div>
   </div>
 </div>
+
+<%# spawning DOs from resources and AOs need some extra frontend help because LargeTree %>
+<% if user_prefs['digital_object_spawn'] && (@resource || @archival_object) %>
+  <%= javascript_include_tag("digital_object_spawning") %>
+<% end %>


### PR DESCRIPTION
Resources and Archival Objects use this LargeTree Javascript
component for navigating and viewing. Since this happens entirely on
the client side, the record object that was provided to the view when
the user initially clicked Edit is no longer valid if the user clicks a
different record in the tree.

As a result, we needed some JavaScript that grabs the ID of the
"current" record (from the Tree) and tacks it on to the parameters
that are submitted by the linker's Create button. Now the controller
can copy fields from the correct record into the new Digital Object.

Also went back and fixed the name of the preference - not sure why
I had  "_description" on it.