### PR TITLE
Check index tmp file exists before mv

### DIFF
--- a/indexer/app/lib/index_state.rb
+++ b/indexer/app/lib/index_state.rb
@@ -19,7 +19,8 @@ class IndexState
       fh.puts(time.to_i)
     end
 
-    File.rename("#{path}.tmp", "#{path}.dat")
+    # check file exists for multi-instance deployment race condition
+    File.rename("#{path}.tmp", "#{path}.dat") if File.exist?("#{path}.tmp")
   end
 
 


### PR DESCRIPTION
This is a small step towards improving support for multi-instance deployments of ArchivesSpace. We need to check the file exists as one instance may already have processed the file before another attempts to act on it, creating a race condition.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
