### PR TITLE
ANW-1706: Add accessions to digital object search result breadcrumbs

### DIFF
--- a/public/app/views/digital_objects/_search_result_breadcrumbs.html.erb
+++ b/public/app/views/digital_objects/_search_result_breadcrumbs.html.erb
@@ -8,12 +8,18 @@
   <div class="result_context">
     <%= render partial: 'shared/result_breadcrumbs_repo', locals: { :result => result } %>
     <% result.linked_instances.each do |uri, instance_record| %>
-      <% if instance_record.primary_type == 'resource' %>
+      <% if ['accession', 'resource'].include? instance_record.primary_type %>
+        <%
+          type = instance_record.primary_type
+          body = type == 'accession' ? 
+            instance_record.display_string :
+            instance_record.breadcrumb[0][:crumb]
+        %>
         <%= render partial: 'shared/result_breadcrumbs_ancestor', locals: {
-        :span_class => 'resource_name',
-        :badge_type => 'resource',
-        :body => instance_record.breadcrumb[0][:crumb],
-        :url => app_prefix(uri) } %>
+          :span_class => "#{type}_name",
+          :badge_type => type,
+          :body => body,
+          :url => app_prefix(uri) } %>
       <% elsif instance_record.primary_type == 'archival_object' %>
         <% num_crumbs = instance_record.breadcrumb.length %>
         <% instance_record.breadcrumb.each_with_index do |crumb, i| %>
@@ -36,11 +42,17 @@
       <ol class="result_linked_instances_tree">
         <% result.linked_instances.each do |uri, instance_record| %>
           <li>
-            <% if instance_record.primary_type == 'resource' %>
+            <% if ['accession', 'resource'].include? instance_record.primary_type %>
+              <%
+                type = instance_record.primary_type
+                body = type == 'accession' ?
+                  instance_record.display_string :
+                  instance_record.breadcrumb[0][:crumb]
+              %>
               <%= render partial: 'shared/result_breadcrumbs_ancestor', locals: {
-                :span_class => 'resource_name',
-                :badge_type => 'resource',
-                :body => instance_record.breadcrumb[0][:crumb],
+                :span_class => "#{type}_name",
+                :badge_type => type,
+                :body => body,
                 :url => app_prefix(uri),
                 :hide_delimiter => true } %>
             <% elsif instance_record.primary_type == 'archival_object' %>

--- a/public/spec/features/digital_objects_spec.rb
+++ b/public/spec/features/digital_objects_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 
 describe 'Digital Objects', js: true do
   def visit_digital_object_page(title)
-    visit '/'
-    click_link 'Digital Materials'
+    visit("/search?utf8=✓&op[]=&q[]='#{title}'&limit=digital_object&field[]=&from_year[]=&to_year[]=")
     click_link title
   end
 

--- a/public/spec/features/record_innards_spec.rb
+++ b/public/spec/features/record_innards_spec.rb
@@ -3,9 +3,7 @@ require 'rails_helper'
 
 describe 'Record innards', js: true do
   it 'should display when a scope note is inherited' do
-    visit('/')
-    click_link 'Collections'
-    expect(current_path).to eq ('/repositories/resources')
+    visit('/search?utf8=✓&op[]=&q[]="Resource+with+scope+note"&limit=resource&field[]=&from_year[]=&to_year[]=')
     resource = first("a[class='record-title']", text: 'Resource with scope note')
     visit(resource['href'])
     click_link 'Collection Organization'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
[ANW-1706](https://archivesspace.atlassian.net/browse/ANW-1706)

This PR includes a digital object's linked accessions in its search result bread crumbs. See the "Aldo S. Leopold Papers" breadcrumbs in the screenshot below.

![ANW-1706](https://user-images.githubusercontent.com/3411019/223424533-12833451-d375-4a4b-9e2c-349b6b96b00f.png)

[ANW-1706]: https://archivesspace.atlassian.net/browse/ANW-1706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ