### PR TITLE
ANW-1719: Allow file version file_uri to start with 'http' or 'data:'

### DIFF
--- a/public/app/controllers/concerns/result_info.rb
+++ b/public/app/controllers/concerns/result_info.rb
@@ -168,7 +168,9 @@ module ResultInfo
       rep_caption = ''
       json['file_versions'].each do |version|
         version['file_uri'].strip!
-        if version.dig('publish') != false
+        if version.dig('publish') != false && (version['file_uri'].start_with?('http') ||
+          version['file_uri'].start_with?('data:'))
+
           if version.dig('xlink_show_attribute') == 'embed'
             dig_f['thumb'] = version['file_uri']
             dig_f['represent'] = 'embed' if version['is_representative']

--- a/public/app/views/digital_objects/_additional_file_versions.html.erb
+++ b/public/app/views/digital_objects/_additional_file_versions.html.erb
@@ -2,7 +2,9 @@
   <% fvs.each do |fv| %>
     <%
       # ANW-1722 additional file version display rules
-      fv_markup = "<a href='#{fv['file_uri']}'>#{fv['file_uri']}</a>"
+      data_url_text = t('digital_object._public.url_encoded_data')
+      uri_text = fv['file_uri'].starts_with?('data:') ? data_url_text : fv['file_uri']
+      fv_markup = "<a href='#{fv['file_uri']}'>#{uri_text}</a>"
       if fv['caption'] && !fv['caption'].empty?
         fv_markup = "<a href='#{fv['file_uri']}'>#{fv['caption']}</a>"
       elsif fv['use_statement'] && !fv['use_statement'].empty?

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -352,6 +352,7 @@ en:
       badge_label: Digital %{level}
       go: Go to file
       additional: Additional File Versions
+      url_encoded_data: URL-encoded data
       browse_number_digital_objects_in_collection: Browse %{num} digital objects in collection
       
   subject:

--- a/public/spec/controllers/objects_controller_spec.rb
+++ b/public/spec/controllers/objects_controller_spec.rb
@@ -60,19 +60,45 @@ describe ObjectsController, type: :controller do
         build(:file_version, {
           :publish => true,
           :is_representative => false,
-          :file_uri => 'not_http',
+          :file_uri => 'data:',
+        })
+      ])
+
+      @do4 = create(:digital_object, publish: true, :file_versions => [
+        build(:file_version, {
+          :publish => true,
+          :is_representative => false,
+          :file_uri => 'http',
+        })
+      ])
+
+      @do5 = create(:digital_object, publish: true, :file_versions => [
+        build(:file_version, {
+          :publish => true,
+          :is_representative => false,
+          :file_uri => 'not_http_or_data',
         })
       ])
 
       run_indexers
     end
 
-    it "shows a 'generic icon' if no representative file version is set and the "\
-       "file version is published, whether or not the file uri starts with 'http'" do
+    it "shows a 'generic icon' if no representative file version is set, the "\
+       "file version is published, and the file uri starts with 'http' or 'data:'" do
       get(:show, params: { rid: @repo.id, obj_type: 'digital_objects', id: @do3.id })
-      icon_css = '.external-digital-object__link[href="not_http"]'
+      icon_css = '.external-digital-object__link[href="data:"]'
       page = response.body
       expect(page).to have_css(icon_css)
+
+      get(:show, params: { rid: @repo.id, obj_type: 'digital_objects', id: @do4.id })
+      icon_css_1 = '.external-digital-object__link[href="http"]'
+      page_1 = response.body
+      expect(page_1).to have_css(icon_css_1)
+
+      get(:show, params: { rid: @repo.id, obj_type: 'digital_objects', id: @do5.id })
+      icon_css_2 = '.external-digital-object__link[href="not_http_or_data"]'
+      page_2 = response.body
+      expect(page_2).not_to have_css(icon_css_2)
     end
 
     describe 'additional file versions' do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR addresses the updated [ANW-1719](https://archivesspace.atlassian.net/browse/ANW-1719).

We have pivoted (from #2976) and decided to keep the http rule since removing it increases the chances for showing broken images.

We also need to accommodate base64 encoded [data urls](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs), so add the data: rule too.

This also updates the markup for additional file versions, so that the full data url (which can be very long!) isn't shown as the text of links where there are no caption or use statement. The text chosen to be displayed can be changed to something else, currently set to "URL-encoded data".

### Additional file versions list
![ANW-1719 data-url](https://user-images.githubusercontent.com/3411019/233412413-6b63a4a6-e0fc-4763-9fde-7f8987714419.png)

### Data url set as text for additional file version list

![data image url as link text](https://user-images.githubusercontent.com/3411019/233412830-02704c26-cb49-4123-9f74-ac3eed3fde77.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See public/spec/controllers/objects_controller_spec.rb


[ANW-1719]: https://archivesspace.atlassian.net/browse/ANW-1719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ