### PR TITLE
Do not set up PUI routes for handling slug-based URLs if use_human_readable_urls is false

### DIFF
--- a/public/app/controllers/application_controller.rb
+++ b/public/app/controllers/application_controller.rb
@@ -59,6 +59,7 @@ class ApplicationController < ActionController::Base
   end
 
   def process_slug_or_id(params)
+
     # we may have an id param. If so, use it. Short circuit processing to come.
     if params[:id]
       true # do nothing
@@ -71,8 +72,8 @@ class ApplicationController < ActionController::Base
         params[:rid] = params[:repo_slug]
       end
 
-    # if it looks like a slug, send it to the backend to resolve ids and other params we need.
-    else
+    # if it looks like a slug, and slugs are enabled, send it to the backend to resolve ids and other params we need.
+    elsif AppConfig[:use_human_readable_urls]
       added_params = resolve_ids_with_slugs(params)
 
       params.merge!(added_params)

--- a/public/config/routes.rb
+++ b/public/config/routes.rb
@@ -13,8 +13,10 @@ Rails.application.routes.draw do
     post '/cite', to: 'cite#show'
 
     # RESOURCES
-    get "resources/:slug_or_id" => 'resources#show'
-    get "repositories/:repo_slug/resources/:slug_or_id" => 'resources#show'
+    if AppConfig[:use_human_readable_urls]
+      get "resources/:slug_or_id" => 'resources#show'
+      get "repositories/:repo_slug/resources/:slug_or_id" => 'resources#show'
+    end
 
     get  'repositories/resources' => 'resources#index'
     get  "repositories/:repo_id/resources/:id/search" => 'resources#search'
@@ -32,8 +34,10 @@ Rails.application.routes.draw do
     get  "repositories/:rid/resources/:id/tree/node_from_root" => 'resources#tree_node_from_root'
 
     #ACCESSIONS
-    get "accessions/:slug_or_id" => 'accessions#show'
-    get "repositories/:repo_slug/accessions/:slug_or_id" => 'accessions#show'
+    if AppConfig[:use_human_readable_urls]
+      get "accessions/:slug_or_id" => 'accessions#show'
+      get "repositories/:repo_slug/accessions/:slug_or_id" => 'accessions#show'
+    end
 
     get  'accessions/search' => 'accessions#search'
     get  'accessions' => 'accessions#index'
@@ -48,8 +52,10 @@ Rails.application.routes.draw do
     get "repositories/:rid/digital_objects/:id/tree/node_from_root" => 'digital_objects#tree_node_from_root'
 
     #CLASSIFICATIONS
-    get "classifications/:slug_or_id" => 'classifications#show'
-    get "repositories/:repo_slug/classifications/:slug_or_id" => 'classifications#show'
+    if AppConfig[:use_human_readable_urls]
+      get "classifications/:slug_or_id" => 'classifications#show'
+      get "repositories/:repo_slug/classifications/:slug_or_id" => 'classifications#show'
+    end
 
     get 'classifications/search' => 'classifications#search'
     get 'classifications' => 'classifications#index'
@@ -63,7 +69,9 @@ Rails.application.routes.draw do
 
     #CLASSIFICATION TERMS
     get  "repositories/:repo_slug/classification_terms/:slug_or_id" => 'classifications#term'
-    get  "classification_terms/:slug_or_id" => 'classifications#term'
+    if AppConfig[:use_human_readable_urls]
+      get  "classification_terms/:slug_or_id" => 'classifications#term'
+    end
 
     #SUBJECTS
     get "subjects/:slug_or_id" => 'subjects#show'
@@ -72,7 +80,9 @@ Rails.application.routes.draw do
     get "repositories/:rid/subjects" => 'subjects#index'
 
     #AGENTS
-    get "agents/:slug_or_id" => 'agents#show'
+    if AppConfig[:use_human_readable_urls]
+      get "agents/:slug_or_id" => 'agents#show'
+    end
 
     get 'agents/search' => 'agents#search'
     get "agents/:eid/:id" => 'agents#show'
@@ -88,8 +98,10 @@ Rails.application.routes.draw do
     get "repositories/:rid/top_containers/:id" => 'containers#show'
 
     # SLUGGED OBJECTS (# ARCHIVAL OBJECTS, DIGITAL OBJECTS, DIGITAL OBJECT COMPONENTS)
-    get ":obj_type/:slug_or_id" => 'objects#show'
-    get "repositories/:repo_slug/:obj_type/:slug_or_id" => 'objects#show'
+    if AppConfig[:use_human_readable_urls]
+      get ":obj_type/:slug_or_id" => 'objects#show'
+      get "repositories/:repo_slug/:obj_type/:slug_or_id" => 'objects#show'
+    end
 
     #OBJECTS (generic, pass in the object_type as a param)
     get 'objects/search' => 'objects#search'


### PR DESCRIPTION
## Description
Similar to #2436, this pull request prevents the PUI from attempting to handle requests for slug-based URLs when `AppConfig[:use_human_readable_urls]` is false (which is the default value.) At present, whenever it receives a request that matches any of the slug-based URLs defined in routes.rb, it sends a request to the backend, which does a lookup in the slug column of the relevant database table. The PUI won't generate any slug-based links, but this route in particular...
```
get ":obj_type/:slug_or_id" => 'objects#show'
```
...means any URL like https://test.archivesspace.org/foo/bar will trigger a lookup. Such a URL might be something a plug-in developer wants to write a controller to handle, but cannot because the above route will take precedence. Also, similar URLs may be probed by bad actors looking for known vulnerabilities in other platforms, such as https://test.archivesspace.org/admin/login.php. They won't find a vulnerability, but it does trigger an unnecessary database lookup every time.

## Related JIRA Ticket or GitHub Issue
None

## How Has This Been Tested?
It does not affect existing routes using `:rid` and `:id` parameters, and obviously won't make any difference to organizations that do have human-readable URLs enabled. There are a few routes that do double duty for both slug-based and ID-based URLs, such as...
```
get "repositories/:slug_or_id" => 'repositories#show'
get "subjects/:slug_or_id" => 'subjects#show'
```
...so I have added another test for `AppConfig[:use_human_readable_urls]` in application_controller.rb to prevent those triggering unnecessary database lookups either.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
