### PR TITLE
ANW-1846: Relabel group permissions

### DIFF
--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -1895,45 +1895,41 @@ en:
       basic_data_entry: "Basic Data Entry users of the %{repo_code} repository"
       repository_viewers: "Viewers of the %{repo_code} repository"
     permission_types:
-      manage_repository: manage this repository (change groups and other settings)
-      update_location_record: create/modify/delete location records in this repository
-      update_subject_record: create/update subject records
-      update_agent_record: create/update agent records
-      view_agent_contact_record: view contact details for agent records
-      show_full_agents: work with agents in full mode
-      update_vocabulary_record: create/update vocabulary records
-      update_accession_record: create/update accessions in this repository
-      update_resource_record: create/update resources in this repository
-      update_digital_object_record: create/update digital objects in this repository
-      update_event_record: create/update event records in this repository
-      view_repository: view the records in this repository
-      view_suppressed: view suppressed records in this repository
-      suppress_archival_record: suppress the major record types in this repository
-      delete_archival_record: delete the major record types in this repository
-      delete_event_record: delete event records in this repository
-      update_classification_record: create/update classifications and classification terms
-      delete_classification_record: delete classifications and classification terms
-      merge_agents_and_subjects: merge agent/subject records
-      merge_archival_record: merge the major record types in this repository
-      manage_rde_templates: manage RDE templates
-      transfer_repository: transfer the entire contents of a repository
-      transfer_archival_record: transfer major record types between repositories
-      manage_subject_record: create/update/delete subject records
-      manage_agent_record: create/update/delete agent records
-      manage_vocabulary_record: create/update/delete vocabulary records
-      import_records: initiate import jobs
-      cancel_importer_job: cancel an import job
-      update_container_record: create/update top container records
-      manage_container_record: delete/bulk update top container records
-      manage_container_profile_record: create/update/delete container profile records
-      manage_location_profile_record: create/update/delete location profile records
-      create_job: create and run a background job
-      cancel_job: cancel a background job
-      update_assessment_record: create/update assessment records
-      delete_assessment_record: delete assessment records
-      manage_assessment_attributes: create/update/delete repository assessment attributes definitions
-      manage_enumeration_record: create/update/delete controlled value records
-      manage_custom_report_templates: manage custom report templates
+      manage_repository: assign <b>users</b> to groups (in this repository)<br/>set <b>group</b> permissions (in this repository)<br/>set <b>repository preferences</b> (in this repository)<br/>configure <b>required fields and default values</b> (in this repository)<br/>create and run <b>batch find and replace jobs</b> (in this repository)<br/>create/update/delete <b>locations</b> (system-wide) # required fields can only be set in staff interface for agents, and despite being global records the fields set as required only apply when user is in the same repository. there is also a preference that must be set before a user will get default values
+      view_agent_contact_record: edit/view contact details section of <b>agents</b> (in this repository)
+      show_full_agents: edit additional sections of <b>agents</b> enabled by full mode (in this repository)
+      update_accession_record: create/update <b>accessions</b> (in this repository)
+      update_resource_record: create/update <b>resources</b> (in this repository)
+      update_digital_object_record: create/update <b>digital objects</b> (in this repository)
+      update_event_record: create/update <b>events</b> (in this repository)
+      view_repository: view <b>all records</b> (in this repository)<br/>view <b>agents</b> (system-wide)<br/>view <b>subjects</b> (system-wide)
+      view_suppressed: view <b>suppressed records</b> (in this repository)
+      suppress_archival_record: suppress <b>accessions, archival objects and resources</b> (in this repository)
+      delete_archival_record: delete <b>accessions, archival objects, digital objects and resources</b> (in this repository)
+      delete_event_record: delete <b>events</b> (in this repository)
+      update_classification_record: create/update <b>classifications</b> (in this repository)
+      delete_classification_record: delete <b>classifications</b> (in this repository)
+      merge_agents_and_subjects: merge <b>agents</b> (system-wide)<br/>merge <b>subjects</b> (system-wide)
+      merge_archival_record: merge <b>digital objects</b> (in this repository)</br>merge <b>resources</b> (in this repository)
+      manage_rde_templates: create/delete <b>rapid data entry templates</b> (in this repository)
+      transfer_repository: transfer <b>the entire contents of this repository</b> to another repository (must also have the same permission in the destination repository)
+      transfer_archival_record: transfer individual <b>accessions, digital objects and resources</b> to another repository (must also have permission to create/update records of the type being transferred in both repositories)
+      manage_subject_record: create/update/delete <b>subjects</b> (system-wide)
+      manage_agent_record: create/update/delete <b>agents</b> (system-wide)
+      manage_vocabulary_record: create/update/delete <b>vocabularies</b> (system-wide)
+      import_records: create/run <b>import jobs</b> (in this repository)
+      cancel_importer_job: cancel <b>import jobs</b> (in this repository)
+      update_container_record: create/update <b>top containers</b> (in this repository)
+      manage_container_record: delete/bulk-update <b>top containers</b> (in this repository)
+      manage_container_profile_record: create/update/delete <b>container profiles</b> (system-wide)
+      manage_location_profile_record: create/update/delete <b>location profiles</b> (system-wide)
+      create_job: create/run <b>background jobs</b> (in this repository)
+      cancel_job: cancel <b>background jobs</b> (in this repository)
+      update_assessment_record: create/update <b>assessments</b> (in this repository)
+      delete_assessment_record: delete <b>assessments</b> (in this repository)
+      manage_assessment_attributes: create/update/delete <b>repository assessment attributes definitions</b> (in this repository)
+      manage_enumeration_record: create/update/delete <b>controlled values</b> (system-wide)
+      manage_custom_report_templates: create/update/delete <b>custom report templates</b> (in this repository)
     _singular: Group
     _plural: Groups
 

--- a/frontend/app/assets/stylesheets/archivesspace/form.less
+++ b/frontend/app/assets/stylesheets/archivesspace/form.less
@@ -921,3 +921,7 @@ div.btn-with-tooltip {
   max-width: fit-content;
   display: inline;
 }
+
+.permission-label {
+  height: auto;
+}

--- a/frontend/app/views/groups/_form.html.erb
+++ b/frontend/app/views/groups/_form.html.erb
@@ -40,7 +40,7 @@
             <% end %>
                    value="<%= permission.permission_code %>" />
           </span>
-          <label class="form-control" for="<%= permission.permission_code %>" disabled>
+          <label class="form-control permission-label" for="<%= permission.permission_code %>" disabled>
             <%= I18n.t("group.permission_types.#{permission.permission_code}", :default => permission.permission_code) %>
           </label>
         </div>

--- a/frontend/app/views/groups/_form.html.erb
+++ b/frontend/app/views/groups/_form.html.erb
@@ -29,19 +29,23 @@
   <fieldset>
     <legend class="control-label col-xs-2"><%= I18n.t("group.permissions") %></legend>
     <div class="col-xs-10">
-      <% JSONModel(:permission).all(:level => "repository").each do |permission| %>
+      <%
+        JSONModel(:permission).all(:level => "repository").map { |permission|
+          [permission.permission_code, I18n.t("group.permission_types.#{permission.permission_code}", :default => permission.permission_code)]
+        }.sort_by {|a| a[1]}.each do |permission_code, permission_label|
+      %>
         <div class="input-group">
           <span class="input-group-addon">
-            <input id="<%= permission.permission_code %>"
-                   name="group[grants_permissions][]"
-                   type="checkbox"
-            <% if @group.grants_permissions.include?(permission.permission_code) %>
-                   checked="checked"
-            <% end %>
-                   value="<%= permission.permission_code %>" />
+            <input id="<%= permission_code %>"
+               name="group[grants_permissions][]"
+               type="checkbox"
+               <% if @group.grants_permissions.include?(permission_code) %>
+                 checked="checked"
+               <% end %>
+               value="<%= permission_code %>" />
           </span>
-          <label class="form-control permission-label" for="<%= permission.permission_code %>" disabled>
-            <%= I18n.t("group.permission_types.#{permission.permission_code}", :default => permission.permission_code) %>
+          <label class="form-control permission-label" for="<%= permission_code %>" disabled>
+            <%= permission_label %>
           </label>
         </div>
       <% end %>


### PR DESCRIPTION
## Description
This implements my suggestions for making the descriptions of permissions more informative and consistent, so that system admins have a clearer understanding of what they are enabling user groups to do in each repository and/or system-wide.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1846

## How Has This Been Tested?
This is only relabelling the permissions, not changing what they do, so does not require extensive testing. Obviously there are usability, translation, and localization considerations before it could be merged. This is merely a proposal to start a discussion.

## Screenshots (if appropriate):
![screenshot_of_modified_permissions_in_group_edit_form](https://github.com/archivesspace/archivesspace/assets/33721187/a0785624-308f-445b-90f7-40e2344ea6d4)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
