### PR TITLE
ANW-1690 ensure record link after +1 event

### DIFF
--- a/frontend/app/controllers/events_controller.rb
+++ b/frontend/app/controllers/events_controller.rb
@@ -51,6 +51,7 @@ class EventsController < ApplicationController
     if params.has_key?(:record_uri)
       @last_linked_record_uri = params[:record_uri]
       @last_linked_record_type = params[:record_type]
+      @last_linked_record_path = params[:record_uri].match('\/\w+\/\d+$')[0]
 
       record = JSONModel(params[:record_type]).find_by_uri(params[:record_uri])
       @event.linked_records = []

--- a/frontend/app/views/events/new.html.erb
+++ b/frontend/app/views/events/new.html.erb
@@ -22,7 +22,11 @@
           <div class="form-actions">
             <div class="btn-group">
               <button type="submit" class="btn btn-primary"><%= I18n.t("event._frontend.action.save") %></button>
-              <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
+              <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn" 
+                linked_record_uri="<%= @last_linked_record_uri %>" 
+                linked_record_type="<%= @last_linked_record_type %>">
+                  <%= I18n.t("actions.save_plus_one") %> 
+              </button>
             </div>
             <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>

--- a/frontend/app/views/events/new.html.erb
+++ b/frontend/app/views/events/new.html.erb
@@ -28,7 +28,7 @@
                   <%= I18n.t("actions.save_plus_one") %> 
               </button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= link_to I18n.t("actions.cancel"), @last_linked_record_path, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/spec/features/events_spec.rb
+++ b/frontend/spec/features/events_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_helper'
+require 'factories'
+
+describe 'Events', js: true do
+
+  before(:all) do
+    @repo = create :repo, repo_code: "default_values_test_#{Time.now.to_i}"
+    set_repo @repo
+    @resource = create :resource
+  end
+
+  it 'retains the linked resource when adding additional events via +1 button' do
+    login_admin
+    select_repository @repo
+    visit "/resources/#{@resource.id}"
+    find('button.add-event-action').click
+    find('button.add-event-button').click
+
+    expect(page).to have_content 'New Event'
+    expect(page).to have_selector 'div.resource'
+    select 'Single', from: 'event[date][date_type]'
+    fill_in 'event[date][begin]', with: '2023'
+    select 'Authorizer', from: 'event[linked_agents][0][role]'
+    fill_in 'token-input-event_linked_agents__0__ref_', with: 'test'
+
+    # Need to wait for evidence of dropdown populating before sending enter to select the agent.
+    # This is accomplished by waiting for the aria attribute to show up. (TODO: better way?)
+    # After that, click the +1, then wait for the form submission to complete, otherwise it will
+    # immediately find the the linked resource div on the current page and short-circuit the test.
+    # Easiest way is probably just to look for the success flash.
+    expect(page).to have_css '#token-input-event_linked_agents__0__ref_[aria-controls]'
+    find(id: 'token-input-event_linked_agents__0__ref_').send_keys(:enter)
+    click_button id: 'createPlusOne'
+    expect(page).to have_content 'Event Created'
+    expect(page).to have_selector 'div.resource'
+  end
+
+end


### PR DESCRIPTION
Adds the record URI and type to the "plus 1" button parameters so the record will again be linked automatically on the new event form. 