### PR TITLE
ANW-1887: upgrade github actions to use updated node

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - name: Cache gems directory
       id: cache-gems
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ runner.os }}-java${{ matrix.java }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         path: |
@@ -18,7 +18,7 @@ runs:
 
     - name: Cache mysql connector
       id: cache-mysql-connector
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ inputs.mysql-connector-url }}
         path: |

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -34,8 +34,8 @@ jobs:
           - 8984:8983
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
         distribution: temurin

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -35,9 +35,9 @@ jobs:
           - 8984:8983
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
         distribution: temurin

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: temurin
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: npm ci
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: npm ci
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -36,8 +36,8 @@ jobs:
           - 8984:8983
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
         distribution: temurin

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -17,8 +17,8 @@ jobs:
         java: [ 8, 11 ]
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
         distribution: temurin

--- a/.github/workflows/public.yml
+++ b/.github/workflows/public.yml
@@ -38,8 +38,8 @@ jobs:
           - 8984:8983
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
         distribution: temurin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
       - run: git fetch --tags
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -70,7 +70,7 @@ AppConfig[:db_debug_log] = false
 # Set to true if you have enabled MySQL binary logging
 AppConfig[:mysql_binlog] = false
 
-# add default solr params, i.e. use AND for search: AppConfig[:solr_params] = { 'mm' => '100%' }
+# Add default solr params, i.e. use AND for search: AppConfig[:solr_params] = { 'mm' => '100%' }
 # Another example below sets the boost query value (bq) to boost the relevancy for the query string in the title,
 # sets the phrase fields parameter (pf) to boost the relevancy for the title when the query terms are in close proximity to
 # each other, and sets the phrase slop (ps) parameter for the pf parameter to indicate how close the proximity should be


### PR DESCRIPTION
Upgrade github actions to latest version

## Description
We have been getting deprecation messages on our github runners such as: 
https://github.com/archivesspace/archivesspace/actions/runs/7717059494/attempts/1?pr=3097


## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1887


## How Has This Been Tested?
I did an irrelevant change on common just to trigger a whole spec run


## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
