### PR TITLE
Indexer efficiency improvements and fixes for side-effects of #3006

### DIFF
--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -14,6 +14,7 @@ require 'nokogiri'
 require 'axe-rspec'
 require 'jsonmodel'
 
+require_relative '../../indexer/app/lib/pui_indexer'
 require_relative '../../indexer/app/lib/realtime_indexer'
 require_relative '../../indexer/app/lib/periodic_indexer'
 

--- a/indexer/app/lib/pui_indexer.rb
+++ b/indexer/app/lib/pui_indexer.rb
@@ -104,9 +104,19 @@ class PUIIndexer < PeriodicIndexer
             end
           end
         end
-        doc['fullrecord'] = IndexerCommon.build_fullrecord(record)
+        build_fullrecord(doc, record)
       end
     }
+  end
+
+  def build_fullrecord(doc, record)
+    doc['fullrecord_published'] = IndexerCommon.extract_string_values(record['record'], :published_only)
+  end
+
+  def add_notes(doc, record)
+    if record['record']['notes']
+      doc['notes_published'] = IndexerCommon.extract_string_values(record['record']['notes'], :published_only)
+    end
   end
 
   def add_infscroll_docs(resource_uris, batch)

--- a/indexer/spec/indexer_common_spec.rb
+++ b/indexer/spec/indexer_common_spec.rb
@@ -30,19 +30,19 @@ describe "indexer common" do
       allow(IndexBatch).to receive(:new) { [] }
 
       allow(indexer).to receive(:index_batch) do |batch, timing = IndexerTiming.new, opts = {}|
-        fullrecord = batch.first['fullrecord']
-        expect(fullrecord).to include("5 wives")
+        fullrecord = batch.first['fullrecord'].join(' ')
+        expect(fullrecord).not_to include("5 wives")
         expect(fullrecord).to include("12 mistresses")
 
-        fullrecord_published = batch.first['fullrecord_published']
+        fullrecord_published = batch.first['fullrecord_published'].join(' ')
         expect(fullrecord_published).to include("5 wives")
         expect(fullrecord_published).not_to include("12 mistresses")
 
-        notes = batch.first['notes']
-        expect(notes).to include("5 wives")
+        notes = batch.first['notes'].join(' ')
+        expect(notes).not_to include("5 wives")
         expect(notes).to include("12 mistresses")
 
-        notes_published = batch.first['notes_published']
+        notes_published = batch.first['notes_published'].join(' ')
         expect(notes_published).to include("5 wives")
         expect(notes_published).not_to include("12 mistresses")
       end
@@ -63,7 +63,7 @@ describe "indexer common" do
     allow(IndexBatch).to receive(:new) { [] }
 
     allow(indexer).to receive(:index_batch) do |batch, timing = IndexerTiming.new, opts = {}|
-      fullrecord = batch.first['fullrecord']
+      fullrecord = (batch.first['fullrecord_published'] + batch.first['fullrecord']).join(' ')
       expect(fullrecord).to include(container_profile.notes)
     end
 

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -12,8 +12,9 @@
     <field name="types" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="primary_type" type="string" indexed="true" stored="true" multiValued="false" />
     <field name="repository" type="string" indexed="true" stored="true" multiValued="false" />
-    <field name="fullrecord" type="text_general" indexed="true" stored="false" multiValued="false" />
-    <field name="fullrecord_published" type="text_general" indexed="true" stored="false" multiValued="false" />
+    <field name="fullrecord" type="text_general" indexed="true" stored="false" multiValued="true" />
+    <field name="fullrecord_published" type="text_general" indexed="true" stored="false" multiValued="true" />
+    <copyField source="fullrecord_published" dest="fullrecord" />
     <field name="suppressed" type="boolean" indexed="true" stored="true" multiValued="false" />
     <field name="publish" type="boolean" indexed="true" stored="true" multiValued="false" />
     <field name="external_id" type="string" indexed="true" stored="true" multiValued="true" />
@@ -30,8 +31,9 @@
     <field name="related_agent_uris" type="string" indexed="true" stored="true" multiValued="true" />
     <!-- why are notes stored? (public app gets them from json for display) probably to support highlighting a long time ago -->
     <!-- https://github.com/archivesspace/archivesspace/commit/87b7270f11456e0db329c45404333a1ce68419b8 -->
-    <field name="notes" type="text_general" indexed="true" stored="true" multiValued="false" />
-    <field name="notes_published" type="text_general" indexed="true" stored="true" multiValued="false" />
+    <field name="notes" type="text_general" indexed="true" stored="true" multiValued="true" />
+    <field name="notes_published" type="text_general" indexed="true" stored="true" multiValued="true" />
+    <copyField source="notes_published" dest="notes" />
     <field name="years" type="int" indexed="true" stored="false" multiValued="true" />
     <field name="year_sort" type="sort_string" indexed="true" stored="false" multiValued="false" />
     <field name="dates" type="text_general" indexed="true" stored="true" multiValued="true" />


### PR DESCRIPTION
## Description
I have observed the following side-effects of #3006:

- Archival objects match keywords in their parent resource when searching in the PUI. That is because the PUI indexer retrieves ancestors in order to do inheritance of selected fields, but *all* the fields in those ancestors are now being included in the new “fullrecord_published” index.
- Indexing is slower, because each record is being scanned for fields to include in the new “fullrecord_published” and “notes_published” indexes. It only adds hundredths of a second per record, but for very large institutions that could add hours to a full re-index.

This pull request contains a possible approach to fixing these issues:

- Change the _extract_string_values_ method to extract both published and unpublished strings at the same time.
- Off-load the merging of published and unpublished in the "fullrecord" and "notes" fields to Solr, using copyField (which requires the fields be changed to multi-valued.)
- Do not call the _build_fullrecord_ field twice for the PUI indexer (only once, the hook defined in the PUIIndexer class, after the ancestor records of archival objects have been deleted.)
- Delete code in _build_fullrecord_ to add finding_aid_subtitle, finding_aid_author, and agents names, which do not appear to be necessary anymore (those fields are already included "fullrecord" index.)

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-261

## How Has This Been Tested?
Set stored attribute on the modified fields in solr/schema.xml and re-indexed with test data containing mixture of published and unpublished notes and records. All the unpublished text was restricted to "fullrecord" and "notes", and not in "fullrecord_published" and "notes_unpublished". Also "fullrecord_published" does not get text from ancestors. Finally, the time required for a full re-index has been reduced back to comparable time as before the changes in #3006.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
