### PR TITLE
Indexer update (all) mtimes only when needed

### DIFF
--- a/indexer/app/lib/periodic_indexer.rb
+++ b/indexer/app/lib/periodic_indexer.rb
@@ -167,9 +167,8 @@ class PeriodicIndexer < IndexerCommon
       index_records(updated_repositories)
       repositories_updated_action(updated_repositories)
       send_commit
+      @state.set_last_mtime('repositories', 'repositories', start)
     end
-
-    @state.set_last_mtime('repositories', 'repositories', start)
 
     # And any records in any repositories
     repositories.each_with_index do |repository, i|
@@ -279,9 +278,8 @@ class PeriodicIndexer < IndexerCommon
 
     if did_something
       send_commit
+      @state.set_last_mtime('_deletes', 'deletes', start)
     end
-
-    @state.set_last_mtime('_deletes', 'deletes', start)
   end
 
   def run

--- a/indexer/app/lib/pui_indexer.rb
+++ b/indexer/app/lib/pui_indexer.rb
@@ -160,6 +160,7 @@ class PUIIndexer < PeriodicIndexer
 
     start = Time.now
     checkpoints = []
+    update_mtimes = false
 
     tree_uris = []
 
@@ -200,6 +201,7 @@ class PUIIndexer < PeriodicIndexer
 
       index_batch(batch, nil, :parent_id_field => 'pui_parent_id')
       send_commit
+      update_mtimes = true
     end
 
     if tree_indexer.deletes.length > 0
@@ -215,7 +217,7 @@ class PUIIndexer < PeriodicIndexer
     @unpublished_records.clear()
 
     checkpoints.each do |repository, type, start|
-      @state.set_last_mtime(repository.id, type, start)
+      @state.set_last_mtime(repository.id, type, start) if update_mtimes
     end
 
   end


### PR DESCRIPTION
This is a small update to the indexer to only set the mtimes for repositories, deletes and pui record types when "some work was done", which is the case for all other record types.

The primary reason for doing this is to get rid of unnecessary i/o operations when the indexer state is running on non-local storage such as EFS or S3, where there can be additional costs or performance overhead from this when running many instances of ArchivesSpace (that may also have many repositories each).

## How Has This Been Tested?

Fire up ArchivesSpace and let it reindex. Check:

- `ls -l build/dev/indexer_state/`
- `ls -l build/dev/indexer_pui_state/`

Note the last modified times and / or check the mtimes. Allow the indexer to run for a minute or 2 (in excess of the indexer frequency cfg) and note that no mtimes have been updated.

In ArchivesSpace update a repository, delete something and update a published archival object record. After the indexer runs around the mtimes will have been updated in the appropriate files.

To compare this with `master`: after initial reindexing, regardless of any updates in the system, the mtimes for repositories, deletes and pui records are being updated whenever the indexer runs (default every 30 seonds).

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
