### PR TITLE
ANW-1906 fix uploaded artifact name

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -74,5 +74,5 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: failed_spec_screenshots_${{ vars.GITHUB_RUN_ID }}_${{ vars.GITHUB_RUN_NUMBER}}
+        name: failed_spec_saved_pages(${{ matrix.java }})
         path: 'frontend/tmp/capybara'

--- a/frontend/spec/rails_helper.rb
+++ b/frontend/spec/rails_helper.rb
@@ -56,7 +56,7 @@ Capybara::Screenshot.register_driver(:firefox) do |driver, path|
 end
 
 # keep the last 30 screenshots / pages of capybara spec failures
-Capybara::Screenshot.prune_strategy = { keep: 30 }
+Capybara::Screenshot.prune_strategy = :keep_last_run
 
 
 RSpec.configure do |config|


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a fix for the uploading of saved pages when capybara specs test fail.

There needs to be a difference in the name of the uploaded zip file for the Java 11 and Java 8 runs, otherwise the one that ends second fails to upload the file because of name collision.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
