### PR TITLE
use correct field in migration

### DIFF
--- a/common/db/migrations/160_persistent_ids_for_notes_created_during_migrations.rb
+++ b/common/db/migrations/160_persistent_ids_for_notes_created_during_migrations.rb
@@ -17,7 +17,7 @@ Sequel.migration do
 
     self[:note]
       .left_join(:note_persistent_id, Sequel.qualify(:note, :id) => Sequel.qualify(:note_persistent_id, :note_id))
-      .filter(Sequel.qualify(:note_persistent_id, :persistent_id) => nil)
+      .filter(Sequel.qualify(:note_persistent_id, :note_id) => nil)
       .select(Sequel.qualify(:note, :id), :notes, *suspect_fks)
       .each do |row|
       notes = JSON.parse(row[:notes].to_s)


### PR DESCRIPTION
## Description
Migration 160 currently fails for us, but probably produces incorrect results for everyone due to using an incorrect field, see issue #3022 for details

## Related GitHub Issue
Fixes #3022 

## How Has This Been Tested?
I've built a release from the fix branch, installed it on our test system and was able to run the migration successfully.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
