### PR TITLE
ANW-1977: Fix Staff tooltip bugs

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/common.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/common.scss
@@ -176,6 +176,10 @@ td .btn-group {
   margin-right: 15px; // because bootstrap `.row`s
 }
 
+.mr-36px {
+  margin-right: 36px !important; // 2.25rem
+}
+
 .p-12px {
   padding: 12px;
 }

--- a/frontend/app/assets/stylesheets/archivesspace/help.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/help.scss
@@ -4,7 +4,7 @@
   @include transition(color 0.5s);
 
   color: var(--bs-text-body);
-  position: static !important;
+  position: relative !important;
   padding-top: 1rem;
   padding-bottom: 1rem;
 
@@ -18,16 +18,22 @@
       color: var(--bs-text-body);
     }
   }
-}
-// h3 > .context-help {
-//   float: right;
-//   margin: 6px 6px 0 0;
-// }
 
-// h4 > .context-help {
-//   float: right;
-//   margin: 2px 6px 0 0;
-// }
+  // ANW-1977: Rectify help links that were nested inside headings before
+  // the Bootstrap 4 upgrade. After upgrade on hover the tooltip forced vertical
+  // scroll on the headings. While some nested help links elsewhere could be solved
+  // by making it a sibling to the heading and wrapping them both in a <header>,
+  // the (nested) subform action button siblings of the previously nested help links
+  // depend on rigid assumptions about the markup to perform. In lieu of changing form
+  // behavior, here's a quick hack to make siblilngs of the help link and heading.
+  &.previously-nested-help-link {
+    position: absolute !important;
+    top: 16px;
+    right: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+}
 
 .record-pane > .context-help {
   float: right;

--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -183,7 +183,8 @@ module ApplicationHelper
       options["data-html"] = true
       options["data-delay"] = 500
       options["data-trigger"] = "manual"
-      options["data-template"] = '<div class="tooltip archivesspace-help"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
+      options["data-boundary"] = "viewport"
+      options["data-template"] = '<div class="tooltip archivesspace-help"><div class="arrow"></div><div class="tooltip-inner"></div></div>'
       options[:class] = " has-tooltip #{classes}"
 
       content_tag(:span, text, options)

--- a/frontend/app/views/agents/new.html.erb
+++ b/frontend/app/views/agents/new.html.erb
@@ -12,7 +12,7 @@
           <%= link_to_help :topic => "#{@agent.agent_type}" %>
           <h2><%= "#{t("agent.new_title.#{@agent.agent_type}")}" %>  <span class="label label-info badge"><%= t("agent._singular") %></span></h2>
           <%= render_aspace_partial :partial => "agents/form", :locals => {:form => form} %>
-          <div class="form-actions">
+          <div class="form-actions pl-0">
             <div class="btn-group">
               <button type="submit" class="btn btn-primary"><%= t("#{@agent.agent_type}._frontend.action.save") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= t("actions.save_plus_one") %></button>

--- a/frontend/app/views/archival_objects/_new_inline.html.erb
+++ b/frontend/app/views/archival_objects/_new_inline.html.erb
@@ -8,7 +8,7 @@
         <%= render_aspace_partial :partial => "shared/toolbar_new_records" %>
         <div class="record-pane">
           <%= render_aspace_partial :partial => "archival_objects/form_container", :locals => {:form => form} %>
-          <div class="form-actions">
+          <div class="form-actions pl-0">
             <div class="btn-group btn-submit-group">
               <button type="submit" class="btn btn-primary"><%= t("archival_object._frontend.action.save") %></button>
               <button type="button" id="createPlusOne" class="btn btn-primary btn-plus-one createPlusOneBtn"><%= t("actions.save_plus_one") %></button>

--- a/frontend/app/views/assessments/new.html.erb
+++ b/frontend/app/views/assessments/new.html.erb
@@ -14,7 +14,7 @@
           <h2><%= t("assessment.new_title") %> <span class="label label-info badge"><%= t("assessment._singular") %></span></h2>
           <%= render_aspace_partial :partial => "assessments/form", :locals => {:form => form} %>
 
-          <div class="form-actions">
+          <div class="form-actions pl-0">
             <button type="submit" class="btn btn-primary"><%= t("assessment._frontend.action.save") %></button>
             <%= link_to t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>

--- a/frontend/app/views/classifications/new.html.erb
+++ b/frontend/app/views/classifications/new.html.erb
@@ -12,7 +12,7 @@
 
            <%= render_aspace_partial :partial => "classifications/form_container", :locals => {:form => form} %>
 
-           <div class="form-actions">
+           <div class="form-actions pl-0">
               <button type="submit" class="btn btn-primary"><%= t("classification._frontend.action.save") %></button>
               <%= link_to t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
            </div>

--- a/frontend/app/views/container_profiles/new.html.erb
+++ b/frontend/app/views/container_profiles/new.html.erb
@@ -14,7 +14,7 @@
           <h2><%= t("container_profile.new_title") %> <span class="label label-info badge"><%= t("container_profile._singular") %></span></h2>
 
           <%= render_aspace_partial :partial => "container_profiles/form", :locals => {:form => form} %>
-          <div class="form-actions">
+          <div class="form-actions pl-0">
             <div class="btn-group">
               <button type="submit" class="btn
               btn-primary"><%= t("container_profile._frontend.action.save") %></button>

--- a/frontend/app/views/custom_report_templates/new.html.erb
+++ b/frontend/app/views/custom_report_templates/new.html.erb
@@ -14,7 +14,7 @@
 				<%= form_context :custom_report_template, @custom_report_template do |form| %>
 					<%= render_aspace_partial :partial => "custom_report_templates/form", :locals => {:form => form} %>
 
-					<div class="form-actions">
+					<div class="form-actions pl-0">
 						<div class="btn-group">
 							<button id="create_template" type="submit" class="btn btn-primary"><%= t("custom_report_template._frontend.action.save") %></button>
 							<button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= t("actions.save_plus_one") %></button>

--- a/frontend/app/views/digital_objects/new.html.erb
+++ b/frontend/app/views/digital_objects/new.html.erb
@@ -18,7 +18,7 @@
 
              <%= render_aspace_partial :partial => "digital_objects/form_container", :locals => {:form => form} %>
 
-             <div class="form-actions">
+             <div class="form-actions pl-0">
                <button type="submit" class="btn btn-primary"><%= t("digital_object._frontend.action.save") %></button>
                 <%= link_to t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
              </div>

--- a/frontend/app/views/instances/_subrecord_form_action.html.erb
+++ b/frontend/app/views/instances/_subrecord_form_action.html.erb
@@ -1,4 +1,4 @@
-<div class="btn-group ml-auto custom-action">
+<div class="btn-group ml-auto custom-action mr-36px">
   <button class="btn btn-sm btn-default" data-instance-type="sub-container"><%= t("sub_container._frontend.action.add") %></button>
   <button class="btn btn-sm btn-default" data-instance-type="digital-instance"><%= t("instance._frontend.action.add_digital_object") %></button>
 </div>

--- a/frontend/app/views/jobs/new.html.erb
+++ b/frontend/app/views/jobs/new.html.erb
@@ -17,7 +17,7 @@
           <%= render_aspace_partial :partial => "form", :locals => {:form => form} %>
 
           <br/>
-          <div class="form-actions">
+          <div class="form-actions pl-0">
             <div class="btn-group">
               <button type="submit" class="btn btn-primary btn-sm"><%= t("job._frontend.actions.save") %></button>
             </div>

--- a/frontend/app/views/location_profiles/new.html.erb
+++ b/frontend/app/views/location_profiles/new.html.erb
@@ -14,7 +14,7 @@
           <h2><%= t("location_profile.new_title") %> <span class="label label-info badge"><%= t("location_profile._singular") %></span></h2>
 
           <%= render_aspace_partial :partial => "location_profiles/form", :locals => {:form => form} %>
-          <div class="form-actions">
+          <div class="form-actions pl-0">
             <div class="btn-group">
               <button type="submit" class="btn
               btn-primary"><%= t("location_profile._frontend.action.save") %></button>

--- a/frontend/app/views/repositories/new.html.erb
+++ b/frontend/app/views/repositories/new.html.erb
@@ -13,7 +13,7 @@
           <h2><%= t("repository.new_title") %>  <span class="label label-info badge"><%= t("repository._singular") %></span></h2>
           <br/>
           <%= render_aspace_partial :partial => "repositories/form_container", :locals => {:form => form} %>
-          <div class="form-actions">
+          <div class="form-actions pl-0">
             <div class="btn-group">
               <button type="submit" class="btn btn-primary"><%= t("repository._frontend.action.save") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= t("actions.save_plus_one") %></button>

--- a/frontend/app/views/resources/new.html.erb
+++ b/frontend/app/views/resources/new.html.erb
@@ -13,7 +13,7 @@
 
              <%= render_aspace_partial :partial => "resources/form_container", :locals => {:form => form} %>
 
-             <div class="form-actions">
+             <div class="form-actions pl-0">
                 <button type="submit" class="btn btn-primary"><%= t("resource._frontend.action.save") %></button>
                 <%= link_to t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
              </div>

--- a/frontend/app/views/shared/_subrecord_form.html.erb
+++ b/frontend/app/views/shared/_subrecord_form.html.erb
@@ -33,7 +33,7 @@
 
 <%= render_aspace_partial :partial => template_erb, :locals => {:form => form} %>
 
-<section id="<%= section_id %>" class="<%= section_classes.reject(&:blank?).join(' ') %><% if required == :conditionally %> conditionally-required<% elsif required %> required<% end %>" data-subrecord-form="true" data-object-name="<%= singular %>" data-template="<%= js_template_name %>" <% if custom_action_template %>data-custom-action="true"<% end %> data-cardinality="<%= cardinality %>" <% if remove_disabled %>data-remove="disabled" <% end %>>
+<section id="<%= section_id %>" class="<%= section_classes.reject(&:blank?).join(' ') %><% if required == :conditionally %> conditionally-required<% elsif required %> required<% end %> position-relative" data-subrecord-form="true" data-object-name="<%= singular %>" data-template="<%= js_template_name %>" <% if custom_action_template %>data-custom-action="true"<% end %> data-cardinality="<%= cardinality %>" <% if remove_disabled %>data-remove="disabled" <% end %>>
   <% unless hidden %>
   <<%= heading_size %> class="subrecord-form-heading d-flex py-2 align-items-center">
     <%= wrap_with_tooltip(heading_text, "#{form.i18n_for(name)}_tooltip", "subrecord-form-heading-label") %>
@@ -42,12 +42,12 @@
      <% if custom_action_template %>
        <%= render :partial => custom_action_template %>
      <% else %>
-       <button class="btn btn-sm btn-default ml-auto"><%= t("#{i18n_prefix}#{action_button_override}._frontend.action.add") %></button>
+       <button class="btn btn-sm btn-default ml-auto mr-36px"><%= t("#{i18n_prefix}#{action_button_override}._frontend.action.add") %></button>
      <% end %>
-     <%= link_to_help :topic => help_topic %>
     <% end %>
 
   </<%= heading_size %>>
+  <%= link_to_help :topic => help_topic, :class => "previously-nested-help-link" %>
   <% end %>
 
   <div class="subrecord-form-container">

--- a/frontend/app/views/subjects/new.html.erb
+++ b/frontend/app/views/subjects/new.html.erb
@@ -13,7 +13,7 @@
           <h2><%= I18n.t("subject.new_title") %>  <span class="label label-info badge"><%= I18n.t("subject._singular") %></span></h2>
           <br/>
           <%= render_aspace_partial :partial => "subjects/form", :locals => {:form => form} %>
-          <div class="form-actions">
+          <div class="form-actions pl-0">
             <div class="btn-group">
               <button type="submit" class="btn btn-primary"><%= t("subject._frontend.action.save") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= t("actions.save_plus_one") %></button>

--- a/frontend/app/views/top_containers/new.html.erb
+++ b/frontend/app/views/top_containers/new.html.erb
@@ -14,7 +14,7 @@
 
           <%= render_aspace_partial :partial => "form", :locals => {:form => form} %>
 
-          <div class="form-actions">
+          <div class="form-actions pl-0">
             <button type="submit" class="btn btn-primary"><%= t("top_container._frontend.action.save") %></button>
             <%= link_to t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>

--- a/frontend/app/views/users/new.html.erb
+++ b/frontend/app/views/users/new.html.erb
@@ -11,7 +11,7 @@
        <%= form_context :user, @user do |form| %>
          <%= render_aspace_partial :partial => "users/form", :locals => {:form => form} %>
 
-         <div class="form-actions">
+         <div class="form-actions pl-0">
            <button id="create_account" type="submit" class="btn btn-primary"><%= t("user._frontend.action.create_account") %></button>
            <%= link_to t("actions.cancel"), {:controller => :welcome}, :class => "btn btn-cancel btn-default" %>
          </div>


### PR DESCRIPTION
This PR:

- Repositions the tooltip generated via `link_to_help()`, and hacks around tightly coupled surbform heading markup and form behavior
- Fixes the tooltip generated via `wrap_with_tooltip()`
- Brings spacing around some .form-actions button groups inline with the rest of the app

[ANW-1977](https://archivesspace.atlassian.net/browse/ANW-1977)

## Before

<img width="1512" alt="ANW-1977-bad-tooltips" src="https://github.com/archivesspace/archivesspace/assets/3411019/87f3d243-6de3-4f94-97ec-a8fc9fb0721c">

## After

<img width="1512" alt="ANW-1977-good-tooltip" src="https://github.com/archivesspace/archivesspace/assets/3411019/3872c929-fc20-4aa3-8d0e-63d458eb7472">




[ANW-1977]: https://archivesspace.atlassian.net/browse/ANW-1977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ