### PR TITLE
ANW-1689 change redirect for editing groups

### DIFF
--- a/frontend/app/controllers/users_controller.rb
+++ b/frontend/app/controllers/users_controller.rb
@@ -144,7 +144,7 @@ class UsersController < ApplicationController
 
     if response.code === '200'
       flash[:success] = I18n.t("user._frontend.messages.updated")
-      redirect_to :action => :index
+      redirect_to :action => :manage_access
     else
       flash[:error] = I18n.t("user._frontend.messages.error_update")
       @groups = JSONModel(:group).all if user_can?('manage_repository')


### PR DESCRIPTION
update_groups was explicitly redirecting to the index page after a successful update; the expected
behavior is to redisplay the manage user access page.