### PR TITLE
ANW-1830 Fix sort by username on the Manage User Access page

### DIFF
--- a/frontend/app/controllers/users_controller.rb
+++ b/frontend/app/controllers/users_controller.rb
@@ -22,7 +22,12 @@ class UsersController < ApplicationController
   end
 
   def manage_access
-    @search_data = JSONModel(:user).all(:page => selected_page)
+    @search_data = JSONModel(:user).all(
+      page: selected_page,
+      page_size: 50,
+      sort_field: params.fetch(:sort, :username),
+      sort_direction: params.fetch(:direction, :asc)
+    )
     @manage_access = true
     render :action => "index"
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes the broken sort-by-username on the [Manage user Access](https://test.archivesspace.org/staff/users/manage_access) page by copying the `@search_data` logic from the `index` action to the `manage_access` action in the User controller.

The [original sort feature](https://github.com/archivesspace/archivesspace/pull/2278/files#diff-b3bb499ec4138704e3d81f0e4c634917fb6fc3c882d69c18cde288b943e7b084) was only added to `index`.

![ANW-1830-username-sort](https://github.com/archivesspace/archivesspace/assets/3411019/c4215754-7da5-47c8-aaaa-ed4ba15a737b)

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-1830

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

There is already a [backend test for the server functionality](https://github.com/archivesspace/archivesspace/pull/2273/files#diff-0cb2908732454ffe0930555ae8611dd9ec468f576118551adf25586b73266fb6).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
