### PR TITLE
Fix resolultion of digital_object reference

### DIFF
--- a/backend/app/lib/job_runners/print_to_pdf_runner.rb
+++ b/backend/app/lib/job_runners/print_to_pdf_runner.rb
@@ -16,7 +16,7 @@ class PrintToPDFRunner < JobRunner
         @job.write_output("Generating PDF for #{resource_jsonmodel["title"]}  ")
 
         obj = URIResolver.resolve_references(resource_jsonmodel,
-                                             [ "repository", "linked_agents", "subjects", "digital_objects", 'top_container', 'top_container::container_profile'])
+                                             [ "repository", "linked_agents", "subjects", "digital_object", 'top_container', 'top_container::container_profile'])
         opts = {
           :include_unpublished => @json.job["include_unpublished"] || false,
           :include_daos => true,


### PR DESCRIPTION
PDF export runner was trying to resolve "digital_objects" instead of "digital_object", so the export helper ended up trying to access a nil _resolved value