### PR TITLE
fixing mismatch between docker-compose & ./proxy/Dockerfile ARG

### DIFF
--- a/docker-compose-dist.yml
+++ b/docker-compose-dist.yml
@@ -40,7 +40,7 @@ services:
     container_name: as_dist_proxy
     build:
       args:
-        default: default.conf.dist
+        DEFAULT_CFG: default.conf.dist
       context: ./proxy
     image: archivesspace/proxy-dist:1.21
     ports:

--- a/docker-compose-release.yml
+++ b/docker-compose-release.yml
@@ -34,7 +34,7 @@ services:
     container_name: as_release_proxy
     build:
       args:
-        default: default.conf.release
+        DEFAULT_CFG: default.conf.release
       context: ./proxy
     image: archivesspace/proxy-release:1.21
     ports:


### PR DESCRIPTION
The file ./proxy/Dockerfile holds an ARG "DEFAULT_CFG"

The files ./docker-compose-release.yml and ./docker-compose-dist.yml have been passing an arg to that Dockerfile above.  But the name of the ARG they are sending is "default" instead of "DEFAULT_CFG".

As such, the Dockerfile will always use "ARG DEFAULT_CFG=default.conf" 
  when running "docker compose -f docker-compose-release.yml build" or
  when running "docker-compose -f docker-compose-dist.yml build".
Those docker-compose seem to intend to use "./proxy/default.conf.release" and "./proxy/default.conf.dist" respectively.

Either that Dockerfile or docker-compose*.yml files can be changed so that the ARG is successfully passed.
This pull request chooses the second option, but either is valid.
