### PR TITLE
ANW 1700, ANW-1705: Link to DO from rep file version img; adjust logic for determing a DO's rep file version

### DIFF
--- a/common/schemas/file_version.rb
+++ b/common/schemas/file_version.rb
@@ -22,6 +22,9 @@
       "checksum" => {"type" => "string", "maxLength" => 255},
       "checksum_method" => {"type" => "string", "dynamic_enum" => "file_version_checksum_methods"},
       "caption" => {"type" => "string", "maxLength" => 16384},
+      "derived_from" => {"type" => [{"type" => "JSONModel(:digital_object) uri"},
+                                    {"type" => "JSONModel(:digital_object_component) uri"}],
+                         "readonly" => true},
     },
   },
 }

--- a/frontend/spec/selenium/spec/resources_spec.rb
+++ b/frontend/spec/selenium/spec/resources_spec.rb
@@ -127,19 +127,8 @@ describe 'Resources and archival objects' do
 
     run_index_round
 
-    @driver.find_element(:link, 'Browse').click
-    @driver.wait_for_dropdown
-    @driver.click_and_wait_until_gone(:link, 'Resources')
+    @driver.get_edit_page(@resource)
 
-    table_rows = @driver.find_elements(css: "tr")
-    table_rows.each do |row|
-      if (row.text.include? "Resource 1")
-        table_rows[2].click_and_wait_until_gone(:link, 'Edit')
-        break
-      end
-    end
-
-    @driver.find_element(:link, 'Browse').click
     @driver.find_element_with_text('//button', /Add Container Instance/).click
 
     resource_title = @driver.find_element(css: 'h2').text[0...-9]

--- a/public/app/views/digital_objects/_additional_file_versions.html.erb
+++ b/public/app/views/digital_objects/_additional_file_versions.html.erb
@@ -1,7 +1,11 @@
 <ol class="list-unstyled mb0">
   <% fvs.each do |fv| %>
     <li class="panel panel-default additional-file-version">
-      <%= render partial: 'shared/representative_file_version_record', locals: {:uri => fv['file_uri'], :caption => fv['caption']} %>
+      <%= render partial: 'shared/representative_file_version_record', locals: {
+        :img_uri => fv['file_uri'],
+        :a_uri => fv['file_uri'],
+        :caption => fv['caption']
+      } %>
     </li>
   <% end %>
 </ol>

--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -2,9 +2,15 @@
 <div class="available-digital-objects">
   <div class="objectimage">
     <div class="panel panel-default">
+      <%
+        rfv = record['json']['representative_file_version']
+        img_uri = rfv['file_uri']
+        a_uri = rfv['derived_from'] || img_uri
+      %>
       <%= render partial: 'shared/representative_file_version_record', locals: {
-        :uri => record['json']['representative_file_version']['file_uri'],
-        :caption => record['json']['representative_file_version']['caption']
+        :a_uri => a_uri,
+        :img_uri => img_uri,
+        :caption => rfv['caption']
       } %>
       <% if representative_link_to_digital_materials?(record) %>
         <% digitized_link_text = t(

--- a/public/app/views/shared/_representative_file_version_record.html.erb
+++ b/public/app/views/shared/_representative_file_version_record.html.erb
@@ -1,6 +1,6 @@
 <figure data-rep-file-version-wrapper>
-  <a href="<%= uri %>" target="new" title="<%= t('digital_object._public.link')%>">
-    <img src="<%= uri %>" alt="<%= caption.blank? ? '' : caption %>">
+  <a href="<%= a_uri %>" target="new" title="<%= t('digital_object._public.link')%>">
+    <img src="<%= img_uri %>" alt="<%= caption.blank? ? '' : caption %>">
   </a>
   <% unless caption.blank? %>
     <figcaption class="bg-lightgray"><%= caption %></figcaption>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR  solves [ANW-1700](https://archivesspace.atlassian.net/browse/ANW-1700) by providing a `derived_from` property on the `representative_file_version` hash for Resources, Archival Objects, and Accessions. This property is the URI for the DO (or child DOC) record that provides the representative file version, from the representative linked instance of the archival record. This property is then used to link to the DO (or child DOC) from the representative file version image shown on PUI archival record pages.

This PR also addresses [ANW-1705](https://archivesspace.atlassian.net/browse/ANW-1705) by limiting a DO's representative file version to its own file versions, and only looking to a DO's children for purpose of showing a representative file version image on a Resourse/AO/Accession record when the representative linked instance DO has no representative file version of its own.

- Add a readonly `derived_from` property to file_version for Resources, AOs, and Accessions, that points to the rep file version's record (DO or DOC) of the representative linked instance (DO)
- Refactor rep file version templates around two uris
- ANW-1705: don't extract representative from digital object tree unless the top-level context is an archival record
- Simplify a glitchy selenium test
- Add tests

Closes #2945 
Closes #2942 

![ANW-1700-link-to-do](https://user-images.githubusercontent.com/3411019/221696070-76703b2f-f68b-43b2-97e4-b6eb7e1caf08.gif)

[ANW-1700]: https://archivesspace.atlassian.net/browse/ANW-1700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-1705]: https://archivesspace.atlassian.net/browse/ANW-1705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ