### PR TITLE
catch PRs merged with GH squash option and add section for Solr schem…

### DIFF
--- a/scripts/tasks/release_notes.rb
+++ b/scripts/tasks/release_notes.rb
@@ -4,7 +4,7 @@ require 'github_api'
 module ReleaseNotes
 
   def self.find_previous_tag(current_tag)
-    current_tag = current_tag.sub(/-RC\d+$/, '')
+    current_tag = current_tag.sub(/-RC\d+[_-a-zA-Z\d]*$/, '')
     git = Git.open('./')
     vtags = git.tags.reject {|t| t.name !~ /^v\d\.\d\.\d(-RC\d)?$/}
     matched = false
@@ -12,6 +12,7 @@ module ReleaseNotes
       return tag if matched
       matched = (tag.sub(/-RC\d+$/, '') == current_tag)
     end
+    raise "Cannot find a previous tag using #{current_tag}!"
   end
 
 


### PR DESCRIPTION
A lot of PRs and community contributions were being missed because of Squash style PR merges. See this gist for details:
https://gist.github.com/quoideneuf/9dd461816982cc56bfcba2864fa20328

This also adds a section to alert admins that Solr cores will need to be rebuilt when the schema has changed.
