### PR TITLE
Fix release notes and release config export

### DIFF
--- a/build/scripts/export_config.rb
+++ b/build/scripts/export_config.rb
@@ -7,10 +7,9 @@ def main
 
   output_file = ARGV[0]
 
-  File.write(output_file, "# Configuration defaults are shown below\n\n" + AppConfig.read_defaults.gsub(/^/, "#")
-            .gsub("#AppConfig[:display_identifiers_in_largetree_container] = false", "#Setting temporarily disabled")
-            .gsub("AppConfig[:pui_display_identifiers_in_resource_tree] = false", "#Setting temporarily disabled"))
+  File.write(output_file, "# Configuration defaults are shown below\n\n" + AppConfig.read_defaults.gsub(/^/, "#"))
 end
 
 
 main
+

--- a/scripts/tasks/doc.thor
+++ b/scripts/tasks/doc.thor
@@ -68,6 +68,7 @@ class Doc < Thor
       match = log_entry[:desc].match /\(#(\d+)\)$/
       if match
         log_entry[:pr_number] = match[1].to_i
+        log_entry[:pr_title] = log_entry[:desc]
       end
     end
 


### PR DESCRIPTION
Some config options were being filtered out when the distribution gets built
PRs merged with squash commits were not getting titles in generated release notes