### PR TITLE
ANW-859 enable partial word searches using Solr filter

### DIFF
--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -189,6 +189,7 @@
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.LowerCaseFilterFactory" />
         <filter class="solr.ASCIIFoldingFilterFactory" />
+        <filter class="solr.NGramFilterFactory" minGramSize="4" maxGramSize="20" />
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory" />
@@ -196,6 +197,7 @@
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true" />
         <filter class="solr.LowerCaseFilterFactory" />
         <filter class="solr.ASCIIFoldingFilterFactory" />
+        <filter class="solr.NGramFilterFactory" minGramSize="4" maxGramSize="20" />
       </analyzer>
     </fieldType>
     <fieldType name="sort_icu" class="solr.ICUCollationField" locale="" strength="primary" numeric="true" />


### PR DESCRIPTION
To allow for partial word searches, this updates the Solr schema to use `NGramFilterFactory`. This filter extracts and indexes tokens from text field types of sizes from `minGramSize` to `maxGramSize` (n-grams). The exact sizes to use are up for discussion; I picked 2  and 10 somewhat arbitrarily, just thinking about how much I typically would type in a search field. I tested this and it seemed to work without any other changes.

This is a schema change, so it will require a core reload/reindex.