### PR TITLE
ANW-1971 Fix mixed content rendering in PUI Collection Organization sidebar tree

### DIFF
--- a/public/app/assets/javascripts/InfiniteTree.js
+++ b/public/app/assets/javascripts/InfiniteTree.js
@@ -188,6 +188,7 @@
      * @returns {DocumentFragment} - DocumentFragment containing the root row
      */
     rootRowMarkup(title) {
+      const titleContent = new MixedContent(title);
       const rootRowFrag = new DocumentFragment();
       const rootRow = document
         .querySelector('#root-row-template')
@@ -198,10 +199,22 @@
         .querySelector('.table-row')
         .setAttribute('data-uri', this.resourceUri);
 
+      rootRow
+        .querySelector('.title')
+        .setAttribute(
+          'title',
+          titleContent.isMixed ? titleContent.derivedString : titleContent.input
+        );
+
       rootRow.querySelector(
         '.record-title'
       ).href = `#tree::resource_${this.resourceId}`;
-      rootRow.querySelector('.record-title').innerHTML = title;
+
+      if (titleContent.isMixed) {
+        rootRow.querySelector('.record-title').innerHTML = titleContent.input;
+      } else {
+        rootRow.querySelector('.record-title').textContent = titleContent.input;
+      }
 
       rootRowFrag.appendChild(rootRow);
 
@@ -253,7 +266,7 @@
     nodeRowMarkup(node, level, shouldObserve, parentId = null, offset = null) {
       const aoId = node.uri.split('/')[4];
       const divId = `archival_object_${aoId}`;
-      const aoTitle = this.nodeTitle(node);
+      const titleContent = new MixedContent(this.nodeTitle(node));
       const aHref = `#tree::${divId}`;
 
       const nodeRowFrag = new DocumentFragment();
@@ -286,7 +299,12 @@
           .setAttribute('data-observe-offset', offset);
       }
 
-      nodeRow.querySelector('.title').setAttribute('title', aoTitle);
+      nodeRow
+        .querySelector('.title')
+        .setAttribute(
+          'title',
+          titleContent.isMixed ? titleContent.derivedString : titleContent.input
+        );
 
       if (node.child_count == 0) {
         nodeRow.querySelector('.expandme').style.visibility = 'hidden';
@@ -303,7 +321,9 @@
           .setAttribute('aria-expanded', 'false');
       }
 
-      nodeRow.querySelector('.sr-only').textContent = aoTitle;
+      nodeRow.querySelector('.sr-only').textContent = titleContent.isMixed
+        ? titleContent.derivedString
+        : titleContent.input;
 
       if (node.has_digital_instance) {
         const iconHtml = `<i class="has_digital_instance fa fa-file-image-o" aria-hidden="true"></i>`;
@@ -313,7 +333,12 @@
       }
 
       nodeRow.querySelector('.record-title').setAttribute('href', aHref);
-      nodeRow.querySelector('.record-title').textContent = aoTitle;
+
+      if (titleContent.isMixed) {
+        nodeRow.querySelector('.record-title').innerHTML = titleContent.input;
+      } else {
+        nodeRow.querySelector('.record-title').textContent = titleContent.input;
+      }
 
       nodeRowFrag.appendChild(nodeRow);
 

--- a/public/app/assets/javascripts/MixedContent.js
+++ b/public/app/assets/javascripts/MixedContent.js
@@ -1,0 +1,66 @@
+(function (exports) {
+  class MixedContent {
+    /**
+     * @constructor
+     * @description - This class checks if a string has mixed content, and if so
+     * provides the derived string without the HTML. MixedContent refers to a string
+     * of content from the backend that includes embedded HTML tags with attributes
+     * that are intended to render some or all content within the string with extra
+     * CSS styles that would not otherwise be applied to the content via some
+     * template. In ArchivesSpace, mixed content usually relates to use of Encoded
+     * Archival Description (EAD), a standard for encoding archival finding aids, via
+     * the `allow_mixed_content_title_fields` config option. The HTML often looks like
+     * `<span class="emph render-none">Some text content</span>`, and can be pre and
+     * proceeded by arbitrary text as well.
+     * @param {string} input - A string that might contain mixed content
+     * @returns {MixedContent} - A MixedContent object
+     */
+    constructor(input) {
+      this.input = input;
+
+      this.regex = /([^<]*)<span[^>]*>(.*?)<\/span>(.*)/;
+      /**
+       * ⚠ Assumes the HTML is a <span> tag with attributes:
+       *
+       * ([^<]*) - Capture anything before the <span> tag's opening <
+       *
+       * <span[^>]*> - Match <span, followed by any characters that are not >, and match >;
+       * used to match the opening of the <span> tag and any arbitrary attributes it may have
+       *
+       * (.*?) - Match and capture all text content between the <span> and </span> tags
+       *
+       * <\/span> - Match the closing </span> tag
+       *
+       * (.*) - Match and capture anything after the </span> tag
+       */
+
+      this.match = this.input.match(this.regex);
+    }
+
+    /**
+     * @description - Determine if the string has mixed content
+     * @returns {boolean} - True if the string has mixed content
+     */
+    get isMixed() {
+      if (!this.match) {
+        return false;
+      }
+
+      return true;
+    }
+
+    /**
+     * @description - Get the derived string without the HTML
+     * @returns {string} - The derived string without HTML
+     */
+    get derivedString() {
+      if (!this.match) {
+        return this.input;
+      }
+
+      return this.match[1] + this.match[2] + this.match[3];
+    }
+  }
+
+  exports.MixedContent = MixedContent;
+})(window);

--- a/public/app/views/resources/infinite.html.erb
+++ b/public/app/views/resources/infinite.html.erb
@@ -59,7 +59,7 @@
 
 <template id="root-row-template">
   <div id="" class="table-row root-row" role="listitem" data-uri="">
-    <div class="table-cell title">
+    <div class="table-cell title" title="">
       <a class="record-title" href=""></a>
     </div>
   </div>

--- a/public/spec/features/collection_organization_spec.rb
+++ b/public/spec/features/collection_organization_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Collection Organization', js: true do
+  describe 'Infinite Tree sidebar' do
+    it 'should handle titles with mixed content appropriately' do
+      @repo = create(:repo, repo_code: "infinite_tree_test_#{Time.now.to_i}")
+      set_repo(@repo)
+      @resource = create(:resource,
+        title: 'This is <emph render="italic">a mixed content</emph> title',
+        publish: true
+      )
+      @ao1 = create(:archival_object,
+        resource: {'ref' => @resource.uri},
+        title: 'This is <emph render="italic">another mixed content</emph> title',
+        publish: true
+      )
+      @ao2 = create(:archival_object,
+        resource: {'ref' => @resource.uri},
+        title: 'This is not a mixed content title',
+        publish: true
+      )
+      run_indexers
+
+      visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
+
+      resource = find(".infinite-tree-sidebar #resource_#{@resource.id}")
+      expect(resource).to have_css('.title[title="This is a mixed content title"]')
+      resource_mixed_content_span = resource.find('.record-title > span.emph.render-italic')
+      expect(resource_mixed_content_span).to have_content('a mixed content')
+
+      ao1 = find(".infinite-tree-sidebar #archival_object_#{@ao1.id}")
+      expect(ao1).to have_css('.title[title="This is another mixed content title"]')
+      ao1_mixed_content_span = ao1.find('.record-title > span.emph.render-italic')
+      expect(ao1_mixed_content_span).to have_content('another mixed content')
+
+      ao2 = find(".infinite-tree-sidebar #archival_object_#{@ao2.id}")
+      ao2_record_title = ao2.find('.record-title')
+      expect(ao2_record_title).to_not have_css('span.emph.render-italic')
+      expect(ao2_record_title).to have_content('This is not a mixed content title')
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes [ANW-1971](https://archivesspace.atlassian.net/browse/ANW-1971) by handling mixed content in record titles listed in the Collection Organization sidebar tree appropriately.

- A new JS class is introduced - `MixedContent` - that checks for mixed content in a string and provides some useful getters.
- A new spec is added to test the functionality.

### Note

This PR represents a quicker client side solution, since the InfiniteTree sidebar is empty on page load and populated later via a fetch. However, a more robust and longer term solution would entail sending HTML down the wire instead of the current JSON on fetch, which is not very common in ArchivesSpace if present at all.

### Before

<img width="1179" alt="ANW-1971 broken" src="https://github.com/archivesspace/archivesspace/assets/3411019/700c4da7-e0fb-466a-841f-3f417757274e">

### After

<img width="1164" alt="ANW-1971 fixed" src="https://github.com/archivesspace/archivesspace/assets/3411019/f9fa7a75-7b6b-4e10-916f-cdcb076a1ef0">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


[ANW-1971]: https://archivesspace.atlassian.net/browse/ANW-1971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ