### PR TITLE
ANW-1341: Display user-friendly message when trying to delete an agent linked to a user

### DIFF
--- a/backend/app/model/agent_person.rb
+++ b/backend/app/model/agent_person.rb
@@ -36,5 +36,12 @@ class AgentPerson < Sequel::Model(:agent_person)
                   end
                 }
 
+  def delete
+    if User.filter(:agent_record_id => self.id).count > 0
+      raise ConflictException.new("linked_to_user")
+    else
+      super
+    end
+  end
 
 end

--- a/backend/spec/model_deletion_spec.rb
+++ b/backend/spec/model_deletion_spec.rb
@@ -160,6 +160,16 @@ describe "Deletion of Archival Records" do
   end
 
 
+  it "cannot delete a user's corresponding agent" do
+    user = create_nobody_user
+    agent = AgentPerson.to_jsonmodel(user.agent_record_id)
+
+    expect {
+      agent.delete
+    }.to raise_error(ConflictException, "linked_to_user")
+  end
+
+
   it "won't delete a system user" do
     expect {
       User[:username => "admin"].delete

--- a/frontend/config/locales/de.yml
+++ b/frontend/config/locales/de.yml
@@ -859,6 +859,7 @@ de:
       Beziehung bevor Sie mit dem Zusammenführen fortfahren.
     linked_to_assessment: Die Aufzeichnung kann nicht gelöscht werden, weil Sie mit
       einem Eingang verknüpft ist
+    linked_to_user: Die Aufzeichnung kann nicht gelöscht werden, weil Sie mit einem Benutzer verknüpft ist
     cannot_delete_repository_agent: Dieser Akteur ist mit einem Aufbewahrungsort verknüpft
       und kann nicht entfernt werden.
     error_403_message: Die aufgerufene Seite könnte nicht mehr existieren oder Sie

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -744,6 +744,7 @@ en:
     merge_denied_relationship: These agents have a relationship. Remove relationship before proceeding with merge.
     merge_restricted_contact_details: The merge cannot be completed because one or more of the agents has contact details you do not have permission to access.
     linked_to_assessment: Record cannot be deleted as it is linked to an assessment
+    linked_to_user: Record cannot be deleted as it is linked to a user
     cannot_delete_repository_agent: This agent is linked to a repository and can't be removed.
 
   component_link:

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -755,7 +755,7 @@ es:
       ser del mismo tipo.
     linked_to_assessment: El registro no se puede eliminar ya que está vinculado a
       una evaluación
-
+    linked_to_user: El registro no se puede eliminar porque está vinculado a un usuario
     merge_denied_relationship: Estos agentes tienen una relación. Elimine la relación
       antes de continuar con la fusión.
     cannot_delete_repository_agent: Este agente está vinculado a un repositorio y

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -765,7 +765,7 @@ fr:
     merge_different_types: Les agents sélectionnés pour la fusion détaillée doivent
       être du même type.
     linked_to_assessment: Notice impossible à supprimer, car liée à une évaluation
-
+    linked_to_user: Notice impossible à supprimer, car liée à un utilisateur
     merge_denied_relationship: Ces agents ont une relation. Supprimez la relation
       avant de procéder à la fusion.
     cannot_delete_repository_agent: Cet agent est lié à un référentiel et ne peut

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -694,7 +694,7 @@ ja:
     merge_too_many_victims: 詳細なマージのために選択できるエージェントは1つだけです.
     merge_different_types: 詳細なマージのために選択されたエージェントは、同じタイプでなければなりません.
     linked_to_assessment: レコードは評価にリンクされているため削除できません
-
+    linked_to_user: レコードはユーザーにリンクされているため削除できません
     cannot_delete_repository_agent: このエージェントはリポジトリにリンクされているため、削除できません。
     merge_denied_relationship: これらのエージェントには関係があります。マージを続行する前に、関係を削除してください。
   accession:


### PR DESCRIPTION
## Description
Check whether an agent is linked to a user before deleting, rather than letting it fail if it violates a foreign key constraint.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1341

## How Has This Been Tested?
1. Log in to staff interface.
2. Find an agent which corresponds to a user.
3. Click the delete button.

It correctly fails to delete, as before, but the message displayed is, in English...

> Record cannot be deleted as it is linked to a user

...rather than...

> Record deletion failed: Java::JavaSql::SQLIntegrityConstraintViolationException: Cannot delete or update a parent row: a foreign key constraint fails (`archivesspace`.`user`, CONSTRAINT `user_ibfk_1` FOREIGN KEY (`agent_record_id`) REFERENCES `agent_person` (`id`))`

Attempting to delete a user's agent via the API return a 409 response:
```
{'error': 'linked_to_user'}
```

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

P.S. There are extra commits in this pull request which appear to be the result of GitHub Actions running on my fork. The net result is no changes to any files other than the ones I intended to change, so it should be safe to merge. I've disabled actions in my fork to hopefully prevent it happening in the future.