### PR TITLE
ANW-1884: Fix representative file version thumbnail spec image url

### DIFF
--- a/frontend/spec/features/representative_file_version_spec.rb
+++ b/frontend/spec/features/representative_file_version_spec.rb
@@ -7,7 +7,7 @@ describe 'Representative File Version', js: true do
 
   describe 'search listing thumbnail' do
     before(:all) do
-      @good_img = 'https://www.archivesspace.org/demos/Congreave%20E-4/ms292_008.jpg'
+      @good_img = 'https://archivesspace.org/wp-content/uploads/2015/06/testimonial_5.jpg'
       @bad_img = 'https://example.com/example.mp3'
       @repo = create(:repo, repo_code: "thumbnail_images_test_#{Time.now.to_i}", publish: true)
       set_repo(@repo)


### PR DESCRIPTION
This PR bandaids over a notoriously flaky test by replacing an image url hardcoded in a spec.

The old url that pointed to an image on an ArchivesSpace domain was not resolving after Lyrasis made some server changes, which resulted in the spec failing.

This PR just changes the image url, pointing to an image hosted on another ArchivesSpace domain.

While this sets us up for possible test failures down the line if the hardcoded image does not persist, it makes this spec _less_ of a flaky test in  the short term, since the test was flaky _before_ Lyrasis made the recent server changes.

[ANW-1884](https://archivesspace.atlassian.net/browse/ANW-1884) is a general catch-all ticket for current flaky tests. As such this PR does not close ANW-1884.

[ANW-1884]: https://archivesspace.atlassian.net/browse/ANW-1884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ