### PR TITLE
ANW-1707: Tweak representative file version image CSS

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -787,6 +787,7 @@ i.giant {
 .additional-file-version img {
   margin: 0 auto;
   display: block;
+  min-width: 200px;
   max-width: 100%;
   border-top-right-radius: var(--bootstrap-rounded-corner-radius);
   border-top-left-radius: var(--bootstrap-rounded-corner-radius);

--- a/public/app/views/shared/_representative_file_version_record.html.erb
+++ b/public/app/views/shared/_representative_file_version_record.html.erb
@@ -1,8 +1,11 @@
 <figure data-rep-file-version-wrapper>
   <a href="<%= a_uri %>" target="new" title="<%= t('digital_object._public.link')%>">
-    <img src="<%= img_uri %>" alt="<%= caption.blank? ? '' : caption %>">
+    <img
+      class="<%= caption.blank? ? 'rounded-bottom' : '' %>"
+      src="<%= img_uri %>"
+      alt="<%= caption.blank? ? '' : caption %>">
   </a>
   <% unless caption.blank? %>
-    <figcaption class="bg-lightgray"><%= caption %></figcaption>
+    <figcaption class="bg-lightgray rounded-bottom"><%= caption %></figcaption>
   <% end %>
 </figure>


### PR DESCRIPTION
[ANW-1707](https://archivesspace.atlassian.net/browse/ANW-1707)

### Before SVG image

![Screen Shot 2023-03-06 at 10 57 14-fullpage](https://user-images.githubusercontent.com/3411019/223163147-37814a32-9e40-430c-941a-a22cd1400229.png)


### After SVG image

![ANW-1707](https://user-images.githubusercontent.com/3411019/223162500-84f20a07-ddd5-4938-aee5-4882ef943e26.png)


[ANW-1707]: https://archivesspace.atlassian.net/browse/ANW-1707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-1707]: https://archivesspace.atlassian.net/browse/ANW-1707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ