### PR TITLE
ANW-1677: Hide broken representative file version thumbnail images in staff search listing

### DIFF
--- a/frontend/app/views/search/_listing.html.erb
+++ b/frontend/app/views/search/_listing.html.erb
@@ -4,10 +4,13 @@
 
   <%= render_aspace_partial :partial => "shared/pagination_summary" %>
 
+  <% has_thumbnails_enabled = false %>
+
   <table id="tabledSearchResults" class="table table-striped table-bordered table-condensed table-hover table-sortable table-search-results" <%= 'data-multiselect="true"' if allow_multiselect? %>>
     <thead>
       <tr>
         <% @columns.each do |col| %>
+          <% has_thumbnails_enabled = true if col.field == 'representative_file_version' %>
           <th class="<%= col.class %>">
             <% if col.sortable? %>
               <%= link_to col.label, build_search_params("sort" => @search_data.sort_filter_for(col.sort_by)) %>
@@ -30,6 +33,17 @@
       <% end %>
     </tbody>
   </table>
+
+  <% if has_thumbnails_enabled %>
+    <script>
+      const thumbnails = document.querySelectorAll(
+        "#tabledSearchResults td.representative_file_version > img"
+      );
+      thumbnails.forEach((img) => {
+        img.addEventListener("error", () => (img.style.display = "none"));
+      });
+    </script>
+  <% end %>
 
   <%= render_aspace_partial :partial => "shared/pagination" %>
 <% else %>

--- a/frontend/spec/features/representative_file_version_spec.rb
+++ b/frontend/spec/features/representative_file_version_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Representative File Version', js: true do
+
+  describe 'search listing thumbnail' do
+    before(:all) do
+      @good_img = 'https://www.archivesspace.org/demos/Congreave%20E-4/ms292_008.jpg'
+      @bad_img = 'https://example.com/example.mp3'
+      @repo = create(:repo, repo_code: "thumbnail_images_test_#{Time.now.to_i}", publish: true)
+      set_repo(@repo)
+      @do_good_rep_fv = create(
+        :digital_object,
+        publish: true,
+        title: 'Digital object with supported image',
+        file_versions: [
+          {
+            publish: true,
+            is_representative: true,
+            file_uri: @good_img,
+            use_statement: 'image-thumbnail'
+          }
+        ]
+      )
+      @do_bad_rep_fv = create(
+        :digital_object,
+        publish: true,
+        title: 'Digital object with unsupported image',
+        file_versions: [
+          {
+            publish: true,
+            is_representative: true,
+            file_uri: @bad_img,
+            use_statement: 'image-thumbnail'
+          }
+        ]
+      )
+
+      $index.run_index_round
+    end
+
+    before(:each) do
+      login_admin
+      select_repository(@repo)
+
+      visit "/preferences/#{@repo.id}/edit"
+      find('#preference_defaults__digital_object_browse_column_2_')
+        .select('Thumbnail Image')
+      click_button('Save')
+    end
+
+    it 'is shown when a supported image format is available' do
+      visit '/digital_objects'
+      expect(page).to have_css("#tabledSearchResults .representative_file_version > img[src='#{@good_img}']", visible: :visible)
+    end
+    it 'is hidden when a supported image format is not available' do
+      visit '/digital_objects'
+      expect(page).to have_css("#tabledSearchResults .representative_file_version > img[src='#{@bad_img}']", visible: :hidden)
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes [ANW-1677](https://archivesspace.atlassian.net/browse/ANW-1677), hides broken thumbnail images in staff search listings when the URL for a record's `representative_file_version` resolves to a [non-supported image format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Img#supported_image_formats).

It works by listening for the loading error event on each thumbnail `<img>`.

![ANW-1677-fix-broken-thumbnails](https://user-images.githubusercontent.com/3411019/217638127-9f011939-0bc7-4c87-883e-30a65b234820.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See frontend/spec/features/representative_file_version_spec.rb


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[ANW-1677]: https://archivesspace.atlassian.net/browse/ANW-1677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ