### PR TITLE
ANW-1869 support emphasis styling in PUI breadcrumbs

### DIFF
--- a/public/app/views/digital_objects/_linked_instances.html.erb
+++ b/public/app/views/digital_objects/_linked_instances.html.erb
@@ -4,13 +4,39 @@
         <li>
           <% record.breadcrumb.each do |crumb| %>
             <% next if crumb[:uri].blank? %>
-            <%= badge_for_type(crumb[:type]) %> <%= link_to crumb[:crumb], app_prefix(crumb[:uri]) %> | 
+            <%= badge_for_type(crumb[:type]) %>
+            <%
+            if crumb[:crumb].include? '<emph'
+              title = MixedContentParser.parse(crumb[:crumb], '/')
+              tag = Nokogiri::HTML::DocumentFragment.parse(title)
+            %>
+              <span class="<%= tag.css('span').attr('class') %>"> <%= link_to tag.content, app_prefix(crumb[:uri]) %> </span>
+            <% else %>
+              <%= link_to crumb[:crumb], app_prefix(crumb[:uri]) %>
+            <% end %>
+            |
           <% end %>
-          <%= badge_for_type(record.primary_type) %> <strong><%= link_to record.display_string, app_prefix(uri) %></strong>
+          <%= badge_for_type(record.primary_type) %>
+          <strong>
+          <% if record.display_string.include? '<span' %>
+            <% tag = Nokogiri::HTML::DocumentFragment.parse(record.display_string) %>
+            <span class="<%= tag.css('span').attr('class') %>"> <%= link_to tag.content, app_prefix(uri) %> </span>
+          <% else %>
+            <%= link_to record.display_string, app_prefix(uri) %>
+          <% end %>
+          </strong>
         </li>
     <% else %>
         <li>
-          <%= badge_for_type(record.primary_type) %> <strong><%= link_to record.display_string, app_prefix(uri) %></strong>
+          <%= badge_for_type(record.primary_type) %>
+          <strong>
+          <% if record.display_string.include? '<span' %>
+            <% tag = Nokogiri::HTML::DocumentFragment.parse(record.display_string) %>
+            <span class="<%= tag.css('span').attr('class') %>"> <%= link_to tag.content, app_prefix(uri) %> </span>
+          <% else %>
+            <%= link_to record.display_string, app_prefix(uri) %>
+          <% end %>
+          </strong>
         </li>
     <% end %>
   <% end %>

--- a/public/app/views/digital_objects/_search_result_breadcrumbs.html.erb
+++ b/public/app/views/digital_objects/_search_result_breadcrumbs.html.erb
@@ -11,7 +11,7 @@
       <% if ['accession', 'resource'].include? instance_record.primary_type %>
         <%
           type = instance_record.primary_type
-          body = type == 'accession' ? 
+          body = type == 'accession' ?
             instance_record.display_string :
             instance_record.breadcrumb[0][:crumb]
         %>
@@ -34,6 +34,7 @@
   </div>
 
 <% else %>
+  <% require 'mixed_content_parser' %>
 
   <div class="flex result_context">
     <strong class="flex-shrink-0"><%= t('context') %>: </strong>
@@ -61,7 +62,9 @@
                 <%= render partial: 'shared/result_breadcrumbs_ancestor', locals: {
                   :span_class => "#{crumb[:type]}_name",
                   :badge_type => crumb[:type],
-                  :body => crumb[:crumb],
+                  :body => crumb[:crumb].include?('<emph') ?
+                    MixedContentParser.parse(crumb[:crumb], '/') :
+                    crumb[:crumb],
                   :url => i != num_crumbs - 1 ? app_prefix(crumb[:uri]) : app_prefix(uri),
                   :hide_delimiter => i == 0 ? true : false } %>
               <% end %>

--- a/public/app/views/shared/_result_breadcrumbs_ancestor.html.erb
+++ b/public/app/views/shared/_result_breadcrumbs_ancestor.html.erb
@@ -3,5 +3,12 @@
 <% end %>
 <span class="<%= span_class %>">
   <%= badge_for_type badge_type %>
-  <%= link_to body, url %>
+
+  <% # there could be styling on this title and we can't have it inside the anchor tag %>
+  <% if body.include? '<span' %>
+    <% tag = Nokogiri::HTML::DocumentFragment.parse(body) %>
+    <span class="<%= tag.css('span').attr('class') %>"> <%= link_to tag.content, url %> </span>
+  <% else %>
+    <%= link_to body, url %>
+  <% end %>
 </span>


### PR DESCRIPTION
Users expect mixed content in titles to be rendered properly in the breadcrumbs shown on the "found in" section for the digital materials in a collection. This was not previously accounted for. Two things needed to be done:
1. handle unprocessed `emph` tags in collection titles
2. move the resulting`span` tags used for the formatting outside of the breadcrumb links so they render properly

before:
![image](https://github.com/archivesspace/archivesspace/assets/2189950/cd130fe9-975d-4763-94d0-7004f5d65d20)


after:
![image](https://github.com/archivesspace/archivesspace/assets/2189950/79a4d849-8132-4833-8de4-1a883d176eb0)
