### PR TITLE
validate search params for from_year and to_year

### DIFF
--- a/public/app/services/archives_space_client.rb
+++ b/public/app/services/archives_space_client.rb
@@ -147,8 +147,7 @@ class ArchivesSpaceClient
       Rails.logger.debug("POST Search url: #{url} ")
     end
     response = do_http_request(request)
-    if response.code != '200'
-      Rails.logger.debug("Code: #{response.code}")
+    if response.code.to_s != '200'
       raise RequestFailedException.new("#{response.code}: #{response.body}")
     end
     results = ASUtils.json_parse(response.body)

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -202,6 +202,7 @@ en:
     backend_down_message: ArchivesSpace is currently experiencing technical difficulties. We
       apologise for the inconvenience. Please try again later.
     unexpected_error: Your request could not be completed due to an unexpected error
+    invalid_search_params: "Invalid search parameter '%{value}' for field '%{field}'"
 
   boolean:
     "true": "Yes"


### PR DESCRIPTION
Adds validation for `from_year` and `to_year`. 

This was done in response to: https://github.com/archivesspace/archivesspace/issues/1691#issuecomment-1671345291

I was not able to reproduce an actually XSS event, but in any case it doesn't make sense to let arbitrary content in those fields get carried over in url params and in the `input` tag's `value` field.


Queries with invalid params will just redirect and show a flash error:

<img width="1365" alt="image" src="https://github.com/archivesspace/archivesspace/assets/1626547/81cd2700-f25e-4a19-8a78-43a3eca1996d">
