### PR TITLE
Ignore AppConfig[:limit_csv_fields] unless the params[:dt] == 'csv'

### DIFF
--- a/backend/app/model/search.rb
+++ b/backend/app/model/search.rb
@@ -31,7 +31,7 @@ class Search
       set_writer_type( params[:dt] || "json" )
 
     query.remove_csv_header if ( params[:dt] == "csv" and params[:no_csv_header] )
-    query.limit_fields_to(params[:fields]) if params[:fields] && AppConfig[:limit_csv_fields]
+    query.limit_fields_to(params[:fields]) if params[:fields] && (AppConfig[:limit_csv_fields] || params[:dt] != "csv")
 
     results = Solr.search(query)
 

--- a/backend/spec/model_search_spec.rb
+++ b/backend/spec/model_search_spec.rb
@@ -20,8 +20,20 @@ describe Search do
     {
       aq: aq_notes,
       "q.op": "AND",
+      fields: ["notes"],
       page: 1,
       page_size: 1
+    }
+  }
+
+  let(:params_csv) {
+    {
+      aq: aq_notes,
+      "q.op": "AND",
+      fields: ["notes"],
+      page: 1,
+      page_size: 1,
+      dt: "csv"
     }
   }
 
@@ -34,6 +46,64 @@ describe Search do
     }
 
     Search.search(params, repo.id)
+  end
+
+  context "when AppConfig[:limit_csv_fields] = false" do
+
+    before do
+      AppConfig[:limit_csv_fields] = false
+    end
+
+    it "includes fl for json data type query" do
+      allow(Solr).to receive(:search) { |solr_query|
+        solr_url = solr_query.to_solr_url
+        params = URI.decode_www_form(solr_url.query)
+        expect(params.find {|param| param.first == 'q'}[1]).to eq "notes:(foobar)"
+        expect(params.find {|param| param.first == 'qf'}[1]).to match /fullrecord$/
+        expect(params.find {|param| param.first == 'fl'}[1]).to eq "notes"
+      }
+      Search.search(params, repo.id)
+    end
+
+    it "excludes fl for csv data type query" do
+      allow(Solr).to receive(:search) { |solr_query|
+        solr_url = solr_query.to_solr_url
+        params = URI.decode_www_form(solr_url.query)
+        expect(params.find {|param| param.first == 'q'}[1]).to eq "notes:(foobar)"
+        expect(params.find {|param| param.first == 'qf'}[1]).to match /fullrecord$/
+        expect(params.find {|param| param.first == 'fl'}).to be_nil
+      }
+      Search.search(params_csv, repo.id)
+    end
+  end
+
+  context "when AppConfig[:limit_csv_fields] = true" do
+
+    before do
+      AppConfig[:limit_csv_fields] = true
+    end
+
+    it "includes fl for json data type query" do
+      allow(Solr).to receive(:search) { |solr_query|
+        solr_url = solr_query.to_solr_url
+        params = URI.decode_www_form(solr_url.query)
+        expect(params.find {|param| param.first == 'q'}[1]).to eq "notes:(foobar)"
+        expect(params.find {|param| param.first == 'qf'}[1]).to match /fullrecord$/
+        expect(params.find {|param| param.first == 'fl'}[1]).to eq "notes"
+      }
+      Search.search(params, repo.id)
+    end
+
+    it "include fl for csv data type query" do
+      allow(Solr).to receive(:search) { |solr_query|
+        solr_url = solr_query.to_solr_url
+        params = URI.decode_www_form(solr_url.query)
+        expect(params.find {|param| param.first == 'q'}[1]).to eq "notes:(foobar)"
+        expect(params.find {|param| param.first == 'qf'}[1]).to match /fullrecord$/
+        expect(params.find {|param| param.first == 'fl'}[1]).to eq "notes"
+      }
+      Search.search(params_csv, repo.id)
+    end
   end
 
   it "can build a url for solr to search the notes field while protecting unpublished data from the public user" do


### PR DESCRIPTION
Ignore the `AppConfig[:limit_csv_fields]` value unless the request type is `csv`

## Description
The `AppConfig[:limit_csv_fields]` property causes the Search model to ignore the `fields` parameter. This causes all fields to be returned from the query. The `AppConfig[:limit_csv_fields]` should limit the fields returned by the search only when `dt=xml`. This change allows a JSON search to limit the number of fields returned when the app is configured with `AppConfig[:limit_csv_fields] = false`.

## Related JIRA Ticket or GitHub Issue
n/a

## How Has This Been Tested?
I added four tests to `model_search_test.rb` to ensure that the `fl` parameter is sent to SOLR appropriately based on `AppConfig[:limit_csv_fields]` and the `dt` parameter.

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
