### PR TITLE
ANW-1426: don't display local access restriction type when not approp…

### DIFF
--- a/frontend/app/views/notes/_template.html.erb
+++ b/frontend/app/views/notes/_template.html.erb
@@ -12,7 +12,7 @@
   <%= form.label_and_date("end") %>
   <% if form.readonly? %>
     <%# ANW-1426: don't display local access restriction type if empty to prevent it from showing for conditions governing use notes, where it is inappropriate %>
-    <% unless form.obj['local_access_restriction_type'] == [] %>
+    <% if form.obj['local_access_restriction_type'] && form.obj['local_access_restriction_type'].present? %>
       <div class="control-group">
         <%= form.label("local_access_restriction_type") %>
         <div class="controls">

--- a/frontend/app/views/notes/_template.html.erb
+++ b/frontend/app/views/notes/_template.html.erb
@@ -10,18 +10,26 @@
 <% define_template "rights_restriction", jsonmodel_definition(:rights_restriction) do |form| %>
   <%= form.label_and_date("begin") %>
   <%= form.label_and_date("end") %>
-  <div class="control-group">
-    <%= form.label("local_access_restriction_type") %>
-    <div class="controls">
-      <% if form.readonly? %>
-        <ul>
-          <% Array.wrap(form.obj['local_access_restriction_type']).
-                   map{|type| I18n.t("enumerations.restriction_type.#{type}",type)}.
-                   sort.each do |type| %>
-            <li><%= type %></li>
-          <% end %>
-        </ul>
-      <% else %>
+  <% if form.readonly? %>
+    <%# ANW-1426: don't display local access restriction type if empty to prevent it from showing for conditions governing use notes, where it is inappropriate %>
+    <% unless form.obj['local_access_restriction_type'] == [] %>
+      <div class="control-group">
+        <%= form.label("local_access_restriction_type") %>
+        <div class="controls">
+          <ul>
+            <% Array.wrap(form.obj['local_access_restriction_type']).
+                     map{|type| I18n.t("enumerations.restriction_type.#{type}",type)}.
+                     sort.each do |type| %>
+              <li><%= type %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+  <% else %>
+    <div class="control-group">
+      <%= form.label("local_access_restriction_type") %>
+      <div class="controls">
         <%= select_tag(form.path("local_access_restriction_type[]"),
                        options_for_select(local_access_restriction_types_for_options, form.obj['local_access_restriction_type']),
                        {
@@ -32,9 +40,10 @@
                        })
         %>
         <span class="help-inline"><%= I18n.t("rights_restriction.local_access_restriction_type_inline_help") %></span>
-      <% end %>
+
+      </div>
     </div>
-  </div>
+  <% end %>
 <% end %>
 
 <%


### PR DESCRIPTION
…riate

<!--- Provide a general summary of your changes in the Title above -->

## Description
Don't display Local Access Restriction Type form label when not appropriate in notes show view template

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1426

## How Has This Been Tested?
manual in browser testing

## Screenshots (if appropriate):
![Screenshot_2023-03-09_09-35-24](https://user-images.githubusercontent.com/130926/224091674-67994c67-902a-4b60-b062-cf22460fa7f1.jpg)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
