### PR TITLE
Ensure prefilled collection in "browse top containers" works with a URL prefix

### DIFF
--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -1,7 +1,9 @@
 //= require jquery.tokeninput
 
 $(function () {
-  let resource_edit_path_regex = /^\/resources\/\d+\/edit$/;
+  let resource_edit_path_regex = new RegExp(
+    '^' + APP_PATH + 'resources/\\d+/edit$'
+  );
   let on_resource_edit_path = window.location.pathname.match(
     resource_edit_path_regex
   );


### PR DESCRIPTION
When you click "Browse" from a Top Container linker, there's some JS in linker.js that prepopulates the "Resource" field in the browse (to show you top containers linked to the current Resource record).

This code relies on a regex on window.location.pathname to work out whether it's running in the context of a resource record, but that regex didn't account for the possibility of a URL prefix.  Modify that regex to work when running under a prefix too.
