### PR TITLE
ANW-1820 Softserv PUI fixes

### DIFF
--- a/public/app/assets/javascripts/handle_accordion.js
+++ b/public/app/assets/javascripts/handle_accordion.js
@@ -18,7 +18,7 @@ function initialize_accordion(what, ex_text, col_text, expand_all) {
       $(what)
         .parents('.acc_holder')
         .prepend(
-          "<a  class='btn btn-primary btn-sm acc_button' role='button' ></a>"
+          "<a  class='btn btn-primary acc_button mb-2' role='button' ></a>"
         );
     }
     expandAllByDefault(what, expand_all);

--- a/public/app/assets/javascripts/resizable_sidebar.js
+++ b/public/app/assets/javascripts/resizable_sidebar.js
@@ -50,8 +50,16 @@ ResizableSidebar.prototype.bind_events = function () {
       var new_content_width = Math.max(self.$row.width() - right_offset, 300);
 
       self.$sidebar.css('width', 0);
-      self.$content_pane.css('width', new_content_width);
-      self.$sidebar.css('width', self.$row.width() - new_content_width - 20);
+      self.$content_pane.css('max-width', new_content_width);
+      self.$content_pane.css('flex-basis', new_content_width);
+      self.$sidebar.css(
+        'max-width',
+        self.$row.width() - new_content_width - 20
+      );
+      self.$sidebar.css(
+        'flex-basis',
+        self.$row.width() - new_content_width - 20
+      );
 
       // position the infinite scrollbar too, if it's about
       if ($('.infinite-record-scrollbar').length > 0) {
@@ -65,7 +73,7 @@ ResizableSidebar.prototype.bind_events = function () {
       self.isResizing = false;
     });
 
-  // ANW-1316: Make resizable input slider work with keyboard commands alone
+  // ANW-1323: Make resizable input slider work with keyboard commands alone
   $(document)
     .on('keydown', function (e) {
       if (!self.isResizing) {
@@ -83,8 +91,10 @@ ResizableSidebar.prototype.bind_events = function () {
       var new_content_width = Math.max(self.$row.width() - right_offset, 300);
 
       self.$sidebar.css('width', 0);
-      self.$content_pane.css('width', new_content_width);
-      self.$sidebar.css('width', self.$row.width() - new_content_width);
+      self.$content_pane.css('max-width', new_content_width);
+      self.$content_pane.css('flex-basis', new_content_width);
+      self.$sidebar.css('max-width', self.$row.width() - new_content_width);
+      self.$sidebar.css('flex-basis', self.$row.width() - new_content_width);
 
       // position the infinite scrollbar too, if it's about
       if ($('.infinite-record-scrollbar').length > 0) {

--- a/public/app/assets/javascripts/smart_staff_links.js
+++ b/public/app/assets/javascripts/smart_staff_links.js
@@ -23,18 +23,13 @@ $(function () {
     .done(function (data) {
       if (data === true) {
         var staff = $('#staff-link');
-        link =
-          FRONTEND_URL +
-          '/resolve/' +
-          STAFF_LINK_MODE +
-          '?uri=' +
-          RECORD_URI +
-          '&autoselect_repo=true';
+        const link = `${FRONTEND_URL}/resolve/${STAFF_LINK_MODE}?uri=${RECORD_URI}&autoselect_repo=true`;
         staff.attr('href', link);
-        staff.removeClass('hide');
+        staff.removeClass('d-none');
 
+        // staff-hidden aka hidden from non-staff users
         var staff_hidden = $('.staff-hidden');
-        staff_hidden.removeClass('hide');
+        staff_hidden.removeClass('d-none');
       }
     })
     .fail(function () {

--- a/public/app/assets/stylesheets/application.scss
+++ b/public/app/assets/stylesheets/application.scss
@@ -20,7 +20,6 @@
 @import 'archivesspace/colors';
 @import 'archivesspace/variables';
 
-// "bootstrap-sprockets" must be imported before "bootstrap" and "bootstrap/variables"
 @import 'bootstrap';
 
 // font-awesome

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -108,7 +108,6 @@ a img {
 
 .tabbing.nav-pills > li > a {
   margin-bottom: 0;
-  margin-left: -10px;
   margin-right: 0;
   background-color: $secondary-color;
   color: $white;
@@ -140,10 +139,12 @@ a img {
   border-top-left-radius: 0;
 }
 
-.tabbing.nav-pills > li > a.disabled-nav-pill:hover {
-  color: #333;
-  background-color: transparent;
-  cursor: default;
+.tabbing.nav-pills > li.nav-item.disabled > a.nav-link:hover,
+.tabbing.nav-pills > li.nav-item.disabled > a.nav-link:focus {
+  color:#777;
+  text-decoration:none;
+  background-color:transparent;
+  cursor:not-allowed;
 }
 
 /* this enables customization of the nav bar. h/t to zessx (http://stackoverflow.com/users/1238019/zessx)
@@ -258,11 +259,6 @@ a img {
   &.small-8 {
     padding-right: rem-calc(20);
   }
-}
-
-#main-content.accessions,
-#main-content.objects {
-  padding: 0 1em;
 }
 
 #sidebar {
@@ -383,7 +379,8 @@ a img {
 .recordrow {
   padding: rem-calc(10);
   border: 1px solid $border;
-  margin-bottom: rem-calc(10);
+  border-radius: var(--bootstrap-rounded-border-radius);
+  margin-bottom: 1rem;
 
   &.featured {
     background-color: $row-background;
@@ -787,8 +784,6 @@ i.giant {
   display: block;
   min-width: 200px;
   max-width: 100%;
-  border-top-right-radius: var(--bootstrap-rounded-corner-radius);
-  border-top-left-radius: var(--bootstrap-rounded-corner-radius);
 }
 .objectimage figcaption,
 .additional-file-version figcaption {
@@ -797,9 +792,6 @@ i.giant {
 .objectimage button[type='submit'] {
   width: 100%;
   white-space: normal;
-}
-.objectimage a.view-all {
-  padding-left: 0.5rem;
 }
 
 @media (min-width: 500px) {
@@ -826,7 +818,7 @@ i.giant {
   margin-bottom: 20px;
   padding: var(--bootstrap-horizontal-white-space-unit);
   border: 1px solid $lightblue;
-  border-radius: var(--bootstrap-rounded-corner-radius);
+  border-radius: var(--bootstrap-rounded-border-radius);
   background-color: #fff;
   text-align: center;
 }
@@ -841,7 +833,7 @@ i.giant {
   margin-bottom: 0;
   padding: 6px 12px;
   border: 1px solid $lightblue;
-  border-radius: var(--bootstrap-rounded-corner-radius);
+  border-radius: var(--bootstrap-rounded-border-radius);
   font-size: 14px;
   font-family: var(--bootstrap-sans);
   font-weight: normal;
@@ -891,6 +883,7 @@ span.head {
 }
 
 .breadcrumb > li + li::before {
+  padding-left: .625rem;
   color: $darkest;
   content: '\007C\00a0';
 }
@@ -922,11 +915,6 @@ span.head {
   padding-left: 20px;
 }
 
-#sidebar form {
-  max-width: 85%;
-  margin: 0 auto;
-}
-
 .panel-heading {
   word-break: break-word;
   white-space: normal;
@@ -950,7 +938,7 @@ span.head {
 @media (min-width: 992px) {
   #sidebar.resizable-sidebar {
     position: relative;
-    padding-left: 12px;
+    padding-left: 18px; // margin-right (10) + handle width (8)
 
     .resizable-sidebar-handle {
       background-color: #eee;
@@ -1043,7 +1031,7 @@ span.head {
     width: 25%;
   }
   .resizable-content-pane {
-    width: 75%;
+    width: 100%;
     @media (min-width: 992px) {
       flex: 1;
     }

--- a/public/app/assets/stylesheets/archivesspace/helpers.scss
+++ b/public/app/assets/stylesheets/archivesspace/helpers.scss
@@ -3,11 +3,20 @@
  */
 :root {
   --bootstrap-horizontal-white-space-unit: 15px;
-  --bootstrap-rounded-corner-radius: 4px;
+  --bootstrap-rounded-border-radius: 0.25rem;
   --bootstrap-sans: 'Helvetica Neue', helvetica, arial, sans-serif;
   --bootstrap-default-white-hover: #eee;
   --bootstrap-default-card-heading-bg-color: #f5f5f5;
+  --bootstrap-4-col-horizontal-padding: 15px;
   --default-border-color: #ccc;
+}
+
+.min-h-screen {
+  min-height: 100dvh;
+}
+
+.h-max {
+  height: max-content;
 }
 
 .flex {
@@ -46,11 +55,28 @@
   padding-bottom: 0.5rem;
 }
 
+.px-bs {
+  padding-right: var(--bootstrap-4-col-horizontal-padding);
+  padding-left: var(--bootstrap-horizontal-white-space-unit);
+}
+
+.gap-2 {
+  gap: 0.5rem;
+}
+
+.gap-x-3 {
+  column-gap: 1rem;
+}
+
 .rounded-bottom {
-  border-bottom-left-radius: var(--bootstrap-rounded-corner-radius);
-  border-bottom-right-radius: var(--bootstrap-rounded-corner-radius);
+  border-bottom-left-radius: var(--bootstrap-rounded-border-radius);
+  border-bottom-right-radius: var(--bootstrap-rounded-border-radius);
 }
 
 .bg-lightgray {
   background-color: var(--bootstrap-default-card-heading-bg-color);
+}
+
+.border-top-default {
+  border-top: 1px solid var(--default-border-color);
 }

--- a/public/app/assets/stylesheets/archivesspace/result-representative-file-version.scss
+++ b/public/app/assets/stylesheets/archivesspace/result-representative-file-version.scss
@@ -25,6 +25,7 @@
   width: var(--result-repfv-figure-width);
   margin-right: 1rem;
   border: 1px solid var(--default-border-color);
+  border-radius: var(--bootstrap-rounded-border-radius);
 }
 
 .result-repfv__img {
@@ -38,5 +39,6 @@
   padding: 0.5rem;
   font-size: 12px;
   background-color: var(--bootstrap-default-card-heading-bg-color);
+  border-radius: var(--bootstrap-rounded-border-radius);
   overflow: hidden;
 }

--- a/public/app/views/accessions/show.html.erb
+++ b/public/app/views/accessions/show.html.erb
@@ -1,15 +1,19 @@
-<div id="main-content" class="row accessions">
+<div id="main-content" class="accessions">
 
-  <div class="row" id="info_row">
-    <div class="information col-sm-7">
+  <div class="d-flex" id="info_row">
+    <section class="information flex-grow-1">
       <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %>
-    </div>
-    <div class="page_actions col-sm-5 right">
+    </section>
+    <section class="page_actions">
       <%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %>
-    </div>
+    </section>
   </div>
 
-  <%= render partial: 'shared/breadcrumbs' %>
+  <section class="row">
+    <div class="information w-100">
+      <%= render partial: 'shared/breadcrumbs' %>
+    </div>
+  </section>
 
   <div class="col-sm-9">
 

--- a/public/app/views/agents/show.html.erb
+++ b/public/app/views/agents/show.html.erb
@@ -2,15 +2,14 @@
 
 <div id="main-content" class="agents">
 
-  <div class="row" id="info_row">
-    <div class="information col-sm-7">
+  <div class="d-flex" id="info_row">
+    <div class="information flex-grow-1">
       <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %>
     </div>
-    <div class="page_actions col-sm-5 right">
+    <div class="page_actions">
       <%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %>
     </div>
   </div>
-
 
 <div class="row">
   <div class="col-sm-9">
@@ -33,8 +32,9 @@
     <%= render partial: 'shared/results', locals: {:results => @results, :pager => @pager} %>
   </div>
 
+  <div class="col-sm-3 align-self-start">
   <% if show_agents_sidebar?(@result) %>
-    <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
+    <div id="sidebar" class="sidebar sidebar-container">
       <h3><%= t('more_about') %> '<%= @result.display_string %>'</h3>
       <div class="acc_holder clear" >
         <div class="panel-group" id="agent_accordion">
@@ -71,5 +71,6 @@
   <% if !@facets.blank? || !@filters.blank? %>
     <%= render partial: 'shared/facets' %>
   <% end %>
+  </div>
   </div>
 </div>

--- a/public/app/views/cite/_modal_body.html.erb
+++ b/public/app/views/cite/_modal_body.html.erb
@@ -1,18 +1,18 @@
-<section class="panel panel-default mt15px">
-  <header class="panel-heading">
-    <h3 class="panel-title"><%= I18n.t("actions.cite_item") %></h3>
+<section class="card">
+  <header class="card-header">
+    <h3 class="card-title mb-0"><%= I18n.t("actions.cite_item") %></h3>
   </header>
-  <div class="panel-body flex align-items-center">
-    <p id="item_citation" class="flex-grow-1 mr15px mb0"><%= item %></p>
-    <button type="button" id="copy_item_citation" class="btn btn-primary clip-btn" data-clipboard-target="#item_citation" aria-label="<%= I18n.t("actions.cilpboard_cite_item") %>"><%= I18n.t("actions.clipboard") %></button>
+  <div class="card-body d-flex align-items-center gap-x-3">
+    <p id="item_citation" class="flex-grow-1 mb-0"><%= item %></p>
+    <button type="button" id="copy_item_citation" class="btn btn-primary flex-shrink-0 clip-btn" data-clipboard-target="#item_citation" aria-label="<%= I18n.t("actions.cilpboard_cite_item") %>"><%= I18n.t("actions.clipboard") %></button>
   </div>
 </section>
-<section class="panel panel-default">
-  <header class="panel-heading">
-    <h3 class="panel-title"><%= I18n.t("actions.cite_item_description") %></h3>
+<section class="card mt-3">
+  <header class="card-header">
+    <h3 class="card-title mb-0"><%= I18n.t("actions.cite_item_description") %></h3>
   </header>
-  <div class="panel-body flex align-items-center">
-    <p id="item_description_citation" class="flex-grow-1 mr15px mb0"><%= description %></p>
-    <button type="button" id="copy_item_description_citation" class="btn btn-primary clip-btn" data-clipboard-target="#item_description_citation" aria-label="<%= I18n.t("actions.cilpboard_cite_item_description") %>"><%= I18n.t("actions.clipboard") %></button>
+  <div class="card-body d-flex align-items-center gap-x-3">
+    <p id="item_description_citation" class="flex-grow-1 mb-0"><%= description %></p>
+    <button type="button" id="copy_item_description_citation" class="btn btn-primary flex-shrink-0 clip-btn" data-clipboard-target="#item_description_citation" aria-label="<%= I18n.t("actions.cilpboard_cite_item_description") %>"><%= I18n.t("actions.clipboard") %></button>
   </div>
 </section>

--- a/public/app/views/classifications/show.html.erb
+++ b/public/app/views/classifications/show.html.erb
@@ -1,27 +1,26 @@
 <div id="main-content" class="classifications">
-  <div class="row">
-    <div class="information col-sm-7">
+  <div class="d-flex">
+    <div class="information flex-grow-1">
       <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %>
     </div>
-    <div class="page_actions col-sm-5 right">
+    <div class="page_actions">
       <%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %>
     </div>
   </div>
-    <div class="row">
-      <div class="information col-sm-12">
+  <div class="row">
+    <div class="information w-100">
       <%= render partial: 'shared/breadcrumbs' %>
-      <div class="description"><%= @result.description %></div>
+      <div class="description px-3"><%= @result.description %></div>
       <% if @result.creator %>
-      <div class="creator clear">
-        <span class="inline-label clear">
-          <%= t('classification.creator') %>: </span>
+        <div class="creator clear">
+          <span class="inline-label clear"><%= t('classification.creator') %>: </span>
           <%= link_to @result.creator.display_string, app_prefix(@result.creator.uri) %>
-      </div>
+        </div>
       <% end %>
     </div>
   </div>
   <div class="row">
-    <div class="col-sm-9">
+    <div class="col-sm-9<%= (@has_children ? ' resizable-content-pane' : '') %>">
       <% unless @results.blank? || @results['total_hits'] == 0 %>
         <h2><%= t('found', {:count => @results['total_hits'], :type => @results['total_hits'] == 1? t('coll_obj._singular') : t('coll_obj._plural')}) %>:</h2>
         <% @results.records.each do |result| %>

--- a/public/app/views/containers/show.html.erb
+++ b/public/app/views/containers/show.html.erb
@@ -1,16 +1,16 @@
 <div id="main-content" class="containers">
-<div class="row">
-  <div class="information col-sm-7">
+<div class="d-flex">
+  <div class="information flex-grow-1">
     <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %>
   </div>
-  <div class="page_actions col-sm-5 right">
+  <div class="page_actions">
     <%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %>
   </div>
 </div>
 <div class="row">
   <div class="col-sm-9">
 
-    <div class="staff-hidden hide">
+    <div class="staff-hidden d-none">
       <% if @result['json']['restricted'] %>
         <p><h4 class='restricted'><%= I18n.t('top_container.restricted') %></h4></p>
       <% end %>

--- a/public/app/views/layouts/application.html.erb
+++ b/public/app/views/layouts/application.html.erb
@@ -40,7 +40,7 @@
 <![endif]-->
 </head>
 
-<body>
+<body class="min-h-screen d-flex flex-column">
 
 	<% ASUtils.find_local_directories('public/views/body_top.html.erb').each do |template| %>
 		<% if File.exists?(template) %>
@@ -57,7 +57,7 @@
 		<%= render partial: 'shared/navigation' %>
 	</div>
 
-	<section id="content" class="container-fluid mt-2 pt-2">
+	<section id="content" class="container-fluid mt-2 pt-2 flex-grow-1">
 		<a name="maincontent" id="maincontent"></a>
 		<%= flash_messages %>
 		<%= yield %>

--- a/public/app/views/objects/show.html.erb
+++ b/public/app/views/objects/show.html.erb
@@ -1,15 +1,19 @@
 <a name="main" title="<%= t('internal_links.main') %>"></a>
-<div id="main-content" class="row objects">
-  <div class="row" id="info_row">
-    <div class="information col-sm-7">
+<div id="main-content" class="objects">
+  <div class="d-flex" id="info_row">
+    <div class="information flex-grow-1">
       <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %>
     </div>
-    <div class="page_actions col-sm-5 right">
+    <div class="page_actions">
     <%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath, :cite => @result.cite } %>
     </div>
   </div>
 
-   <%= render partial: 'shared/breadcrumbs' %>
+  <section class="row">
+    <div class="information w-100">
+      <%= render partial: 'shared/breadcrumbs' %>
+    </div>
+  </section>
 
   <div class="row" id="notes_row">
    <div class="col-sm-9">

--- a/public/app/views/repositories/_repository.html.erb
+++ b/public/app/views/repositories/_repository.html.erb
@@ -12,7 +12,7 @@
 		<% end %>
 	</div>
 	<%= (full ? '</h1>' : '</h2>').html_safe %>
-	<div class="row">
+	<div class="row mx-0">
 		<div class="badge-and-identifier text-center text-sm-left">
 			<div class="d-flex flex-wrap">
 				<div class="record-type-badge repository col-12">

--- a/public/app/views/repositories/index.html.erb
+++ b/public/app/views/repositories/index.html.erb
@@ -1,12 +1,10 @@
 <div class="row">
-<div class="col-sm-9">
-<h2><%= @search_data['total_hits'] %> <%= (@search_data['total_hits'] == 1 ? t('repository._singular'): t('repository._plural')) %></h2>
-
-<%= render partial: 'shared/pagination', locals: {:pager => @pager} %>
-<% @json.each do |result| %>
-<%= render partial: 'repositories/repository', locals: {:result => result, :full => false} %>
-
-<% end %>
-<%= render partial: 'shared/pagination', locals: {:pager => @pager} %>
-</div>
+  <div class="col-sm-9">
+    <h2><%= @search_data['total_hits'] %> <%= (@search_data['total_hits'] == 1 ? t('repository._singular'): t('repository._plural')) %></h2>
+    <%= render partial: 'shared/pagination', locals: {:pager => @pager} %>
+    <% @json.each do |result| %>
+      <%= render partial: 'repositories/repository', locals: {:result => result, :full => false} %>
+    <% end %>
+    <%= render partial: 'shared/pagination', locals: {:pager => @pager} %>
+  </div>
 </div>

--- a/public/app/views/resources/_resource_tab.erb
+++ b/public/app/views/resources/_resource_tab.erb
@@ -1,6 +1,6 @@
 <% active = (action.to_s == controller.action_name) %>
 <% unless hidden && !active %>
-  <li class="nav-item" <% unless enabled %>class="disabled"<% end %>>
+  <li class="<%= enabled ? 'nav-item' : 'nav-item disabled' %>">
   	<% case action
   		 when :show
          url = app_prefix("/repositories/#{params[:rid]}/resources/#{params[:id]}")

--- a/public/app/views/resources/digitized.html.erb
+++ b/public/app/views/resources/digitized.html.erb
@@ -15,7 +15,7 @@
 
 <%= render partial: 'resources/resource_alltabs' %>
 
-<div class="row">
+<div class="row mt-3">
   <div class="col-sm-9">
     <% unless @results.blank? || @results['total_hits'] == 0 %>
       <% @results.records.each do |result| %>

--- a/public/app/views/resources/inventory.html.erb
+++ b/public/app/views/resources/inventory.html.erb
@@ -15,7 +15,7 @@
 
 <%= render partial: 'resources/resource_alltabs' %>
 
-<div class="row">
+<div class="row mt-3">
   <div class="col-sm-9">
     <% unless @results.blank? || @results['total_hits'] == 0 %>
       <% @results.records.each do |result| %>

--- a/public/app/views/resources/show.html.erb
+++ b/public/app/views/resources/show.html.erb
@@ -1,15 +1,17 @@
 <a name="main" title="<%= t('internal_links.main') %>"></a>
 <div id="main-content" class="row">
-  <div id="info_row">
-  <% unless defined?(@no_statement) || !defined?(@search) %>
-  <div class="searchstatement"><%= @search[:search_statement].html_safe %></div>
-  <% end %>
-  </div>
-    <div class="information col-12 col-lg-6">
+  <div id="info_row" class="col-12">
+    <% unless defined?(@no_statement) || !defined?(@search) %>
+      <div class="searchstatement"><%= @search[:search_statement].html_safe %></div>
+    <% end %>
+    <div class="d-flex flex-column flex-md-row">
+      <div class="information flex-grow-1">
         <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %>
+      </div>
+      <div class="page_actions">
+        <%= render partial: 'shared/page_actions', locals: {:record => @result, :title =>  @result.display_string, :url => request.fullpath, :cite => @result.cite } %>
+      </div>
     </div>
-  <div class="page_actions col-12 col-lg-6">
-    <%= render partial: 'shared/page_actions', locals: {:record => @result, :title =>  @result.display_string, :url => request.fullpath, :cite => @result.cite } %>
   </div>
 </div>
 <div class="row">
@@ -18,8 +20,8 @@
 
 <%= render partial: 'resources/resource_alltabs' %>
 
-<div class="row mt-5" id="notes_row">
-  <div class="resizable-content-pane">
+<div class="row mt-5 flex-column flex-lg-row" id="notes_row">
+  <div class="col-12 col-lg-9 px-3 resizable-content-pane">
     <%= render partial: 'shared/digital', locals: {
       :dig_objs => @dig,
       record: @result,
@@ -27,7 +29,7 @@
     } %>
     <%= render partial: 'shared/record_innards' %>
   </div>
-  <div id="sidebar" class="col-sm-3 sidebar sidebar-container resizable-sidebar" <% unless @has_children %>style="display: none"<% end %>>
+  <div id="sidebar" class="h-max col-12 col-lg-3 sidebar sidebar-container resizable-sidebar" <% unless @has_children %>style="display: none"<% end %>>
     <% if defined?(@filters) && defined?(@search) %>
     <%= render partial: 'shared/facets' %>
    <% end %>

--- a/public/app/views/search/search_results.html.erb
+++ b/public/app/views/search/search_results.html.erb
@@ -63,10 +63,16 @@
   <div class="col-sm-9">
     <a name="main" title="<%= t('internal_links.main') %>"></a>
     <div class="row my-3">
-      <div class="col-sm-8">
-        <%= render partial: 'shared/pagination', locals: {:pager  => @pager}  %>
+      <div class="w-100 px-bs d-flex flex-wrap justify-content-end gap-2">
+        <% unless @pager.last_page == 1 %>
+          <div class="flex-grow-1">
+            <%= render partial: 'shared/pagination', locals: {:pager  => @pager}  %>
+          </div>
+        <% end %>
+        <div>
+          <%= render partial: 'shared/sorter' %>
+        </div>
       </div>
-      <%= render partial: 'shared/sorter' %>
     </div>
     <div class="row search-results"><div class="col-sm-12">
 
@@ -76,7 +82,7 @@
       <%= render partial: 'shared/result', locals: {:result => result, :props => (@result_props || {}).merge({:full => false})} %>
     <% end %>
     </div></div>
-    <div class="row"><div class="col-sm-9">
+    <div class="row mt-2"><div class="col-sm-12">
     <%= render partial: 'shared/pagination', locals: {:pager  => @pager, :pager_id => 'paging_bottom'}  %>
     </div></div>
   </div>

--- a/public/app/views/shared/_accordion_panel.html.erb
+++ b/public/app/views/shared/_accordion_panel.html.erb
@@ -1,7 +1,7 @@
 <% if !p_body.strip.blank? %>
   <div class="card">
     <div class="card-header">
-      <h2 class="card-title">
+      <h2 class="card-title mb-0">
         <a class="accordion-toggle" data-toggle="collapse"  href="#<%= p_id %>" aria-expanded="true">
           <%= p_title %>
         </a>

--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -1,29 +1,29 @@
 <% if record['json']['representative_file_version'].present? %>
 <div class="available-digital-objects">
   <div class="objectimage">
-    <div class="panel panel-default">
+    <div class="card">
       <%
         rfv = record['json']['representative_file_version']
         img_uri = rfv['file_uri']
         a_uri = rfv['derived_from'] || rfv['link_uri']
+        dig_materials_link = nil
+
+        if representative_link_to_digital_materials?(record)
+          digitized_link_text = t(
+            'digital_object._public.browse_number_digital_objects_in_collection',
+            num: n_digital_objects
+          )
+          dig_materials_link = link_to digitized_link_text,
+            app_prefix("/repositories/#{params[:rid]}/resources/#{params[:id]}/digitized"),
+            data: { 'view-all-digital-objects' => true }
+        end
       %>
       <%= render partial: 'shared/representative_file_version_record', locals: {
         :a_uri => a_uri,
         :img_uri => img_uri,
-        :caption => rfv['caption']
+        :caption => rfv['caption'],
+        :dig_materials_link => dig_materials_link
       } %>
-      <% if representative_link_to_digital_materials?(record) %>
-        <% digitized_link_text = t(
-          'digital_object._public.browse_number_digital_objects_in_collection',
-          num: n_digital_objects
-        ) %>
-        <p class="mb0 pb1 rounded-bottom bg-lightgray">
-          <%= link_to digitized_link_text,
-              app_prefix("/repositories/#{params[:rid]}/resources/#{params[:id]}/digitized"),
-              class: 'view-all'
-          %>
-        </p>
-      <% end %>
     </div>
   </div>
 </div>

--- a/public/app/views/shared/_footer.html.erb
+++ b/public/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
-<div class="container-fluid panel-footer">
+<div class="container-fluid panel-footer p-3 bg-lightgray border-top-default">
   <div class="row">
      <div class="col-md-12">
-       <p class="footer-items"><%= I18n.t("footer.staff_interface", staff_url: AppConfig[:frontend_proxy_url]).html_safe %>
+       <p class="footer-items mb-0"><%= I18n.t("footer.staff_interface", staff_url: AppConfig[:frontend_proxy_url]).html_safe %>
          | <%= I18n.t("footer.archivesspace_home").html_safe %>
          | <%= ASConstants.VERSION %>
          <% if AppConfig[:feedback_url] && !AppConfig[:feedback_url].blank? %> | <%= I18n.t("footer.feedback", :feedback_url => AppConfig[:feedback_url]).html_safe %><% end %></p>

--- a/public/app/views/shared/_modal.html.erb
+++ b/public/app/views/shared/_modal.html.erb
@@ -1,16 +1,22 @@
 <%# handles modals.  Requires: modal_id, title, modal_body %>
+<%
+  size_variant = ''
+  if local_assigns.has_key? :modal_size_class
+    size_variant = " #{modal_size_class}"
+  end
+%>
 <div class="modal fade" id="<%=modal_id %>" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="<%= modal_id%>Label">
-  <div class="modal-dialog">
+  <div class="modal-dialog<%= size_variant %>">
     <div class="modal-content">
       <header class="modal-header">
-        <button type="button" class="close" id="<%= modal_id %>_header_close" data-dismiss="modal" aria-label="<%= I18n.t("actions.close") %>">&times;</button>
         <h2 class="modal-title h3" id="<%= modal_id %>Label"><%= title %></h2>
+        <button type="button" class="close" id="<%= modal_id %>_header_close" data-dismiss="modal" aria-label="<%= I18n.t("actions.close") %>">&times;</button>
       </header>
       <div class="modal-body">
         <%= modal_body %>
       </div>
       <footer class="modal-footer">
-        <button type="button" class="btn btn-default" id="<%= modal_id %>_footer_close" data-dismiss="modal" aria-label="<%= I18n.t("actions.close") %>"><%= I18n.t("actions.close") %></button>
+        <button type="button" class="btn btn-secondary" id="<%= modal_id %>_footer_close" data-dismiss="modal" aria-label="<%= I18n.t("actions.close") %>"><%= I18n.t("actions.close") %></button>
         <% if title != t('actions.cite') %>
           <button type="button" class="btn btn-primary action-btn"></button>
         <% end %>

--- a/public/app/views/shared/_modal_actions.html.erb
+++ b/public/app/views/shared/_modal_actions.html.erb
@@ -1,11 +1,16 @@
 <%# shared modal(s) %>
 <% if @result.respond_to?(:cite) && @result.cite_item && @result.cite_item_description %>
   <% modal_body = render partial: 'cite/modal_body', locals: {:item => @result.cite_item, :description => @result.cite_item_description} %>
-  <%= render partial: 'shared/modal', locals: {:modal_id => 'cite_modal', :title => t('actions.cite'), :modal_body => modal_body} %>
+  <%= render partial: 'shared/modal', locals: {
+    :modal_id => 'cite_modal',
+    :modal_size_class => 'modal-lg',
+    :title => t('actions.cite'),
+    :modal_body => modal_body
+  } %>
 <script type ="text/javascript" >setupCite()</script>
 <% end %>
 <% if defined?(@request) && !@request.nil? %>
-   <% req = render partial: 'shared/request_form' %>
+  <% req = render partial: 'shared/request_form' %>
   <%= render partial: 'shared/modal', locals: {:modal_id => 'request_modal', :title => t('actions.request'),
       :modal_body => req } %>
 <script type ="text/javascript" >setupRequest("request_modal",  "<%= t('actions.request') %>")</script>

--- a/public/app/views/shared/_page_actions.html.erb
+++ b/public/app/views/shared/_page_actions.html.erb
@@ -1,34 +1,32 @@
-<div title="<%= t('page_actions')%>">
- <div class="row float-lg-right">
-    <% ASUtils.wrap($RECORD_PAGE_ACTIONS[record.primary_type]).each do |page_action| %>
-      <div class="col-6 col-md-3 large-badge text-center resource p-1">
-        <% if page_action.has_key?('erb_partial') %>
-          <%= render :partial => page_action.fetch('erb_partial'), :locals => { :record => record } %>
-        <% else %>
-          <% label = I18n.t(page_action.fetch('label'), :default => page_action.fetch('label')) %>
-          <% icon_class = page_action.fetch('icon') %>
-          <% icon = "<i class='fa fa-3x #{icon_class}'></i>" %>
-          <% link_content = "#{icon}<br>#{label}".html_safe %>
+<div title="<%= t('page_actions')%>" class="d-flex justify-content-end">
+  <% ASUtils.wrap($RECORD_PAGE_ACTIONS[record.primary_type]).each do |page_action| %>
+    <div class="large-badge text-center resource p-1">
+      <% if page_action.has_key?('erb_partial') %>
+        <%= render :partial => page_action.fetch('erb_partial'), :locals => { :record => record } %>
+      <% else %>
+        <% label = I18n.t(page_action.fetch('label'), :default => page_action.fetch('label')) %>
+        <% icon_class = page_action.fetch('icon') %>
+        <% icon = "<i class='fa fa-3x #{icon_class}'></i>" %>
+        <% link_content = "#{icon}<br>#{label}".html_safe %>
 
-          <% if page_action.has_key?('onclick_javascript') %>
-            <% javascript = page_action.fetch('onclick_javascript') %>
-            <%= link_to link_content, 'javascript:void(0);',
+        <% if page_action.has_key?('onclick_javascript') %>
+          <% javascript = page_action.fetch('onclick_javascript') %>
+          <%= link_to link_content, 'javascript:void(0);',
+                      :class => 'btn btn-default page_action',
+                      :title => label,
+                      :'data-title' =>  record.display_string,
+                      :'data-uri' =>  record.uri,
+                      :onclick => javascript %>
+        <% elsif page_action.has_key?('url_proc') %>
+            <% proc = page_action.fetch('url_proc') %>
+            <% url = proc.call(record) %>
+            <%= link_to link_content, url,
                         :class => 'btn btn-default page_action',
-                        :title => label,
-                        :'data-title' =>  record.display_string,
-                        :'data-uri' =>  record.uri,
-                        :onclick => javascript %>
-          <% elsif page_action.has_key?('url_proc') %>
-              <% proc = page_action.fetch('url_proc') %>
-              <% url = proc.call(record) %>
-              <%= link_to link_content, url,
-                          :class => 'btn btn-default page_action',
-                          :title => label %>
-          <% else %>
-            <!-- Nothing we can do for this action -->
-          <% end %>
+                        :title => label %>
+        <% else %>
+          <!-- Nothing we can do for this action -->
         <% end %>
-      </div>
-    <% end %>
- </div>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/public/app/views/shared/_pagination.html.erb
+++ b/public/app/views/shared/_pagination.html.erb
@@ -1,8 +1,7 @@
 <% pager_id ||= 'paging' %>
 <% if pager && pager.pages.last > 1 %>
-<div id="<%= pager_id %>">
-  
-  <ul class="pagination mb-0">
+<nav id="<%= pager_id %>" class="d-flex">
+  <ul class="pagination flex-wrap mb-0">
     <% if pager.need_prev %>
       <li class="previous page-item"><a class="page-link" href="<%= app_prefix(pager.link) %>&page=<%= pager.prev %>"><span aria-hidden="true">&larr;</span> <%= t 'actions.previous' %></a></li>
     <% end %>
@@ -20,6 +19,6 @@
     <% if pager.need_next %>
       <li class="next page-item"><a class="page-link"  href="<%= app_prefix(pager.link) %>&page=<%= pager.next %>"><%= t 'actions.next' %> <span aria-hidden="true">&rarr;</span></a></li>
     <% end %>
-</ul>
-</div>
+  </ul>
+</nav>
 <% end %>

--- a/public/app/views/shared/_record_innards.html.erb
+++ b/public/app/views/shared/_record_innards.html.erb
@@ -13,7 +13,7 @@
     <% end %>
 
     <% unless @result.dates.blank? %>
-      <h2 class="pt-4"><%= t('resource._public.dates') %></h2>
+      <h2><%= t('resource._public.dates') %></h2>
       <%= render partial: 'shared/dates', locals: {:dates => @result.dates} %>
     <% end %>
 
@@ -30,7 +30,7 @@
     <% end %>
 
     <% unless @result.extents.blank? %>
-      <h2 class="pt-4"><%= t('resource._public.extent') %></h2>
+      <h2><%= t('resource._public.extent') %></h2>
        <% @result.extents.each do |ext| %>
         <p class="extent"><%= inheritance(ext['_inherited']).html_safe %>
 	  <%= ext['display']%>
@@ -60,7 +60,7 @@
 </div>
 
     <div class="acc_holder clear" >
-      <div id="res_accordion">
+      <div id="res_accordion" class="accordion">
 	<% x = render partial: 'shared/multi_notes', locals: {:types => folder} %>
 	<% unless x.blank? %>
 	<%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('resource._public.additional'),

--- a/public/app/views/shared/_representative_file_version_record.html.erb
+++ b/public/app/views/shared/_representative_file_version_record.html.erb
@@ -1,15 +1,23 @@
-<figure data-rep-file-version-wrapper>
+<% add_figcaption = !caption.blank? || !dig_materials_link.blank? %>
+<figure class="mb-0" data-rep-file-version-wrapper>
   <% if a_uri %>
     <a href="<%= a_uri %>" target="new" title="<%= t('digital_object._public.link')%>">
   <% end %>
     <img
-      class="<%= caption.blank? ? 'rounded-bottom' : '' %>"
+      class="<%= add_figcaption ? '' : 'rounded-bottom' %>"
       src="<%= img_uri %>"
       alt="<%= caption.blank? ? '' : caption %>">
   <% if a_uri %>
     </a>
   <% end %>
-  <% unless caption.blank? %>
-    <figcaption class="bg-lightgray rounded-bottom"><%= caption %></figcaption>
+  <% if add_figcaption %>
+    <figcaption class="bg-lightgray rounded-bottom">
+      <% unless caption.blank? %>
+        <p class="mb-0"><%= caption %></p>
+      <% end %>
+      <% unless dig_materials_link.blank? %>
+        <p class="mb-0"><%= dig_materials_link %></p>
+      <% end %>
+    </figcaption>
   <% end %>
 </figure>

--- a/public/app/views/shared/_request_form.html.erb
+++ b/public/app/views/shared/_request_form.html.erb
@@ -1,29 +1,29 @@
 <%= form_tag(app_prefix("fill_request"), method: 'post', :id => 'request_form') do %>
   <%= render partial: 'shared/request_hiddens' %>
-  <div  id="request">
-    <div class="form-group required ">
+  <div id="request">
+    <div class="form-group required">
       <%= label_tag(:user_name, "#{t('request.user_name')} #{t('request.required')}" ,  :class => 'sr-only') %>
       <div class="input-group">
         <%= text_field_tag :user_name, nil, :placeholder => t('request.user_name'), :class => "form-control"%>
-        <div class="input-group-addon">
-          <span class="required aria-hidden"><%= t('request.required') %></span>
+        <div class="input-group-append">
+          <span class="input-group-text required"><%= t('request.required') %></span>
         </div>
       </div>
     </div>
-    <div class="form-group required ">
+    <div class="form-group required">
       <%= label_tag(:user_email, "#{t('request.user_email')} #{t('request.required')}",  :class => 'sr-only') %>
       <div class="input-group">
         <%= text_field_tag :user_email, nil, :type => 'email', :placeholder => t('request.user_email'), :class => 'form-control' %>
-        <div class="input-group-addon">
-          <span class="required aria-hidden"><%= t('request.required') %></span>
+        <div class="input-group-append">
+          <span class="input-group-text required"><%= t('request.required') %></span>
         </div>
       </div>
     </div>
-    <div class="form-group ">
+    <div class="form-group">
       <%= label_tag(:date, t('request.date'),  :class => 'sr-only') %>
       <%= text_field_tag :date, nil, :placeholder => t('request.date'), :class => 'form-control' %>
     </div>
-    <div class="form-group ">
+    <div class="form-group">
       <%= label_tag(:note, t('request.note'),  :class => 'sr-only') %>
       <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
     </div>

--- a/public/app/views/shared/_result_record_summary.html.erb
+++ b/public/app/views/shared/_result_record_summary.html.erb
@@ -52,7 +52,7 @@
     </div>
   <% end %>
 
-  <div class="staff-hidden hide">
+  <div class="staff-hidden d-none">
     <% if result['json']['restricted'] %>
       <p><h4 class='restricted'><%= I18n.t('top_container.restricted') %></h4></p>
     <% end %>

--- a/public/app/views/shared/_search_collection_form.html.erb
+++ b/public/app/views/shared/_search_collection_form.html.erb
@@ -1,7 +1,7 @@
 <a name="search" title="<%= t('internal_links.search_collection') %>"></a>
 <div class="search">
 
-  <%= form_tag(app_prefix("#{resource_uri}/search"), method: 'get', :class=> "form-horizontal container mx-0 mt-4 mb-5") do %>
+  <%= form_tag(app_prefix("#{resource_uri}/search"), method: 'get', :class=> "form-horizontal container mx-0 mb-5") do %>
 
     <div class="form-group row">
       <%= label_tag('filter_q0',
@@ -15,13 +15,13 @@
                          :class=> "form-control") %>
     </div>
 
-    <div class="form-group row">
+    <div class="form-group row gap-x-3">
       <%= hidden_field_tag('op[]','') %>
       <%= hidden_field_tag('field[]','') %>
       <%= hidden_field_tag('limit','') %>
       <%= hidden_field_tag('q[]','*') %>
 
-      <div class="col-md-6 year_from p-0 pr-md-1">
+      <div class="year_from p-0 flex-grow-1">
         <%= label_tag('filter_from_year', 
                       "#{t('search_results.filter.from_year')}", 
                       :class => 'sr-only') %>
@@ -34,7 +34,7 @@
                            :class=>"form-control") %>
       </div>
 
-      <div class="col-md-6 year_to p-0 pr-md-1">
+      <div class="year_to p-0 flex-grow-1">
         <%= label_tag('filter_to_year', 
                       "#{t('search_results.filter.to_year')}",
                       :class=> 'sr-only') %>
@@ -49,7 +49,9 @@
 
     </div>
 
-    <%= submit_tag(t('search-button.label'), :class=>'btn btn-primary btn-sm') %>
+    <div class="form-group row">
+      <%= submit_tag(t('search-button.label'), :class=>'btn btn-primary') %>
+    </div>
 
   <% end %>
 

--- a/public/app/views/shared/_sorter.html.erb
+++ b/public/app/views/shared/_sorter.html.erb
@@ -2,7 +2,7 @@
 <% if defined?(@sort) && defined?(@sort_opts) && defined?(@base_search) %>
 
 
-<div class="col-sm-4 text-right sorter d-flex align-items-center justify-content-end">
+<div class="sorter d-flex align-items-center justify-content-end">
  <%= form_tag(app_prefix("#{@base_search}"), method: 'get', :class=> "form-horizontal d-flex align-items-center justify-content-end") do %>
    <%= render partial: 'shared/hidden_params' %>
    <%= label_tag(:sort, "#{t('search_sorting.sort_by')}", :class=>'sr-only') %>

--- a/public/app/views/shared/_staff_link_action.html.erb
+++ b/public/app/views/shared/_staff_link_action.html.erb
@@ -1,5 +1,5 @@
 <% if AppConfig[:pui_enable_staff_link] %>
-    <a id="staff-link" href="#" class="btn btn-default hide" target="_blank">
+    <a id="staff-link" href="#" class="btn btn-default page_action staff d-none" target="_blank">
         <i class="fa fa-pencil fa-3x"></i>
         <br/>
         <%= t('actions.staff_link') %>

--- a/public/app/views/subjects/show.html.erb
+++ b/public/app/views/subjects/show.html.erb
@@ -7,7 +7,7 @@
       <%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %>
     </div>
   </div>
-  <div class="row">
+  <div class="row align-items-start">
     <div class="information col-sm-9">
       <div class="clear">
         <span class="inline-label clear"><%= t('enumeration_names.subject_source') %>: </span><%= t("enumerations.subject_source.#{@result['json']['source']}" ) %>

--- a/public/spec/controllers/resources_controller_spec.rb
+++ b/public/spec/controllers/resources_controller_spec.rb
@@ -154,7 +154,7 @@ describe ResourcesController, type: :controller do
       page.find(:css, 'figure[data-rep-file-version-wrapper] figcaption') do |fc|
         expect(fc.text).to have_content(@fv_caption)
       end
-      expect(response.body).to have_css(".objectimage a[class='view-all']")
+      expect(response.body).to have_css(".objectimage a[data-view-all-digital-objects]")
     end
   end
 


### PR DESCRIPTION
[ANW-1820](https://archivesspace.atlassian.net/browse/ANW-1820), which is a subtask of the larger Softserv upgrades branch of [ANW-1727](https://archivesspace.atlassian.net/browse/ANW-1727).

## Changes in this PR

- Breadcrumbs separator whitespace
- Staff only page action button and other hidden-from-non-staff-users elements
- Disabled pill buttons on a resource page
- Search collection widget whitespace external and internal
- Fix resize handle height on Collection Overview
- Fix missing resize handle on Colleciton Organization largetree
- Color consistency of headings and buttons
- Representative file version caption + link to browse all digital objects
- Accordion headers + expand/collapse all button
- Footer background color and whitespace; sticky footer when content is less than dynamic viewport height
- Misc whitespace (margins, padding, layout)
- Pagination responsiveness
- Subjects sidebar flex height and accordion
- Page actions alignment in multiple views
- Digital Objects `show` view
- Subjects `show` view
- Classifications `show` view
- Accessions `show` view
- Agents `show` view
- Citation modal
- Request modal
- Resizable sidebar functionality in Resource `show` and `infinite` views
- Lack of resizable handle in Resource `infinite` view

## Example screenshot of this PR

![ANW-1820 Resource show view](https://github.com/archivesspace/archivesspace/assets/3411019/ce28fc0e-8196-4bbe-8e4a-b72e9a972068)

[ANW-1820]: https://archivesspace.atlassian.net/browse/ANW-1820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-1727]: https://archivesspace.atlassian.net/browse/ANW-1727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ