### PR TITLE
ANW-1534: Link to image search in PUI

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -799,6 +799,9 @@ i.giant {
   width: 100%;
   white-space: normal;
 }
+.objectimage a.view-all {
+  padding-left: 0.5rem;
+}
 
 @media (min-width: 500px) {
   .additional-file-version {

--- a/public/app/helpers/view_helper.rb
+++ b/public/app/helpers/view_helper.rb
@@ -37,6 +37,10 @@ module ViewHelper
     "(" + I18n.t("enumerations.#{type}.#{value}") + ")"
   end
 
+  def representative_link_to_digital_materials?(record)
+    record.primary_type == 'resource'
+  end
+
   def nl2ws(text)
     text = text.join(' ') if text.respond_to? :each
     sanitize(text).gsub(/\n/, ' ').html_safe

--- a/public/app/views/accessions/show.html.erb
+++ b/public/app/views/accessions/show.html.erb
@@ -14,7 +14,7 @@
   <div class="col-sm-9">
 
     <% if @result['json']['representative_file_version'].present? %>
-      <%= render partial: 'shared/digital' %>
+      <%= render partial: 'shared/digital', locals: {record: @result} %>
     <% end %>
 
   <% if @result.content_description %>
@@ -31,12 +31,12 @@
     <h2><%= t('accession._public.section.provenance') %></h2>
     <p><%= @result.provenance %></p>
   <% end %>
-  
+
   <% if @result.language %>
     <h2><%= t('accession._public.section.language') %></h2>
     <p><%= @result.language %></p>
   <% end %>
-  
+
   <% if @result.script %>
     <h2><%= t('accession._public.section.script') %></h2>
     <p><%= @result.script %></p>

--- a/public/app/views/objects/show.html.erb
+++ b/public/app/views/objects/show.html.erb
@@ -16,7 +16,7 @@
     <% if  defined?(comp_id) && !comp_id && !@result['json']['ref_id'].blank? %>
       <span class='ref_id'>[<%=  t('archival_object._public.header.ref_id') %>: <%= @result['json']['ref_id'] %>]</span>
     <% end %>
-    <%= render partial: 'shared/digital', locals: {:dig_objs => @dig} %>
+    <%= render partial: 'shared/digital', locals: {:dig_objs => @dig, record: @result} %>
     <%= render partial: 'shared/record_innards' %>
    </div>
 

--- a/public/app/views/resources/show.html.erb
+++ b/public/app/views/resources/show.html.erb
@@ -20,7 +20,7 @@
 
 <div class="row" id="notes_row">
   <div class="col-sm-9">
-    <%= render partial: 'shared/digital', locals: {:dig_objs => @dig} %>
+    <%= render partial: 'shared/digital', locals: {:dig_objs => @dig, record: @result} %>
     <%= render partial: 'shared/record_innards' %>
   </div>
   <div id="sidebar" class="col-sm-3 sidebar sidebar-container resizable-sidebar" <% unless @has_children %>style="display: none"<% end %>>

--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -1,11 +1,19 @@
-<% if @result['json']['representative_file_version'].present? %>
+<% if record['json']['representative_file_version'].present? %>
 <div class="available-digital-objects">
   <div class="objectimage">
     <div class="panel panel-default">
       <%= render partial: 'shared/representative_file_version', locals: {
-        :uri => @result['json']['representative_file_version']['file_uri'],
-        :caption => @result['json']['representative_file_version']['caption']
+        :uri => record['json']['representative_file_version']['file_uri'],
+        :caption => record['json']['representative_file_version']['caption']
       } %>
+      <% if representative_link_to_digital_materials?(record) %>
+        <p>
+          <%= link_to t('actions.digitized'),
+              app_prefix("/repositories/#{params[:rid]}/resources/#{params[:id]}/digitized"),
+              class: 'view-all'
+          %>
+        </p>
+      <% end %>
     </div>
   </div>
 </div>

--- a/public/spec/controllers/resources_controller_spec.rb
+++ b/public/spec/controllers/resources_controller_spec.rb
@@ -137,12 +137,13 @@ describe ResourcesController, type: :controller do
       expect(instance_data[0]['caption']).to eq(@digital_object.title)
     end
 
-    it 'displays a representative file version image and caption when set' do
+    it 'displays a representative file version image, caption and link to view all digital objects when set' do
       get(:show, params: {rid: @repo.id, id: @resource_with_rep_instance.id})
 
       expect(response).to render_template("shared/_representative_file_version")
       expect(response.body).to have_css("figure img[src='#{@fv_uri}']")
       expect(response.body).to match("<figcaption>#{@fv_caption}")
+      expect(response.body).to have_css(".objectimage a[class='view-all']")
     end
   end
 end


### PR DESCRIPTION
Adds a link to view all digital objects that are related to the resource record being viewed below the representative file version.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
