### PR TITLE
ANW-1699: Add tree-view breadcrumbs to a PUI resource's digitized list results

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/helpers.scss
+++ b/public/app/assets/stylesheets/archivesspace/helpers.scss
@@ -26,6 +26,10 @@
   flex-grow: 1;
 }
 
+.flex-shrink-0 {
+  flex-shrink: 0;
+}
+
 .mt15px {
   margin-top: var(--bootstrap-horizontal-white-space-unit);
 }

--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -315,6 +315,13 @@ class ResourcesController < ApplicationController
       'sort' => sort,
       'facet.mincount' => 1
     })
+    if query == DIGITAL_QUERY
+      if search_opts.include? 'resolve[]'
+        search_opts['resolve[]'].append('linked_instance_uris:id')
+      else
+        search_opts['resolve[]'] = ['linked_instance_uris:id']
+      end
+    end
     search_opts['fq']=[qry]
     set_up_search([type], enums, search_opts, params, qry)
     @base_search= @base_search.sub("q=#{qry}", '')

--- a/public/app/views/digital_objects/_search_result_breadcrumbs.html.erb
+++ b/public/app/views/digital_objects/_search_result_breadcrumbs.html.erb
@@ -1,5 +1,4 @@
 <% if result.linked_instances.length == 0 %>
-
   <div class="result_context">
     <%= render partial: 'shared/result_breadcrumbs_repo', locals: { :result => result } %>
   </div>
@@ -30,8 +29,8 @@
 
 <% else %>
 
-  <div class="result_context" style="display: flex">
-    <strong style="flex-shrink: 0"><%= t('context') %>: </strong>
+  <div class="flex result_context">
+    <strong class="flex-shrink-0"><%= t('context') %>: </strong>
     <div>
       <%= render partial: 'shared/result_breadcrumbs_repo', locals: { :result => result, :hide_label => true } %>
       <ol class="result_linked_instances_tree">

--- a/public/app/views/shared/_result_breadcrumbs_ancestor.html.erb
+++ b/public/app/views/shared/_result_breadcrumbs_ancestor.html.erb
@@ -1,7 +1,7 @@
 <% if !local_assigns[:hide_delimiter] %>
   <%= t('context_delimiter') %>
 <% end %>
-<span class="#{span_class}">
+<span class="<%= span_class %>">
   <%= badge_for_type badge_type %>
   <%= link_to body, url %>
 </span>

--- a/public/spec/controllers/resources_controller_spec.rb
+++ b/public/spec/controllers/resources_controller_spec.rb
@@ -34,6 +34,14 @@ describe ResourcesController, type: :controller do
         is_representative: true
       )]
     )
+    @resource_with_rep_instance_2 = create(:resource,
+      publish: true,
+      title: "Yet another Resource with representative file version",
+      instances: [build(:instance_digital,
+        digital_object: {'ref' => @digital_object_with_rep_file_ver.uri},
+        is_representative: true
+      )]
+    )
     @unpublished_resource = create(:resource)
 
     subject = create(:subject, terms: [build(:term, {term: 'Term 1', term_type: 'temporal'}), build(:term, term: 'Term 2')])
@@ -147,6 +155,22 @@ describe ResourcesController, type: :controller do
         expect(fc.text).to have_content(@fv_caption)
       end
       expect(response.body).to have_css(".objectimage a[class='view-all']")
+    end
+  end
+
+  describe 'digitized action' do
+    it 'displays tree breadcrumbs for digital objects linked to more than one Resource' do
+      get(:digitized, params: {rid: @repo.id, id: @resource_with_rep_instance.id})
+
+      page = Capybara.string(response.body)
+
+      page.find(:css, ".recordrow[data-uri='#{@digital_object_with_rep_file_ver.uri}'] ol.result_linked_instances_tree li:first-of-type span.resource_name") do |span|
+        expect(span).to have_content @resource_with_rep_instance.title
+      end
+
+      page.find(:css, ".recordrow[data-uri='#{@digital_object_with_rep_file_ver.uri}'] ol.result_linked_instances_tree li:last-of-type span.resource_name") do |span|
+        expect(span).to have_content @resource_with_rep_instance_2.title
+      end
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This PR addresses [ANW-1699](https://archivesspace.atlassian.net/browse/ANW-1699) by showing the tree-like breadcrumbs ("treecrumbs") for results on the "View Digital Materials" pill section of a PUI resource record.

- Resolve linked_instances for /digitized results
- Add test
- Minor: fix class name interpolation bug in template
- Minor: swap out inline styles for classes in markup

![ANW-1699-treecrumbs](https://user-images.githubusercontent.com/3411019/222260844-c48fc242-114b-4428-b8cc-904174ec25e2.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See public/spec/controllers/resources_controller_spec.rb.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[ANW-1699]: https://archivesspace.atlassian.net/browse/ANW-1699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ