### PR TITLE
ANW-1896 Fix always-on largetree reorder mode drag and drop

### DIFF
--- a/frontend/app/assets/javascripts/largetree_dragdrop.js.erb
+++ b/frontend/app/assets/javascripts/largetree_dragdrop.js.erb
@@ -229,6 +229,8 @@
         });
 
         $(largetree.elt).on('mousedown', '.table-row.largetree-node', function (event) {
+            if (!$(largetree.elt).hasClass('drag-enabled')) return;
+
             // ANW-1024, ANW-625 make whole row draggable not just .drag-handle
             
             // Allow expanding/collapsing a tree while rows are selected


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The drag and drop functionality from "reorder mode" in an Archival Object's largetree is available when reorder mode is not enabled. This PR checks for reorder mode on mousedown inside the largetree.

![ANW-1896-reorder-mode-drag](https://github.com/archivesspace/archivesspace/assets/3411019/a4bea666-2fd3-4d74-baf0-4f206f8aabf7)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
Closes GH #3108 

https://archivesspace.atlassian.net/browse/ANW-1896

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
