### PR TITLE
ANW-1738: respect digital object publish flag when selecting a representative digital object for an archival object

### DIFF
--- a/public/app/controllers/concerns/result_info.rb
+++ b/public/app/controllers/concerns/result_info.rb
@@ -147,7 +147,7 @@ module ResultInfo
         unless !instance.dig('digital_object', '_resolved')
           dig_f = {}
           it =  instance['digital_object']['_resolved']
-          unless it['file_versions'].blank?
+          unless !it['publish'] || it['file_versions'].blank?
             title = strip_mixed_content(it['title'])
             dig_f = process_file_versions(it)
             dig_f['caption'] = CGI::escapeHTML(title) if dig_f['caption'].blank? && !title.blank?

--- a/public/spec/features/file_version_link_spec.rb
+++ b/public/spec/features/file_version_link_spec.rb
@@ -87,11 +87,26 @@ describe 'File Version Link', js: true do
         }
       ]
     )
+    @do_unpublished = create(
+      :digital_object,
+      publish: false,
+      file_versions: [
+        {
+          publish: true,
+          file_uri: 'http://example.com',
+        }
+      ]
+    )
     @resource = create(:resource, publish: true,
                        instances: [build(:instance_digital, digital_object: { ref: @do1.uri }), build(:instance_digital, digital_object: { ref: @do2.uri }), build(:instance_digital, digital_object: { ref: @do3.uri })])
+    @resource_w_unpub_do = create(:resource, publish: true,
+                                  instances: [build(:instance_digital, digital_object: { ref: @do_unpublished.uri })])
     @aobj = create(:archival_object, publish: true,
                        resource: { 'ref' => @resource.uri },
                        instances: [build(:instance_digital, digital_object: { ref: @do1.uri }), build(:instance_digital, digital_object: { ref: @do2.uri })])
+    @aobj_w_unpub_do = create(:archival_object, publish: true,
+                              resource: { 'ref' => @resource_w_unpub_do.uri },
+                              instances: [build(:instance_digital, digital_object: { ref: @do_unpublished.uri })])
 
     @do_movie = create(:digital_object, publish: true, digital_object_type: 'moving_image', file_versions: [{publish: true, file_uri: file_base + '0.avi', file_format_name: 'avi'}])
     @do_sound1 = create(:digital_object, publish: true, digital_object_type: 'sound_recording', file_versions: [{publish: true, file_uri: file_base + '0.aiff', file_format_name: 'aiff'}])
@@ -123,6 +138,18 @@ describe 'File Version Link', js: true do
     expect(page.all('.available-digital-objects > .objectimage').length).to eq 2
     expect(page).to have_css('.available-digital-objects .external-digital-object__link[href="https://example.com/fv1.jpg"]')
     expect(page).to have_css('.available-digital-objects .external-digital-object__link[href="https://example.com/fv1.gif"]')
+  end
+
+  it "is not shown on a resource page when a linked digital object is unpublished "\
+     "with published file versions" do
+    visit(@resource_w_unpub_do.uri)
+    expect(page).not_to have_css('.available-digital-objects .external-digital-object__link')
+  end
+
+  it "is not shown on an archival object page when a linked digital object is unpublished "\
+      "with published file versions" do
+    visit(@aobj_w_unpub_do.uri)
+    expect(page).not_to have_css('.available-digital-objects .external-digital-object__link')
   end
 
   it "shows the correct icon for digital_object_type moving_image" do


### PR DESCRIPTION
This change modifies ArchivesSpace to check the publish flag of a digital object before selecting a file version to display as part of an archival object.

## Description
In `process_digital_instance`, digital objects are selected for display but do not check their `publish` flags.  There is a very similar piece of code in `get_rep_image` from the same file that does check this flag.  I think this change is required because without it, the public view displays published file versions for digital objects that are not published.

We noticed this when users attempted to hide digital objects by unchecking their `publish` checkboxes, but their file versions were still displayed with the archival object in the public view.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1738

## How Has This Been Tested?
I tested this by toggling the `publish` flag for a digital object, and toggling the `publish` flag for its only file version, to confirm that the file version is only displayed on an archival object's public view when both of the respective `publish` values are `true`.

This change was initially developed and tested against version 2.8.1.  However, we observed the same symptoms on vanilla 3.3.1, and the relevant code is nearly identical, so I believe this fix is still applicable.  (Due to our new deploy process I have not been able to test this against 3.3.1 directly yet.)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
