### PR TITLE
Make dockerfile db migrate conditional

### DIFF
--- a/.env.docker.release
+++ b/.env.docker.release
@@ -1,5 +1,6 @@
 # db config
 APPCONFIG_DB_URL='jdbc:mysql://db:3306/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123&useSSL=false&allowPublicKeyRetrieval=true'
+ASPACE_DB_MIGRATE=true
 # solr config
 APPCONFIG_SOLR_URL="http://solr:8983/solr/archivesspace"
 # proxy config (release testing only)

--- a/docker-compose-dist.yml
+++ b/docker-compose-dist.yml
@@ -1,6 +1,6 @@
 # docker-compose -f docker-compose-dist.yml build
-# docker-compose -f docker-compose-dist.yml up -d db solr app # allow the migrations to run 1st or trouble
-# docker-compose -f docker-compose-dist.yml up # bring up everything else
+# docker-compose -f docker-compose-dist.yml up
+# docker compose -f docker-compose-dist.yml restart app2 # post migration restart app2 (or wait for healthcheck failure to kick in)
 
 version: '3.8'
 services:
@@ -10,6 +10,8 @@ services:
     depends_on:
       - db
       - solr
+    environment:
+      ASPACE_DB_MIGRATE: true
     env_file:
       - .env.docker.release
   app2:
@@ -18,6 +20,8 @@ services:
     depends_on:
       - db
       - solr
+    environment:
+      ASPACE_DB_MIGRATE: false # only run db migrations via app1
     env_file:
       - .env.docker.release
   db:

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -30,10 +30,12 @@ fi
 # clear out tmp pre-startup as it can build up if persisted
 rm -rf $DATA_TMP_DIR/*
 
-/archivesspace/scripts/setup-database.sh
-if [[ "$?" != 0 ]]; then
-  echo "Error running the database setup script."
-  exit 1
+if [ "$ASPACE_DB_MIGRATE" = true ]; then
+  /archivesspace/scripts/setup-database.sh
+  if [[ "$?" != 0 ]]; then
+    echo "Error running the database setup script."
+    exit 1
+  fi
 fi
 
 exec /archivesspace/archivesspace.sh


### PR DESCRIPTION
This enables running > 1 container instances safely (i.e. without overlapping and potentially conflicting db migrations).

Example is provided in docker-compose-dist.yml.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
