### PR TITLE
ANW-312: restore original item order in PUI Finding Aid & Administrative Information section

### DIFF
--- a/public/app/views/resources/_finding_aid.html.erb
+++ b/public/app/views/resources/_finding_aid.html.erb
@@ -1,10 +1,15 @@
-<% order = %w(title subtitle author date description_rules language script language_note sponsor edition_statement series statement) %>
+<% order = %w(subtitle author date description_rules language script language_note sponsor edition_statement series statement) %>
 
 <% unless @result.finding_aid.blank? %>
   <% if @result.finding_aid.size > 1 || @result.finding_aid['revisions'].blank? %>
     <dl class="dl-horizontal-fa">
+      
+      <% unless @result.finding_aid['title'].blank? %>
+        <dt><%= t("resource._public.finding_aid.title") %></dt>
+        <dd><%= @result.finding_aid['title'] %></dd>
+      <% end %>
 
-        <%# ANW-312: finding aid status has a separate toggle that determines whether it is displayed %>
+       <%# ANW-312: finding aid status has a separate toggle that determines whether it is displayed %>
 
       <% unless @result.finding_aid['status'].blank? %>
         <% if @result.json['is_finding_aid_status_published'] %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
bug fix addressing the change item of order in the Finding Aid & Administrative Information section of the PUI introduced by adding the selectable status feature in ANW-312

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-312

## How Has This Been Tested?
Manual testing

## Screenshots (if appropriate):
![Screenshot_20231026_113731](https://github.com/archivesspace/archivesspace/assets/130926/6ff72631-c833-4604-8cc5-1774d12f9b93)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
