### PR TITLE
Dedupe ancestor title requests and lookup once per field

### DIFF
--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -325,7 +325,9 @@ module SearchHelper
     params.has_key?("deleted_uri") and Array(params["deleted_uri"]).include?(record["id"])
   end
 
-  def get_ancestor_title(field)
+  def get_ancestor_title(field, titles)
+    return titles[field] if titles.key? field
+
     begin
       field_json = JSONModel::HTTP.get_json(field)
     # one record might be "found in" another that is suppressed
@@ -333,13 +335,15 @@ module SearchHelper
     rescue RecordNotFound
       return nil
     end
-    unless field_json.nil?
-      if field.include?('resources') || field.include?('digital_objects')
-        clean_mixed_content(field_json['title'])
-      else
-        clean_mixed_content(field_json['display_string'])
-      end
+    return if field_json.nil?
+
+    if field.include?('resources') || field.include?('digital_objects')
+      titles[field] = clean_mixed_content(field_json['title'])
+    else
+      titles[field] = clean_mixed_content(field_json['display_string'])
     end
+
+    titles[field]
   end
 
   def context_separator(result)

--- a/frontend/app/views/search/_context_cell.html.erb
+++ b/frontend/app/views/search/_context_cell.html.erb
@@ -1,11 +1,15 @@
-<% ancestors = context_ancestor(record) %>
+<%
+  ancestors = context_ancestor(record)
+  ancestor_titles = {}
+%>
 <% if ancestors != nil && ancestors != [''] %>
   <% ancestors.reverse.each_with_index do |ancestor, i| %>
-    <% unless get_ancestor_title(ancestor) == nil %>
+    <% title = get_ancestor_title(ancestor, ancestor_titles) %>
+    <% unless title.nil? %>
       <% if params['listing_only'] %>
-        <%= get_ancestor_title(ancestor) %>
+        <%= title %>
       <% else %>
-        <%= resolve_readonly_link_to((get_ancestor_title(ancestor).html_safe), ancestor) %>
+        <%= resolve_readonly_link_to((title.html_safe), ancestor) %>
       <% end %>
       <% if i < ancestors.length - 1 %>
         <%= context_separator(record) %>


### PR DESCRIPTION
This PR addresses 2 issues we encountered with "search" adjacent performance rendering the context cell (particularly with larger page sizes).

1. Currently a call to `get_ancestor_title` is made at least twice per "ancestor". Once to see if there's a value, then again to get the value. The PR updates this to just happen once and use the result.

2. Requests for ancestors are repeated per result (record). If a result shares ancestors the same request is being made without reference to any previous lookups for the same "ancestor". To help with this this PR goes with a minimally intrusive approach of introducing a local variable per controller action. It's simple, can be easily replaced or updated in the future for something more sophisticated (it may eventually be better to do something that isn't requesting an entire json record to get a single field), but does the job of reducing the no. of requests to once per "field" (uri), per search request.

Using the ATTracer repository and searching for "bulk":

master (118 requests):

```
/repositories/3/resources/12
/repositories/3/resources/12
/repositories/3/archival_objects/336
/repositories/3/archival_objects/336
/repositories/3/resources/12
/repositories/3/resources/12
/repositories/3/archival_objects/336
/repositories/3/archival_objects/336
/repositories/3/archival_objects/337
/repositories/3/archival_objects/337
/repositories/3/resources/12
/repositories/3/resources/12
/repositories/3/archival_objects/336
/repositories/3/archival_objects/336
/repositories/3/archival_objects/337
/repositories/3/archival_objects/337
/repositories/3/archival_objects/338
/repositories/3/archival_objects/338
/repositories/3/resources/12
/repositories/3/resources/12
/repositories/3/archival_objects/336
/repositories/3/archival_objects/336
/repositories/3/archival_objects/337
/repositories/3/archival_objects/337
/repositories/3/archival_objects/338
/repositories/3/archival_objects/338
/repositories/3/archival_objects/339
/repositories/3/archival_objects/339
/repositories/3/resources/12
/repositories/3/resources/12
/repositories/3/archival_objects/336
/repositories/3/archival_objects/336
/repositories/3/archival_objects/337
/repositories/3/archival_objects/337
/repositories/3/archival_objects/338
/repositories/3/archival_objects/338
/repositories/3/archival_objects/339
/repositories/3/archival_objects/339
/repositories/3/archival_objects/340
/repositories/3/archival_objects/340
/repositories/3/archival_objects/341
/repositories/3/archival_objects/341
/repositories/3/resources/12
/repositories/3/resources/12
/repositories/3/archival_objects/336
/repositories/3/archival_objects/336
/repositories/3/archival_objects/337
/repositories/3/archival_objects/337
/repositories/3/archival_objects/338
/repositories/3/archival_objects/338
/repositories/3/archival_objects/339
/repositories/3/archival_objects/339
/repositories/3/archival_objects/340
/repositories/3/archival_objects/340
/repositories/3/archival_objects/341
/repositories/3/archival_objects/341
/repositories/3/archival_objects/342
/repositories/3/archival_objects/342
/repositories/3/resources/12
/repositories/3/resources/12
/repositories/3/archival_objects/336
/repositories/3/archival_objects/336
/repositories/3/archival_objects/337
/repositories/3/archival_objects/337
/repositories/3/archival_objects/338
/repositories/3/archival_objects/338
/repositories/3/archival_objects/339
/repositories/3/archival_objects/339
/repositories/3/archival_objects/340
/repositories/3/archival_objects/340
/repositories/3/archival_objects/341
/repositories/3/archival_objects/341
/repositories/3/archival_objects/342
/repositories/3/archival_objects/342
/repositories/3/archival_objects/343
/repositories/3/archival_objects/343
/repositories/3/resources/12
/repositories/3/resources/12
/repositories/3/archival_objects/336
/repositories/3/archival_objects/336
/repositories/3/archival_objects/337
/repositories/3/archival_objects/337
/repositories/3/archival_objects/338
/repositories/3/archival_objects/338
/repositories/3/archival_objects/339
/repositories/3/archival_objects/339
/repositories/3/archival_objects/340
/repositories/3/archival_objects/340
/repositories/3/archival_objects/341
/repositories/3/archival_objects/341
/repositories/3/archival_objects/342
/repositories/3/archival_objects/342
/repositories/3/archival_objects/343
/repositories/3/archival_objects/343
/repositories/3/archival_objects/344
/repositories/3/archival_objects/344
/repositories/3/resources/12
/repositories/3/resources/12
/repositories/3/archival_objects/336
/repositories/3/archival_objects/336
/repositories/3/archival_objects/337
/repositories/3/archival_objects/337
/repositories/3/archival_objects/338
/repositories/3/archival_objects/338
/repositories/3/archival_objects/339
/repositories/3/archival_objects/339
/repositories/3/archival_objects/340
/repositories/3/archival_objects/340
/repositories/3/archival_objects/341
/repositories/3/archival_objects/341
/repositories/3/archival_objects/342
/repositories/3/archival_objects/342
/repositories/3/archival_objects/343
/repositories/3/archival_objects/343
/repositories/3/archival_objects/344
/repositories/3/archival_objects/344
/repositories/3/archival_objects/345
/repositories/3/archival_objects/345
```

PR (11 requests):

```
/repositories/3/resources/12
/repositories/3/archival_objects/336
/repositories/3/archival_objects/337
/repositories/3/archival_objects/338
/repositories/3/archival_objects/339
/repositories/3/archival_objects/340
/repositories/3/archival_objects/341
/repositories/3/archival_objects/342
/repositories/3/archival_objects/343
/repositories/3/archival_objects/344
/repositories/3/archival_objects/345
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
