### PR TITLE
ANW-2022 variables not available on PRs from forks

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   accessibility:
-    name: Accessibility_Java_v${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+    name: Accessibility_Java_v${{ inputs.java-version || 11 }}
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
-        java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+        java-version: ${{ inputs.java-version || 11 }}
         distribution: temurin
 
     - uses: './.github/actions/bootstrap'

--- a/.github/workflows/all_specs_dispatch.yml
+++ b/.github/workflows/all_specs_dispatch.yml
@@ -17,34 +17,34 @@ jobs:
     uses: ./.github/workflows/codescan.yml
     secrets: inherit
     with:
-      java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+      java-version: ${{ inputs.java-version || 11 }}
 
   frontend:
     uses: ./.github/workflows/frontend.yml
     secrets: inherit
     with:
-      java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+      java-version: ${{ inputs.java-version || 11 }}
 
   backend:
     uses: ./.github/workflows/backend.yml
     secrets: inherit
     with:
-      java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+      java-version: ${{ inputs.java-version || 11 }}
 
   accessibility:
     uses: ./.github/workflows/accessibility.yml
     secrets: inherit
     with:
-      java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+      java-version: ${{ inputs.java-version || 11 }}
 
   indexer:
     uses: ./.github/workflows/indexer.yml
     secrets: inherit
     with:
-      java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+      java-version: ${{ inputs.java-version || 11 }}
 
   public:
     uses: ./.github/workflows/public.yml
     secrets: inherit
     with:
-      java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+      java-version: ${{ inputs.java-version || 11 }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   backend:
-    name: Backend_Java_v${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+    name: Backend_Java_v${{ inputs.java-version || 11 }}
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
@@ -56,7 +56,7 @@ jobs:
 
     - uses: actions/setup-java@v4
       with:
-        java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+        java-version: ${{ inputs.java-version || 11 }}
         distribution: temurin
 
     - uses: './.github/actions/bootstrap'

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -26,14 +26,14 @@ on:
 
 jobs:
   rubocop:
-    name: Rubocop_Java_v${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+    name: Rubocop_Java_v${{ inputs.java-version || 11 }}
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+          java-version: ${{ inputs.java-version || 11 }}
           distribution: temurin
 
       - name: Run rubocop
@@ -41,7 +41,7 @@ jobs:
           ./build/run rubocop
 
   eslint:
-    name: ESLint_Java_v${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+    name: ESLint_Java_v${{ inputs.java-version || 11 }}
     runs-on: ubuntu-latest
 
     steps:
@@ -54,7 +54,7 @@ jobs:
         run: npm run eslint:ci
 
   stylelint:
-    name: Stylelint_Java_v${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+    name: Stylelint_Java_v${{ inputs.java-version || 11 }}
     runs-on: ubuntu-latest
 
     steps:
@@ -67,7 +67,7 @@ jobs:
         run: npm run stylelint:ci
 
   prettier:
-    name: Prettier_Java_v${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+    name: Prettier_Java_v${{ inputs.java-version || 11 }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/common-frontend.yml
+++ b/.github/workflows/common-frontend.yml
@@ -96,7 +96,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
-        java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+        java-version: ${{ inputs.java-version || 11 }}
         distribution: temurin
 
     - uses: './.github/actions/bootstrap'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -29,41 +29,41 @@ on:
 
 jobs:
   frontend_part_a:
-    name: part_a_Java_v${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+    name: part_a_Java_v${{ inputs.java-version || 11 }}
     uses: ./.github/workflows/common-frontend.yml
     secrets: inherit
     with:
       run-cmd: |
         ./build/run frontend:test -Dpattern="spec/features/[a-c]*_spec.rb"
       name: part_a
-      java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+      java-version: ${{ inputs.java-version || 11 }}
 
   frontend_part_b:
-    name: part_b_Java_v${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+    name: part_b_Java_v${{ inputs.java-version || 11 }}
     uses: ./.github/workflows/common-frontend.yml
     secrets: inherit
     with:
       run-cmd: |
         ./build/run frontend:test -Dpattern="spec/features/[d-l]*_spec.rb"
       name: part_b
-      java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+      java-version: ${{ inputs.java-version || 11 }}
 
   frontend_part_c:
-    name: part_c_Java_v${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+    name: part_c_Java_v${{ inputs.java-version || 11 }}
     uses: ./.github/workflows/common-frontend.yml
     secrets: inherit
     with:
       run-cmd: |
         ./build/run frontend:test -Dpattern="spec/features/[m-r]*_spec.rb"
       name: part_c
-      java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+      java-version: ${{ inputs.java-version || 11 }}
 
   frontend_part_d:
-    name: part_d_Java_v${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+    name: part_d_Java_v${{ inputs.java-version || 11 }}
     uses: ./.github/workflows/common-frontend.yml
     secrets: inherit
     with:
       run-cmd: |
         ./build/run frontend:test -Dpattern="spec/features/[s-z]*_spec.rb"
       name: part_d
-      java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+      java-version: ${{ inputs.java-version || 11 }}

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   indexer:
-    name: indexer_Java_v${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+    name: indexer_Java_v${{ inputs.java-version || 11 }}
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
-        java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+        java-version: ${{ inputs.java-version || 11 }}
         distribution: temurin
 
     - uses: './.github/actions/bootstrap'

--- a/.github/workflows/public.yml
+++ b/.github/workflows/public.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   public:
-    name: Public_Java_v${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }}
+    name: Public_Java_v${{ inputs.java-version || 11 }}
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
@@ -56,7 +56,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
-        java-version: ${{ inputs.java-version || vars.DEFAULT_JAVA_VERSION }} # https://github.com/actions/runner/issues/2372
+        java-version: ${{ inputs.java-version || 11 }} # https://github.com/actions/runner/issues/2372
         distribution: temurin
 
     - uses: './.github/actions/bootstrap'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
set a default java version when github action variables are not available (fork PRs) see also: https://github.com/orgs/community/discussions/44322

I have noticed this as soon as we got a PR from a fork:
https://github.com/archivesspace/archivesspace/pull/3190

Because also no secrets are available when running github actions on a fork PR, it is not possible (for now) to run our frontend specs (running on AWS workers and requiring secrets to start them) on PRs from forks

I tried to use env variables within the workflows but it is not possible to use them as input arguments to call other workflows (such as the frontend.yml calling the common-frontend.yml workflows)

I tried to use a job that just sets the Java version as an output variable and define that job as a prerequisite for all java depending jobs but that makes the code much more complex. 

I thought just hardcoding the java version is actually the best compromise for now to keep the code maintainable and avoid unnecessary complexity.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
[ANW-2022]
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[ANW-2022]: https://archivesspace.atlassian.net/browse/ANW-2022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ