### PR TITLE
ANW-1879 fix title and action button label on accessions and component linkers

### DIFF
--- a/frontend/app/views/accession_links/_accession_linker.html.erb
+++ b/frontend/app/views/accession_links/_accession_linker.html.erb
@@ -14,8 +14,8 @@
     <div class="input-group linker-wrapper">
       <input type="text" class="linker"
              id="<%= linker_id %>"
-             data-label="<%= I18n.t "archival_object.accession_link" %>"
-             data-label_plural="<%= I18n.t "archival_object.accession_links" %>"
+             data-label_link="<%= I18n.t "accession_link._frontend.action.add" %>"
+             data-label_browse="<%= I18n.t "top_container._frontend.bulk_operations.collection_accession_linker.browse" %>"
              data-path="<%= form.path %>"
              data-name="ref"
              data-url="<%= url_for :controller => :search, :action => :do_search, :format => :json %>"

--- a/frontend/app/views/component_links/_component_linker.html.erb
+++ b/frontend/app/views/component_links/_component_linker.html.erb
@@ -14,8 +14,8 @@
     <div class="input-group linker-wrapper">
       <input type="text" class="linker"
              id="<%= linker_id %>"
-             data-label="<%= I18n.t "accession.component_link" %>"
-             data-label_plural="<%= I18n.t "accession.component_links" %>"
+             data-label_link="<%= I18n.t "linker.link" %>"
+             data-label_browse="<%= I18n.t "linker.components.browse" %>"
              data-path="<%= form.path %>"
              data-name="ref"
              data-url="<%= url_for :controller => :search, :action => :do_search, :format => :json %>"

--- a/frontend/config/locales/de.yml
+++ b/frontend/config/locales/de.yml
@@ -829,6 +829,8 @@ de:
     delete: '&times;'
     no_results: Keine passenden Ergebnisse.  Versuchen Sie 'Blättern'.
     searching: Suche...
+    components:
+      browse: Komponenten durchsuchen
   mixed_content:
     wrap_prefix: 'Umschließen mit:'
     help: Gemischter Inhalt aktiviert&#160;&#160;--&#160;&#160;Tippen Sie '<', um

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -691,6 +691,8 @@ en:
     no_results: No matching results.  Try 'Browse'.
     searching: Searching...
     delete: "&times;"
+    components:
+      browse: Browse Components
 
   mixed_content:
     wrap_prefix: "Wrap with:"

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -672,6 +672,8 @@ es:
     no_results: No hay resultados coincidentes.  Trate de 'Examinar'.
     searching: Buscando...
     delete: "x"
+    components:
+      browse: Explorar componentes
 
   mixed_content:
     wrap_prefix: "Envolver con"

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -684,6 +684,8 @@ fr:
     no_results: Pas de résultats correspondants.  Essayez 'Parcourir'.
     searching: Recherche en cours...
     delete: "&times;"
+    components:
+      browse: Parcourir les composants
 
   mixed_content:
     wrap_prefix: "Mettre en forme avec:"

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -622,6 +622,8 @@ ja:
     no_results: 一致する結果はありません。 「ブラウズ」を試みてください。
     searching: 検索中...
     delete: "×"
+    components:
+      browse: コンポーネントを参照する
 
   mixed_content:
     wrap_prefix: ラップ：


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
The title and the label on the "add link action" button are missing on:

- /staff/accessions/<accession id>/edit#accession_component_links_
- /staff/resources/<resource id>/edit#archival_object_accession_links_

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1879
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
