### PR TITLE
Use instance variable to speedup context cell (lookup ancestor titles)

### DIFF
--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -31,6 +31,8 @@ class ApplicationController < ActionController::Base
 
   before_action :unauthorised_access
 
+  before_action :init_ancestor_titles
+
   around_action :set_locale
 
   def self.permission_mappings
@@ -506,6 +508,11 @@ class ApplicationController < ActionController::Base
   def render_aspace_partial(args)
     defaults = {:formats => [:html], :handlers => [:erb]}
     return render(defaults.merge(args))
+  end
+
+
+  def init_ancestor_titles
+    @ancestor_titles = {}
   end
 
 

--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -325,7 +325,8 @@ module SearchHelper
     params.has_key?("deleted_uri") and Array(params["deleted_uri"]).include?(record["id"])
   end
 
-  def get_ancestor_title(field, titles)
+  def get_ancestor_title(field)
+    titles = @ancestor_titles
     return titles[field] if titles.key? field
 
     begin

--- a/frontend/app/views/search/_context_cell.html.erb
+++ b/frontend/app/views/search/_context_cell.html.erb
@@ -1,10 +1,9 @@
 <%
   ancestors = context_ancestor(record)
-  ancestor_titles = {}
 %>
 <% if ancestors != nil && ancestors != [''] %>
   <% ancestors.reverse.each_with_index do |ancestor, i| %>
-    <% title = get_ancestor_title(ancestor, ancestor_titles) %>
+    <% title = get_ancestor_title(ancestor) %>
     <% unless title.nil? %>
       <% if params['listing_only'] %>
         <%= title %>


### PR DESCRIPTION
This updates: https://github.com/archivesspace/archivesspace/pull/3025

Additional testing has been done to ensure the instance variable is valid in all views (hence initted in application controller).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
