### PR TITLE
Fix route not found for password reset

### DIFF
--- a/docker-compose-fake-smtp.yml
+++ b/docker-compose-fake-smtp.yml
@@ -1,0 +1,25 @@
+# Run a fake smtp server:
+# docker-compose -f docker-compose-fake-smtp.yml up --detach
+
+# Config for fake smtp:
+
+# AppConfig[:email_delivery_method] = :smtp
+# AppConfig[:email_smtp_settings] = {
+#      address:              'localhost',
+#      port:                 1025,
+#      domain:               'foobar.com',
+#      user_name:            'hello',
+#      password:             'goodbye',
+#      openssl_verify_mode:  'none'
+# }
+# AppConfig[:email_perform_deliveries] = true
+# AppConfig[:email_raise_delivery_errors] = true
+# AppConfig[:allow_password_reset] = true
+
+services:
+  mail:
+    container_name: fake_smtp_server
+    image: reachfive/fake-smtp-server
+    ports:
+      - "1025:1025"
+      - "1080:1080"

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -43,7 +43,7 @@ ArchivesSpace::Application.routes.draw do
     match 'users/:id/delete' => 'users#delete', :via => [:post]
     match('/users/:id/activate' => 'users#activate', :via => [:get], :as => :user_activate)
     match('/users/:id/deactivate' => 'users#deactivate', :via => [:get], :as => :user_deactivate)
-    match 'users/:username/:token' => 'session#token_login', :via => [:get]
+    match 'users/:username/:token' => 'session#token_login', :via => [:get], constraints: { username: /[^\/]+/ }
 
     resources :users
 


### PR DESCRIPTION
Usernames containing periods get a 404.

There's a good explanation here:

https://prathamesh.tech/2020/06/15/allowing-dots-in-rails-routes/

For testing, without the PR, start the dev servers and visit:

http://localhost:3000/users/username/123456789 - ok, redirected to error

When the username contains a period (for example, an email address):

http://localhost:3000/users/my.email@example.org/123456789 - 404, routing not working

With the PR, for the latter you'll get the error (for the non-existing user) but routing is working.

An alternative implementation would be to `Base64.urlsafe_encode64(username)` on the way out and `Base64.urlsafe_decode64(username)` on the way in (as is being done during the authentication process).

I've also included the fake-smtp compose file previously referenced by Brian Hoffman, it's very useful for testing.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
