### PR TITLE
ANW-1703: scope d.obj collection to published a.objs

### DIFF
--- a/backend/app/model/digital_object.rb
+++ b/backend/app/model/digital_object.rb
@@ -86,9 +86,12 @@ class DigitalObject < Sequel::Model(:digital_object)
           end
 
           if link[:archival_object_id]
-            json["collection"] << {"ref" => self.uri_for(
-              :resource, ArchivalObject.find(id: link[:archival_object_id]).root_record_id
-            )}
+            archival_object = ArchivalObject.find(id: link[:archival_object_id])
+
+            # ANW-1703: only include resource uri from AO if the AO is published. Publish will be 0|1
+            if archival_object.publish.positive?
+              json["collection"] << {"ref" => self.uri_for(:resource, archival_object.root_record_id)}
+            end
           else
             json["collection"] << {"ref" => uri}
           end

--- a/public/spec/features/record_digital_materials_spec.rb
+++ b/public/spec/features/record_digital_materials_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Digital Materials listing from a record context', js: true do
+  before(:each) do
+    visit('/')
+    click_link 'Collections'
+    click_link 'Resource with digital instance'
+    click_link 'View Digital Material'
+  end
+
+  context 'identified in the breadcrumbs' do
+    it 'should display a digital object linked through a published archival object' do
+      expect(page).to have_content('AO with DO')
+    end
+
+    it 'should not display a digital object linked through an unpublished archival object' do
+      expect(page).not_to have_content('AO with DO unpublished')
+    end
+  end
+end

--- a/public/spec/spec_helper.rb
+++ b/public/spec/spec_helper.rb
@@ -189,6 +189,13 @@ def setup_test_data
   )
 
   create(:archival_object,
+    title: "AO with DO unpublished",
+    resource: { 'ref' => resource_with_tree.uri },
+    instances: [build(:instance_digital)],
+    publish: false
+  )
+
+  create(:archival_object,
     title: "AO without DO",
     resource: { 'ref' => resource_with_tree.uri },
     publish: true


### PR DESCRIPTION
## Description

The digital object "collection" property should only be added to from an archival object when that object is published.
This will prevent digital objects linked to unpublished archival objects from appearing in the Digital Materials list / total for a resource (aka the "collection") in the PUI.

## Related JIRA Ticket or GitHub Issue

https://archivesspace.atlassian.net/browse/ANW-1703

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
