### PR TITLE
ANW-1689 change redirect for editing groups

### DIFF
--- a/frontend/app/controllers/users_controller.rb
+++ b/frontend/app/controllers/users_controller.rb
@@ -144,15 +144,14 @@ class UsersController < ApplicationController
 
     if response.code === '200'
       flash[:success] = I18n.t("user._frontend.messages.updated")
-      redirect_to :action => :index
     else
       flash[:error] = I18n.t("user._frontend.messages.error_update")
-      @groups = JSONModel(:group).all if user_can?('manage_repository')
-
-      render :action => :edit_groups
     end
-  end
 
+    @user = JSONModel(:user).find(params[:id])
+    @groups = JSONModel(:group).all if user_can?('manage_repository')
+    render :action => :edit_groups
+  end
 
   def create
     handle_crud(:instance => :user,

--- a/frontend/app/views/users/edit_groups.html.erb
+++ b/frontend/app/views/users/edit_groups.html.erb
@@ -1,5 +1,7 @@
 <%= setup_context :trail => [[I18n.t("user._frontend.section.manage_access"), {:controller => :users, :action => :manage_access}]], :title => @user.username %>
 
+<%= render_aspace_partial :partial => "shared/flash_messages" %>
+
 <div class="row">
   <div class="col-md-12">
     <div class="record-pane">


### PR DESCRIPTION
`update_groups` was explicitly redirecting to the index page after a successful update; the expected behavior is to redisplay the group editing page.