### PR TITLE
ANW-1599: only display help text on top container search form if multiselect is…

### DIFF
--- a/frontend/app/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_results.html.erb
@@ -14,11 +14,13 @@
   <p><%= I18n.t("top_container._frontend.messages.results_summary", {:num_found => num_found}) %></p>
 <% end %>
 
-<p>
-  <small><%= I18n.t("top_container._frontend.messages.bulk_selection_sort_help") %></small>
-  <br/>
-  <small><%= I18n.t("search_results.help.row_selection") %></small>
-</p>
+<% if multiselect == true %>
+  <p>
+    <small><%= I18n.t("top_container._frontend.messages.bulk_selection_sort_help") %></small>
+    <br/>
+    <small><%= I18n.t("search_results.help.row_selection") %></small>
+  </p>
+<% end %>
 
 <table class="table table-striped table-bordered table-condensed table-hover table-sortable table-search-results">
   <thead>


### PR DESCRIPTION
… enabled

<!--- Provide a general summary of your changes in the Title above -->

## Description
only display help text on top container search form if multiselect is enabled.

Multiselect is enabled if top container rows are selectable via checkboxes, and not selectable if top container rows are selectable via radio buttons.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1599

## How Has This Been Tested?
manual in browser testing

## Screenshots (if appropriate):
![Screenshot_2023-04-06_08-09-11](https://user-images.githubusercontent.com/130926/230405570-5c80d16a-3dbb-40b8-92f1-b0c54561303e.jpg)
![Screenshot_2023-04-06_08-08-59](https://user-images.githubusercontent.com/130926/230405584-f5a05465-b984-44d0-9221-6acc4db88bec.jpg)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
