### PR TITLE
ANW-1906 add functionality to take screenshots every time a spec fails

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -68,3 +68,9 @@ jobs:
         ./build/run frontend:test
       env:
         ARCHIVESSPACE_VERSION: ${{ github.ref }}
+
+    - uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: failed_spec_screenshots_${{ vars.GITHUB_RUN_ID }}_${{ vars.GITHUB_RUN_NUMBER}}
+        path: 'frontend/tmp/capybara'

--- a/frontend/Gemfile
+++ b/frontend/Gemfile
@@ -47,6 +47,7 @@ group :test do
   gem 'selenium-webdriver', '~> 3.142', '>= 3.142.3'
 
   gem 'capybara'
+  gem 'capybara-screenshot'
   # need access to ActiveSupport for helpers
   gem 'activesupport'
   # if the indexer requires it, our test suite requires it

--- a/frontend/Gemfile.lock
+++ b/frontend/Gemfile.lock
@@ -70,6 +70,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-screenshot (1.0.26)
+      capybara (>= 1.0, < 4)
+      launchy
     childprocess (3.0.0)
     choice (0.2.0)
     coderay (1.1.3)
@@ -137,6 +140,8 @@ GEM
     jruby-jars (9.2.20.1)
     json (2.6.3-java)
     json-schema (1.0.10)
+    launchy (2.5.2)
+      addressable (~> 2.8)
     less (2.6.0)
       commonjs (~> 0.2.7)
     less-rails (2.8.0)
@@ -351,6 +356,7 @@ DEPENDENCIES
   atomic (= 1.0.1)
   axe-core-rspec
   capybara
+  capybara-screenshot
   coffee-rails (= 4.2.2)
   coffee-script
   coffee-script-source

--- a/frontend/config/environments/test.rb
+++ b/frontend/config/environments/test.rb
@@ -36,4 +36,6 @@ ArchivesSpace::Application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  config.assets.prefix = AppConfig[:frontend_proxy_prefix] + "assets"
 end

--- a/frontend/spec/rails_helper.rb
+++ b/frontend/spec/rails_helper.rb
@@ -3,6 +3,7 @@ require 'exceptions'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'capybara/rails'
+require 'capybara-screenshot/rspec'
 require 'rails-controller-testing'
 require 'selenium-webdriver'
 require_relative 'selenium/common/webdriver'
@@ -41,6 +42,21 @@ end
 # This should change once the app gets to a point where it's not just throwing
 # tons of errors...
 Capybara.raise_server_errors = false
+
+# Html pages saved after Capybara spec failures will reference this to load assets
+# so running a local dev server will help displaying the page correctly in a browser
+Capybara.asset_host = 'http://localhost:3000/'
+
+Capybara::Screenshot.register_driver(:chrome) do |driver, path|
+  driver.browser.save_screenshot(path)
+end
+
+Capybara::Screenshot.register_driver(:firefox) do |driver, path|
+  driver.browser.save_screenshot(path)
+end
+
+# keep the last 30 screenshots / pages of capybara spec failures
+Capybara::Screenshot.prune_strategy = { keep: 30 }
 
 
 RSpec.configure do |config|


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This is partly implemented in https://github.com/archivesspace/archivesspace/tree/ANW-1727-softserv-upgrades-final-build but without the configuration that uploads the artifacts when a capybara spec fails in CI. 

I thought adding just this functionality could help us debug the capybara specs that are currently flakky as well as the ones I am porting over from selenium as part of: https://archivesspace.atlassian.net/jira/software/c/projects/ANW/boards/46?selectedIssue=ANW-1825

I will also create an accompanying PR on tech-docs to document this functionality. 

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1906
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
