### PR TITLE
ANW-1209: Limit use of the PUI shared/_digital.html.erb template*

### DIFF
--- a/public/app/views/objects/show.html.erb
+++ b/public/app/views/objects/show.html.erb
@@ -16,7 +16,11 @@
     <% if  defined?(comp_id) && !comp_id && !@result['json']['ref_id'].blank? %>
       <span class='ref_id'>[<%=  t('archival_object._public.header.ref_id') %>: <%= @result['json']['ref_id'] %>]</span>
     <% end %>
-    <%= render partial: 'shared/digital', locals: {:dig_objs => @dig, record: @result} %>
+    <% if @result.instance_of?(ArchivalObject) %>
+      <%= render partial: 'shared/digital', locals: {record: @result} %>
+    <% else %>
+      <%= render partial: 'shared/digital', locals: {:dig_objs => @dig, record: @result} %>
+    <% end %>
     <%= render partial: 'shared/record_innards' %>
    </div>
 

--- a/public/app/views/resources/show.html.erb
+++ b/public/app/views/resources/show.html.erb
@@ -20,7 +20,9 @@
 
 <div class="row" id="notes_row">
   <div class="col-sm-9">
-    <%= render partial: 'shared/digital', locals: {:dig_objs => @dig, record: @result} %>
+    <% if @result['json']['representative_file_version'].present? %>
+      <%= render partial: 'shared/digital', locals: {record: @result} %>
+    <% end %>
     <%= render partial: 'shared/record_innards' %>
   </div>
   <div id="sidebar" class="col-sm-3 sidebar sidebar-container resizable-sidebar" <% unless @has_children %>style="display: none"<% end %>>

--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -17,7 +17,7 @@
     </div>
   </div>
 </div>
-<% elsif dig_objs.present? %>
+<% elsif local_assigns[:dig_objs] && dig_objs.present? %>
 <div class="available-digital-objects">
   <% dig_objs.each do |d_file| %>
     <% if !d_file['out'].blank? %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

The need for this PR came from the Program Team standup, 2023-02-20, where we observed that the older, "generic" blue icon representing linked instances, was showing up on some PUI Resource and Archival Object record pages that did not have a representative instance. This was viewed by the team as work from ANW-1209 that is unintentionally "leaking" into unrelated parts of the application.

This PR stops the leakage by constraining the use of the public/app/views/shared/_digital.html.erb template.

### Before this PR

![GH-2939-before](https://user-images.githubusercontent.com/3411019/220195054-f9a15ba1-1365-4d02-a68c-38df9d2f06b2.png)

### After this PR

![GH-2939-after](https://user-images.githubusercontent.com/3411019/220195076-16aa3362-a9d9-49f0-93e6-d1aa3ff17dd8.png)

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

[ANW-1209](https://archivesspace.atlassian.net/browse/ANW-1209)


[ANW-1209]: https://archivesspace.atlassian.net/browse/ANW-1209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ