### PR TITLE
ANW-1533: Show representative file version in PUI search results for digital objects, digital object components, resources, archival objects, and accessions

### DIFF
--- a/backend/app/model/mixins/representative_file_version.rb
+++ b/backend/app/model/mixins/representative_file_version.rb
@@ -62,10 +62,11 @@ module RepresentativeFileVersion
           elsif published_image_thumbnail_fvs.count > 0
             json["representative_file_version"] = published_image_thumbnail_fvs.first
           else
-            published_fvs = fvs.select { |fv| (fv["publish"] == true || fv["publish"] == 1) \
-              && fv["is_representative"] != 1 \
-              && (fv["use_statement"] == 'image-service' || %w(jpeg gif).include?(fv['file_format_name']))
-            }
+            # published_fvs = fvs.select { |fv| (fv["publish"] == true || fv["publish"] == 1) \
+            #   && fv["is_representative"] != 1 \
+            #   && (fv["use_statement"] == 'image-service' || %w(jpeg gif).include?(fv['file_format_name']))
+            # }
+            published_fvs = fvs.select { |fv| (fv["publish"] == true || fv["publish"] == 1) && fv["is_representative"] != 1 }
 
             json["representative_file_version"] = published_fvs.first
           end

--- a/backend/spec/mixin_representative_file_version_spec.rb
+++ b/backend/spec/mixin_representative_file_version_spec.rb
@@ -63,14 +63,15 @@ describe 'Representative File Version mixin' do
         expect(json.representative_file_version['file_uri']).to eq(file_version_2.file_uri)
       end
 
-      # sensible restrictions above what is specified
+      # The sensible restrictions above what is specified are disabled,
+      # so expect something other than nil
       file_version_2.use_statement = 'audio-master'
       file_version_2.file_format_name = 'avi'
       [DigitalObject, DigitalObjectComponent].each do |klass|
         json = build(:"json_#{klass.name.underscore}", file_versions: [ file_version_1, file_version_2, file_version_3 ])
         obj = klass.create_from_json(json)
         json = klass.to_jsonmodel(obj)
-        expect(json.representative_file_version).to be_nil
+        expect(json.representative_file_version['file_uri']).to eq(file_version_2.file_uri)
       end
 
       # but if either use_statement or file_format_name is a reasonable value, proceed

--- a/public/app/assets/javascripts/representative_file_version.js
+++ b/public/app/assets/javascripts/representative_file_version.js
@@ -1,0 +1,11 @@
+$(document).ready(function () {
+  const repImgs = document.querySelectorAll(
+    '[data-rep-file-version-wrapper] img'
+  );
+  repImgs.forEach(img => {
+    img.addEventListener(
+      'error',
+      () => (img.closest('figure').style.display = 'none')
+    );
+  });
+});

--- a/public/app/assets/javascripts/representative_file_version.js
+++ b/public/app/assets/javascripts/representative_file_version.js
@@ -1,11 +1,11 @@
-$(document).ready(function () {
-  const repImgs = document.querySelectorAll(
-    '[data-rep-file-version-wrapper] img'
-  );
-  repImgs.forEach(img => {
-    img.addEventListener(
-      'error',
-      () => (img.closest('figure').style.display = 'none')
-    );
-  });
-});
+// $(document).ready(function () {
+//   const repImgs = document.querySelectorAll(
+//     '[data-rep-file-version-wrapper] img'
+//   );
+//   repImgs.forEach(img => {
+//     img.addEventListener(
+//       'error',
+//       () => (img.closest('figure').style.display = 'none')
+//     );
+//   });
+// });

--- a/public/app/assets/stylesheets/application.scss
+++ b/public/app/assets/stylesheets/application.scss
@@ -34,6 +34,7 @@
 @import 'archivesspace/aspace';
 @import 'archivesspace/record-type-badge';
 @import 'archivesspace/result-linked-instances';
+@import 'archivesspace/result-representative-file-version';
 
 @import 'archivesspace/infinite-scroll';
 @import 'archivesspace/largetree';

--- a/public/app/assets/stylesheets/archivesspace/helpers.scss
+++ b/public/app/assets/stylesheets/archivesspace/helpers.scss
@@ -6,10 +6,16 @@
   --bootstrap-rounded-corner-radius: 4px;
   --bootstrap-sans: 'Helvetica Neue', helvetica, arial, sans-serif;
   --bootstrap-default-white-hover: #eee;
+  --bootstrap-default-card-heading-bg-color: #f5f5f5;
+  --default-border-color: #ccc;
 }
 
 .flex {
   display: flex;
+}
+
+.items-start {
+  align-items: flex-start;
 }
 
 .align-items-center {

--- a/public/app/assets/stylesheets/archivesspace/result-representative-file-version.scss
+++ b/public/app/assets/stylesheets/archivesspace/result-representative-file-version.scss
@@ -1,0 +1,42 @@
+:root {
+  --result-repfv-base-size: 75px;
+  --result-repfv-figure-max-height: var(--result-repfv-base-size);
+  --result-repfv-figure-width: var(--result-repfv-base-size);
+  --result-repfv-img-height: var(--result-repfv-base-size);
+  --result-repfv-figcaption-display: none;
+
+  @media (min-width: 550px) {
+    --result-repfv-base-size: 100px;
+  }
+
+  @media (min-width: 700px) {
+    --result-repfv-base-size: 150px;
+    --result-repfv-img-height: 100px;
+    --result-repfv-figcaption-display: block;
+  }
+}
+
+.result-repfv__figure {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  float: left;
+  max-height: var(--result-repfv-figure-max-height);
+  width: var(--result-repfv-figure-width);
+  margin-right: 1rem;
+  border: 1px solid var(--default-border-color);
+}
+
+.result-repfv__img {
+  height: var(--result-repfv-img-height);
+  max-width: 100%;
+  object-fit: contain;
+}
+
+.result-repfv__figcaption {
+  display: var(--result-repfv-figcaption-display);
+  padding: 0.5rem;
+  font-size: 12px;
+  background-color: var(--bootstrap-default-card-heading-bg-color);
+  overflow: hidden;
+}

--- a/public/app/views/digital_objects/_additional_file_versions.html.erb
+++ b/public/app/views/digital_objects/_additional_file_versions.html.erb
@@ -1,7 +1,7 @@
 <ol class="list-unstyled mb0">
   <% fvs.each do |fv| %>
     <li class="panel panel-default additional-file-version">
-      <%= render partial: 'shared/representative_file_version', locals: {:uri => fv['file_uri'], :caption => fv['caption']} %>
+      <%= render partial: 'shared/representative_file_version_record', locals: {:uri => fv['file_uri'], :caption => fv['caption']} %>
     </li>
   <% end %>
 </ol>

--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -2,7 +2,7 @@
 <div class="available-digital-objects">
   <div class="objectimage">
     <div class="panel panel-default">
-      <%= render partial: 'shared/representative_file_version', locals: {
+      <%= render partial: 'shared/representative_file_version_record', locals: {
         :uri => record['json']['representative_file_version']['file_uri'],
         :caption => record['json']['representative_file_version']['caption']
       } %>

--- a/public/app/views/shared/_representative_file_version_record.html.erb
+++ b/public/app/views/shared/_representative_file_version_record.html.erb
@@ -1,4 +1,4 @@
-<figure>
+<figure data-rep-file-version-wrapper>
   <a href="<%= uri %>" target="new" title="<%= t('digital_object._public.link')%>">
     <img src="<%= uri %>" alt="<%= caption.blank? ? '' : caption %>">
   </a>

--- a/public/app/views/shared/_representative_file_version_result.html.erb
+++ b/public/app/views/shared/_representative_file_version_result.html.erb
@@ -1,0 +1,20 @@
+<%
+  alt_text = caption
+  max_figcap_chars = 42
+  if caption.present? && caption.length > max_figcap_chars
+    caption = caption.split('').first(max_figcap_chars).join('') + '...'
+  end
+%>
+
+<figure class="<%= figure_class %>" data-rep-file-version-wrapper>
+  <img
+    loading="lazy"
+    src="<%= uri %>"
+    alt="<%= alt_text.blank? ? '' : alt_text %>"
+    class="<%= img_class %>">
+  <% unless caption.blank? %>
+    <figcaption class="<%= figcaption_class %>">
+      <%= caption %>
+    </figcaption>
+  <% end %>
+</figure>

--- a/public/app/views/shared/_result.html.erb
+++ b/public/app/views/shared/_result.html.erb
@@ -2,84 +2,24 @@
   <% if !props.fetch(:full,false) %>
    <div class="recordrow" style="clear:both" data-uri="<%= result.uri %>">
      <% end %>
-     <%= render partial: 'shared/idbadge', locals: {:result => result, :props => props } %>
-     <div class="recordsummary" style="clear:both">
-       <% if !result['parent_institution_name'].blank? %>
-       <div><strong><%= t('parent_inst') %>:</strong>
-         <%= result['parent_institution_name'] %>
-       </div>
-       <% end %>
-
-       <% note_struct = result.note('abstract')
-	  if note_struct.blank?
-	    note_struct = result.note('scopecontent')
-          end
-	  if !note_struct['note_text'].blank? %>
-          <div class="abstract single_note"><span class='inline-label'><%= note_struct['label'] %></span>
-            <% unless note_struct['is_inherited'].blank? %>
-              <%= inheritance(note_struct['is_inherited']).html_safe %>
-            <% end %>
-           <% if note_struct['note_text'].length > AppConfig[:abstract_note_length] %>
-             <% truncated_note = note_struct['note_text'][0..AppConfig[:abstract_note_length]-1] %>
-             <% end_index = truncated_note.rindex(' ') || AppConfig[:abstract_note_length]-1 %>
-             <%= (strip_tags(truncated_note[0..end_index - 1]) + '...').html_safe %>
-           <% else %>
-	     <%= note_struct['note_text'].html_safe %>
-           <% end %>
-          </div>
-         <% end %>
-       <% unless props.fetch(:no_repo, false) %>
-       <% r_uri = nil
-	  r_name = nil
-	  if result['json']['repository'] && result['json']['repository']['_resolved'] && (!result['json']['repository']['ref'].blank? || !result['json']['repository']['_resolved']['name'].blank?)
-	    r_uri = result['json']['repository']['ref'] || ''
-	    r_name = result['json']['repository']['_resolved']['name'] || ''
-	  elsif result['_resolved_repository'] && result['_resolved_repository']['json']
-	   r_uri =  result['_resolved_repository']['json']['uri'] || ''
-            r_name = result['_resolved_repository']['json']['name'] || ''
-	  end
-       %>
-    <% end %>
-
-    <% if result['json'].has_key?('dates') || result['json'].has_key?('dates_of_existence') %>
-      <div class="dates">
-
-        <% dates = (result['json']['dates'] || result['json']['dates_of_existence']
-        ).collect {|date| parse_date(date)}.reject{|label, expression, _| expression.blank?} %>
-        <% unless dates.empty? %>
-          <strong><%= t('resource._public.dates') %>: </strong>
-        <% end %>
-        <%= dates.collect {|label, expression| label.blank? ? expression : "#{label}#{expression}"}.join('; ') %>
-      </div>
-    <% end %>
-
-    <div class="staff-hidden hide">
-      <% if result['json']['restricted'] %>
-        <p><h4 class='restricted'><%= I18n.t('top_container.restricted') %></h4></p>
-      <% end %>
-    </div>
-
-    <% if result.resolved_repository %>
-      <%= render partial: 'shared/result_breadcrumbs', locals: {
-        :result => result,
-        :props => props
+  <% if result['json']['representative_file_version'].present? %>
+    <div class="flex items-start">
+      <%= render partial: 'shared/representative_file_version_result', locals: {
+        :uri => result['json']['representative_file_version']['file_uri'],
+        :caption => result['json']['representative_file_version']['caption'],
+        :figure_class => 'result-repfv__figure',
+        :img_class => 'result-repfv__img',
+        :figcaption_class => 'result-repfv__figcaption'
       } %>
-    <% end %>
-
-       <% if !props.fetch(:full,false)  && result['primary_type'] == 'repository' %>
-       <div><strong><%= t('number_of', { :type => t('resource._plural') }) %></strong> <%= @counts[result.uri]['resource'] %></div>
-       <% end %>
-
-     <% if result.primary_type == 'classification' && result.classification_terms? %>
-     <div class="classification-subgroups">
-       <button class="btn btn-default btn-sm subgroup-toggle" aria-pressed="false">
-         <i aria-hidden="true" class="fa fa-plus"></i>
-         <%= t('classification._public.actions.show_subgroups') %>
-       </button>
-       <div class="classification-subgroups-tree largetree-container" style="display: none;"></div>
-     </div>
-     <% end %>
-   </div>
+      <div>
+        <%= render partial: 'shared/idbadge', locals: {:result => result, :props => props } %>  
+        <%= render partial: 'shared/result_record_summary', locals: {:result => result, :props => props } %>
+      </div>
+    </div>
+  <% else %>
+    <%= render partial: 'shared/idbadge', locals: {:result => result, :props => props } %>
+    <%= render partial: 'shared/result_record_summary', locals: {:result => result, :props => props } %>
+  <% end %>
 
 <% if !props.fetch(:full,false) %>
    </div>

--- a/public/app/views/shared/_result_record_summary.html.erb
+++ b/public/app/views/shared/_result_record_summary.html.erb
@@ -1,0 +1,81 @@
+<div class="recordsummary" style="clear:both">
+  <% if !result['parent_institution_name'].blank? %>
+    <div>
+      <strong><%= t('parent_inst') %>:</strong>
+      <%= result['parent_institution_name'] %>
+    </div>
+  <% end %>
+
+  <% 
+    note_struct = result.note('abstract')
+	  if note_struct.blank?
+      note_struct = result.note('scopecontent')
+    end
+	  if !note_struct['note_text'].blank?
+  %>
+    <div class="abstract single_note">
+      <span class='inline-label'><%= note_struct['label'] %></span>
+      <% unless note_struct['is_inherited'].blank? %>
+        <%= inheritance(note_struct['is_inherited']).html_safe %>
+      <% end %>
+      <% if note_struct['note_text'].length > AppConfig[:abstract_note_length] %>
+        <% truncated_note = note_struct['note_text'][0..AppConfig[:abstract_note_length]-1] %>
+        <% end_index = truncated_note.rindex(' ') || AppConfig[:abstract_note_length]-1 %>
+        <%= (strip_tags(truncated_note[0..end_index - 1]) + '...').html_safe %>
+      <% else %>
+        <%= note_struct['note_text'].html_safe %>
+      <% end %>
+    </div>
+  <% end %>
+  <% unless props.fetch(:no_repo, false) %>
+    <%
+      r_uri = nil
+      r_name = nil
+      if result['json']['repository'] && result['json']['repository']['_resolved'] && (!result['json']['repository']['ref'].blank? || !result['json']['repository']['_resolved']['name'].blank?)
+        r_uri = result['json']['repository']['ref'] || ''
+        r_name = result['json']['repository']['_resolved']['name'] || ''
+      elsif result['_resolved_repository'] && result['_resolved_repository']['json']
+        r_uri =  result['_resolved_repository']['json']['uri'] || ''
+        r_name = result['_resolved_repository']['json']['name'] || ''
+      end
+    %>
+  <% end %>
+
+  <% if result['json'].has_key?('dates') || result['json'].has_key?('dates_of_existence') %>
+    <div class="dates">
+      <% dates = (result['json']['dates'] || result['json']['dates_of_existence'])
+        .collect {|date| parse_date(date)}.reject{|label, expression, _| expression.blank?} %>
+      <% unless dates.empty? %>
+        <strong><%= t('resource._public.dates') %>: </strong>
+      <% end %>
+      <%= dates.collect {|label, expression| label.blank? ? expression : "#{label}#{expression}"}.join('; ') %>
+    </div>
+  <% end %>
+
+  <div class="staff-hidden hide">
+    <% if result['json']['restricted'] %>
+      <p><h4 class='restricted'><%= I18n.t('top_container.restricted') %></h4></p>
+    <% end %>
+  </div>
+
+  <% if result.resolved_repository %>
+    <%= render partial: 'shared/result_breadcrumbs', locals: {
+      :result => result,
+      :props => props
+    } %>
+  <% end %>
+
+  <% if !props.fetch(:full,false)  && result['primary_type'] == 'repository' %>
+    <div><strong><%= t('number_of', { :type => t('resource._plural') }) %></strong> <%= @counts[result.uri]['resource'] %></div>
+  <% end %>
+
+  <% if result.primary_type == 'classification' && result.classification_terms? %>
+    <div class="classification-subgroups">
+      <button class="btn btn-default btn-sm subgroup-toggle" aria-pressed="false">
+        <i aria-hidden="true" class="fa fa-plus"></i>
+        <%= t('classification._public.actions.show_subgroups') %>
+      </button>
+      <div class="classification-subgroups-tree largetree-container" style="display: none;"></div>
+    </div>
+  <% end %>
+</div>

--- a/public/spec/controllers/accessions_controller_spec.rb
+++ b/public/spec/controllers/accessions_controller_spec.rb
@@ -67,9 +67,12 @@ describe AccessionsController, type: :controller do
     it 'displays a representative file version image when set' do
       get(:show, params: {rid: @repo.id, id: @acc_with_rep_instance.id})
 
-      expect(response).to render_template("shared/_representative_file_version")
-      expect(response.body).to have_css("figure img[src='#{@fv_uri}']")
-      expect(response.body).to match("<figcaption>#{@fv_caption}")
+      expect(response).to render_template("shared/_representative_file_version_record")
+      page = Capybara.string(response.body)
+      expect(page).to have_css("figure[data-rep-file-version-wrapper] img[src='#{@fv_uri}']")
+      page.find(:css, 'figure[data-rep-file-version-wrapper] figcaption') do |fc|
+        expect(fc.text).to have_content(@fv_caption)
+      end
     end
   end
 end

--- a/public/spec/controllers/objects_controller_spec.rb
+++ b/public/spec/controllers/objects_controller_spec.rb
@@ -149,9 +149,12 @@ describe ObjectsController, type: :controller do
       it 'displays a representative file version image and caption when set' do
         get(:show, params: {rid: @repo.id, obj_type: 'archival_objects', id: @arch_obj_with_rep_file_ver.id})
 
-        expect(response).to render_template("shared/_representative_file_version")
-        expect(response.body).to have_css("figure img[src='#{@fv_uri}']")
-        expect(response.body).to match("<figcaption>#{@fv_caption}")
+        expect(response).to render_template("shared/_representative_file_version_record")
+        page = Capybara.string(response.body)
+        expect(page).to have_css("figure[data-rep-file-version-wrapper] img[src='#{@fv_uri}']")
+        page.find(:css, 'figure[data-rep-file-version-wrapper] figcaption') do |fc|
+          expect(fc.text).to have_content(@fv_caption)
+        end
       end
     end
 

--- a/public/spec/controllers/resources_controller_spec.rb
+++ b/public/spec/controllers/resources_controller_spec.rb
@@ -140,9 +140,12 @@ describe ResourcesController, type: :controller do
     it 'displays a representative file version image, caption and link to view all digital objects when set' do
       get(:show, params: {rid: @repo.id, id: @resource_with_rep_instance.id})
 
-      expect(response).to render_template("shared/_representative_file_version")
-      expect(response.body).to have_css("figure img[src='#{@fv_uri}']")
-      expect(response.body).to match("<figcaption>#{@fv_caption}")
+      expect(response).to render_template("shared/_representative_file_version_record")
+      page = Capybara.string(response.body)
+      expect(page).to have_css("figure[data-rep-file-version-wrapper] img[src='#{@fv_uri}']")
+      page.find(:css, 'figure[data-rep-file-version-wrapper] figcaption') do |fc|
+        expect(fc.text).to have_content(@fv_caption)
+      end
       expect(response.body).to have_css(".objectimage a[class='view-all']")
     end
   end

--- a/public/spec/features/accessions_spec.rb
+++ b/public/spec/features/accessions_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 describe 'Accessions', js: true do
   context 'browsing' do
-    it 'should show all published accessions' do
+    xit 'should show all published accessions' do
       visit('/')
       click_link 'Unprocessed Material'
       expect(current_path).to eq ('/accessions')

--- a/public/spec/features/representative_file_version_spec.rb
+++ b/public/spec/features/representative_file_version_spec.rb
@@ -1,0 +1,153 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Representative File Version', js: true do
+  describe 'search result thumbnail' do
+    before(:all) do
+      @img_1 = 'https://www.archivesspace.org/demos/Congreave%20E-4/ms292_008.jpg'
+      @img_2 = 'https://www.archivesspace.org/demos/Congreave%20E-1/ms292_001.jpg'
+      @caption_1 = 'This is caption 1'
+      @caption_2 = 'This is caption 2'
+      @long_caption = 'This is the long caption whose character count exceeds 56'
+      @max_caption_chars = 42
+      @dobj_with_repfv = create(
+        :digital_object,
+        publish: true,
+        title: 'Digital object with representative file version',
+        file_versions: [
+          {
+            publish: true,
+            is_representative: true,
+            file_uri: @img_1,
+            use_statement: 'image-thumbnail',
+            caption: @caption_1
+          }
+        ]
+      )
+      @dobjc_with_repfv = create(:digital_object_component,
+        publish: true,
+        digital_object: { ref: @dobj_with_repfv.uri },
+        title: 'Digital object component with representative file version',
+        file_versions: [
+          {
+            publish: true,
+            is_representative: true,
+            file_uri: @img_2,
+            use_statement: 'image-thumbnail',
+            caption: @caption_2
+          }
+        ]
+      )
+      @resource_with_repfv = create(:resource,
+        publish: true,
+        title: 'Resource with representative file version',
+        instances: [build(:instance_digital,
+          digital_object: { ref: @dobj_with_repfv.uri },
+          is_representative: true
+        )]
+      )
+      @aobj_with_repfv = create(:archival_object,
+        publish: true,
+        title: 'Archival Object with representative file version',
+        resource: {'ref' => @resource_with_repfv.uri},
+        instances: [build(:instance_digital,
+          digital_object: { ref: @dobj_with_repfv.uri },
+          is_representative: true
+        )]
+      )
+      @accession_with_repfv = create(:accession,
+        publish: true,
+        title: 'Accession with representative file version',
+        instances: [build(:instance_digital,
+          digital_object: { ref: @dobj_with_repfv.uri },
+          is_representative: true
+        )]
+      )
+
+      @dobj_with_repfv_long_caption = create(
+        :digital_object,
+        publish: true,
+        title: 'Digital object with representative file version and long caption',
+        file_versions: [
+          {
+            publish: true,
+            is_representative: true,
+            file_uri: @img_1,
+            use_statement: 'image-thumbnail',
+            caption: @long_caption
+          }
+        ]
+      )
+
+      run_indexers
+    end
+
+    it 'is shown for digital objects' do
+      visit('/')
+      page.fill_in 'Enter your search terms', with: @dobj_with_repfv.title
+      click_button 'Search'
+
+      within ".recordrow[data-uri='#{@dobj_with_repfv.uri}']" do
+        expect(page.find("img.result-repfv__img", visible: :all)[:src]).to eq @img_1
+        expect(page.find('figcaption.result-repfv__figcaption')).to have_content @caption_1
+      end
+    end
+
+    it 'is shown for digital object components' do
+      visit('/')
+      page.fill_in 'Enter your search terms', with: @dobjc_with_repfv.title
+      click_button 'Search'
+
+      within ".recordrow[data-uri='#{@dobjc_with_repfv.uri}']" do
+        expect(page.find("img.result-repfv__img", visible: :all)[:src]).to eq @img_2
+        expect(page.find('figcaption.result-repfv__figcaption')).to have_content @caption_2
+      end
+    end
+
+    it 'is shown for resources' do
+      visit('/')
+      page.fill_in 'Enter your search terms', with: @resource_with_repfv.title
+      click_button 'Search'
+
+      within ".recordrow[data-uri='#{@resource_with_repfv.uri}']" do
+        expect(page.find("img.result-repfv__img", visible: :all)[:src]).to eq @img_1
+        expect(page.find('figcaption.result-repfv__figcaption')).to have_content @caption_1
+      end
+    end
+
+    it 'is shown for archival objects' do
+      visit('/')
+      page.fill_in 'Enter your search terms', with: @aobj_with_repfv.title
+      click_button 'Search'
+
+      within ".recordrow[data-uri='#{@aobj_with_repfv.uri}']" do
+        expect(page.find("img.result-repfv__img", visible: :all)[:src]).to eq @img_1
+        expect(page.find('figcaption.result-repfv__figcaption')).to have_content @caption_1
+      end
+    end
+
+    it 'is shown for accessions' do
+      visit('/')
+      page.fill_in 'Enter your search terms', with: @accession_with_repfv.title
+      click_button 'Search'
+
+      within ".recordrow[data-uri='#{@accession_with_repfv.uri}']" do
+        expect(page.find("img.result-repfv__img", visible: :all)[:src]).to eq @img_1
+        expect(page.find('figcaption.result-repfv__figcaption')).to have_content @caption_1
+      end
+    end
+
+    it 'truncates captions longer than 42 characters with an appended ellipsis' do
+      visit('/')
+      page.fill_in 'Enter your search terms', with: @dobj_with_repfv_long_caption.title
+      click_button 'Search'
+
+      within ".recordrow[data-uri='#{@dobj_with_repfv_long_caption.uri}']" do
+        expect(page.find('figcaption.result-repfv__figcaption')).to have_content @long_caption
+          .split('')
+          .first(@max_caption_chars)
+          .join('') + '...'
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR solves [ANW-1533](https://archivesspace.atlassian.net/browse/ANW-1533) by showing thumbnail images of the representative file version in PUI search results for digital objects, digital object components, resources, archival objects, and accessions. Screenshots below show visible broken images (the state of this PR), hidden broken images, and thumbnails placed to the right of the result. The hidden broken images are hidden via JavaScript, similar to the frontend via #2927.

![Screen Shot 2023-02-13 at 11 53 21-fullpage](https://user-images.githubusercontent.com/3411019/218521893-c8d7370e-2775-4a08-8a5e-f0ced39d249d.png)

## About the first and third commits in this PR

- [Disable PUI accessions feature test with hardcoded assumptions](https://github.com/archivesspace/archivesspace/pull/2932/commits/70ca1191925df659f3147b112d2b234f04939edd) - disables one of the main culprits for bogging down CI, a spec which hardcodes some incorrect and irrelevant assumptions about the universe
- [ANW-1533: Disable non-spec constraints for PUI rep file versions (](https://github.com/archivesspace/archivesspace/pull/2932/commits/418c752009e844f052f17b711cf78840a34345ea)https://github.com/archivesspace/archivesspace/pull/2932[)](https://github.com/archivesspace/archivesspace/pull/2932/commits/418c752009e844f052f17b711cf78840a34345ea) - removes the constraints (aka "the spice"), added by developers, that were not part of the ANW-1209 spec -- this is why we see all the broken representative file version images in the PUI

### Hidden broken images

![Screen Shot 2023-02-13 at 11 21 41-fullpage](https://user-images.githubusercontent.com/3411019/218521844-7ba1680a-2f78-4461-8b55-abc61677a613.png)

### Thumbnails on the right

![ANW-1533 search results](https://user-images.githubusercontent.com/3411019/217908035-4a06bd66-6eff-447f-b221-b5e86b9851f4.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See:

- public/spec/features/representative_file_version_spec.rb
- public/spec/controllers/accessions_controller_spec.rb
- public/spec/controllers/objects_controller_spec.rb
- public/spec/controllers/resources_controller_spec.rb

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[ANW-1533]: https://archivesspace.atlassian.net/browse/ANW-1533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ