### PR TITLE
ANW-1719: Remove PUI file_uri 'http' rule for showing icon

### DIFF
--- a/public/app/controllers/concerns/result_info.rb
+++ b/public/app/controllers/concerns/result_info.rb
@@ -168,7 +168,7 @@ module ResultInfo
       rep_caption = ''
       json['file_versions'].each do |version|
         version['file_uri'].strip!
-        if version.dig('publish') != false && version['file_uri'].start_with?('http')
+        if version.dig('publish') != false
           if version.dig('xlink_show_attribute') == 'embed'
             dig_f['thumb'] = version['file_uri']
             dig_f['represent'] = 'embed' if version['is_representative']

--- a/public/spec/controllers/objects_controller_spec.rb
+++ b/public/spec/controllers/objects_controller_spec.rb
@@ -37,6 +37,14 @@ describe ObjectsController, type: :controller do
         })
       ])
 
+      @do3 = create(:digital_object, publish: true, :file_versions => [
+        build(:file_version, {
+          :publish => true,
+          :is_representative => false,
+          :file_uri => 'not_http',
+        })
+      ])
+
       run_indexers
     end
 
@@ -54,6 +62,16 @@ describe ObjectsController, type: :controller do
       expect(page).to have_css(additional_file_version_css, :count => 2)
       expect(page).to have_css(additional_file_version_1_src)
       expect(page).to have_css(additional_file_version_2_src)
+    end
+
+    it "shows a 'generic icon' if no representative file version is set and the "\
+       "file version is published, whether or not the file uri starts with 'http'" do
+      get(:show, params: { rid: @repo.id, obj_type: 'digital_objects', id: @do3.id })
+
+      icon_css = '.external-digital-object__link[href="not_http"]'
+
+      page = response.body
+      expect(page).to have_css(icon_css)
     end
 
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR addresses [ANW-1719](https://archivesspace.atlassian.net/browse/ANW-1719). It removes the rule that the file_uri must start with 'http' for showing what we've termed the 'generic icon' that shows on a digital object's PUI record page.


[ANW-1719]: https://archivesspace.atlassian.net/browse/ANW-1719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ