### PR TITLE
ANW-799: allow users with admin privs access to system_information page

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -756,3 +756,8 @@ AppConfig[:pui_pdf_title_line_height] = "140%"
 # Password recovery - requires email configuration
 # See example email configuration above
 AppConfig[:allow_password_reset] = false
+
+# Allow users with the 'administer_system' role to view the system_info route (e.g., FRONTEND_BASE_URL/system_info)
+# By default, this route is only accessible to the 'admin' user, and no other admins.
+
+AppConfig[:allow_other_admins_access_to_system_info] = false

--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -253,7 +253,11 @@ class ApplicationController < ActionController::Base
   end
 
   def user_is_global_admin?
-    session['user'] and session['user'] == "admin"
+    if AppConfig[:allow_other_admins_access_to_system_info]
+      session['user'] and user_can? 'administer_system'
+    else
+      session['user'] and session['user'] == "admin"
+    end
   end
 
 

--- a/frontend/spec/features/system_information_spec.rb
+++ b/frontend/spec/features/system_information_spec.rb
@@ -8,7 +8,7 @@ describe 'System Information', js: true do
   let!(:repository) { create(:repo, repo_code: "system_information_#{Time.now.to_i}") }
   let(:archivist_user) { create_user(repository => ['repository-archivists']) }
 
-  it 'should not let any old fool see this' do
+  it 'should not let an archivist user see this' do
     login_user(archivist_user)
     select_repository(repository)
 
@@ -17,12 +17,85 @@ describe 'System Information', js: true do
 
     visit '/system_info'
 
-    expect(page).to have_text 'Unable to Access Page'
-    expect(page).to have_text "The page you've tried to access may no longer exist or you may not have permission to view it."
+    element = find('.alert.alert-danger.with-hide-alert')
+    expect(element.text).to eq "Unable to Access Page\nThe page you've tried to access may no longer exist or you may not have permission to view it."
   end
 
   it 'should let the admin see this' do
     login_user(admin_user)
+    select_repository(repository)
+
+    click_on 'System'
+    click_on 'System Information'
+
+    expect(page).to have_text 'Frontend System Information'
+    expect(page).to have_text 'VERSION'
+    expect(page).to have_text 'APPCONFIG'
+    expect(page).to have_text 'MEMORY'
+    expect(page).to have_text 'CPU_COUNT'
+  end
+
+  it 'should not let a user with administer_system perrmissions see this if allow_other_admins_access_to_system_info is set to false' do
+    AppConfig[:allow_other_admins_access_to_system_info] = false
+
+    user_with_administer_system = create_user(repository => ['repository-archivists'])
+
+    login_user(admin_user)
+    select_repository(repository)
+
+    click_on 'System'
+    click_on 'Manage Users'
+
+    element = find('tr', text: user_with_administer_system.username)
+    within element do
+      click_on 'Edit'
+    end
+
+    expect(page).to have_text 'Edit Account'
+    find('#user_is_admin_').click
+    find('button', text: 'Update Account', match: :first).click
+
+    element = find('.alert.alert-success.with-hide-alert')
+    expect(element.text).to eq 'User Saved'
+
+    visit 'logout'
+
+    login_user(user_with_administer_system)
+    select_repository(repository)
+
+    click_on 'System'
+    click_on 'System Information'
+
+    element = find('.alert.alert-danger.with-hide-alert')
+    expect(element.text).to eq "Unable to Access Page\nThe page you've tried to access may no longer exist or you may not have permission to view it."
+  end
+
+  it 'should let a user with administer_system perrmissions see this if allow_other_admins_access_to_system_info is set to true' do
+    AppConfig[:allow_other_admins_access_to_system_info] = true
+
+    user_with_administer_system = create_user(repository => ['repository-archivists'])
+
+    login_user(admin_user)
+    select_repository(repository)
+
+    click_on 'System'
+    click_on 'Manage Users'
+
+    element = find('tr', text: user_with_administer_system.username)
+    within element do
+      click_on 'Edit'
+    end
+
+    expect(page).to have_text 'Edit Account'
+    find('#user_is_admin_').click
+    find('button', text: 'Update Account', match: :first).click
+
+    element = find('.alert.alert-success.with-hide-alert')
+    expect(element.text).to eq 'User Saved'
+
+    visit 'logout'
+
+    login_user(user_with_administer_system)
     select_repository(repository)
 
     click_on 'System'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow users with admin privs to access system_information page
## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-799

## How Has This Been Tested?
manual and unit testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
