### PR TITLE
Use frontend proxy url for password reset

### DIFF
--- a/backend/app/lib/user_mailer.rb
+++ b/backend/app/lib/user_mailer.rb
@@ -31,7 +31,7 @@ class UserMailer < ActionMailer::Base
 
   def send_reset_token(username, token)
     @user = User.first(username: username)
-    @magic_link = AppConfig[:frontend_url] + "/users/#{username}/#{token}"
+    @magic_link = AppConfig[:frontend_proxy_url] + "/users/#{username}/#{token}"
 
     begin
       msg = mail headers do |format|


### PR DESCRIPTION
By default it is equivalent to frontend_url but is more typically used to record the proxy addressable url that a user uses to access the staff ui in line with the config.rb and tech docs recommendation:

- https://archivesspace.github.io/tech-docs/provisioning/https.html
- https://archivesspace.github.io/tech-docs/provisioning/prefix.html

Without this, when using a proxy (url) with the default frontend_url, you'll receive a reset link like:

http://localhost:8080/users/$USERNAME/$TOKEN

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
