### PR TITLE
Fix nil reference for unresolved DO

### DIFF
--- a/backend/app/exporters/lib/export_helpers.rb
+++ b/backend/app/exporters/lib/export_helpers.rb
@@ -157,6 +157,7 @@ module ASpaceExport
     def instances_with_digital_objects
       instances = self.instances.select { |inst| inst['digital_object']}.compact
       instances.each do |inst|
+        next unless inst['digital_object']['_resolved']
         inst['digital_object']['_resolved']['_is_in_representative_instance'] = inst['is_representative']
       end
     end


### PR DESCRIPTION
PDF export seems to pass records with unresolved digital object instances into the export helper, trippin up some new code.