### PR TITLE
Fix agents plugin support in staff interface

### DIFF
--- a/frontend/app/helpers/plugin_helper.rb
+++ b/frontend/app/helpers/plugin_helper.rb
@@ -49,7 +49,8 @@ module PluginHelper
 
       result << render_aspace_partial(:partial => "shared/subrecord_form",
                        :locals => {:form => context, :name => parent['name'],
-                         :cardinality => parent['cardinality'].intern, :plugin => true})
+                         :cardinality => parent['cardinality'].intern, :plugin => true,
+                                   :section_id => "#{jsonmodel_type}_#{parent['name']}_"})
 
     end
 

--- a/frontend/app/views/agents/_form.html.erb
+++ b/frontend/app/views/agents/_form.html.erb
@@ -137,6 +137,6 @@
     </section>
   <% end %>
 
-  <%= form_plugins_for("agent", form) %>
+  <%= form_plugins_for(@agent.agent_type.to_s, form) %>
 
 </fieldset>

--- a/frontend/app/views/agents/_form_required.html.erb
+++ b/frontend/app/views/agents/_form_required.html.erb
@@ -65,6 +65,6 @@
 
   <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_resources", help_topic: "agent_resources", type: :agent_resource, field_names: ["linked_agent_role", "linked_resource", "linked_resource_description", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute",  "last_verified_date"] } %>
 
-  <%= form_plugins_for("agent", form) %>
+  <%= form_plugins_for(@agent.agent_type.to_s, form) %>
 
 </fieldset>

--- a/frontend/config/initializers/plugin.rb
+++ b/frontend/config/initializers/plugin.rb
@@ -12,7 +12,16 @@ module Plugins
 
       config_path = File.join(plugin_dir, 'config.yml')
       if File.exist?(config_path)
-        @config[:plugin][plugin] = cfg = YAML.load_file config_path
+        cfg = YAML.load_file config_path
+        # If "agent" has been specified in config.yml as a "parent", expand that to all agent-types
+        if agent_parent = cfg['parents']['agent']
+          cfg['parents']['agent_person'] ||= agent_parent
+          cfg['parents']['agent_family'] ||= agent_parent
+          cfg['parents']['agent_corporate_entity'] ||= agent_parent
+          cfg['parents']['agent_software'] ||= agent_parent
+          cfg['parents'].delete('agent')
+        end
+        @config[:plugin][plugin] = cfg
         @config[:system_menu_items] << cfg['system_menu_controller'] if cfg['system_menu_controller']
         @config[:repository_menu_items] << cfg['repository_menu_controller'] if cfg['repository_menu_controller']
         (cfg['parents'] || {}).keys.each do |parent|


### PR DESCRIPTION
## Description
This addresses the following problems I have encountered while developing a plug-in that adds new sections to agent forms in the staff interface:

 * If you add individual agent types (e.g. "agent_person") to the "parents" list in the plug-in's config.yml, that adds new sections in read-only mode, and links in the sidebar, but the new sections are missing in edit mode.
 * If you add "agent" to the "parents" list in config.yml, then new sections are added to edit mode, but they don't appear in the sidebar or read-only mode.
 * You can work around this by adding both to config.yml, but the sidebar links don't jump to the new sections.
 * That workaround also means plug-ins cannot add sections to only some of the agent types, or different ones to different types.

To fix this, I have changed the calls to `form_plugins_for` in the edit mode template (and the template for editing defaults) so they send the specific agent type being displayed. That takes care of the first two points above. Then passing the `section_id` parameter to the template that renders sections of the form makes it consistent with the links in the sidebar. Finally, I have modified the code that reads config.yml, so that adding "agent" to the "parents" list is equivalent to including all the individual agent types. So any plug-ins that have used that will continue to work, as will the workaround mentioned above, or developers can choose to only add sections to one agent type.

## Related JIRA Ticket or GitHub Issue
None

## How Has This Been Tested?
As this involves interactions with a plug-in, it cannot be tested with automated tests, or someone testing an out-of-the-box system, so I have ensured that all the following scenarios work: 
| Parents in config.yml | Displays in edit mode | Displays in read-only mode | Displays in sidebar | Sidebar link works |
|--------|--------|--------|--------|--------|
| agent_person | Y | Y | Y | Y |
| agent | Y | Y | Y | Y |
| Both agent_person and agent | Y | Y | Y | Y |

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
