### PR TITLE
Return display string in compact resource respresentations

### DIFF
--- a/backend/app/model/search_resolver_compact_resource.rb
+++ b/backend/app/model/search_resolver_compact_resource.rb
@@ -1,6 +1,6 @@
 class SearchResolverCompactResource
 
-  FIELDS_TO_KEEP = ['id_0', 'id_1', 'id_2', 'id_3', 'level', 'other_level', 'title', 'uri', 'publish']
+  FIELDS_TO_KEEP = ['id_0', 'id_1', 'id_2', 'id_3', 'level', 'other_level', 'title', 'display_string', 'uri', 'publish']
 
   # Really just including this as a demo.  Let's parse the JSON and extract a few fields.
   def resolve(record)

--- a/public/app/views/shared/_result_breadcrumbs.html.erb
+++ b/public/app/views/shared/_result_breadcrumbs.html.erb
@@ -27,7 +27,7 @@
         <%= render partial: 'shared/result_breadcrumbs_ancestor', locals: {
           :span_class => "#{ancestor_type}_name",
           :badge_type => ancestor_type,
-          :body => ancestor.fetch('title'),
+          :body => ancestor.fetch('title', ancestor['display_string']),
           :url => app_prefix(ancestor.fetch('uri')) } %>
       <% end %>
     <% end %>


### PR DESCRIPTION
Not all records have (or require) titles. However the PUI breadcrumbs for search were expecting a title, which when absent results in an error.

This is resolved by including the display string in compact results and using that as a fallback when title is not present.

Before (ao has no no title, display string not included):

```
      "_resolved_ancestors": {
        <!-- others ... -->
        "/repositories/2/archival_objects/2684": [
          {
            "publish": true,
            "level": "other level",
            "uri": "/repositories/2/archival_objects/2684"
          }
        ]
      }
```

After (ao has no title, includes display_string):

```
      "_resolved_ancestors": {
        <!-- others ... -->
        "/repositories/2/archival_objects/2684": [
          {
            "publish": true,
            "level": "other level",
            "uri": "/repositories/2/archival_objects/2684",
            "display_string": "1909, 1919, undated"
          }
        ]
      }
```

## Steps to reproduce the issue

Create published records: `resource -> child 1 (no title) -> child 2 (title)`
In PUI search for child 2 title. Will error on master branch.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
