### PR TITLE
revise release notes workflow to avoid rate limiting on github action…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  pull-requests: read
+  contents: write
+
 jobs:
   build_release:
     runs-on: ubuntu-latest
@@ -28,7 +32,8 @@ jobs:
           VERSION=$(echo $GITHUB_REF | cut -d / -f 3)
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "RELEASE_NAME=$(echo $VERSION | sed 's/v/V/')" >> $GITHUB_OUTPUT
-          ./build/run doc:release_notes -Dcurrent_tag=$VERSION -Doutfile=RELEASE_NOTES.md -Dtoken=${{ secrets.GITHUB_TOKEN }}
+          ./build/run doc:release_notes -Dcurrent_tag=$VERSION -Doutfile=RELEASE_NOTES.md -Dtoken=${{ secrets.ASPACE_PR_READING_TOKEN }}
+          cat RELEASE_NOTES.md
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_OUTPUT
           cat RELEASE_NOTES.md >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT

--- a/build/build.xml
+++ b/build/build.xml
@@ -572,6 +572,7 @@
     <property name="current_tag" value=""/>
     <property name="outfile" value="RELEASE_NOTES_${current_tag}.md" />
     <property name="token" value=""/>
+    <property name="gh_user" value="archivesspace" />
     <antcall target="bundler">
       <param name="gemfile" value="../Gemfile" />
       <param name="included-gem-groups" value="thor release_notes" />
@@ -579,7 +580,7 @@
     </antcall>
     <antcall target="thor">
       <param name="task" value="doc:release_notes" />
-      <param name="task_args" value="--current_tag=${current_tag} --out=${outfile} --token=${token}" />
+      <param name="task_args" value="--current_tag=${current_tag} --out=${outfile} --token=${token} --gh_user=${gh_user}" />
     </antcall>
   </target>
 


### PR DESCRIPTION
Update to the `release.yml` actions workflow. For whatever reason, I have not been able to get the GITHUB_TOKEN to work as an authentication token for GitHub Api calls from within the workflow runner, so I created my own [fine-grained token](https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/) and authorized it (from within ArchivesSpace organizational settings) to read pull requests from `archivesspace/archivesspace`. I then assigned this token to a repository-level secret called ASPACE_PR_READING_TOKEN - this token will expire in 1 year and someone will need to replace it with a new token then.