### PR TITLE
ANW-1534 Implement spec link text

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/helpers.scss
+++ b/public/app/assets/stylesheets/archivesspace/helpers.scss
@@ -37,3 +37,16 @@
 .mb0 {
   margin-bottom: 0;
 }
+
+.pb1 {
+  padding-bottom: 0.5rem;
+}
+
+.rounded-bottom {
+  border-bottom-left-radius: var(--bootstrap-rounded-corner-radius);
+  border-bottom-right-radius: var(--bootstrap-rounded-corner-radius);
+}
+
+.bg-lightgray {
+  background-color: var(--bootstrap-default-card-heading-bg-color);
+}

--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -161,6 +161,8 @@ class ResourcesController < ApplicationController
       fill_request_info
       @dig = process_digital_instance(@result['json']['instances'])
       process_extents(@result['json'])
+
+      @n_digital_objects = get_digital_object_count
     rescue RecordNotFound
       record_not_found(uri, 'resource')
     end
@@ -297,6 +299,13 @@ class ResourcesController < ApplicationController
     qry = "collection_uri_u_sstr:\"#{uri}\" AND (#{DIGITAL_QUERY})"
 
     archivesspace.search(qry, 1).records.any?
+  end
+
+  def get_digital_object_count
+    uri = "/repositories/#{params[:rid]}/resources/#{params[:id]}"
+    qry = "collection_uri_u_sstr:\"#{uri}\" AND (#{DIGITAL_QUERY})"
+
+    archivesspace.search(qry, 1, {:rows => 0})['total_hits']
   end
 
   def fetch(resource_uri, page_uri, params, query, sort, type, enums = [])

--- a/public/app/views/resources/show.html.erb
+++ b/public/app/views/resources/show.html.erb
@@ -21,7 +21,10 @@
 <div class="row" id="notes_row">
   <div class="col-sm-9">
     <% if @result['json']['representative_file_version'].present? %>
-      <%= render partial: 'shared/digital', locals: {record: @result} %>
+      <%= render partial: 'shared/digital', locals: {
+        record: @result,
+        n_digital_objects: @n_digital_objects
+      } %>
     <% end %>
     <%= render partial: 'shared/record_innards' %>
   </div>

--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -7,8 +7,12 @@
         :caption => record['json']['representative_file_version']['caption']
       } %>
       <% if representative_link_to_digital_materials?(record) %>
-        <p>
-          <%= link_to t('actions.digitized'),
+        <% digitized_link_text = t(
+          'digital_object._public.browse_number_digital_objects_in_collection',
+          num: n_digital_objects
+        ) %>
+        <p class="mb0 pb1 rounded-bottom bg-lightgray">
+          <%= link_to digitized_link_text,
               app_prefix("/repositories/#{params[:rid]}/resources/#{params[:id]}/digitized"),
               class: 'view-all'
           %>

--- a/public/app/views/shared/_representative_file_version_record.html.erb
+++ b/public/app/views/shared/_representative_file_version_record.html.erb
@@ -3,6 +3,6 @@
     <img src="<%= uri %>" alt="<%= caption.blank? ? '' : caption %>">
   </a>
   <% unless caption.blank? %>
-    <figcaption><%= caption %></figcaption>
+    <figcaption class="bg-lightgray"><%= caption %></figcaption>
   <% end %>
 </figure>

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -352,7 +352,8 @@ en:
       badge_label: Digital %{level}
       go: Go to file
       additional: Additional File Versions
-
+      browse_number_digital_objects_in_collection: Browse %{num} digital objects in collection
+      
   subject:
     _singular: Subject
     _plural: Subjects

--- a/public/config/locales/ja.yml
+++ b/public/config/locales/ja.yml
@@ -302,6 +302,7 @@ ja:
       go: ファイルに移動
       section: {}
       messages: {}
+      browse_number_digital_objects_in_collection: コレクションの%{num}つのディジタルオブジェクトを閲覧する
   digital_object_component:
     _public:
       section: {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This is a follow up from #2934 regarding [ANW-1534](https://archivesspace.atlassian.net/browse/ANW-1534) that implements the language from the spec regarding the link to the list of linked instances for Resources and AObjs.

### Spec design

<img width="376" alt="ANW-1534 spec" src="https://user-images.githubusercontent.com/3411019/220159907-8f970444-b49f-4a25-ae7b-691ab25840f6.png">

### This PR

<img width="547" alt="ANW-1534 app" src="https://user-images.githubusercontent.com/3411019/220159924-257eaf3c-7aeb-4153-804d-1787263f6a60.png">

[ANW-1534]: https://archivesspace.atlassian.net/browse/ANW-1534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ