### PR TITLE
Fix vertical jank in reorder mode row selection

### DIFF
--- a/frontend/app/assets/javascripts/tree_renderers.js.erb
+++ b/frontend/app/assets/javascripts/tree_renderers.js.erb
@@ -297,18 +297,18 @@ function dragHandleMarkup() {
   const rows = [8, 12, 16, 20, 24, 28];
   const cols = [10, 14, 18];
 
-  return `
-    <span class="drag-handle__span">
-      <svg role="presentation" viewBox="7 4 28 28">
-        <g fill="currentcolor" fill-rule="evenodd">
-          ${rows.reduce((acc, y) => {
-            cols.forEach((x) => {
-              acc += `<circle cx="${x}" cy="${y}" r="1"></circle>`;
-            });
-            return acc;
-          }, ``)}
-        </g>
-      </svg>
-    </span>
+  const bs4Gray700 = '#495057'; // Bootstrap 4's $gray-700
+  const faGripVertical = `
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="${bs4Gray700}"
+      width="40%"
+      role="presentation"
+      viewBox="0 0 320 512">
+      <!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+      <path d="M40 352l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40zm192 0l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40zM40 320c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0zM232 192l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40zM40 160c-22.1 0-40-17.9-40-40L0 72C0 49.9 17.9 32 40 32l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0zM232 32l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40z"/>
+    </svg>
   `;
+
+  return `<span class="pl-1">${faGripVertical}</span>`;
 }

--- a/frontend/app/assets/stylesheets/archivesspace/common.less
+++ b/frontend/app/assets/stylesheets/archivesspace/common.less
@@ -186,6 +186,10 @@ td .btn-group {
   padding: 30px;
 }
 
+.pl-1 {
+  padding-left: 0.25rem;
+}
+
 @media (max-width: 767px) {
   .xs-py15px {
     padding-right: 15px;

--- a/frontend/app/assets/stylesheets/archivesspace/largetree.less
+++ b/frontend/app/assets/stylesheets/archivesspace/largetree.less
@@ -90,11 +90,6 @@
     .drag-handle {
       width: 2em;
     }
-    .drag-handle__span {
-      position: absolute;
-      height: 2em;
-      width: 2em;
-    }
     .drag-handle.drag-disabled {
       visibility: hidden;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes the vertical jank/movement that happens in the Staff app in record reorder mode when an individual row is selected. It does so by rewriting the styles related to the row's drag handle. It also updates the drag handle grip icon svg to that which is used in the upcoming [Softserv Staff fixes](https://github.com/archivesspace/archivesspace/pull/3090).

The need for this work was observed while working on the related [ANW-1447](https://archivesspace.atlassian.net/browse/ANW-1447) although it doesn't directly solve the issues in ANW-1447. Since work on ANW-1447 was halted via a recent staff meeting, this quick fix was pushed up.

## Problem

![GH-3113-reorder-mode-jank problem](https://github.com/archivesspace/archivesspace/assets/3411019/f4a04ba8-c223-4544-8612-87c5c1ede9d1)

## Solution

![GH-3113-reorder-mode-jank solution](https://github.com/archivesspace/archivesspace/assets/3411019/ddd1e52c-2410-42b1-a165-ef3455e1b6d6)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual in-browser

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

[ANW-1447]: https://archivesspace.atlassian.net/browse/ANW-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ