### PR TITLE
ANW-1700: Link to DO record from representative file version image on PUI Resource/AO/Accession pages

### DIFF
--- a/backend/app/model/mixins/representative_file_version.rb
+++ b/backend/app/model/mixins/representative_file_version.rb
@@ -45,7 +45,10 @@ module RepresentativeFileVersion
         when "Resource", "Accession", "ArchivalObject"
           if representative_instance = json.instances.select {|i| i["is_representative"] == true && i["instance_type"] == "digital_object" }.first
             id = JSONModel(:digital_object).id_for(representative_instance["digital_object"]["ref"])
-            json["representative_file_version"] = DigitalObject.to_jsonmodel(id, opts)["representative_file_version"]
+            digital_object = DigitalObject.to_jsonmodel(id, opts)
+            if digital_object["representative_file_version"]
+              json["representative_file_version"] = digital_object["representative_file_version"].merge({"digital_object" => digital_object.uri})
+            end
           end
         when "DigitalObject", "DigitalObjectComponent"
           fvs = json[:file_versions]

--- a/backend/spec/mixin_representative_file_version_spec.rb
+++ b/backend/spec/mixin_representative_file_version_spec.rb
@@ -125,6 +125,7 @@ describe 'Representative File Version mixin' do
 
         json = klass.to_jsonmodel(obj.id)
         expect(json.representative_file_version['file_uri']).to eq(file_version_3.file_uri)
+        expect(json.representative_file_version['digital_object']).to eq(do2.uri)
       end
     end
   end

--- a/common/schemas/file_version.rb
+++ b/common/schemas/file_version.rb
@@ -22,6 +22,7 @@
       "checksum" => {"type" => "string", "maxLength" => 255},
       "checksum_method" => {"type" => "string", "dynamic_enum" => "file_version_checksum_methods"},
       "caption" => {"type" => "string", "maxLength" => 16384},
+      "digital_object" => {"type" => "JSONModel(:digital_object) uri", "readonly" => true},
     },
   },
 }

--- a/public/app/views/digital_objects/_additional_file_versions.html.erb
+++ b/public/app/views/digital_objects/_additional_file_versions.html.erb
@@ -1,7 +1,11 @@
 <ol class="list-unstyled mb0">
   <% fvs.each do |fv| %>
     <li class="panel panel-default additional-file-version">
-      <%= render partial: 'shared/representative_file_version_record', locals: {:uri => fv['file_uri'], :caption => fv['caption']} %>
+      <%= render partial: 'shared/representative_file_version_record', locals: {
+        :img_uri => fv['file_uri'],
+        :a_uri => fv['file_uri'],
+        :caption => fv['caption']
+      } %>
     </li>
   <% end %>
 </ol>

--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -2,9 +2,15 @@
 <div class="available-digital-objects">
   <div class="objectimage">
     <div class="panel panel-default">
+      <%
+        rfv = record['json']['representative_file_version']
+        img_uri = rfv['file_uri']
+        a_uri = rfv['digital_object'] || img_uri
+      %>
       <%= render partial: 'shared/representative_file_version_record', locals: {
-        :uri => record['json']['representative_file_version']['file_uri'],
-        :caption => record['json']['representative_file_version']['caption']
+        :a_uri => a_uri,
+        :img_uri => img_uri,
+        :caption => rfv['caption']
       } %>
       <% if representative_link_to_digital_materials?(record) %>
         <% digitized_link_text = t(

--- a/public/app/views/shared/_representative_file_version_record.html.erb
+++ b/public/app/views/shared/_representative_file_version_record.html.erb
@@ -1,6 +1,6 @@
 <figure data-rep-file-version-wrapper>
-  <a href="<%= uri %>" target="new" title="<%= t('digital_object._public.link')%>">
-    <img src="<%= uri %>" alt="<%= caption.blank? ? '' : caption %>">
+  <a href="<%= a_uri %>" target="new" title="<%= t('digital_object._public.link')%>">
+    <img src="<%= img_uri %>" alt="<%= caption.blank? ? '' : caption %>">
   </a>
   <% unless caption.blank? %>
     <figcaption class="bg-lightgray"><%= caption %></figcaption>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR  solves [ANW-1700](https://archivesspace.atlassian.net/browse/ANW-1700) by linking to the digital object record that provides the representative file version, from the representative file version image shown on PUI resource, archival object, and accession records. The representative file version shown on digital object and digital object component records links to its own file uri.

Closes #2945 

- Add a readonly 'digital_object' attribute to file_version schema
- Refactor PUI rep file version templates around two uris
- Test links on Resource, AO, Accession, DO, DOC records

![ANW-1700-link-to-do](https://user-images.githubusercontent.com/3411019/221696070-76703b2f-f68b-43b2-97e4-b6eb7e1caf08.gif)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See public/spec/features/representative_file_version_spec.rb.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[ANW-1700]: https://archivesspace.atlassian.net/browse/ANW-1700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ