### PR TITLE
ANW-1477 Password reset fixes/updates

### DIFF
--- a/backend/app/controllers/users.rb
+++ b/backend/app/controllers/users.rb
@@ -81,7 +81,7 @@ class ArchivesSpaceService < Sinatra::Base
   end
 
 
-  Endpoint.post('/users/recover-password')
+  Endpoint.post('/users/reset-password')
     .description("Initiate a password reset process by sending a one-time token to the user")
     .params(["email", String, "The requestor's email address"])
     .permissions([])

--- a/backend/app/lib/user_mailer.rb
+++ b/backend/app/lib/user_mailer.rb
@@ -13,7 +13,7 @@ class UserMailer < ActionMailer::Base
 
   def headers
     delivery_method = ActionMailer::Base.delivery_method
-    { delivery_method: delivery_method, to: @user.email, from: AppConfig[:global_email_from_address], subject: I18n.t('user.recover_password') }
+    { delivery_method: delivery_method, to: @user.email, from: AppConfig[:global_email_from_address], subject: I18n.t('user.reset_password') }
   end
 
   # It's unfortunate that this is necessary, but being that the backend is not a Rails app,

--- a/backend/app/lib/user_mailer.rb
+++ b/backend/app/lib/user_mailer.rb
@@ -1,6 +1,12 @@
 require 'action_mailer'
+require 'java'
 
 class UserMailer < ActionMailer::Base
+
+  def initialize
+    super
+    update_view_path
+  end
 
   class MailError < StandardError
   end
@@ -10,8 +16,20 @@ class UserMailer < ActionMailer::Base
     { delivery_method: delivery_method, to: @user.email, from: AppConfig[:global_email_from_address], subject: I18n.t('user.recover_password') }
   end
 
+  # It's unfortunate that this is necessary, but being that the backend is not a Rails app,
+  # ActionMailer will need help finding view templates.
+  def update_view_path
+    view_path = File.join(ASUtils.find_base_directory, 'backend', 'app', 'views')
+
+    # above method does not work when running in Jetty
+    unless File.exist?(view_path)
+      view_path = File.join('app', 'views')
+    end
+
+    self.append_view_path(view_path)
+  end
+
   def send_reset_token(username, token)
-    self.append_view_path(File.join(ASUtils.find_base_directory, 'backend', 'app', 'views'))
     @user = User.first(username: username)
     @magic_link = AppConfig[:frontend_url] + "/users/#{username}/#{token}"
 

--- a/backend/spec/controller_user_spec.rb
+++ b/backend/spec/controller_user_spec.rb
@@ -267,7 +267,7 @@ describe 'User controller' do
 
     it "emails a user a token when they lose their password" do
       count = ActionMailer::Base.deliveries.count
-      post "/users/recover-password", email: user.email
+      post "/users/reset-password", email: user.email
       expect(last_response).to be_ok
       expect(ActionMailer::Base.deliveries.count).to eq(count+1)
       msg = ActionMailer::Base.deliveries.last
@@ -295,7 +295,7 @@ describe 'User controller' do
 
     it "returns a 400 error if password reset is not configured" do
       allow(AppConfig).to receive(:[]).with(:allow_password_reset).and_return(false)
-      post "/users/recover-password", email: user.email
+      post "/users/reset-password", email: user.email
       expect(last_response.status).to eq(400)
     end
   end

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -2249,7 +2249,7 @@ en:
     admin: Administrator
     _singular: User
     _plural: Users
-    recover_password: Recover Password
+    reset_password: Reset Password
 
   collection_management: &collection_management_attributes
     cataloged_note: Cataloged Note

--- a/frontend/app/controllers/users_controller.rb
+++ b/frontend/app/controllers/users_controller.rb
@@ -217,11 +217,11 @@ class UsersController < ApplicationController
 
   def recover_password
     if !AppConfig[:allow_password_reset]
-      flash[:error] = I18n.t("user._frontend.messages.password_recovery_not_allowed", email: params.fetch(:email))
+      flash[:error] = I18n.t("user._frontend.messages.password_reset_not_allowed", email: params.fetch(:email))
     else
       result = User.recover_password(params.fetch(:email, nil))
-      if result[:status] == :success
-        flash[:success] = I18n.t("user._frontend.messages.password_recovery_email_sent", email: params.fetch(:email))
+      if result[:status] == :success || result[:status] == :not_found
+        flash[:success] = I18n.t("user._frontend.messages.password_reset_email_sent", email: params.fetch(:email))
       else
         flash[:error] = result[:error]
       end

--- a/frontend/app/views/users/password_form.html.erb
+++ b/frontend/app/views/users/password_form.html.erb
@@ -3,19 +3,19 @@
 <div class="row">
   <% if !session[:user] %>
   <div class="col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-0 col-lg-4 lg-min-w-450px p30px">
-    <h2><%= I18n.t "login.recover_password" %></h2>
+    <h2><%= I18n.t "login.reset_password" %></h2>
     <%= I18n.t "login.reset_form_instructions" %>
   </div>
   <div class="col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-0 col-lg-4 md-mt20px p30px">
     <%= render_aspace_partial :partial => "shared/flash_messages" %>
     <main class="well" id="login-form-wrapper">
-      <h3 class="mt0"><%= I18n.t "login.recover_password" %></h3>
+      <h3 class="mt0"><%= I18n.t "login.reset_password" %></h3>
 
       <%= form_tag({controller: "users", action: "recover_password"}, method: "post") do %>
       <div class="form-group">
         <input id="user_email" type="text" name="email" size="30" placeholder="<%= I18n.t "login.email_placeholder" %>" class="form-control" aria-label="<%= I18n.t "login.email_placeholder" %>"/>
       </div>
-      <input class="btn btn-primary navbar-btn btn-default" type="submit" name="commit" value="<%= I18n.t("login.recover_password") %>" id="submit" />
+      <input class="btn btn-primary navbar-btn btn-default" type="submit" name="commit" value="<%= I18n.t("login.reset_password") %>" id="submit" />
       <% end %>
 
     </main>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1379,10 +1379,10 @@ en:
         deactivated: User deactivated
         error_activate: User not activated
         error_deactivate: User not deactivated
-        password_recovery_email_sent: An email has been sent to %{email} with instructions for recovering your password
+        password_reset_email_sent: If an account for %{email} exists, an email with instructions for resetting your password will be sent.
         error_not_found: A username account for %{email} could not be found. Contact your administrator for help.
-        password_recovery_not_allowed: Password Recovery is not allowed. Contact your administrator.
-        password_recovery_fail: Password Recovery failed. Contact your administrator.
+        password_reset_not_allowed: Password Recovery is not allowed. Contact your administrator.
+        password_reset_fail: Password Recovery failed. Contact your administrator.
       section:
         manage_access: Manage User Access
         account: Account


### PR DESCRIPTION
This addresses an issue and discussion on #2979

The view path setup for ActionMailer was not correct for release builds running on Jetty (via archivesspace.sh). This should take care of that. We now don't indicate to the user that an email address was not found for password reset, instead stating that if the account exists, and email will be sent. Also removes "recover" terminology in favor of "reset" for clarity/consistency.