### PR TITLE
ANW-1260: adding failed string to error messages when extent type not found in …

### DIFF
--- a/backend/app/converters/lib/marcxml_bib_base_map.rb
+++ b/backend/app/converters/lib/marcxml_bib_base_map.rb
@@ -959,7 +959,7 @@ module MarcXMLBibBaseMap
                 elsif ext =~ /^([0-9\.,]+)/
                   extent.number = $1
                 else
-                  raise "The extent field (300) could not be parsed."
+                  raise "The extent field (300, #{ext}) could not be parsed."
                 end
 
               # $a and $f present, a must be numeric, f must be an extent value that's present in the extent_extent_type enumeration
@@ -969,7 +969,7 @@ module MarcXMLBibBaseMap
                 if a_content.inner_text =~ /^[+-]?([0-9]+\.?[0-9]*|\.[0-9]+)$/
                   extent.number = a_content.inner_text
                 else
-                  raise "No numeric value found in field 300, subfield a"
+                  raise "No numeric value found in field 300, subfield a (#{a_content.inner_text})"
                 end
 
                 # remove punctuation and replace underscores with spaces to better match extent_type translation values
@@ -979,7 +979,7 @@ module MarcXMLBibBaseMap
                 if extent_values.include?(f_content_cleaned)
                   extent.extent_type = f_content.inner_text
                 else
-                  raise "Extent type in field 300, subfield f is not found in the extent type controlled vocabulary."
+                  raise "Extent type in field 300, subfield f (#{f_content.inner_text}) is not found in the extent type controlled vocabulary."
                 end
               end
 

--- a/backend/spec/lib_marcxml_bib_converter_spec.rb
+++ b/backend/spec/lib_marcxml_bib_converter_spec.rb
@@ -555,13 +555,13 @@ describe 'MARCXML Bib converter' do
 
   describe "300 tag with $a and $f defined, $a not numeric" do
     it "fails with error message when $a is not numeric" do
-      expect { convert_test_file("at-tracer-marc-3.xml") }.to raise_error(StandardError, "No numeric value found in field 300, subfield a")
+      expect { convert_test_file("at-tracer-marc-3.xml") }.to raise_error(StandardError, "No numeric value found in field 300, subfield a (5.0 linear feet)")
     end
   end
 
   describe "300 tag with $a and $f defined, $f not in controlled vocabulary" do
     it "fails with error message when $f is not in controlled vocabulary" do
-      expect { convert_test_file("at-tracer-marc-4.xml") }.to raise_error(StandardError, "Extent type in field 300, subfield f is not found in the extent type controlled vocabulary.")
+      expect { convert_test_file("at-tracer-marc-4.xml") }.to raise_error(StandardError, "Extent type in field 300, subfield f (5.0 Linear feet) is not found in the extent type controlled vocabulary.")
     end
   end
 


### PR DESCRIPTION
…marcxml import

<!--- Provide a general summary of your changes in the Title above -->

## Description
adding failed string to error messages when extent type not found in marcxml import

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1260

## How Has This Been Tested?
manual and unit testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
