### PR TITLE
ANW-1024: Staff reorder mode improvements

### DIFF
--- a/frontend/app/assets/javascripts/largetree_dragdrop.js.erb
+++ b/frontend/app/assets/javascripts/largetree_dragdrop.js.erb
@@ -181,7 +181,8 @@
             self.setDragHandleState();
         });
 
-        $(largetree.elt).on('mousedown', '.drag-handle', function (event) {
+        $(largetree.elt).on('mousedown', '.table-row.largetree-node', function (event) {
+            // ANW-1024 make whole row draggable not just .drag-handle
             var selection = $(this);
 
             if (self.isMultiSelectKeyHeld(event)) {

--- a/frontend/app/assets/javascripts/tree_renderers.js.erb
+++ b/frontend/app/assets/javascripts/tree_renderers.js.erb
@@ -44,7 +44,7 @@ function ResourceRenderer() {
                           '</div>');
 
     this.nodeTemplate = $('<div class="table-row"> ' +
-                          '  <div class="table-cell drag-handle"></div>' +
+                          `  <div class="table-cell drag-handle">${dragHandleMarkup()}</div>` +
                           '  <div class="table-cell title"><span class="indentor"><button class="expandme" aria-expanded="false"><i class="expandme-icon glyphicon glyphicon-chevron-right" /></button></span> </div>' +
                           '  <div class="table-cell resource-level"></div>' +
                           '  <div class="table-cell resource-type"></div>' +
@@ -175,7 +175,7 @@ function DigitalObjectRenderer() {
 
 
     this.nodeTemplate = $('<div class="table-row"> ' +
-                          '  <div class="table-cell drag-handle"></div>' +
+                          `  <div class="table-cell drag-handle">${dragHandleMarkup()}</div>` +
                           '  <div class="table-cell title"><span class="indentor"><button class="expandme" aria-expanded="false"><i class="expandme-icon glyphicon glyphicon-chevron-right" /></button></span> </div>' +
                           '  <div class="table-cell digital-object-type"></div>' +
                           '  <div class="table-cell file-uri-summary"></div>' +
@@ -285,4 +285,24 @@ function recordTitleHandler(suppressed, title) {
   const suppressedMarkup = `<span class="label label-info"><%= I18n.t("states.suppressed") %></span>`;
 
   return suppressed ? `${suppressedMarkup} ${title}` : title;
+}
+
+function dragHandleMarkup() {
+  const rows = [8, 12, 16, 20, 24];
+  const cols = [10, 14, 18, 22];
+
+  return `
+    <span class="drag-handle__span">
+      <svg role="presentation" viewBox="2 2 28 28">
+        <g fill="currentcolor" fill-rule="evenodd">
+          ${rows.reduce((acc, y) => {
+            cols.forEach((x) => {
+              acc += `<circle cx="${x}" cy="${y}" r="1"></circle>`;
+            });
+            return acc;
+          }, ``)}
+        </g>
+      </svg>
+    </span>
+  `;
 }

--- a/frontend/app/assets/stylesheets/archivesspace/largetree.less
+++ b/frontend/app/assets/stylesheets/archivesspace/largetree.less
@@ -86,10 +86,12 @@
     }
     .drag-handle {
       width: 2em;
-      background-image: asset-url('archivesspace/tree_drag_handle.gif');
-      background-repeat: no-repeat;
-      background-position: 4px 50%;
       cursor: move;
+    }
+    .drag-handle__span {
+      position: absolute;
+      height: 2em;
+      width: 2em;
     }
     .drag-handle.drag-disabled {
       visibility: hidden;

--- a/frontend/app/assets/stylesheets/archivesspace/largetree.less
+++ b/frontend/app/assets/stylesheets/archivesspace/largetree.less
@@ -77,6 +77,9 @@
     display: none;
   }
   &.drag-enabled {
+    .table-row.largetree-node {
+      cursor: move;
+    }
     .drag-handle,
     .no-drag-handle {
       display: table-cell;
@@ -86,7 +89,6 @@
     }
     .drag-handle {
       width: 2em;
-      cursor: move;
     }
     .drag-handle__span {
       position: absolute;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR addresses [ANW-1024](https://archivesspace.atlassian.net/browse/ANW-1024) via the following changes:

- the a11y color contrast violation of the Staff reorder mode drag and drop handle (to the far left of each child row shown below) has been solved by replacing the existing handle image with inline svg
- each row in a reorder mode tree can now be dragged, whereas the current reorder mode only allows dragging of the drag-handle at the far left of each row

## Before handle drag

![ANW-1024-before-drag](https://user-images.githubusercontent.com/3411019/227323869-b270bc00-3b41-4af1-83a8-9871651dea5e.gif)

## After row drag

![ANW-1024-after-drag](https://user-images.githubusercontent.com/3411019/227323878-d5693bbd-4b45-4519-b1fc-306a729d0c6e.gif)

## Before drag handle color contrast

![ANW-1024 before](https://user-images.githubusercontent.com/3411019/227245077-6f7b379c-750c-4e9a-8eb7-f8b5f7524f43.png)

## After drag handle color contrast

![ANW-1024 after RES](https://user-images.githubusercontent.com/3411019/227244446-28f2f0d0-2f71-4d91-aaad-4eb120ab58de.png)

![ANW-1024-after-DO](https://user-images.githubusercontent.com/3411019/227244475-c0e8939a-c3be-41d2-800f-1455863a86ca.png)


[ANW-1024]: https://archivesspace.atlassian.net/browse/ANW-1024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ