### PR TITLE
ANW-1848: PUI PDF tweaks

### DIFF
--- a/public/app/views/pdf/_resource.html.erb
+++ b/public/app/views/pdf/_resource.html.erb
@@ -21,7 +21,7 @@
     <dt><%= I18n.t('resource._public.identifier_pdf') %>:</dt><dd><%= record.identifier %></dd>
 
     <% if record['ark_name'] %> 
-      <dt><%= I18n.t('resource._public.identifier_ark') %>:</dt><dd><%= record['ark_name'].first %></dd>
+      <dt><%= I18n.t('resource._public.identifier_ark') %>:</dt><dd><a href='<%= record['ark_name'].first %>'>Archival Resource Key</a></dd>
 
     <% end %> 
 
@@ -46,6 +46,15 @@
 
     <% record.notes.each do |note_type, note| %>
         <% if note_type == 'physdesc' %>
+            <a id="note-<%= note_type %>"></a>
+            <% note.each do |n| %>
+              <dt><%= n['label'] ? n['label'] : I18n.t("enumerations._note_types.#{note_type}") %>:</dt><dd><%== process_mixed_content(n['note_text']) %></dd>
+            <% end %>
+        <% end %>
+    <% end %>
+
+    <% record.notes.each do |note_type, note| %>
+        <% if note_type == 'langmaterial' %>
             <a id="note-<%= note_type %>"></a>
             <% note.each do |n| %>
               <dt><%= n['label'] ? n['label'] : I18n.t("enumerations._note_types.#{note_type}") %>:</dt><dd><%== process_mixed_content(n['note_text']) %></dd>
@@ -211,13 +220,15 @@
   <% next if note_type == "scopecontent" %> 
   <% next if note_type == "relatedmaterial" %> 
   <% next if note_type == "odd" %> 
+  <% next if note_type == "arrangement" %> 
+  <% next if note_type == "prefercite" %> 
 
   <% record.notes[note_type].each do |n| %>
     <% next unless n['subnotes'] %>
     <% n['subnotes'].each do |sn| %>
       <% next unless sn['content'] %>
       <h4><%= I18n.t("enumerations._note_types.#{note_type}") %></h4>
-      <p><%= sn['content'] %></p>
+      <p><%= simple_format(sn['content']) %></p>
     <% end %>
   <% end %>
 <% end %>

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -263,8 +263,8 @@ en:
   context: Found in
   context_delimiter: "/"
   bulk:
-    _singular: "Majority of material found in %{dates}"
-    _plural: "Majority of material found within %{dates}"
+    _singular: "%{dates}"
+    _plural: "%{dates}"
 
   archive:
     _singular: The Archive

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -263,8 +263,8 @@ en:
   context: Found in
   context_delimiter: "/"
   bulk:
-    _singular: "%{dates}"
-    _plural: "%{dates}"
+    _singular: "Majority of material found in %{dates}"
+    _plural: "Majority of material found within %{dates}"
 
   archive:
     _singular: The Archive


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
PUI PDF tweaks/fixes for issues raised by testers: Specific Issues fixed:

- Arrangement note is duplicated in PUI PDF
- Preferred citation note is duplicated in PUI PDF. One is immediately after the abstract, and the other is above processing information
- ID [ark] is hyperlinked on SUI PDF whereas it appears as ark:/99999/1 on PUI PDF
- Date [bulk] has additional language in PUI PDF (e.g. “1998-2005” vs “Majority of material found within 1998-2005”)
- Language of material is in the SUI PDF, but not the PUI PDF.
- Line breaks are not retained in processing information note in PUI PDF (I’m guessing this is not isolated in the processing information note)

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1848

## How Has This Been Tested?
Manual testing using this record:
https://test.archivesspace.org/repositories/4/resources/11

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
