### PR TITLE
Provide cfg to enable setting db pool timeout

### DIFF
--- a/backend/app/model/db.rb
+++ b/backend/app/model/db.rb
@@ -24,10 +24,11 @@ class DB
   class DBPool
     DATABASE_READ_ONLY_REGEX = /is read only|server is running with the --read-only option/
 
-    attr_reader :pool_size
+    attr_reader :pool_size, :pool_timeout
 
-    def initialize(pool_size = AppConfig[:db_max_connections], opts = {})
+    def initialize(pool_size = AppConfig[:db_max_connections], pool_timeout = AppConfig[:db_pool_timeout], opts = {})
       @pool_size = pool_size
+      @pool_timeout = pool_timeout
       @opts = opts
 
       @lock = Mutex.new
@@ -44,6 +45,7 @@ class DB
           Log.info("Connecting to database: #{AppConfig[:db_url_redacted]}. Max connections: #{pool_size}")
           pool = Sequel.connect(AppConfig[:db_url],
                                 :max_connections => pool_size,
+                                :pool_timeout => pool_timeout,
                                 :test => true,
                                 :loggers => (AppConfig[:db_debug_log] ? [Logger.new($stderr)] : [])
                                )

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -18,6 +18,7 @@ AppConfig[:db_url] = proc { AppConfig.demo_db_url }
 # Set the maximum number of database connections used by the application.
 # Default is derived from the number of indexer threads.
 AppConfig[:db_max_connections] = proc { 20 + (AppConfig[:indexer_thread_count] * 2) }
+AppConfig[:db_pool_timeout] = 5 # number of seconds to wait before raising a PoolTimeout error
 
 # The ArchivesSpace backend listens on port 8089 by default.  You can set it to
 # something else below.


### PR DESCRIPTION
In cases where the db pool becomes full it can be helpful in some cases to increase the pool timeout to give the db connections addtl. time to complete before throwing pool timeout errors.

The default timeout is 5 which preserves the current cfg / behavior.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
