### PR TITLE
Add variable substition to `solrconfig.xml` for `indexConfig`/`lockType` (#3088)

### DIFF
--- a/solr/solrconfig.xml
+++ b/solr/solrconfig.xml
@@ -56,4 +56,7 @@
     <defaultQuery>*:*</defaultQuery>
   </admin>
   <requestHandler name="/admin/luke" class="org.apache.solr.handler.admin.LukeRequestHandler" />
+  <indexConfig>
+    <lockType>${solr.lock.type:native}</lockType>
+  </indexConfig>
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This change allows for changing of the `lockType` setting in `solrconfig.xml` using the [`SOLR_OPTS` environment variable](https://solr.apache.org/guide/8_10/taking-solr-to-production.html#override-settings-in-solrconfig-xml) instead of modifying the `solrconfig.xml` file itself. While this does not change the default, it allows my team to use a different needed value (single) in our deployment environment without maintaining our own version of `solrconfig.xml`. See #3088 for more information.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
#3088

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- I started up the Solr service locally using `docker-compose-dev.yml` and I verified that the substitution variable was now present.
- I added the following to the `solr` blocks of `docker-compose-dev.yml` and confirm that substitutions work:
  ```
    environment:
      - SOLR_OPTS=$SOLR_OPTS -Dsolr.lock.type=single
  ```
- I ran the backend test suite with the configuration change, and saw no issues.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I tried my best to fill all this out. Please let me know if you want me to try anything else, make modifications, or provide more info.