### PR TITLE
ANW-1101 small fixes for top container mgmt column prefs

### DIFF
--- a/common/schemas/defaults.rb
+++ b/common/schemas/defaults.rb
@@ -23,6 +23,9 @@ column_opts.keys.each do |type|
   }
 end
 
+# this one is a special case
+browse_columns['top_container_mgmt_sort_column']['enum'].delete('score')
+
 {
   :schema => {
     "$schema" => "http://www.archivesspace.org/archivesspace.json",

--- a/frontend/app/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_results.html.erb
@@ -27,6 +27,7 @@
     <tr class="sortable-columns">
       <th><% if multiselect %><label for="select_all" class="sr-only"><%= I18n.t("search_results.selected") %></label><%= check_box_tag "select_all" %><% end %></th>
       <% @pref_cols.each do |field| %>
+        <% next if field == 'no_value' %>
         <th><%= t("search.top_container_mgmt.#{field}") %></th>
       <% end %>
       <% if show_edit_actions %>
@@ -49,6 +50,7 @@
           <% end %>
         </td>
         <% @pref_cols.each do |field| %>
+          <% next if field == 'no_value' %>
           <% if field == 'resource_accession'%>
             <td class="top-container-collection">
               <% if container_json['collection'].present? %>


### PR DESCRIPTION
Stops "no value" columns from showing up in top container management table, and stop "score" field from showing up in sort column options. (This is a special case because "top container management" is not actually a record type, so whatever is hiding that option in the other preference sections seems to not be applying to this one.)