### PR TITLE
add a readonly 'digital_object' attribute to file_version schema

### DIFF
--- a/backend/app/model/mixins/representative_file_version.rb
+++ b/backend/app/model/mixins/representative_file_version.rb
@@ -45,7 +45,10 @@ module RepresentativeFileVersion
         when "Resource", "Accession", "ArchivalObject"
           if representative_instance = json.instances.select {|i| i["is_representative"] == true && i["instance_type"] == "digital_object" }.first
             id = JSONModel(:digital_object).id_for(representative_instance["digital_object"]["ref"])
-            json["representative_file_version"] = DigitalObject.to_jsonmodel(id, opts)["representative_file_version"]
+            digital_object = DigitalObject.to_jsonmodel(id, opts)
+            if digital_object["representative_file_version"]
+              json["representative_file_version"] = digital_object["representative_file_version"].merge({"digital_object" => digital_object.uri})
+            end
           end
         when "DigitalObject", "DigitalObjectComponent"
           fvs = json[:file_versions]

--- a/backend/spec/mixin_representative_file_version_spec.rb
+++ b/backend/spec/mixin_representative_file_version_spec.rb
@@ -125,6 +125,7 @@ describe 'Representative File Version mixin' do
 
         json = klass.to_jsonmodel(obj.id)
         expect(json.representative_file_version['file_uri']).to eq(file_version_3.file_uri)
+        expect(json.representative_file_version['digital_object']).to eq(do2.uri)
       end
     end
   end

--- a/common/schemas/file_version.rb
+++ b/common/schemas/file_version.rb
@@ -22,6 +22,7 @@
       "checksum" => {"type" => "string", "maxLength" => 255},
       "checksum_method" => {"type" => "string", "dynamic_enum" => "file_version_checksum_methods"},
       "caption" => {"type" => "string", "maxLength" => 16384},
+      "digital_object" => {"type" => "JSONModel(:digital_object) uri", "readonly" => true},
     },
   },
 }


### PR DESCRIPTION
Adds a `digital_object` property to the `file_uri` schema and populated it in cases where a `representative_file_version` is being set on a Resource, Accession, or ArchivalObject.