### PR TITLE
ANW-1723 Thumbnail Column in Search Results

### DIFF
--- a/common/config/search_browse_column_config.rb
+++ b/common/config/search_browse_column_config.rb
@@ -110,7 +110,8 @@ module SearchAndBrowseColumnConfig
       "create_time" => {:field => "create_time", :sortable => true},
       "user_mtime" => {:field => "user_mtime", :sortable => true},
       "audit_info" => {:field => "audit_info", :sort_by => ["create_time", "user_mtime"]},
-      "uri" => {:field => "uri", :sortable => true}
+      "uri" => {:field => "uri", :sortable => true},
+      "representative_file_version" => {:field => "representative_file_version", :sortable => false}
     },
     "location" => {
       "title" => {:field => "title", :sortable => true, :sort_by => "title_sort"},

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -505,6 +505,7 @@ en:
       asc: Ascending
       desc: Descending
       uri: URI
+      representative_file_version: Thumbnail Image
     blank_facet_query_fields:
       owner_repo_display_string_u_ssort: Repository
 

--- a/frontend/spec/controllers/search_controller_spec.rb
+++ b/frontend/spec/controllers/search_controller_spec.rb
@@ -152,10 +152,11 @@ describe SearchController, type: :controller do
         }
       end
 
+      preference_prefixes = RECORD_TYPES + ['multi']
       allow(JSONModel::HTTP).to receive(:get_json)
                                   .with("/repositories/999/current_preferences")
                                   .and_return({
-                                                "defaults" => Hash[RECORD_TYPES.map { |record_type|
+                                                "defaults" => Hash[preference_prefixes.map { |record_type|
                                                                      ["#{record_type}_browse_column_1", "representative_file_version"]
                                                                    }]})
     end
@@ -171,6 +172,14 @@ describe SearchController, type: :controller do
         expect(body.xpath("//td[starts-with(@class, 'col representative_file_version')][1]").first.inner_html.strip)
           .to eq "<img src=\"http://foo.com/bar.jpg\">"
       end
+    end
+
+    it "shows the representative file version image when searching across types" do
+      get :do_search, format: :js, params: {}, xhr: true
+      body = Nokogiri::HTML.parse(response.body)
+      expect(body.xpath("//th[starts-with(@class, 'col representative_file_version')]").size).to eq 1
+      expect(body.xpath("//td[starts-with(@class, 'col representative_file_version')][1]").first.inner_html.strip)
+        .to eq "<img src=\"http://foo.com/bar.jpg\">"
     end
   end
 end


### PR DESCRIPTION
Allows user to select "Thumbnail Image" as a browse column for general search results in staff interface.

<img width="1610" alt="image" src="https://user-images.githubusercontent.com/1626547/233355946-380fb1b6-3b12-41f1-846d-513632fd552e.png">
