### PR TITLE
ANW-1075: Better error messages for PUI PDF errors

### DIFF
--- a/public/app/models/finding_aid_pdf.rb
+++ b/public/app/models/finding_aid_pdf.rb
@@ -1,5 +1,12 @@
 require 'tempfile'
 
+class PDFRenderErrorHeader < StandardError; end
+class PDFRenderErrorTitlePage < StandardError; end
+class PDFRenderErrorTOC < StandardError; end
+class PDFRenderErrorResource < StandardError; end
+class PDFRenderErrorArchivalObject < StandardError; end
+class PDFRenderErrorFooter < StandardError; end
+
 class FindingAidPDF
 
   DEPTH_1_LEVELS = ['collection', 'recordgrp', 'series']
@@ -35,81 +42,168 @@ class FindingAidPDF
   end
 
   def source_file
-    # We'll use the original controller so we can find and render the PDF
-    # partials, but just for its ERB rendering.
-    renderer = PdfController.new
-    start_time = Time.now
+    begin
+      # We'll use the original controller so we can find and render the PDF
+      # partials, but just for its ERB rendering.
+      renderer = PdfController.new
+      start_time = Time.now
 
-    @repo_code = @resource.repository_information.fetch('top').fetch('repo_code')
+      @repo_code = @resource.repository_information.fetch('top').fetch('repo_code')
 
-    # .length == 1 would be just the resource itself.
-    has_children = @ordered_records.entries.length > 1
+      # .length == 1 would be just the resource itself.
+      has_children = @ordered_records.entries.length > 1
 
-    out_html = Tempfile.new
+      out_html = Tempfile.new
 
-    # Use a NokogiriPushParser-based
-    writer = Nokogiri::XML::SAX::PushParser.new(XMLCleaner.new(out_html))
-    writer.write(renderer.render_to_string partial: 'header', layout: false, :locals => {:record => @resource})
+      # Use a NokogiriPushParser-based
+      writer = Nokogiri::XML::SAX::PushParser.new(XMLCleaner.new(out_html))
 
-    writer.write(renderer.render_to_string partial: 'titlepage', layout: false, :locals => {:record => @resource})
-
-    # Drop the resource and filter the AOs
-    toc_aos = @ordered_records.entries.drop(1).select {|entry|
-      if entry.depth == 1
-        DEPTH_1_LEVELS.include?(entry.level)
-      elsif entry.depth == 2
-        DEPTH_2_LEVELS.include?(entry.level)
-      else
-        false
-      end
-    }
-
-    writer.write(renderer.render_to_string partial: 'toc', layout: false, :locals => {:resource => @resource, :has_children => has_children, :ordered_aos => toc_aos})
-
-    writer.write(renderer.render_to_string partial: 'resource', layout: false, :locals => {:record => @resource, :has_children => has_children})
-
-    page_size = 50
-
-    @ordered_records.entries.drop(1).each_slice(page_size) do |entry_set|
-      if AppConfig[:pui_pdf_timeout] && AppConfig[:pui_pdf_timeout] > 0 && (Time.now.to_i - start_time.to_i) >= AppConfig[:pui_pdf_timeout]
-        raise TimeoutError.new("PDF generation timed out.  Sorry!")
+      begin
+        writer.write(renderer.render_to_string partial: 'header', layout: false, :locals => {:record => @resource})
+      rescue => e
+        raise PDFRenderErrorHeader, "#{e.class};#{e.message}"
       end
 
-      uri_set = entry_set.map(&:uri)
-      record_set = archivesspace.search_records(uri_set, {}, true).records
+      begin
+        writer.write(renderer.render_to_string partial: 'titlepage', layout: false, :locals => {:record => @resource})
+      rescue => e
+        raise PDFRenderErrorTitlePage, "#{e.class};#{e.message}"
+      end
 
-
-      unprocessed_record_list = record_set.zip(entry_set)
-      ao_list = []
-
-      # tuple looks like [ArchivalObject, Entry]
-      unprocessed_record_list.each_with_index do |tuple, i|
-        record = tuple[0]
-        next_record = unprocessed_record_list[i + 1][0] rescue nil
-
-        next unless record.is_a?(ArchivalObject)
-
-        if next_record && record.uri == next_record.parent_for_md_mapping
-          has_children = true
+      # Drop the resource and filter the AOs
+      toc_aos = @ordered_records.entries.drop(1).select {|entry|
+        if entry.depth == 1
+          DEPTH_1_LEVELS.include?(entry.level)
+        elsif entry.depth == 2
+          DEPTH_2_LEVELS.include?(entry.level)
         else
-          has_children = false
+          false
+        end
+      }
+
+      begin
+        writer.write(renderer.render_to_string partial: 'toc', layout: false, :locals => {:resource => @resource, :has_children => has_children, :ordered_aos => toc_aos})
+      rescue => e
+        raise PDFRenderErrorTOC, "#{e.class};#{e.message}"
+      end
+
+      begin
+        writer.write(renderer.render_to_string partial: 'resource', layout: false, :locals => {:record => @resource, :has_children => has_children})
+      rescue => e
+        raise PDFRenderErrorResource, "#{e.class};#{e.message}"
+      end
+
+      page_size = 50
+
+      @ordered_records.entries.drop(1).each_slice(page_size) do |entry_set|
+        if AppConfig[:pui_pdf_timeout] && AppConfig[:pui_pdf_timeout] > 0 && (Time.now.to_i - start_time.to_i) >= AppConfig[:pui_pdf_timeout]
+          raise TimeoutError.new("PDF generation timed out.  Sorry!")
         end
 
-        tuple[2] = has_children
+        uri_set = entry_set.map(&:uri)
+        record_set = archivesspace.search_records(uri_set, {}, true).records
 
-        ao_list.push(tuple)
+
+        unprocessed_record_list = record_set.zip(entry_set)
+        ao_list = []
+
+        # tuple looks like [ArchivalObject, Entry]
+        unprocessed_record_list.each_with_index do |tuple, i|
+          record = tuple[0]
+          next_record = unprocessed_record_list[i + 1][0] rescue nil
+
+          next unless record.is_a?(ArchivalObject)
+
+          if next_record && record.uri == next_record.parent_for_md_mapping
+            has_children = true
+          else
+            has_children = false
+          end
+
+          tuple[2] = has_children
+
+          ao_list.push(tuple)
+        end
+
+
+        ao_list.each do |record, entry, is_parent|
+          begin
+            writer.write(renderer.render_to_string partial: 'archival_object', layout: false, :locals => {:record => record, :level => entry.depth, :is_parent => is_parent})
+
+          rescue => e
+            message = e.message + " (while processing Archival Object '#{record['title']}')"
+            raise PDFRenderErrorArchivalObject, "#{e.class};#{message}"
+          end
+        end
       end
 
-
-      ao_list.each do |record, entry, is_parent|
-        writer.write(renderer.render_to_string partial: 'archival_object', layout: false, :locals => {:record => record, :level => entry.depth, :is_parent => is_parent})
+      begin
+        writer.write(renderer.render_to_string partial: 'footer', layout: false, :locals => {:record => @resource})
+      rescue => e
+        raise PDFRenderErrorFooter, "#{e.class};#{e.message}"
       end
+      out_html.close
+
+      out_html
+    rescue => e
+      out_html = Tempfile.new
+
+      writer = Nokogiri::XML::SAX::PushParser.new(XMLCleaner.new(out_html))
+
+      location = case e.class.to_s
+                 when "PDFRenderErrorHeader"
+                   I18n.t('pdf_error.location.location_header')
+                 when "PDFRenderErrorTitlePage"
+                   I18n.t('pdf_error.location.location_title_page')
+                 when "PDFRenderErrorTOC"
+                   I18n.t('pdf_error.location.location_toc')
+                 when "PDFRenderErrorResource"
+                   I18n.t('pdf_error.location.location_resource')
+                 when "PDFRenderErrorArchivalObject"
+                   I18n.t('pdf_error.location.location_archival_object')
+                 when "PDFRenderErrorFooter"
+                   I18n.t('pdf_error.location.location_footer')
+                 else
+                   nil
+                 end
+
+      # nil means some other error occured
+      if location == nil
+        message    = e.message
+        orig_class = e.class.to_s
+      else
+        orig_class, message = e.message.split(';')
+      end
+
+      error_html = ""
+      error_html += "<body>"
+      error_html += "<h1>#{I18n.t('pdf_error.title')}</h1>"
+      error_html += "<p>#{I18n.t('pdf_error.description')}</p>"
+
+      unless location == nil
+        error_html += "<p><b>#{I18n.t('pdf_error.headings.location')}</b></p>"
+        error_html += "<p>#{location}</p>"
+      end
+
+      error_html += "<p><b>#{I18n.t('pdf_error.headings.message')}</b></p>"
+      error_html += "<p>#{message}</p>"
+
+      error_html += "<p><b>#{I18n.t('pdf_error.headings.type')}</b></p>"
+      error_html += "<p>#{orig_class}</p>"
+
+      if orig_class == "Nokogiri::XML::SyntaxError"
+        error_html += "<p><b>#{I18n.t('pdf_error.headings.additional_info')}</b></p>"
+        error_html += "<p>#{I18n.t('pdf_error.additional_info.invalid_markup')}</p>"
+      end
+
+      error_html += "</body>"
+
+      writer.write(error_html)
+
+      out_html.close
+
+      out_html
     end
-
-    writer.write(renderer.render_to_string partial: 'footer', layout: false, :locals => {:record => @resource})
-    out_html.close
-
-    out_html
   end
 
   def generate

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -565,3 +565,21 @@ en:
     fr: French
     de: German
     ja: Japanese
+
+  pdf_error:
+    title: There was an error generating this PDF.
+    description: "We're sorry, there was an error generating this PDF finding aid. Here is some diagnostic information to help determine what went wrong." 
+    headings:
+      location: Error Location
+      message: Error Message
+      type: Error Type
+      additional_info: Additional Information
+    location:
+      location_header: "The error occurred while generating the header."
+      location_title_page: "The error occurred while generating the title page."
+      location_toc: "The error occurred while generating the table of contents."
+      location_resource: "The error occurred while generating sections relating to the Resource record, which includes Summary Information, Controlled Access Headings, and the Notes sections."
+      location_archival_object: "The error occurred while generating the Collection Inventory."
+      location_footer: "The error occurred while generating the footer."
+    additional_info:
+      invalid_markup: "This error can result from invalid markup present in a note or subrecord."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Instead of the app returning a generic 500 error page when a PDF fails to generate, this returns a PDF with a better description of the error, including what went wrong, what part of the PDF the error occurred in, etc.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/jira/software/c/projects/ANW/issues/ANW-1075

## How Has This Been Tested?
Manual testing

## Screenshots (if appropriate):
![Screenshot_20240411_102610](https://github.com/archivesspace/archivesspace/assets/130926/3bf35b11-88f8-4322-843d-8066c4e745b0)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
