### PR TITLE
ANW-1691 ANW-1771 fixes small extent calculator bugs

### DIFF
--- a/frontend/app/assets/javascripts/extent_calculator.js
+++ b/frontend/app/assets/javascripts/extent_calculator.js
@@ -10,7 +10,7 @@ $(function () {
           $('#extent_extent_type_').val()
         )
       ) {
-        alert('Please ensure that all required fields contain a value.');
+        alert($('#required_fields_alert_message').attr('message'));
         return;
       }
 

--- a/frontend/app/assets/javascripts/extent_calculator.js
+++ b/frontend/app/assets/javascripts/extent_calculator.js
@@ -1,13 +1,26 @@
 $(function () {
-  function ExtentCalculatorForm() {}
+  function ExtentCalculatorForm() { }
 
   ExtentCalculatorForm.prototype.init_form = function () {
     $('.create-extent-btn').on('click', function (event) {
+      if (
+        !(
+          $('#extent_portion_').val() &&
+          $('#extent_number_').val() &&
+          $('#extent_extent_type_').val()
+        )
+      ) {
+        alert('Please ensure that all required fields contain a value.');
+        return;
+      }
+
       var parent_id = '';
       if ($('#resource_extents_').length) {
         parent_id = '#resource_extents_';
       } else if ($('#accession_extents_').length) {
         parent_id = '#accession_extents_';
+      } else if ($('#archival_object_extents_').length) {
+        parent_id = '#archival_object_extents_';
       }
       $(parent_id + ' .subrecord-form-heading .btn').click();
 

--- a/frontend/app/assets/javascripts/extent_calculator.js
+++ b/frontend/app/assets/javascripts/extent_calculator.js
@@ -1,5 +1,5 @@
 $(function () {
-  function ExtentCalculatorForm() { }
+  function ExtentCalculatorForm() {}
 
   ExtentCalculatorForm.prototype.init_form = function () {
     $('.create-extent-btn').on('click', function (event) {

--- a/frontend/app/views/extent_calculator/_show_calculation.html.erb
+++ b/frontend/app/views/extent_calculator/_show_calculation.html.erb
@@ -1,4 +1,5 @@
 <div class="col-md-10 col-md-offset-1">
+  <span id="required_fields_alert_message" message="<%= t('extent_calculator.required_fields_alert_message') %>" />
   <div>
     <h3>
       <% if results['resource'] %>

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1839,6 +1839,7 @@ en:
     calculate_extent: Calculate Extent
     create_extent_record_message: Run the Extent Calculator in edit mode to have the option of creating an extent record based on the report.
     waiting_for_report_message: Calculating extent ...
+    required_fields_alert_message: Please ensure that all required fields contain a value.
     container_summary_type:
       _singular: container
       _plural: containers

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -1624,6 +1624,7 @@ ja:
     calculate_extent: エクステントの計算
     create_extent_record_message: エクステント電卓を編集モードで実行すると、レポートに基づいてエクステント・レコードを作成するオプションがあります。
     waiting_for_report_message: エクステントの計算...
+    required_fields_alert_message: 必須のフィールドを入力してください
     container_summary_type:
       _singular: コンテナ
       _plural: コンテナ

--- a/frontend/spec/selenium/spec/resources_spec.rb
+++ b/frontend/spec/selenium/spec/resources_spec.rb
@@ -762,10 +762,32 @@ describe 'Resources and archival objects' do
     @driver.find_element(:link, 'Calculate Extent').click
     sleep 1
 
+    @driver.find_element(id: 'extent_portion_').select_option('whole')
+    @driver.find_element(id: 'extent_number_').send_keys('1')
+    @driver.find_element(id: 'extent_extent_type_').select_option('linear_feet')
+
     @driver.find_element(:link, 'Create Extent').click
     sleep 1
 
     @driver.find_element(xpath: '//section[@id="resource_extents_"]//li[@data-index="1"]')
 
   end
+
+  it 'enforces required fields in extent calculator' do
+    @driver.get_edit_page(@resource)
+
+    @driver.find_element(id: 'other-dropdown').click
+    @driver.wait_for_dropdown
+
+    @driver.find_element(:link, 'Calculate Extent').click
+    sleep 1
+
+    @driver.find_element(id: 'extent_number_').clear
+
+    @driver.find_element(:link, 'Create Extent').click
+    sleep 1
+
+    expect { @driver.switch_to.alert }.not_to raise_error
+  end
+
 end

--- a/frontend/spec/selenium/spec/resources_spec.rb
+++ b/frontend/spec/selenium/spec/resources_spec.rb
@@ -788,6 +788,9 @@ describe 'Resources and archival objects' do
     sleep 1
 
     expect { @driver.switch_to.alert }.not_to raise_error
+
+    #make sure to close it so as not to interfere with other tests
+    @driver.switch_to.alert.accept
   end
 
 end


### PR DESCRIPTION
There were a couple of issues with the extent calculator "form" javascript. There were no checks to ensure required fields were filled in before creating the calculated extent, so they were added (ANW-1691) as well as a test for it.  It was also failing to recognize that it might be running on top on an archival object, so that check has been added in order to construct the appropriate selectors in that case (ANW-1771). Also had to update a test due to required fields being enforced.

