### PR TITLE
ANW-1196 rework appconfig for optional tree identifier display

### DIFF
--- a/frontend/app/assets/javascripts/tree.js.erb
+++ b/frontend/app/assets/javascripts/tree.js.erb
@@ -5,12 +5,13 @@
 //= require largetree
 //= require largetree_dragdrop
 
-
 (function (exports) {
     "use strict";
 
     var renderers = {
-        resource: new ResourceRenderer(),
+        resource: new ResourceRenderer({
+            show_identifiers: SHOW_IDENTIFIERS_IN_TREE
+        }),
         digital_object: new DigitalObjectRenderer(),
         classification: new ClassificationRenderer(),
     };

--- a/frontend/app/assets/javascripts/tree_renderers.js.erb
+++ b/frontend/app/assets/javascripts/tree_renderers.js.erb
@@ -31,16 +31,15 @@ BaseRenderer.prototype.i18n = function (enumeration, enumeration_value) {
 };
 
 
-function ResourceRenderer() {
+function ResourceRenderer(config = {}) {
     BaseRenderer.call(this);
-
+    this.config = config;
     this.rootTemplate = $('<div class="table-row"> ' +
                           '  <div class="table-cell no-drag-handle"></div>' +
                           '  <div class="table-cell title"></div>' +
                           '  <div class="table-cell resource-level"></div>' +
                           '  <div class="table-cell resource-type"></div>' +
                           '  <div class="table-cell resource-container"></div>' +
-                          '  <div class="table-cell resource-identifier"></div>' +
                           '</div>');
 
     this.nodeTemplate = $('<div class="table-row"> ' +
@@ -49,8 +48,15 @@ function ResourceRenderer() {
                           '  <div class="table-cell resource-level"></div>' +
                           '  <div class="table-cell resource-type"></div>' +
                           '  <div class="table-cell resource-container"></div>' +
-                          '  <div class="table-cell resource-identifier"></div>' +
                           '</div>');
+
+    if (config.show_identifiers) {
+        console.log("show identifiers");
+        this.rootTemplate.addClass("five-fields");
+        this.nodeTemplate.addClass("five-fields");
+        this.rootTemplate.append('<div class="table-cell resource-identifier"></div>');
+        this.nodeTemplate.append('<div class="table-cell resource-identifier"></div>');
+    }
 }
 
 ResourceRenderer.prototype = Object.create(BaseRenderer.prototype);
@@ -66,7 +72,7 @@ ResourceRenderer.prototype.add_root_columns = function (row, rootNode) {
         .html(() => recordTitleHandler(rootNode.suppressed, rootNode.parsed_title));
     }
 
-    if (<%= AppConfig[:display_identifiers_in_largetree_container] %> && rootNode.identifier) {
+    if (this.config.show_identifiers && rootNode.identifier) {
       row.find('.resource-identifier').text(rootNode.identifier).attr('title', rootNode.identifier);
     }
 
@@ -87,7 +93,7 @@ ResourceRenderer.prototype.add_node_columns = function (row, node) {
       .html(() => recordTitleHandler(node.suppressed, title))
       .attr('title', title);
 
-    if (<%= AppConfig[:display_identifiers_in_largetree_container] %> && node.identifier) {
+    if (this.config.show_identifiers && node.identifier) {
       row.find('.resource-identifier').text(node.identifier).attr('title', node.identifier);
     }
 

--- a/frontend/app/assets/stylesheets/archivesspace/largetree.less
+++ b/frontend/app/assets/stylesheets/archivesspace/largetree.less
@@ -117,6 +117,15 @@
     width: 28%;
   }
 
+  .table-row.five-fields {
+    .resource-container {
+      width: 18%;
+    }
+    .resource-identifier {
+      width: 10%;
+    }
+  }
+
   .digital-object-type {
     width: 12%;
   }

--- a/frontend/app/views/layouts/application.html.erb
+++ b/frontend/app/views/layouts/application.html.erb
@@ -25,6 +25,7 @@
     APP_PATH = "<%= j(AppConfig[:frontend_proxy_prefix]) %>";
     COOKIE_PREFIX = "<%= j(AppConfig[:cookie_prefix]) %>";
     FRONTEND_URL = "<%= j(AppConfig[:frontend_proxy_url]) %>";
+    SHOW_IDENTIFIERS_IN_TREE = <%= AppConfig[:display_identifiers_in_largetree_container] %>;
   </script>
 
   <%= javascript_include_tag "application" %>

--- a/frontend/spec/features/resource_tree_spec.rb
+++ b/frontend/spec/features/resource_tree_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Resource Tree', js: true do
+
+  before(:all) do
+    @repo = create(:repo, repo_code: "resource_tree_test_#{Time.now.to_i}")
+    set_repo(@repo)
+    @resource = create(:resource, id_0: "1", id_1: "2", id_2: "3", id_3: "4")
+    @ao = create(:json_archival_object,
+                 resource: {'ref' => @resource.uri},
+                 title: "Component",
+                 component_id: "abc",
+                 dates: [build(:json_date, date_type: "single")]
+                )
+  end
+
+  before(:each) do
+    login_admin
+    select_repository(@repo)
+    allow(AppConfig).to receive(:[]).and_call_original
+  end
+
+  after(:each) do
+    wait_for_ajax
+    Capybara.reset_sessions!
+  end
+
+  it "shows the record id in the tree if configured to do so" do
+    allow(AppConfig).to receive(:[]).with(:display_identifiers_in_largetree_container) { true }
+    visit "/resources/#{@resource.id}"
+    ids = find_all('.resource-identifier').map { |node| node.text }
+    expect(ids).to eq(["1-2-3-4", "abc"])
+  end
+
+  it "does not show the record id in the tree if not configured to do so" do
+    allow(AppConfig).to receive(:[]).with(:display_identifiers_in_largetree_container) { false }
+    visit "/resources/#{@resource.id}"
+    expect(page).not_to have_css('.resource-identifier')
+  end
+end

--- a/public/app/assets/javascripts/tree_renderer.js.erb
+++ b/public/app/assets/javascripts/tree_renderer.js.erb
@@ -50,7 +50,7 @@
 
         if (rootNode.jsonmodel_type == 'classification') {
             $link.prepend(rootNode.identifier + '<%= I18n.t('classification.identifier_separator') %> ');
-        } else if (rootNode.jsonmodel_type == 'resource' && <%= AppConfig[:pui_display_identifiers_in_resource_tree] %> && rootNode.identifier) {
+        } else if (rootNode.jsonmodel_type == 'resource' && SHOW_IDENTIFIERS_IN_TREE && rootNode.identifier) {
             $link.prepend(rootNode.identifier + '<%= I18n.t('resource.identifier_separator') %> ');
         }
     }
@@ -65,9 +65,6 @@
         } else {
             var title = this.build_node_title(node);
             $link.html(title);
-            if (node.jsonmodel_type == 'archival_object' && <%= AppConfig[:pui_display_identifiers_in_resource_tree] %> && node.identifier) {
-                $link.prepend(node.identifier + '<%= I18n.t('resource.identifier_separator') %> ');
-            }
         }
 
         if (this.should_link_to_record) {
@@ -83,7 +80,9 @@
 
     SimpleRenderer.prototype.build_node_title = function (node) {
         var title_bits = [];
-        if (node.parsed_title) {
+        if (SHOW_IDENTIFIERS_IN_TREE && node.identifier && node.parsed_title) {
+            title_bits.push(node.identifier + '<%= I18n.t('resource.identifier_separator') %> ' + node.parsed_title)
+        } else if (node.parsed_title) {
             title_bits.push(node.parsed_title);
         }
 

--- a/public/app/views/layouts/application.html.erb
+++ b/public/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
 
 	<script>
 	 var APP_PATH = '<%= PrefixHelper.app_prefix("") %>';
+	 var SHOW_IDENTIFIERS_IN_TREE = <%= AppConfig[:pui_display_identifiers_in_resource_tree] %>;
 	</script>
 
 	<%= stylesheet_link_tag    'application', media: 'all' %>

--- a/public/spec/controllers/objects_controller_spec.rb
+++ b/public/spec/controllers/objects_controller_spec.rb
@@ -61,6 +61,7 @@ describe ObjectsController, type: :controller do
           :publish => true,
           :is_representative => false,
           :file_uri => 'data:',
+          :xlink_show_attribute => "new", # can't be 'embed'!
         })
       ])
 
@@ -69,6 +70,7 @@ describe ObjectsController, type: :controller do
           :publish => true,
           :is_representative => false,
           :file_uri => 'http',
+          :xlink_show_attribute => "new", # can't be 'embed'!
         })
       ])
 
@@ -77,6 +79,7 @@ describe ObjectsController, type: :controller do
           :publish => true,
           :is_representative => false,
           :file_uri => 'not_http_or_data',
+          :xlink_show_attribute => "new",  # can't be 'embed'!
         })
       ])
 
@@ -85,6 +88,7 @@ describe ObjectsController, type: :controller do
 
     it "shows a 'generic icon' if no representative file version is set, the "\
        "file version is published, and the file uri starts with 'http' or 'data:'" do
+
       get(:show, params: { rid: @repo.id, obj_type: 'digital_objects', id: @do3.id })
       icon_css = '.external-digital-object__link[href="data:"]'
       page = response.body

--- a/public/spec/features/resource_tree_spec.rb
+++ b/public/spec/features/resource_tree_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Resource Tree', js: true do
+  before(:all) do
+    @repo = create(:repo, repo_code: "resource_tree_test_#{Time.now.to_i}")
+    set_repo(@repo)
+    @resource = create(:resource, id_0: "1", id_1: "2", id_2: "3", id_3: "4", publish: true)
+    @ao = create(:json_archival_object,
+                 resource: {'ref' => @resource.uri},
+                 title: "Component",
+                 component_id: "abc",
+                 publish: true
+                )
+    run_indexers
+  end
+
+  before(:each) do
+    allow(AppConfig).to receive(:[]).and_call_original
+  end
+
+  it "shows the record id in the tree if configured to do so" do
+    allow(AppConfig).to receive(:[]).with(:pui_display_identifiers_in_resource_tree) { true }
+    visit @resource.uri
+    node_titles = find_all('.sidebar .record-title').map { |node| node.text }
+    expect(node_titles[0]).to match /^1-2-3-4:/
+    expect(node_titles[1]).to match /^abc:/
+  end
+
+  it "does not show the record id in the tree if not configured to do so" do
+    allow(AppConfig).to receive(:[]).with(:pui_display_identifiers_in_resource_tree) { false }
+    visit @resource.uri
+    node_titles = find_all('.sidebar .record-title').map { |node| node.text }
+    expect(node_titles[0]).not_to match /^1-2-3-4:/
+    expect(node_titles[1]).not_to match /^abc:/
+  end
+
+end


### PR DESCRIPTION
This will allow admins to configure both staff and public apps to show record identifiers in trees.

Toggle these config values:
```ruby
AppConfig[:display_identifiers_in_largetree_container] = true
AppConfig[:pui_display_identifiers_in_resource_tree] = true
```

You should see the identifiers thusly:
<img width="1500" alt="image" src="https://user-images.githubusercontent.com/1626547/234305762-f0a9f564-5f57-43ec-940f-f724cda7c350.png">

<img width="1500" alt="image" src="https://user-images.githubusercontent.com/1626547/234305852-5daecf42-b8b2-44b3-8b9a-671a772931fa.png">

