### PR TITLE
Add EAD export hooks to allow plugins to add extra information in child elements of origination and controlaccess

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -401,6 +401,7 @@ class EADSerializer < ASpaceExport::Serializer
 
           xml.send(node_name, atts) {
             sanitize_mixed_content(sort_name, xml, fragments )
+            EADSerializer.run_serialize_step(agent, xml, fragments, node_name.to_sym)
           }
         }
       end
@@ -410,15 +411,17 @@ class EADSerializer < ASpaceExport::Serializer
   def serialize_controlaccess(data, xml, fragments)
     if (data.controlaccess_subjects.length + data.controlaccess_linked_agents(@include_unpublished).length) > 0
       xml.controlaccess {
-        data.controlaccess_subjects.each do |node_data|
+        data.controlaccess_subjects.zip(data.subjects).each do |node_data, subject|
           xml.send(node_data[:node_name], node_data[:atts]) {
             sanitize_mixed_content( node_data[:content], xml, fragments, ASpaceExport::Utils.include_p?(node_data[:node_name]) )
+            EADSerializer.run_serialize_step(subject['_resolved'], xml, fragments, node_data[:node_name].to_sym)
           }
         end
 
-        data.controlaccess_linked_agents(@include_unpublished).each do |node_data|
+        data.controlaccess_linked_agents(@include_unpublished).zip(data.linked_agents).each do |node_data, agent|
           xml.send(node_data[:node_name], node_data[:atts]) {
             sanitize_mixed_content( node_data[:content], xml, fragments, ASpaceExport::Utils.include_p?(node_data[:node_name]) )
+            EADSerializer.run_serialize_step(agent['_resolved'], xml, fragments, node_data[:node_name].to_sym)
           }
         end
       } #</controlaccess>

--- a/backend/app/exporters/serializers/ead3.rb
+++ b/backend/app/exporters/serializers/ead3.rb
@@ -1121,6 +1121,7 @@ class EAD3Serializer < EADSerializer
           xml.send(node_name, atts) {
             xml.part() {
               sanitize_mixed_content(sort_name, xml, fragments )
+              EAD3Serializer.run_serialize_step(agent, xml, fragments, node_name.to_sym)
             }
           }
         }
@@ -1259,7 +1260,7 @@ class EAD3Serializer < EADSerializer
     if (data.controlaccess_subjects.length + data.controlaccess_linked_agents(@include_unpublished).length) > 0
       xml.controlaccess {
 
-        data.controlaccess_subjects.each do |node_data|
+        data.controlaccess_subjects.zip(data.subjects).each do |node_data, subject|
 
           if node_data[:atts]['authfilenumber']
             node_data[:atts]['identifier'] = node_data[:atts]['authfilenumber'].clone
@@ -1269,11 +1270,12 @@ class EAD3Serializer < EADSerializer
           xml.send(node_data[:node_name], node_data[:atts]) {
             xml.part() {
               sanitize_mixed_content( node_data[:content], xml, fragments, ASpaceExport::Utils.include_p?(node_data[:node_name]) )
+              EAD3Serializer.run_serialize_step(subject['_resolved'], xml, fragments, node_data[:node_name].to_sym)
             }
           }
         end
 
-        data.controlaccess_linked_agents(@include_unpublished).each do |node_data|
+        data.controlaccess_linked_agents(@include_unpublished).zip(data.linked_agents).each do |node_data, agent|
 
           if node_data[:atts][:role]
             node_data[:atts][:relator] = node_data[:atts][:role]
@@ -1288,6 +1290,7 @@ class EAD3Serializer < EADSerializer
           xml.send(node_data[:node_name], node_data[:atts]) {
             xml.part() {
               sanitize_mixed_content( node_data[:content], xml, fragments, ASpaceExport::Utils.include_p?(node_data[:node_name]) )
+              EAD3Serializer.run_serialize_step(agent['_resolved'], xml, fragments, node_data[:node_name].to_sym)
             }
           }
         end


### PR DESCRIPTION
## Description
This enhances the ability of plug-in developers to customize the EAD exporter, but adding hooks to allow extra information to be added to children of origination and controlaccess (e.g. persname, subject, etc.)

## Related JIRA Ticket or GitHub Issue
None

## How Has This Been Tested?
Unless you install a plug-in that makes use of these new hooks, these changes will have no effect. So, it cannot be tested with automated tests, nor by someone testing an out-of-the-box system. But I have been able to use it for my use-case (adding extptr linking to authority URLs.) 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
