### PR TITLE
Set additional file version links to target=new

### DIFF
--- a/public/app/views/digital_objects/_additional_file_versions.html.erb
+++ b/public/app/views/digital_objects/_additional_file_versions.html.erb
@@ -4,11 +4,11 @@
       # ANW-1722 additional file version display rules
       data_url_text = t('digital_object._public.url_encoded_data')
       uri_text = fv['file_uri'].starts_with?('data:') ? data_url_text : fv['file_uri']
-      fv_markup = "<a href='#{fv['file_uri']}'>#{uri_text}</a>"
+      fv_markup = "<a href='#{fv['file_uri']}' target='new' title='Link to digital object'>#{uri_text}</a>"
       if fv['caption'] && !fv['caption'].empty?
-        fv_markup = "<a href='#{fv['file_uri']}'>#{fv['caption']}</a>"
+        fv_markup = "<a href='#{fv['file_uri']}' target='new' title='Link to digital object'>#{fv['caption']}</a>"
       elsif fv['use_statement'] && !fv['use_statement'].empty?
-        fv_markup = "<a href='#{fv['file_uri']}'>#{fv['use_statement']}</a>"
+        fv_markup = "<a href='#{fv['file_uri']}' target='new' title='Link to digital object'>#{fv['use_statement']}</a>"
       end
     %>
     <li data-additional-file-version>


### PR DESCRIPTION
This will match the thumbnail images links and open the file version text links in a new tab or window. Also gives them a title to match the same.

## Related JIRA Ticket or GitHub Issue
I don't think there is one, at least not one I could find for just this little thing

## How Has This Been Tested?
Ran local

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
