### PR TITLE
Fix frontend plugin initializer

### DIFF
--- a/frontend/config/initializers/plugin.rb
+++ b/frontend/config/initializers/plugin.rb
@@ -14,7 +14,8 @@ module Plugins
       if File.exist?(config_path)
         cfg = YAML.load_file config_path
         # If "agent" has been specified in config.yml as a "parent", expand that to all agent-types
-        if agent_parent = cfg['parents']['agent']
+        if cfg.dig('parents', 'agent')
+          agent_parent = cfg['parents']['agent']
           cfg['parents']['agent_person'] ||= agent_parent
           cfg['parents']['agent_family'] ||= agent_parent
           cfg['parents']['agent_corporate_entity'] ||= agent_parent


### PR DESCRIPTION
Don't assume plugin config.yml has a parent key as it's not required (and for example lcnaf does not).

## To replicate

Do something like:

```bash
git clone --recurse-submodules https://github.com/archivesspace/archivesspace aspace-with-submodules
cd aspace-with-submodules
./build/run build-dist
```

## How Has This Been Tested?

As above and locally updated the `hello_world` example plugin to test the conditions (no `parents` and with `parents.agent`).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
