### PR TITLE
Do not re-index records in private repositories unnecessarily

### DIFF
--- a/indexer/app/lib/periodic_indexer.rb
+++ b/indexer/app/lib/periodic_indexer.rb
@@ -161,10 +161,11 @@ class PeriodicIndexer < IndexerCommon
       }
     }
 
-    # indexing repos is usually easy, since its unlikely there will be lots of
-    # them.
+    # Indexing repos is usually easy, since its unlikely there will be lots of
+    # them. Also, in case a repository has just been unpublished, delete PUI-only records
     if !updated_repositories.empty?
       index_records(updated_repositories)
+      delete_pui_only_documents(updated_repositories)
       send_commit
     end
 
@@ -172,6 +173,7 @@ class PeriodicIndexer < IndexerCommon
 
     # And any records in any repositories
     repositories.each_with_index do |repository, i|
+      next if !repository.publish and self.instance_of?(PUIIndexer)
       JSONModel.set_repository(repository.id)
 
       checkpoints = []
@@ -249,6 +251,11 @@ class PeriodicIndexer < IndexerCommon
   def index_round_complete(repository)
     # Give subclasses a place to hang custom behavior.
   end
+
+  def delete_pui_only_documents(updated_repositories)
+    # Give subclasses a place to hang custom behavior.
+  end
+
 
   def handle_deletes(opts = {})
     start = Time.now

--- a/indexer/app/lib/periodic_indexer.rb
+++ b/indexer/app/lib/periodic_indexer.rb
@@ -165,7 +165,7 @@ class PeriodicIndexer < IndexerCommon
     # them. Also, in case a repository has just been unpublished, delete PUI-only records
     if !updated_repositories.empty?
       index_records(updated_repositories)
-      delete_pui_only_documents(updated_repositories)
+      repositories_updated_action(updated_repositories)
       send_commit
     end
 

--- a/indexer/app/lib/periodic_indexer.rb
+++ b/indexer/app/lib/periodic_indexer.rb
@@ -252,7 +252,7 @@ class PeriodicIndexer < IndexerCommon
     # Give subclasses a place to hang custom behavior.
   end
 
-  def delete_pui_only_documents(updated_repositories)
+  def repositories_updated_action(updated_repositories)
     # Give subclasses a place to hang custom behavior.
   end
 

--- a/indexer/app/lib/pui_indexer.rb
+++ b/indexer/app/lib/pui_indexer.rb
@@ -214,11 +214,13 @@ class PUIIndexer < PeriodicIndexer
     @unpublished_records.add(doc_id) if doc_id =~ /#pui$/
   end
 
-  def delete_pui_only_documents(updated_repositories)
+  def repositories_updated_action(updated_repositories)
 
     updated_repositories.each do |repository|
 
       if !repository['record']['publish']
+
+        # Delete PUI-only Solr documents in case this is the first index run after the repository has been unpublished
         req = Net::HTTP::Post.new("#{solr_url.path}/update")
         req['Content-Type'] = 'application/json'
         delete_request = {:delete => {'query' => "repository:\"#{repository['uri']}\" AND types:pui_only"}}
@@ -229,6 +231,7 @@ class PUIIndexer < PeriodicIndexer
         else
           Log.error "SolrIndexerError when deleting PUI-only records in private repository #{repository['record']['repo_code']}: #{response.body}"
         end
+
       end
 
     end


### PR DESCRIPTION
## Description
This is an efficiency improvement in the indexer. There is no need for the PUI Indexer to index individual archival objects (or anything else) belonging to a private repository. Currently it does, and on the production system I run that adds half an hour to a full re-index, because there is a very large private repository used for staging new records prior to publishing. Maybe that is an niche case, but the principle remains that it should just skip such repositories, not retrieve every record from the database, then individually determine that each one should not be published.

The one scenario when PUI Indexer needs to do something is the first time the PUI Indexer runs after a public repository is unpublished. That one time, it needs to delete all the "pui only" documents from Solr (the ones whose id fields end with `#pui`) belonging to that repository. But, once done, those "pui only" records will not be recreated unless/until the repository is made public again. So, I've added a routine to delete them en masse, only when the repository itself has been modified.

## Related JIRA Ticket or GitHub Issue
None

## How Has This Been Tested?
1. Create a new repository, with its Publish? checkbox selected.
2. Switch to that repository and create a resource and some archival objects (e.g. by importing an EAD file.)
3. Check that they appear in the public interface.
4. Confirm in Solr that a search with a filter of `types:pui_only`, also filtered to the new repository, returns however many archival objects you created.
5. Edit the repository, deselecting its Publish? checkbox, and click Save.
6. Watch the indexer log, waiting for a `Deleted PUI-only documents in private repository` info message.
7. Check that the repository and its records have disappeared from the public interface.
8. Confirm in Solr that there are no documents returned for `types:pui_only` in the new repository.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
