### PR TITLE
ANW-1701: Add xlink method for determining a representative file version

### DIFF
--- a/backend/app/model/file_version.rb
+++ b/backend/app/model/file_version.rb
@@ -8,7 +8,7 @@ class FileVersion < Sequel::Model(:file_version)
   corresponds_to JSONModel(:file_version)
 
   def representative_for_types
-    { is_representative: [:digital_object] }
+    { is_representative: [:digital_object, :digital_object_component] }
   end
 
   def self.handle_publish_flag(ids, val)

--- a/backend/spec/mixin_representative_file_version_spec.rb
+++ b/backend/spec/mixin_representative_file_version_spec.rb
@@ -51,41 +51,14 @@ describe 'Representative File Version mixin' do
       end
     end
 
-    it "has a representative_file_version read-only value of the first published file_version if there is no"\
-       " file_version marked 'is_representative' and there is no published file_version with a use-statement marked 'image-thumbnail'" do
+    it "has a representative_file_version read-only value of the first published file_version with a file_uri"\
+       " that starts with 'http' and a xlink_show_attribute value of 'embed' if there is no"\
+       " file_version marked 'is_representative' and there is no published file_version with a"\
+       " use-statement marked 'image-thumbnail'" do
       file_version_1.publish = false
       file_version_3.publish = false
       file_version_3.use_statement = 'image-thumbnail'
-      [DigitalObject, DigitalObjectComponent].each do |klass|
-        json = build(:"json_#{klass.name.underscore}", file_versions: [ file_version_1, file_version_2, file_version_3 ])
-        obj = klass.create_from_json(json)
-        json = klass.to_jsonmodel(obj)
-        expect(json.representative_file_version['file_uri']).to eq(file_version_2.file_uri)
-      end
-
-      # The sensible restrictions above what is specified are disabled,
-      # so expect something other than nil
-      file_version_2.use_statement = 'audio-master'
-      file_version_2.file_format_name = 'avi'
-      [DigitalObject, DigitalObjectComponent].each do |klass|
-        json = build(:"json_#{klass.name.underscore}", file_versions: [ file_version_1, file_version_2, file_version_3 ])
-        obj = klass.create_from_json(json)
-        json = klass.to_jsonmodel(obj)
-        expect(json.representative_file_version['file_uri']).to eq(file_version_2.file_uri)
-      end
-
-      # but if either use_statement or file_format_name is a reasonable value, proceed
-      file_version_2.use_statement = 'image-service'
-      file_version_2.file_format_name = 'avi'
-      [DigitalObject, DigitalObjectComponent].each do |klass|
-        json = build(:"json_#{klass.name.underscore}", file_versions: [ file_version_1, file_version_2, file_version_3 ])
-        obj = klass.create_from_json(json)
-        json = klass.to_jsonmodel(obj)
-        expect(json.representative_file_version['file_uri']).to eq(file_version_2.file_uri)
-      end
-
-      file_version_2.use_statement = 'audio-master'
-      file_version_2.file_format_name = 'gif'
+      file_version_2.xlink_show_attribute = 'embed'
       [DigitalObject, DigitalObjectComponent].each do |klass|
         json = build(:"json_#{klass.name.underscore}", file_versions: [ file_version_1, file_version_2, file_version_3 ])
         obj = klass.create_from_json(json)
@@ -103,6 +76,7 @@ describe 'Representative File Version mixin' do
 
       do1 = create(:json_digital_object, publish: true, file_versions: [file_version_1])
       file_version_2.publish = false
+      file_version_3.is_representative = true
       do2 = create(:json_digital_object, publish: true, file_versions: [file_version_2, file_version_3])
       create_args = { instances: [
                         build(:json_instance_digital, {
@@ -235,6 +209,9 @@ describe 'Representative File Version mixin' do
        " until one is found with a representative instance linking to a digital object representative_file_version." do
 
       resource = create_resource
+      file_version_1.xlink_show_attribute = 'embed'
+      file_version_2.is_representative = true
+      file_version_3.use_statement = 'image-thumbnail'
       do1 = create(:json_digital_object, publish: true, file_versions: [file_version_1])
       do2 = create(:json_digital_object, publish: true, file_versions: [file_version_2])
       do3 = create(:json_digital_object, publish: true, file_versions: [])
@@ -345,6 +322,8 @@ describe 'Representative File Version mixin' do
       #     - ao 4
 
       resource = create_resource
+      file_version_4.is_representative = true
+      file_version_5.xlink_show_attribute = 'embed'
       do4 = create(:json_digital_object, publish: true, file_versions: [file_version_4])
       do5 = create(:json_digital_object, publish: true, file_versions: [file_version_5])
 

--- a/backend/spec/model_digital_object_spec.rb
+++ b/backend/spec/model_digital_object_spec.rb
@@ -94,34 +94,6 @@ describe 'Digital object model' do
     expect {
       DigitalObject.create_from_json(json)
     }.to raise_error(Sequel::ValidationFailed)
-
-
-    json = build(:json_digital_object, {
-                   :publish => true,
-                   :file_versions => [build(:json_file_version, {
-                                              :publish => true,
-                                              :is_representative => true,
-                                              :file_uri => 'http://foo.com/bar1',
-                                              :use_statement => 'image-service'
-                                            }),
-                                      build(:json_file_version, {
-                                              :publish => true,
-                                              :file_uri => 'http://foo.com/bar2',
-                                              :use_statement => 'image-service'
-                                            }),
-                                      build(:json_file_version, {
-                                              :publish => true,
-                                              :file_uri => 'http://foo.com/bar3',
-                                              :use_statement => 'image-service'
-                                            })
-
-                                     ]})
-
-
-    expect {
-      DigitalObject.create_from_json(json)
-    }.not_to raise_error
-
   end
 
   it "doesn't allow an unpublished file_version to be representative" do
@@ -143,25 +115,6 @@ describe 'Digital object model' do
     expect {
       DigitalObject.create_from_json(json)
     }.to raise_error(Sequel::ValidationFailed)
-
-    json = build(:json_digital_object, {
-                   :publish => true,
-                   :file_versions => [build(:json_file_version, {
-                                              :publish => true,
-                                              :is_representative => true,
-                                              :file_uri => 'http://foo.com/bar1',
-                                              :use_statement => 'image-service'
-                                            }),
-                                      build(:json_file_version, {
-                                              :publish => true,
-                                              :file_uri => 'http://foo.com/bar2',
-                                              :use_statement => 'image-service'
-                                            })
-                                     ]})
-
-    expect {
-      DigitalObject.create_from_json(json)
-    }.not_to raise_error
   end
 
   it "supports optional captions for file versions" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This PR addresses [ANW-1701](https://archivesspace.atlassian.net/browse/ANW-1701) by changing the logic of the rep file version spec's REQ-3.2. This PR significantly cuts down on the number of possible broken images that will be shown as representative file versions.

The original REQ-3.2 is too aggressive in defining a representative file version by _any_ published file version.

> **REQ-3.2**: If no published File Version is designated as representative, and there is no entry with a Use-Statement value of "Image-Thumbnail", the system shall display the first available linked, published File Version subrecord. 

This PR replaces the _any_ published file version catch-all with the older `xlink_attribute_show` method for showing an image, which is [defined by](https://github.com/archivesspace/archivesspace/blob/93988ee87c09b30c86b7482b9962aff18f6a1aa7/public/app/controllers/concerns/result_info.rb#L171-L172) the following file version rules:

1. publish = true
2. file_uri starts with 'http'
3. xlink_attribute_show = 'embed'

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[ANW-1701]: https://archivesspace.atlassian.net/browse/ANW-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ