### PR TITLE
ANW-1477 allow users to recover / reset password 

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -65,3 +65,5 @@ jobs:
       run: |
         ./build/run frontend:selenium
         ./build/run frontend:test
+      env:
+        ARCHIVESSPACE_VERSION: ${{ github.ref }}

--- a/.github/workflows/public.yml
+++ b/.github/workflows/public.yml
@@ -64,3 +64,5 @@ jobs:
     - name: Run Public tests
       run: |
         ./build/run public:test
+      env:
+        ARCHIVESSPACE_VERSION: ${{ github.ref }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    actionmailer (5.2.8.1)
+      actionpack (= 5.2.8.1)
+      actionview (= 5.2.8.1)
+      activejob (= 5.2.8.1)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
+    actionpack (5.2.8.1)
+      actionview (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
+      rack (~> 2.0, >= 2.0.8)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.2.8.1)
+      activesupport (= 5.2.8.1)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activejob (5.2.8.1)
+      activesupport (= 5.2.8.1)
+      globalid (>= 0.3.6)
     activesupport (5.2.8.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -18,13 +40,16 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.3.0)
+    crass (1.0.6)
     csv (3.2.6)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.0)
+    digest (3.1.1-java)
     docile (1.4.0)
     erb (2.2.3)
       cgi
+    erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     faraday (1.10.3)
@@ -63,9 +88,12 @@ GEM
       faraday (>= 0.8, < 2)
       hashie (~> 3.5, >= 3.5.2)
       oauth2 (~> 1.0)
+    globalid (1.1.0)
+      activesupport (>= 5.0)
     hashie (3.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    io-wait (0.3.0-java)
     jdbc-derby (10.12.1.1)
     jdbc-mysql (8.0.27)
     jruby-jars (9.2.20.1)
@@ -73,7 +101,16 @@ GEM
     json (2.6.3-java)
     json-schema (1.0.10)
     jwt (2.7.0)
+    loofah (2.20.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     method_source (1.0.0)
+    mini_mime (1.1.2)
     minitest (5.15.0)
     mizuno-aspace (9.4.44)
       childprocess (>= 0.2.6)
@@ -87,7 +124,20 @@ GEM
       ruby2_keywords (~> 0.0.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
+    net-imap (0.2.2)
+      digest
+      net-protocol
+      strscan
     net-ldap (0.16.3)
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.1.2)
+      io-wait
+      timeout
+    net-smtp (0.3.0)
+      digest
+      net-protocol
+      timeout
     nokogiri (1.12.5-java)
       racc (~> 1.4)
     oai (0.4.0)
@@ -119,6 +169,11 @@ GEM
       rack
     rack-test (2.0.2)
       rack (>= 1.3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.5.0)
+      loofah (~> 2.19, >= 2.19.1)
     rainbow (3.1.1)
     rake (13.0.6)
     rchardet (1.8.0)
@@ -186,10 +241,12 @@ GEM
       tilt (~> 2.0)
     spoon (0.0.6)
       ffi
+    strscan (3.0.6-java)
     thor (1.2.1)
     thread_safe (0.3.6-java)
     tidy (1.1.2)
     tilt (2.1.0)
+    timeout (0.3.2)
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
     tzinfo-data (1.2022.7)
@@ -208,6 +265,7 @@ PLATFORMS
   java
 
 DEPENDENCIES
+  actionmailer (~> 5.2)
   activesupport (< 6.0)
   atomic (= 1.0.1)
   bcrypt (= 3.1.7)

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -55,3 +55,5 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 # Allow plugins to provide their own Gemfiles too.
 require 'asutils'
 ASUtils.load_plugin_gems(self)
+
+gem "actionmailer", "~> 5.2"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -1,6 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    actionmailer (5.2.8.1)
+      actionpack (= 5.2.8.1)
+      actionview (= 5.2.8.1)
+      activejob (= 5.2.8.1)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
+    actionpack (5.2.8.1)
+      actionview (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
+      rack (~> 2.0, >= 2.0.8)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.2.8.1)
+      activesupport (= 5.2.8.1)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activejob (5.2.8.1)
+      activesupport (= 5.2.8.1)
+      globalid (>= 0.3.6)
     activesupport (5.2.8.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -14,8 +36,11 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.3.0)
+    crass (1.0.6)
     diff-lcs (1.5.0)
+    digest (3.1.1-java)
     docile (1.4.0)
+    erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     faraday (1.10.3)
@@ -45,15 +70,27 @@ GEM
       faraday (~> 1.0)
     fastimage (2.2.6)
     ffi (1.15.5-java)
+    globalid (1.1.0)
+      activesupport (>= 5.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    io-wait (0.3.0-java)
     jdbc-derby (10.12.1.1)
     jdbc-mysql (8.0.27)
     jruby-jars (9.2.20.1)
     jruby-rack (1.1.22)
     json (2.6.3-java)
     json-schema (1.0.10)
+    loofah (2.19.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     method_source (1.0.0)
+    mini_mime (1.1.2)
     minitest (5.15.0)
     mizuno-aspace (9.4.44)
       childprocess (>= 0.2.6)
@@ -66,7 +103,20 @@ GEM
       ruby2_keywords (~> 0.0.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
+    net-imap (0.2.2)
+      digest
+      net-protocol
+      strscan
     net-ldap (0.16.3)
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.1.2)
+      io-wait
+      timeout
+    net-smtp (0.3.0)
+      digest
+      net-protocol
+      timeout
     nokogiri (1.12.5-java)
       racc (~> 1.4)
     oai (0.4.0)
@@ -88,6 +138,11 @@ GEM
       rack
     rack-test (2.0.2)
       rack (>= 1.3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.5.0)
+      loofah (~> 2.19, >= 2.19.1)
     rake (13.0.6)
     rjack-jackson (1.8.11.0-java)
     rrtf (1.3.1)
@@ -139,9 +194,11 @@ GEM
       tilt (~> 2.0)
     spoon (0.0.6)
       ffi
+    strscan (3.0.6-java)
     thread_safe (0.3.6-java)
     tidy (1.1.2)
     tilt (2.1.0)
+    timeout (0.3.2)
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
     tzinfo-data (1.2022.7)
@@ -156,6 +213,7 @@ PLATFORMS
   java
 
 DEPENDENCIES
+  actionmailer (~> 5.2)
   activesupport (< 6.0)
   atomic (= 1.0.1)
   bcrypt (= 3.1.7)

--- a/backend/app/lib/exceptions.rb
+++ b/backend/app/lib/exceptions.rb
@@ -111,6 +111,9 @@ class ImportException < StandardError
   end
 end
 
+class NotAllowed < StandardError
+end
+
 
 module Exceptions
 
@@ -208,6 +211,14 @@ module Exceptions
         error JSON::ParserError do
           Log.exception(request.env['sinatra.error'])
           json_response({:error => "Had some trouble parsing your request: #{request.env['sinatra.error']}"}, 400)
+        end
+
+        error NotAllowed do
+          json_response({:error => request.env['sinatra.error']}, 400)
+        end
+
+        error UserMailer::MailError do
+          json_response({:error => request.env['sinatra.error']}, 400)
         end
 
 

--- a/backend/app/lib/user_mailer.rb
+++ b/backend/app/lib/user_mailer.rb
@@ -1,0 +1,46 @@
+require 'action_mailer'
+
+class UserMailer < ActionMailer::Base
+
+  class MailError < StandardError
+  end
+
+  def headers
+    delivery_method = ActionMailer::Base.delivery_method
+    { delivery_method: delivery_method, to: @user.email, from: AppConfig[:global_email_from_address], subject: I18n.t('user.recover_password') }
+  end
+
+  def send_reset_token(username, token)
+    self.append_view_path(File.join(ASUtils.find_base_directory, 'backend', 'app', 'views'))
+    @user = User.first(username: username)
+    @magic_link = AppConfig[:frontend_url] + "/users/#{username}/#{token}"
+
+    begin
+      msg = mail headers do |format|
+        format.html {
+          render 'send_reset_token'
+        }
+      end
+      msg.deliver
+    rescue Exception => e
+      Log.error("Mailing password reset link failed: #{e.inspect}")
+      raise MailError.new
+    end
+  end
+end
+
+# move these config settings if more mailing
+# actions are added
+ActionMailer::Base.raise_delivery_errors = true
+
+if ASpaceEnvironment.environment == :unit_test
+  ActionMailer::Base.delivery_method = :test
+elsif AppConfig.has_key?(:email_delivery_method)
+  if AppConfig[:email_delivery_method] == :smtp
+    ActionMailer::Base.delivery_method = :smtp
+    ActionMailer::Base.smtp_settings = AppConfig[:email_smtp_settings].dup
+  elsif AppConfig[:email_delivery_method] == :sendmail
+    ActionMailer::Base.delivery_method = :sendmail
+    ActionMailer::Base.sendmail_settings = AppConfig[:email_sendmail_settings].dup
+  end
+end

--- a/backend/app/main.rb
+++ b/backend/app/main.rb
@@ -32,8 +32,8 @@ require_relative 'lib/request_context'
 require_relative 'lib/component_transfer'
 require_relative 'lib/progress_ticker'
 require_relative 'lib/csv_template_generator'
-
 require_relative 'lib/ark/ark_minter'
+require_relative 'lib/user_mailer'
 
 require 'barcode_check'
 require 'benchmark'

--- a/backend/app/model/authentication_manager.rb
+++ b/backend/app/model/authentication_manager.rb
@@ -5,7 +5,6 @@ class AuthenticationManager
   def self.prepare_sources(sources)
     sources.map { |source|
       model = Kernel.const_get(source[:model].intern)
-
       model.new(source)
     }
   end
@@ -82,6 +81,28 @@ class AuthenticationManager
     authentication_sources.map {|source|
       source.matching_usernames(query)
     }.flatten(1).sort.uniq
+  end
+
+
+  def self.authenticate_token(username, token)
+    authentication_sources.each do |source|
+      next unless source == DBAuth
+      if (user = source.authenticate_token(username, token))
+        return user
+      end
+    end
+    nil
+  end
+
+
+  def self.generate_token(username)
+    authentication_sources.each do |source|
+      next unless source == DBAuth
+      if (token = source.generate_token(username))
+        return token
+      end
+    end
+    nil
   end
 
 

--- a/backend/app/model/user.rb
+++ b/backend/app/model/user.rb
@@ -204,6 +204,9 @@ class User < Sequel::Model(:user)
       end
     end
 
+    # assume all users can edit themselves for now
+    global_permissions << 'edit_user_self'
+
     # Attach permissions in the global repository under the symbolic name too
     result[Repository.GLOBAL] = global_permissions + derived
 

--- a/backend/app/views/user_mailer/send_reset_token.en.html.erb
+++ b/backend/app/views/user_mailer/send_reset_token.en.html.erb
@@ -1,0 +1,9 @@
+<p>Dear user,<br />
+We received a request to reset your password for ArchivesSpace. Please click the link below to create your new password (or copy and paste the web site address in a new browser window).</p>
+<p>
+<a href="<%= @magic_link %>"><%= @magic_link %></a>
+</p>
+<p>
+For security reasons, this link expires in thirty minutes. It can only be used once. Do not click on the link multiple times.
+Please contact your system administrator if you need further assistance.
+</p>

--- a/backend/spec/model_authentication_manager_spec.rb
+++ b/backend/spec/model_authentication_manager_spec.rb
@@ -157,7 +157,7 @@ describe 'Authentication manager' do
       # now get one and wait 5 minutes
       token = AuthenticationManager.generate_token(username)
       time_now = Time.now
-      allow(Time).to receive(:now).and_return(time_now + 5*60)
+      allow(Time).to receive(:now).and_return(time_now + 30*60)
       expect(AuthenticationManager.authenticate_token(username, token)).to be_nil
       # now go back in time 5 seconds
       allow(Time).to receive(:now).and_return(time_now + (5*60)-5)

--- a/backend/spec/model_authentication_manager_spec.rb
+++ b/backend/spec/model_authentication_manager_spec.rb
@@ -138,4 +138,30 @@ describe 'Authentication manager' do
       expect(AuthenticationManager.authenticate(username, "world")).not_to be_nil
     end
   end
+
+  context "Lost passwords" do
+
+    it "can generate and authenticate an expiring, single-use token" do
+      username = "forgetful"
+      password = "iforget"
+      user = build(:json_user, username: username)
+      user.save(password: password)
+
+      token = AuthenticationManager.generate_token(username)
+      expect(AuthenticationManager.authenticate_token(username, token)).not_to be_nil
+      # token is single-use
+      expect(AuthenticationManager.authenticate_token(username, token)).to be_nil
+      # so let's get a new one
+      token = AuthenticationManager.generate_token(username)
+      expect(AuthenticationManager.authenticate_token(username, token)).not_to be_nil
+      # now get one and wait 5 minutes
+      token = AuthenticationManager.generate_token(username)
+      time_now = Time.now
+      allow(Time).to receive(:now).and_return(time_now + 5*60)
+      expect(AuthenticationManager.authenticate_token(username, token)).to be_nil
+      # now go back in time 5 seconds
+      allow(Time).to receive(:now).and_return(time_now + (5*60)-5)
+      expect(AuthenticationManager.authenticate_token(username, token)).not_to be_nil
+    end
+  end
 end

--- a/backend/spec/model_user_spec.rb
+++ b/backend/spec/model_user_spec.rb
@@ -134,7 +134,7 @@ describe 'User model' do
 
     expect(user.permissions[repo_a.uri].sort).to eq(["manage_repository", "update_location_record"])
     expect(user.permissions[repo_b.uri].sort).to eq(["update_location_record", "view_repository"])
-    expect(user.permissions[Repository.GLOBAL].sort).to eq(["update_location_record"])
+    expect(user.permissions[Repository.GLOBAL].sort).to eq(["edit_user_self", "update_location_record"])
   end
 
   it "can delete a user even if it has preferences and import jobs" do
@@ -159,5 +159,8 @@ describe 'User model' do
 
   end
 
-
+  it "lets any user edit themself" do
+    new_user = create(:user)
+    expect(new_user.permissions[Repository.GLOBAL]).to include('edit_user_self')
+  end
 end

--- a/common/aspace_i18n.rb
+++ b/common/aspace_i18n.rb
@@ -2,6 +2,10 @@ require 'i18n'
 require 'asutils'
 require 'aspace_i18n_enumeration_support'
 
+class Backend < I18n::Backend::Simple
+  include I18n::Backend::Fallbacks
+end
+
 I18n.enforce_available_locales = false # do not require locale to be in available_locales for export
 
 I18n.load_path += ASUtils.find_locales_directories("#{AppConfig[:locale]}.yml")
@@ -17,7 +21,8 @@ end
 I18n.load_path += Dir[File.join(ASUtils.find_base_directory, 'reports', '**', '*.yml')]
 
 I18n.default_locale = AppConfig[:locale]
-
+I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
+I18n.fallbacks = I18n::Locale::Fallbacks.new(de: :en, es: :en, fr: :en, ja: :en)
 module I18n
 
   LOCALES = {

--- a/common/config/config-aliases.rb
+++ b/common/config/config-aliases.rb
@@ -16,3 +16,11 @@ AppConfig.add_deprecated(:solr_backup_schedule)
 AppConfig.add_deprecated(:solr_backup_number_to_keep)
 
 AppConfig.set_options(:pui_repositories_sort, [:display_string, :position])
+
+AppConfig.add_alias(option: :pui_email_delivery_method, maps_to: :email_delivery_method, deprecated: true)
+AppConfig.add_alias(option: :pui_email_sendmail_settings, maps_to: :email_sendmail_settings, deprecated: true)
+AppConfig.add_alias(option: :pui_email_perform_deliveries, maps_to: :email_smtp_settings, deprecated: true)
+AppConfig.add_alias(option: :pui_email_raise_delivery_errors, maps_to: :email_raise_delivery_errors, deprecated: true)
+AppConfig.add_alias(option: :pui_email_smtp_settings, maps_to: :email_smtp_settings, deprecated: true)
+
+AppConfig.set_options(:email_delivery_method, [:smtp, :sendmail])

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -562,18 +562,18 @@ AppConfig[:pui_email_enabled] = false
 
 # use the repository record email address for requests (overrides config email)
 AppConfig[:pui_request_use_repo_email] = false
-
+AppConfig[:global_email_from_address] = "noreply@yourdomain.com"
 # Example sendmail configuration:
-# AppConfig[:pui_email_delivery_method] = :sendmail
-# AppConfig[:pui_email_sendmail_settings] = {
+# AppConfig[:email_delivery_method] = :sendmail
+# AppConfig[:email_sendmail_settings] = {
 #   location: '/usr/sbin/sendmail',
 #   arguments: '-i'
 # }
-#AppConfig[:pui_email_perform_deliveries] = true
-#AppConfig[:pui_email_raise_delivery_errors] = true
+#AppConfig[:email_perform_deliveries] = true
+#AppConfig[:email_raise_delivery_errors] = true
 # Example SMTP configuration:
-#AppConfig[:pui_email_delivery_method] = :smtp
-#AppConfig[:pui_email_smtp_settings] = {
+#AppConfig[:email_delivery_method] = :smtp
+#AppConfig[:email_smtp_settings] = {
 #      address:              'smtp.gmail.com',
 #      port:                 587,
 #      domain:               'gmail.com',
@@ -582,8 +582,9 @@ AppConfig[:pui_request_use_repo_email] = false
 #      authentication:       'plain',
 #      enable_starttls_auto: true,
 #}
-#AppConfig[:pui_email_perform_deliveries] = true
-#AppConfig[:pui_email_raise_delivery_errors] = true
+#AppConfig[:email_perform_deliveries] = true
+#AppConfig[:email_raise_delivery_errors] = true
+
 
 # Add page actions via the configuration
 AppConfig[:pui_page_custom_actions] = []
@@ -731,3 +732,7 @@ AppConfig[:pui_repositories_sort] = :display_string
 # Set the font used to generate PDFs in the PUI
 AppConfig[:pui_pdf_font_file] = "NotoSerif-Regular.ttf"
 AppConfig[:pui_pdf_font_name] = "Noto Serif"
+
+# Password recovery - requires email configuration
+# See example email configuration above
+AppConfig[:allow_password_reset] = false

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -2249,6 +2249,7 @@ en:
     admin: Administrator
     _singular: User
     _plural: Users
+    recover_password: Recover Password
 
   collection_management: &collection_management_attributes
     cataloged_note: Cataloged Note

--- a/frontend/Gemfile
+++ b/frontend/Gemfile
@@ -74,3 +74,5 @@ require 'asutils'
 
 # Allow plugins to provide their own Gemfiles too.
 ASUtils.load_plugin_gems(self)
+
+gem "zxcvbn-ruby", "~> 1.2"

--- a/frontend/Gemfile.lock
+++ b/frontend/Gemfile.lock
@@ -341,6 +341,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    zxcvbn-ruby (1.2.0)
 
 PLATFORMS
   java
@@ -387,6 +388,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier
   web-console
+  zxcvbn-ruby (~> 1.2)
 
 BUNDLED WITH
    2.1.4

--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -21,13 +21,13 @@ class ApplicationController < ActionController::Base
   end
 
   # Note: This should be first!
-  before_action :store_user_session
+  before_action :store_user_session, unless: -> { params[:login] && !session[:user] }
 
-  before_action :refresh_permissions
+  before_action :refresh_permissions, unless: -> { params[:login] && !session[:user] }
 
-  before_action :refresh_preferences
+  before_action :refresh_preferences, unless: -> { params[:login] && !session[:user] }
 
-  before_action :load_repository_list
+  before_action :load_repository_list, unless: -> { params[:login] && !session[:user] }
 
   before_action :unauthorised_access
 

--- a/frontend/app/controllers/session_controller.rb
+++ b/frontend/app/controllers/session_controller.rb
@@ -1,6 +1,6 @@
 class SessionController < ApplicationController
 
-  set_access_control  :public => [:login, :logout, :check_session, :has_session, :login_inline],
+  set_access_control  :public => [:login, :token_login, :logout, :check_session, :has_session, :login_inline],
                       "become_user" => [:select_user, :become_user]
 
 
@@ -60,6 +60,23 @@ class SessionController < ApplicationController
   def has_session
     render :json => {:has_session => !session[:user].nil?}
   end
+
+
+  def token_login
+    backend_session = User.token_login(params[:username], params[:token])
+    if backend_session
+      # this can't prevent a determined user from using a token-acquired
+      # session to do things they could do with a regular login token, but it should
+      # suffice to make a typical user reset password and log back in.
+      backend_session['user']['permissions'] = {}
+      User.establish_session(self, backend_session, params[:username])
+    else
+      flash[:error] = I18n.t('login.password_update_error')
+    end
+
+    redirect_to :controller => :users, :action => :password_form
+  end
+
 
   private
 

--- a/frontend/app/models/user.rb
+++ b/frontend/app/models/user.rb
@@ -4,6 +4,9 @@ require 'zlib'
 
 class User < JSONModel(:user)
 
+  class MailError < StandardError
+  end
+
   def self.establish_session(context, backend_session, username)
     context.session[:session] = backend_session["session"]
 
@@ -56,6 +59,44 @@ class User < JSONModel(:user)
       true
     else
       false
+    end
+  end
+
+
+  def self.recover_password(email)
+    uri = JSONModel(:user).uri_for("recover-password")
+
+    begin
+      response = JSONModel::HTTP.post_form(uri, email: email)
+      message = ASUtils.json_parse(response.body)
+      if response.code == '200'
+        return {status: :success}
+      else
+        msg = case message['error']
+              when "UserMailer::MailError"
+                I18n.t("user._frontend.messages.password_recovery_fail")
+              when "NotFoundException"
+                I18n.t("user._frontend.messages.error_not_found", email: email)
+              else
+                message['error']
+              end
+        return { status: :error, error: msg }
+      end
+    rescue Exception => e
+      Rails.logger.error(e)
+      return { status: :error, error: I18n.t("user._frontend.messages.password_recovery_fail") }
+    end
+  end
+
+  def self.token_login(username, token)
+    uri = JSONModel(:user).uri_for("#{username}/#{token}")
+
+    response = JSONModel::HTTP.post_form(uri)
+
+    if response.code == '200'
+      ASUtils.json_parse(response.body)
+    else
+      nil
     end
   end
 

--- a/frontend/app/views/users/password_form.html.erb
+++ b/frontend/app/views/users/password_form.html.erb
@@ -1,0 +1,45 @@
+<%= setup_context :title => "Home", :suppress_breadcrumb => true %>
+
+<div class="row">
+  <% if !session[:user] %>
+  <div class="col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-0 col-lg-4 lg-min-w-450px p30px">
+    <h2><%= I18n.t "login.recover_password" %></h2>
+    <%= I18n.t "login.reset_form_instructions" %>
+  </div>
+  <div class="col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-0 col-lg-4 md-mt20px p30px">
+    <%= render_aspace_partial :partial => "shared/flash_messages" %>
+    <main class="well" id="login-form-wrapper">
+      <h3 class="mt0"><%= I18n.t "login.recover_password" %></h3>
+
+      <%= form_tag({controller: "users", action: "recover_password"}, method: "post") do %>
+      <div class="form-group">
+        <input id="user_email" type="text" name="email" size="30" placeholder="<%= I18n.t "login.email_placeholder" %>" class="form-control" aria-label="<%= I18n.t "login.email_placeholder" %>"/>
+      </div>
+      <input class="btn btn-primary navbar-btn btn-default" type="submit" name="commit" value="<%= I18n.t("login.recover_password") %>" id="submit" />
+      <% end %>
+
+    </main>
+  </div>
+  <% else %>
+  <div class="col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-0 col-lg-4 lg-min-w-450px p30px">
+    <h2><%= I18n.t "login.new_password" %></h2>
+    <%= I18n.t "login.new_password_instructions", user: session[:user] %>
+  </div>
+  <div class="col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-0 col-lg-4 md-mt20px p30px">
+    <%= render_aspace_partial :partial => "shared/flash_messages" %>
+    <main class="well" id="login-form-wrapper">
+      <h3 class="mt0"><%= I18n.t "login.new_password" %></h3>
+      <%= form_tag({controller: "users", action: "update_password"}, method: "post") do %>
+      <div class="form-group">
+        <input id="user_password" type="password" minlength="8" name="password" size="30" placeholder="<%= I18n.t "login.password_placeholder" %>" class="form-control" aria-label="<%= I18n.t "login.password_placeholder" %>"/>
+      </div>
+      <div class="form-group">
+        <input id="user_confirm_password" type="password" minlength="8" name="confirm_password" size="30" placeholder="<%= I18n.t "login.confirm_password" %>" class="form-control" aria-label="<%= I18n.t "login.confirm_password" %>"/>
+      </div>
+      <input class="btn btn-primary navbar-btn btn-default" type="submit" name="commit" value="<%= I18n.t("login.reset_password") %>" id="submit" />
+      <% end %>
+
+    </main>
+  </div>
+  <% end %>
+</div>

--- a/frontend/app/views/welcome/index.html.erb
+++ b/frontend/app/views/welcome/index.html.erb
@@ -17,7 +17,10 @@
       <h3 class="mt0"><%= I18n.t "login.login_please" %></h3>
       <%= render_aspace_partial :partial => "shared/login" %>
       <% if AppConfig[:allow_user_registration] %>
-        <p><%= I18n.t "navbar.register_prefix" %> <%= link_to I18n.t("navbar.register"), {:controller => "users", :action => "new"}, :class => "boring-link" %></p>
+        <p><%= I18n.t "navbar.register_prefix" %> <%= link_to I18n.t("navbar.register"), {controller: "users", action: "new"}, class: "boring-link" %></p>
+      <% end %>
+      <% if AppConfig[:allow_password_reset] %>
+        <p><%= I18n.t "login.lost_password" %> <%= link_to I18n.t("login.reset_password"), {controller: "users", action: "password_form"}, class: "boring-link" %></p>
       <% end %>
     </main>
   </div>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -640,8 +640,20 @@ en:
     login_success: Login Successful. Redirecting...
     username_placeholder: Username
     password_placeholder: Password
+    confirm_password: Confirm Password
     username_aria_label: User Name
     password_aria_label: User Password
+    lost_password: Forgot Password?
+    reset_password: Reset Password
+    recover_password: Recover Password
+    email_placeholder: Email Address
+    reset_form_instructions: Enter the email associated with your user account. If an account exists for that email address, a link [or verification code] to reset your password will be sent to that email address.
+    new_password: New Password
+    new_password_instructions: Create a new password for %{user} using the form, then login again.
+    password_mismatch_error: Passwords do not match.
+    password_update_success: Password successfully updated.
+    password_update_error: Password could not be updated. Try again or contact an administrator.
+    password_too_simple: This password is too easy to guess. Try adding words or use a random password generator.
 
   breadcrumb:
     home: Home
@@ -1363,6 +1375,10 @@ en:
         deactivated: User deactivated
         error_activate: User not activated
         error_deactivate: User not deactivated
+        password_recovery_email_sent: An email has been sent to %{email} with instructions for recovering your password
+        error_not_found: A username account for %{email} could not be found. Contact your administrator for help.
+        password_recovery_not_allowed: Password Recovery is not allowed. Contact your administrator.
+        password_recovery_fail: Password Recovery failed. Contact your administrator.
       section:
         manage_access: Manage User Access
         account: Account

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -30,6 +30,9 @@ ArchivesSpace::Application.routes.draw do
     match 'users/manage_access' => 'users#manage_access', :via => [:get]
     match 'users/edit_self' => 'users#edit_self', :via => [:get]
     match 'users/update_self' => 'users#update_self', :via => [:post]
+    match 'users/edit_password' => 'users#password_form', :via => [:get]
+    match 'users/recover_password' => 'users#recover_password', :via => [:post]
+    match 'users/update_password' => 'users#update_password', :via => [:post]
     match 'users/:id/edit_groups' => 'users#edit_groups', :via => [:get]
     match 'users/:id/edit' => 'users#edit', :via => [:get]
     match 'users/:id/update_groups' => 'users#update_groups', :via => [:post]
@@ -40,6 +43,7 @@ ArchivesSpace::Application.routes.draw do
     match 'users/:id/delete' => 'users#delete', :via => [:post]
     match('/users/:id/activate' => 'users#activate', :via => [:get], :as => :user_activate)
     match('/users/:id/deactivate' => 'users#deactivate', :via => [:get], :as => :user_deactivate)
+    match 'users/:username/:token' => 'session#token_login', :via => [:get]
 
     resources :users
 

--- a/frontend/spec/controllers/users_controller_spec.rb
+++ b/frontend/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe UsersController, type: :controller do
+
+  before(:each) do
+    set_repo($repo)
+    url = URI.parse(AppConfig[:backend_url] + '/users/admin/login')
+    request = Net::HTTP::Post.new(url.request_uri)
+    request.set_form_data('expiring' => 'false',
+                          'password' => 'admin')
+    response = do_http_request(url, request)
+
+    if response.code == '200'
+      auth = ASUtils.json_parse(response.body)
+
+      JSONModel::HTTP.current_backend_session = auth['session']
+    else
+      raise "Authentication to backend failed: #{response.body}"
+    end
+
+    allow(controller).to receive(:user_must_have).and_return(true)
+    user = build(:json_user).save(password: "saa2020")
+    user = User.find(user)
+    group = create(:json_group,
+                   member_usernames: [user.username],
+                   grants_permissions: [])
+    session = User.login(user.username, "saa2020")
+    User.establish_session(controller, session, user.username)
+    controller.send(:load_repository_list)
+  end
+
+  it 'validates password and confirmation password' do
+    post :update_password, params: { password: "foo", confirm_password: "bar" }
+    expect(response).to redirect_to('/users/edit_password')
+    expect(request.flash[:error]).to eq("Passwords do not match.")
+  end
+
+  it 'ensures password is minimally complex' do
+    post :update_password, params: { password: "foo", confirm_password: "foo" }
+    expect(response).to redirect_to('/users/edit_password')
+    expect(request.flash[:error]).to match(/too easy to guess/)
+  end
+
+end

--- a/frontend/spec/features/spawning_spec.rb
+++ b/frontend/spec/features/spawning_spec.rb
@@ -136,7 +136,7 @@ describe 'Spawning', js: true do
     click_button('Create and Link')
 
     within(id: 'accession_instances_') do
-      find('.digital_object').click
+      find('.digital_object.initialised').click
       digital_object_tab = window_opened_by {click_link('View')}
       within_window digital_object_tab do
         expect(page).to have_content("Spawned Accession")

--- a/public/config/application.rb
+++ b/public/config/application.rb
@@ -81,17 +81,17 @@ module ArchivesSpacePublic
 
     # mailer configuration
     if AppConfig[:pui_email_enabled]
-      config.action_mailer.delivery_method = AppConfig[:pui_email_delivery_method]
-      config.action_mailer.perform_deliveries = AppConfig[:pui_email_perform_deliveries]
-      config.action_mailer.raise_delivery_errors = AppConfig[:pui_email_raise_delivery_errors]
+      config.action_mailer.delivery_method = AppConfig[:email_delivery_method]
+      config.action_mailer.perform_deliveries = AppConfig[:email_perform_deliveries]
+      config.action_mailer.raise_delivery_errors = AppConfig[:email_raise_delivery_errors]
 
       if config.action_mailer.delivery_method == :sendmail
-        if AppConfig.has_key? :pui_email_sendmail_settings
-          config.action_mailer.smtp_settings = AppConfig[:pui_email_sendmail_settings]
+        if AppConfig.has_key? :email_sendmail_settings
+          config.action_mailer.smtp_settings = AppConfig[:email_sendmail_settings]
         end
       end
       if config.action_mailer.delivery_method == :smtp
-        config.action_mailer.smtp_settings = AppConfig[:pui_email_smtp_settings]
+        config.action_mailer.smtp_settings = AppConfig[:email_smtp_settings]
       end
     else
       config.action_mailer.delivery_method = :test


### PR DESCRIPTION
For local testing, recommend using https://www.npmjs.com/package/fake-smtp-server
I could not get the npm install working, so used docker: 

```
# Run a fake smtp server:
# docker-compose -f docker-compose-fake-smtp.yml up --detach

services:
  mail:
    container_name: fake_smtp_server
    image: reachfive/fake-smtp-server
    ports:
      - "1025:1025"
      - "1080:1080"
```
with the following in `common/config.rb`:
```

AppConfig[:email_delivery_method] = :smtp
AppConfig[:email_smtp_settings] = {
     address:              'localhost',
     port:                 1025,
     domain:               'foobar.com',
     user_name:            'hello',
     password:             'goodbye',
     openssl_verify_mode:  'none'
}
AppConfig[:email_perform_deliveries] = true
AppConfig[:email_raise_delivery_errors] = true

AppConfig[:allow_password_reset] = true
```

![ANW-1477-screencast](https://user-images.githubusercontent.com/1626547/231506646-43413b6d-9fe9-43cc-9b40-ca6bb59d2ced.gif)
