### PR TITLE
ANW-1715: fix digital object classification term links

### DIFF
--- a/backend/app/model/classification_term.rb
+++ b/backend/app/model/classification_term.rb
@@ -23,7 +23,7 @@ class ClassificationTerm < Sequel::Model(:classification_term)
 
   define_relationship(:name => :classification,
                       :json_property => 'linked_records',
-                      :contains_references_to_types => proc {[Accession, Resource]})
+                      :contains_references_to_types => proc {[Accession, Resource, DigitalObject]})
 
   auto_generate :property => :display_string,
                 :generator => proc { |json|

--- a/frontend/app/views/classification_terms/_record_linker.html.erb
+++ b/frontend/app/views/classification_terms/_record_linker.html.erb
@@ -32,7 +32,7 @@
              data-selected="<%= selected_json %>"
              data-multiplicity="one"
              data-format_template="title"
-             data-types='["accession", "resource"]'
+             data-types='["accession", "resource", "digital_object"]'
              />
 
       <% if form.obj.has_key?('_resolved') %>
@@ -55,7 +55,7 @@
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
         </ul>
       </div>
-      
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adds two missing pieces:

- DigitalObject as a referenced type by ClassificationTerm
- digital_object as data type for classification_term record linker

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
