### PR TITLE
ANW-1721: Add `link_uri` to `representative_file_version` based on proceeding file version

### DIFF
--- a/common/schemas/file_version.rb
+++ b/common/schemas/file_version.rb
@@ -25,6 +25,7 @@
       "derived_from" => {"type" => [{"type" => "JSONModel(:digital_object) uri"},
                                     {"type" => "JSONModel(:digital_object_component) uri"}],
                          "readonly" => true},
+      "link_uri" => {"type" => "string", "maxLength" => 16384, "readonly" => true},
     },
   },
 }

--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -5,7 +5,7 @@
       <%
         rfv = record['json']['representative_file_version']
         img_uri = rfv['file_uri']
-        a_uri = rfv['derived_from'] || img_uri
+        a_uri = rfv['derived_from'] || rfv['link_uri']
       %>
       <%= render partial: 'shared/representative_file_version_record', locals: {
         :a_uri => a_uri,

--- a/public/app/views/shared/_record_innards.html.erb
+++ b/public/app/views/shared/_record_innards.html.erb
@@ -66,11 +66,15 @@
 	<%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('resource._public.additional'),
 	      :p_id => 'add_desc', :p_body => x } %>
 	<% end %>
-  <% have_additional_file_versions = @result['json']['representative_file_version'].present? && @result.json['file_versions'].present? && @result.json['file_versions'].length > 1 %>  
-  <% if have_additional_file_versions %>
+  <%
+    additional_published_fvs = []
+    if @result.json['file_versions'].present? && @result.json['representative_file_version'].present?
+      additional_published_fvs = @result.json['file_versions'].select { |fv| fv['publish'] && fv['file_uri'] != @result.json['representative_file_version']['file_uri'] }
+    end
+  %>
+  <% unless additional_published_fvs.empty? %>
     <%
-      additional_file_versions = @result.json['file_versions'].select { |fv| fv['file_uri'] != @result['json']['representative_file_version']['file_uri'] }
-      x = render partial: 'digital_objects/additional_file_versions', locals: { :fvs => additional_file_versions }
+      x = render partial: 'digital_objects/additional_file_versions', locals: { :fvs => additional_published_fvs }
     %>
     <%= render partial: 'shared/accordion_panel', locals: {
       :p_title => t('digital_object._public.additional'),

--- a/public/app/views/shared/_representative_file_version_record.html.erb
+++ b/public/app/views/shared/_representative_file_version_record.html.erb
@@ -1,10 +1,14 @@
 <figure data-rep-file-version-wrapper>
-  <a href="<%= a_uri %>" target="new" title="<%= t('digital_object._public.link')%>">
+  <% if a_uri %>
+    <a href="<%= a_uri %>" target="new" title="<%= t('digital_object._public.link')%>">
+  <% end %>
     <img
       class="<%= caption.blank? ? 'rounded-bottom' : '' %>"
       src="<%= img_uri %>"
       alt="<%= caption.blank? ? '' : caption %>">
-  </a>
+  <% if a_uri %>
+    </a>
+  <% end %>
   <% unless caption.blank? %>
     <figcaption class="bg-lightgray rounded-bottom"><%= caption %></figcaption>
   <% end %>

--- a/public/spec/features/representative_file_version_spec.rb
+++ b/public/spec/features/representative_file_version_spec.rb
@@ -5,6 +5,7 @@ describe 'Representative File Version', js: true do
   before(:all) do
     @img_1 = 'https://www.archivesspace.org/demos/Congreave%20E-4/ms292_008.jpg'
     @img_2 = 'https://www.archivesspace.org/demos/Congreave%20E-1/ms292_001.jpg'
+    @img_3 = 'https://www.archivesspace.org/demos/Congreave%20E-1/ms292_002.jpg'
     @caption_1 = 'This is caption 1'
     @caption_2 = 'This is caption 2'
     @long_caption = 'This is the long caption whose character count exceeds 56'
@@ -34,6 +35,80 @@ describe 'Representative File Version', js: true do
           file_uri: @img_2,
           use_statement: 'image-thumbnail',
           caption: @caption_2
+        }
+      ]
+    )
+    @dobj_with_repfv_02 = create(
+      :digital_object,
+      publish: true,
+      title: 'Digital object with representative file version 02',
+      file_versions: [
+        {
+          publish: true,
+          is_representative: true,
+          file_uri: @img_1,
+          use_statement: 'image-thumbnail',
+          caption: @caption_1
+        },
+        {
+          publish: true,
+          is_representative: false,
+          file_uri: @img_3,
+        }
+      ]
+    )
+    @dobj_with_repfv_03 = create(
+      :digital_object,
+      publish: true,
+      title: '03 Digital object with representative file version',
+      file_versions: [
+        {
+          publish: true,
+          is_representative: true,
+          file_uri: @img_1,
+          use_statement: 'image-thumbnail',
+          caption: @caption_1
+        },
+        {
+          publish: false,
+          file_uri: @img_3,
+        }
+      ]
+    )
+    @dobjc_with_repfv_02 = create(:digital_object_component,
+      publish: true,
+      digital_object: { ref: @dobj_with_repfv.uri },
+      title: 'Digital object component with representative file version 02',
+      file_versions: [
+        {
+          publish: true,
+          is_representative: true,
+          file_uri: @img_2,
+          use_statement: 'image-thumbnail',
+          caption: @caption_2
+        },
+        {
+          publish: true,
+          is_representative: false,
+          file_uri: @img_3,
+        }
+      ]
+    )
+    @dobjc_with_repfv_03 = create(:digital_object_component,
+      publish: true,
+      digital_object: { ref: @dobj_with_repfv.uri },
+      title: 'Digital object component with representative file version 03',
+      file_versions: [
+        {
+          publish: true,
+          is_representative: true,
+          file_uri: @img_2,
+          use_statement: 'image-thumbnail',
+          caption: @caption_2
+        },
+        {
+          publish: false,
+          file_uri: @img_3,
         }
       ]
     )
@@ -93,12 +168,21 @@ describe 'Representative File Version', js: true do
     expect(page).to have_css "figure[data-rep-file-version-wrapper] > a[href='#{@dobj_with_repfv.uri}']"
   end
 
-  it 'links to its own file uri on Digital Object and Digital Object Component records' do
-    visit @dobj_with_repfv.uri
-    expect(page).to have_css "figure[data-rep-file-version-wrapper] > a[href='#{@img_1}']"
+  it 'links to the file uri of the proceeding file version, if one exists and is published '\
+  'in the Digital Object or Digital Object Component, on DO/DOC/Resource/AO/Accession pages' do
+    link_css = ".objectimage figure[data-rep-file-version-wrapper] > a[href='#{@img_3}']"
 
-    visit @dobjc_with_repfv.uri
-    expect(page).to have_css "figure[data-rep-file-version-wrapper] > a[href='#{@img_2}']"
+    visit @dobj_with_repfv_02.uri
+    expect(page).to have_css link_css
+
+    visit @dobj_with_repfv_03.uri
+    expect(page).not_to have_css link_css
+
+    visit @dobjc_with_repfv_02.uri
+    expect(page).to have_css link_css
+
+    visit @dobjc_with_repfv_03.uri
+    expect(page).not_to have_css link_css
   end
 
   describe 'search result thumbnail' do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR addresses [ANW-1721](https://archivesspace.atlassian.net/browse/ANW-1721), which is feedback from the first round of user testing after the initial representative file version work related to ANW-1209.

This PR brings the app into backwards compatibility with regard to how a representative file version, or an 'embedded thumbnail' in the pre-ANW-1209 parlance, can be clicked.

Since before ANW-1209, an embedded thumbnail could have a link wrapped around it. The link was defined by _the `file_uri` of the proceeding file version_ to the file version which provides the thumbnail for embedding. While there weren't any tests covering this behavior, the [user manual](https://archivesspace.atlassian.net/wiki/spaces/ArchivesSpaceUserManual/pages/894566839/Publishing+Digital+Objects+and+Embedding+Thumbnails?src=search#Embedding-Thumbnails) documents this behavior.

This implements the rule of only providing a link around a representative file version (which has co-opted the embedded thumbnail) on a DO/DOC page when the rep file version is proceeded with a published file version.

The behavior of linking to the DO/DOC page from the representative file version image on a Resource/AO/Accession page has not changed.

Closes #2981 

## Changes

- add a link_uri calculated field to file_version so files can link to a proceeding published sibling file version
- strip off link_uri when attaching a representative to a resource, ao, or accession
- use the link_uri in the PUI front end
- only show published additional file versions on a do or doc page

[ANW-1721]: https://archivesspace.atlassian.net/browse/ANW-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ