### PR TITLE
Drop unique constraint on event refid

### DIFF
--- a/common/db/migrations/174_drop_event_refid_uniqueness.rb
+++ b/common/db/migrations/174_drop_event_refid_uniqueness.rb
@@ -1,0 +1,17 @@
+require_relative 'utils'
+
+Sequel.migration do
+
+  up do
+    # this is coded defensively in case fix was pre-applied
+    if self.indexes(:event).values.map { |x| x[:columns]}.include?([:refid])
+      alter_table(:event) do
+        drop_index :refid, name: 'refid'
+      end
+    end
+  end
+
+  down do
+  end
+
+end


### PR DESCRIPTION
A bit of a deep cut here. The refid field for the event record type isn't exposed in the UI. Therefore, if used at all it would be through the api. The problem is if it is used (which came up for us recently) and the event is part of a transfer that requires the cloning event behavior (generating multiple records) then the transfer will fail owing to the uniqueness constraint.

Two options:

1. This PR, drops the constraint. It's very, very unlikely to be significant, given how buried the field is and if used via the api the use case is open to interpretation anyway (should it be unique or not). This also seems to conform better and be more consistent with the "expected" behavior around events (being a transactional more than curated record type).
2. Provide special handling of the refid field in the transferable mixin. This isn't ideal because the mixin is mostly clean in terms of not handling table/field specific requirements currently and it's generally preferable to keep things that way. Also it requires changing data which is always difficult to do in a way that is universally agreed upon.

* Note I did also look into scoping the constraint to `[:repo_id, :refid]`, but that doesn't work in the clone case when > 1 clone is being created in the destination repository (in that case special handling would be required and the data would need to be modified one way or another).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
