### PR TITLE
ANW-1735: Undo the removal of generic icons from PUI Resource and Archival Object pages

### DIFF
--- a/public/app/views/objects/show.html.erb
+++ b/public/app/views/objects/show.html.erb
@@ -16,11 +16,7 @@
     <% if  defined?(comp_id) && !comp_id && !@result['json']['ref_id'].blank? %>
       <span class='ref_id'>[<%=  t('archival_object._public.header.ref_id') %>: <%= @result['json']['ref_id'] %>]</span>
     <% end %>
-    <% if @result.instance_of?(ArchivalObject) %>
-      <%= render partial: 'shared/digital', locals: {record: @result} %>
-    <% else %>
-      <%= render partial: 'shared/digital', locals: {:dig_objs => @dig, record: @result} %>
-    <% end %>
+    <%= render partial: 'shared/digital', locals: {:dig_objs => @dig, record: @result} %>
     <%= render partial: 'shared/record_innards' %>
    </div>
 

--- a/public/app/views/resources/show.html.erb
+++ b/public/app/views/resources/show.html.erb
@@ -20,12 +20,11 @@
 
 <div class="row" id="notes_row">
   <div class="col-sm-9">
-    <% if @result['json']['representative_file_version'].present? %>
-      <%= render partial: 'shared/digital', locals: {
-        record: @result,
-        n_digital_objects: @n_digital_objects
-      } %>
-    <% end %>
+    <%= render partial: 'shared/digital', locals: {
+      :dig_objs => @dig,
+      record: @result,
+      n_digital_objects: @n_digital_objects
+    } %>
     <%= render partial: 'shared/record_innards' %>
   </div>
   <div id="sidebar" class="col-sm-3 sidebar sidebar-container resizable-sidebar" <% unless @has_children %>style="display: none"<% end %>>

--- a/public/spec/features/file_version_link_spec.rb
+++ b/public/spec/features/file_version_link_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'rails_helper'
 
 describe 'File Version Link', js: true do
+  # aka 'generic icon'
   def check_uri_css(uri, css)
     visit(uri)
     expect(page).to have_css(css)
@@ -88,6 +89,9 @@ describe 'File Version Link', js: true do
     )
     @resource = create(:resource, publish: true,
                        instances: [build(:instance_digital, digital_object: { ref: @do1.uri }), build(:instance_digital, digital_object: { ref: @do2.uri }), build(:instance_digital, digital_object: { ref: @do3.uri })])
+    @aobj = create(:archival_object, publish: true,
+                       resource: { 'ref' => @resource.uri },
+                       instances: [build(:instance_digital, digital_object: { ref: @do1.uri }), build(:instance_digital, digital_object: { ref: @do2.uri })])
 
     @do_movie = create(:digital_object, publish: true, digital_object_type: 'moving_image', file_versions: [{publish: true, file_uri: file_base + '0.avi', file_format_name: 'avi'}])
     @do_sound1 = create(:digital_object, publish: true, digital_object_type: 'sound_recording', file_versions: [{publish: true, file_uri: file_base + '0.aiff', file_format_name: 'aiff'}])
@@ -112,6 +116,13 @@ describe 'File Version Link', js: true do
     expect(page).to have_css('.available-digital-objects .external-digital-object__link[href="https://example.com/fv1.jpg"]')
     expect(page).to have_css('.available-digital-objects .external-digital-object__link[href="https://example.com/fv1.gif"]')
     expect(page).to have_css('.available-digital-objects .external-digital-object__link[href="https://example.com/fv1.mp3"]')
+  end
+
+  it "shows links to all linked digital objects' most recently published file versions on an archival object's page" do
+    visit(@aobj.uri)
+    expect(page.all('.available-digital-objects > .objectimage').length).to eq 2
+    expect(page).to have_css('.available-digital-objects .external-digital-object__link[href="https://example.com/fv1.jpg"]')
+    expect(page).to have_css('.available-digital-objects .external-digital-object__link[href="https://example.com/fv1.gif"]')
   end
 
   it "shows the correct icon for digital_object_type moving_image" do

--- a/public/spec/features/file_version_link_spec.rb
+++ b/public/spec/features/file_version_link_spec.rb
@@ -1,115 +1,112 @@
 require 'spec_helper'
 require 'rails_helper'
 
-# TODO revisit this spec to decide if necessary once all the
-# ANW-1209/representative_file_version dust settles
-
 describe 'File Version Link', js: true do
-  # def check_uri_css(uri, css)
-  #   visit(uri)
-  #   expect(page).to have_css(css)
-  # end
+  def check_uri_css(uri, css)
+    visit(uri)
+    expect(page).to have_css(css)
+  end
 
-  # type_map = {
-  #   'default': '.fa-file-o',
-  #   'moving_image': '.fa-file-video-o',
-  #   'sound_recording': '.fa-file-audio-o',
-  #   'sound_recording_musical': '.fa-file-audio-o',
-  #   'sound_recording_nonmusical': '.fa-file-audio-o',
-  #   'still_image': '.fa-file-image-o',
-  #   'text': '.fa-file-text-o'
-  # }
+  type_map = {
+    'default': '.fa-file-o',
+    'moving_image': '.fa-file-video-o',
+    'sound_recording': '.fa-file-audio-o',
+    'sound_recording_musical': '.fa-file-audio-o',
+    'sound_recording_nonmusical': '.fa-file-audio-o',
+    'still_image': '.fa-file-image-o',
+    'text': '.fa-file-text-o'
+  }
 
-  # before(:all) do
-  #   file_base = 'https://example.com/fv'
+  before(:all) do
+    file_base = 'https://example.com/fv'
 
-  #   @do1 = create(
-  #     :digital_object,
-  #     publish: true,
-  #     digital_object_type: 'still_image',
-  #     file_versions: [
-  #       {
-  #         publish: true,
-  #         file_uri: file_base + '0.jpg',
-  #         file_format_name: 'jpeg'
-  #       },
-  #       {
-  #         publish: true,
-  #         file_uri: file_base + '1.jpg',
-  #         file_format_name: 'jpeg'
-  #       },
-  #       {
-  #         publish: false,
-  #         file_uri: file_base + '2.jpg',
-  #         file_format_name: 'jpeg'
-  #       }
-  #     ]
-  #   )
-  #   @do2 = create(
-  #     :digital_object,
-  #     publish: true,
-  #     digital_object_type: 'still_image',
-  #     file_versions: [
-  #       {
-  #         publish: true,
-  #         file_uri: file_base + '0.gif',
-  #         file_format_name: 'gif'
-  #       },
-  #       {
-  #         publish: true,
-  #         file_uri: file_base + '1.gif',
-  #         file_format_name: 'gif'
-  #       },
-  #       {
-  #         publish: false,
-  #         file_uri: file_base + '2.gif',
-  #         file_format_name: 'gif'
-  #       }
-  #     ]
-  #   )
-  #   @do3 = create(
-  #     :digital_object,
-  #     publish: true,
-  #     digital_object_type: 'sound_recording',
-  #     file_versions: [
-  #       {
-  #         publish: true,
-  #         file_uri: file_base + '0.mp3',
-  #         file_format_name: 'mp3'
-  #       },
-  #       {
-  #         publish: true,
-  #         file_uri: file_base + '1.mp3',
-  #         file_format_name: 'mp3'
-  #       },
-  #       {
-  #         publish: false,
-  #         file_uri: file_base + '2.mp3',
-  #         file_format_name: 'mp3'
-  #       }
-  #     ]
-  #   )
-  #   @resource = create(:resource, publish: true,
-  #                      instances: [build(:instance_digital, digital_object: { ref: @do1.uri }), build(:instance_digital, digital_object: { ref: @do2.uri }), build(:instance_digital, digital_object: { ref: @do3.uri })])
+    @do1 = create(
+      :digital_object,
+      publish: true,
+      digital_object_type: 'still_image',
+      file_versions: [
+        {
+          publish: true,
+          file_uri: file_base + '0.jpg',
+          file_format_name: 'jpeg'
+        },
+        {
+          publish: true,
+          file_uri: file_base + '1.jpg',
+          file_format_name: 'jpeg'
+        },
+        {
+          publish: false,
+          file_uri: file_base + '2.jpg',
+          file_format_name: 'jpeg'
+        }
+      ]
+    )
+    @do2 = create(
+      :digital_object,
+      publish: true,
+      digital_object_type: 'still_image',
+      file_versions: [
+        {
+          publish: true,
+          file_uri: file_base + '0.gif',
+          file_format_name: 'gif'
+        },
+        {
+          publish: true,
+          file_uri: file_base + '1.gif',
+          file_format_name: 'gif'
+        },
+        {
+          publish: false,
+          file_uri: file_base + '2.gif',
+          file_format_name: 'gif'
+        }
+      ]
+    )
+    @do3 = create(
+      :digital_object,
+      publish: true,
+      digital_object_type: 'sound_recording',
+      file_versions: [
+        {
+          publish: true,
+          file_uri: file_base + '0.mp3',
+          file_format_name: 'mp3'
+        },
+        {
+          publish: true,
+          file_uri: file_base + '1.mp3',
+          file_format_name: 'mp3'
+        },
+        {
+          publish: false,
+          file_uri: file_base + '2.mp3',
+          file_format_name: 'mp3'
+        }
+      ]
+    )
+    @resource = create(:resource, publish: true,
+                       instances: [build(:instance_digital, digital_object: { ref: @do1.uri }), build(:instance_digital, digital_object: { ref: @do2.uri }), build(:instance_digital, digital_object: { ref: @do3.uri })])
 
-  #   @do_movie = create(:digital_object, publish: true, digital_object_type: 'moving_image', file_versions: [{publish: true, file_uri: file_base + '0.avi', file_format_name: 'avi'}])
-  #   @do_sound1 = create(:digital_object, publish: true, digital_object_type: 'sound_recording', file_versions: [{publish: true, file_uri: file_base + '0.aiff', file_format_name: 'aiff'}])
-  #   @do_sound2 = create(:digital_object, publish: true, digital_object_type: 'sound_recording_musical', file_versions: [{publish: true, file_uri: file_base + '0.mp3', file_format_name: 'mp3'}])
-  #   @do_sound3 = create(:digital_object, publish: true, digital_object_type: 'sound_recording_nonmusical', file_versions: [{publish: true, file_uri: file_base + '0.mp3', file_format_name: 'mp3'}])
-  #   @do_image = create(:digital_object, publish: true, digital_object_type: 'still_image', file_versions: [{publish: true, file_uri: file_base + '0.tiff', file_format_name: 'tiff'}])
-  #   @do_text = create(:digital_object, publish: true, digital_object_type: 'text', file_versions: [{publish: true, file_uri: file_base + '0.txt', file_format_name: 'txt'}])
-  #   @do_default = create(:digital_object, publish: true, file_versions: [{publish: true, file_uri: file_base + '0.pdf', file_format_name: 'pdf'}])
+    @do_movie = create(:digital_object, publish: true, digital_object_type: 'moving_image', file_versions: [{publish: true, file_uri: file_base + '0.avi', file_format_name: 'avi'}])
+    @do_sound1 = create(:digital_object, publish: true, digital_object_type: 'sound_recording', file_versions: [{publish: true, file_uri: file_base + '0.aiff', file_format_name: 'aiff'}])
+    @do_sound2 = create(:digital_object, publish: true, digital_object_type: 'sound_recording_musical', file_versions: [{publish: true, file_uri: file_base + '0.mp3', file_format_name: 'mp3'}])
+    @do_sound3 = create(:digital_object, publish: true, digital_object_type: 'sound_recording_nonmusical', file_versions: [{publish: true, file_uri: file_base + '0.mp3', file_format_name: 'mp3'}])
+    @do_image = create(:digital_object, publish: true, digital_object_type: 'still_image', file_versions: [{publish: true, file_uri: file_base + '0.tiff', file_format_name: 'tiff'}])
+    @do_text = create(:digital_object, publish: true, digital_object_type: 'text', file_versions: [{publish: true, file_uri: file_base + '0.txt', file_format_name: 'txt'}])
+    @do_default = create(:digital_object, publish: true, file_versions: [{publish: true, file_uri: file_base + '0.pdf', file_format_name: 'pdf'}])
 
-  #   run_indexers
-  # end
+    run_indexers
+  end
 
-  xit "shows a link to only the most recently published file version on a digital object's page" do
+  it "shows a link to only the most recently published file version on a digital object's page" do
     visit(@do1.uri)
     expect(page.all('.available-digital-objects > .objectimage').length).to eq 1
     expect(page).to have_css('.available-digital-objects .external-digital-object__link[href="https://example.com/fv1.jpg"]')
   end
 
-  xit "shows links to all linked digital objects' most recently published file versions on a resource's page" do
+  it "shows links to all linked digital objects' most recently published file versions on a resource's page" do
     visit(@resource.uri)
     expect(page.all('.available-digital-objects > .objectimage').length).to eq 3
     expect(page).to have_css('.available-digital-objects .external-digital-object__link[href="https://example.com/fv1.jpg"]')
@@ -117,32 +114,31 @@ describe 'File Version Link', js: true do
     expect(page).to have_css('.available-digital-objects .external-digital-object__link[href="https://example.com/fv1.mp3"]')
   end
 
-  xit "shows the correct icon for digital_object_type moving_image" do
+  it "shows the correct icon for digital_object_type moving_image" do
     check_uri_css(@do_movie.uri, type_map[:moving_image])
   end
 
-  xit "shows the correct icon for digital_object_type sound_recording" do
+  it "shows the correct icon for digital_object_type sound_recording" do
     check_uri_css(@do_sound1.uri, type_map[:sound_recording])
   end
 
-  xit "shows the correct icon for digital_object_type sound_recording_musical" do
+  it "shows the correct icon for digital_object_type sound_recording_musical" do
     check_uri_css(@do_sound2.uri, type_map[:sound_recording_musical])
   end
 
-  xit "shows the correct icon for digital_object_type sound_recording_nonmusical" do
+  it "shows the correct icon for digital_object_type sound_recording_nonmusical" do
     check_uri_css(@do_sound3.uri, type_map[:sound_recording_nonmusical])
   end
 
-  xit "shows the correct icon for digital_object_type still_image" do
+  it "shows the correct icon for digital_object_type still_image" do
     check_uri_css(@do_image.uri, type_map[:still_image])
   end
 
-  xit "shows the correct icon for digital_object_type text" do
+  it "shows the correct icon for digital_object_type text" do
     check_uri_css(@do_text.uri, type_map[:text])
   end
 
-  xit "shows the correct icon for digital_object_type default" do
+  it "shows the correct icon for digital_object_type default" do
     check_uri_css(@do_default.uri, type_map[:default])
   end
-
 end


### PR DESCRIPTION
This PR addresses [ANW-1735](https://archivesspace.atlassian.net/browse/ANW-1735).

This PR undoes the work from #2939 to show the 'generic icons' for each eligible file version of each of a Resource's or AO's linked digital objects, when there is no eligible representative file version for the Resource or AO.

![ANW-1735 resource](https://user-images.githubusercontent.com/3411019/233450252-59086b73-ef94-44fb-82bc-1d9ad263dd2b.png)

![ANW-1735 ao](https://user-images.githubusercontent.com/3411019/233450264-fdaab392-b01f-4dcd-9281-2dec4a910fc9.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See public/spec/features/file_version_link_spec.rb


[ANW-1735]: https://archivesspace.atlassian.net/browse/ANW-1735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ