### PR TITLE
ANW-1722 Add PUI additional file version display logic

### DIFF
--- a/public/app/views/digital_objects/_additional_file_versions.html.erb
+++ b/public/app/views/digital_objects/_additional_file_versions.html.erb
@@ -1,11 +1,16 @@
-<ol class="list-unstyled mb0">
+<ul>
   <% fvs.each do |fv| %>
-    <li class="panel panel-default additional-file-version">
-      <%= render partial: 'shared/representative_file_version_record', locals: {
-        :img_uri => fv['file_uri'],
-        :a_uri => fv['file_uri'],
-        :caption => fv['caption']
-      } %>
+    <%
+      # ANW-1722 additional file version display rules
+      fv_markup = "<a href='#{fv['file_uri']}'>#{fv['file_uri']}</a>"
+      if fv['caption'] && !fv['caption'].empty?
+        fv_markup = "<a href='#{fv['file_uri']}'>#{fv['caption']}</a>"
+      elsif fv['use_statement'] && !fv['use_statement'].empty?
+        fv_markup = "<a href='#{fv['file_uri']}'>#{fv['use_statement']}</a>"
+      end
+    %>
+    <li data-additional-file-version>
+      <%= fv_markup.html_safe %>
     </li>
   <% end %>
-</ol>
+</ul>

--- a/public/spec/controllers/objects_controller_spec.rb
+++ b/public/spec/controllers/objects_controller_spec.rb
@@ -4,6 +4,12 @@ describe ObjectsController, type: :controller do
   img_uri1 = 'http://foo.com/image.jpg'
   img_uri2 = 'http://foo.com/image2.jpg'
   img_uri3 = 'http://foo.com/image3.jpg'
+  img_uri4 = 'http://foo.com/image4.jpg'
+  img_uri5 = 'http://foo.com/image5.jpg'
+  caption1 = 'caption1'
+  caption2 = 'caption2'
+  additional_file_versions_accordion_css = '#res_accordion > .panel.panel-default > #additional_file_versions_list'
+  additional_file_version_css = '#additional_file_versions_list li[data-additional-file-version]'
 
   before(:all) do
     @repo = create(:repo, repo_code: "do_test_#{Time.now.to_i}",
@@ -21,7 +27,7 @@ describe ObjectsController, type: :controller do
           :publish => true,
           :is_representative => false,
           :file_uri => img_uri1,
-          :use_statement => 'image-service'
+          :caption => caption1,
         }),
         build(:file_version, {
           :publish => true,
@@ -34,6 +40,19 @@ describe ObjectsController, type: :controller do
           :is_representative => false,
           :file_uri => img_uri3,
           :use_statement => 'image-service'
+        }),
+        build(:file_version, {
+          :publish => true,
+          :is_representative => false,
+          :file_uri => img_uri4,
+          :use_statement => 'image-service',
+          :caption => caption2,
+        }),
+        build(:file_version, {
+          :publish => true,
+          :is_representative => false,
+          :file_uri => img_uri5,
+          :use_statement => '',
         })
       ])
 
@@ -48,32 +67,42 @@ describe ObjectsController, type: :controller do
       run_indexers
     end
 
-    it 'should display additional published File Versions not designated as representative in an Additional File Versions accordion' do
-      get(:show, params: { rid: @repo.id, obj_type: 'digital_objects', id: @do1.id })
-
-      page = response.body
-
-      additional_file_versions_accordion_css = '#res_accordion > .panel.panel-default > #additional_file_versions_list'
-      additional_file_version_css = '#additional_file_versions_list li.additional-file-version'
-      additional_file_version_1_src = "#{additional_file_version_css} img[src='#{img_uri1}']"
-      additional_file_version_2_src = "#{additional_file_version_css} img[src='#{img_uri3}']"
-
-      expect(page).to have_css(additional_file_versions_accordion_css)
-      expect(page).to have_css(additional_file_version_css, :count => 2)
-      expect(page).to have_css(additional_file_version_1_src)
-      expect(page).to have_css(additional_file_version_2_src)
-    end
-
     it "shows a 'generic icon' if no representative file version is set and the "\
        "file version is published, whether or not the file uri starts with 'http'" do
       get(:show, params: { rid: @repo.id, obj_type: 'digital_objects', id: @do3.id })
-
       icon_css = '.external-digital-object__link[href="not_http"]'
-
       page = response.body
       expect(page).to have_css(icon_css)
     end
 
+    describe 'additional file versions' do
+      it 'not designated as representative when there is a representative, are listed '\
+         'in an Additional File Versions accordion' do
+        get(:show, params: { rid: @repo.id, obj_type: 'digital_objects', id: @do1.id })
+        page = response.body
+        expect(page).to have_css(additional_file_versions_accordion_css)
+        expect(page).to have_css(additional_file_version_css, :count => 4)
+      end
+
+      it 'with a caption should display text of caption and link to uri' do
+        get(:show, params: { rid: @repo.id, obj_type: 'digital_objects', id: @do1.id })
+        page = response.body
+        expect(page).to have_css("#{additional_file_versions_accordion_css} a[href='#{img_uri1}']", :text => caption1)
+        expect(page).to have_css("#{additional_file_versions_accordion_css} a[href='#{img_uri4}']", :text => caption2)
+      end
+
+      it 'with a use statement and no caption should display text of use statement and link to uri' do
+        get(:show, params: { rid: @repo.id, obj_type: 'digital_objects', id: @do1.id })
+        page = response.body
+        expect(page).to have_css("#{additional_file_versions_accordion_css} a[href='#{img_uri3}']", :text => 'image-service')
+      end
+
+      it 'with no caption or use statement should display text of the uri and link to the uri' do
+        get(:show, params: { rid: @repo.id, obj_type: 'digital_objects', id: @do1.id })
+        page = response.body
+        expect(page).to have_css("#{additional_file_versions_accordion_css} a[href='#{img_uri5}']", :text => img_uri5)
+      end
+    end
   end
 
   describe 'Digital Object Components' do
@@ -117,14 +146,10 @@ describe ObjectsController, type: :controller do
       page = response.body
 
       additional_file_versions_accordion_css = '#res_accordion > .panel.panel-default > #additional_file_versions_list'
-      additional_file_version_css = '#additional_file_versions_list li.additional-file-version'
-      additional_file_version_1_src = "#{additional_file_version_css} img[src='#{img_uri1}']"
-      additional_file_version_2_src = "#{additional_file_version_css} img[src='#{img_uri3}']"
+      additional_file_version_css = '#additional_file_versions_list li[data-additional-file-version]'
 
       expect(page).to have_css(additional_file_versions_accordion_css)
       expect(page).to have_css(additional_file_version_css, :count => 2)
-      expect(page).to have_css(additional_file_version_1_src)
-      expect(page).to have_css(additional_file_version_2_src)
     end
 
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR addresses [ANW-1722](https://archivesspace.atlassian.net/browse/ANW-1722) by updating the logic of how file versions in addition to a DO's/DOC's representative file version are shown on the DO/DOC record page.

Before this PR the ANW-1209 spec was implemented as written, which tried to show each additional file version as an image, a la the representative file version.

This new work changes the display logic according to the following rules via the issue ticket:

1. If there's a caption only, display text of caption and link to URI
2. If there's a use statement only - display text of use statement and link to URI
3. If there's both a caption and a use statement, display text of caption and link to URI (_same as rule \# 1_)
4. If there's no use statement or caption - display text of URI and link to the URI

![ANW-1722](https://user-images.githubusercontent.com/3411019/233136308-6fc0afa2-aaa6-4050-96ff-7549e504573e.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See public/spec/controllers/objects_controller_spec.rb

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


[ANW-1722]: https://archivesspace.atlassian.net/browse/ANW-1722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ