### PR TITLE
ANW-2025 Replace https in XML namespaces with http

### DIFF
--- a/backend/app/exporters/serializers/dc.rb
+++ b/backend/app/exporters/serializers/dc.rb
@@ -22,13 +22,13 @@ class DCSerializer < ASpaceExport::Serializer
   private
 
   def _root(dc, xml)
-    schema_locations = "https://purl.org/dc/elements/1.1/ https://dublincore.org/schemas/xmls/qdc/2006/01/06/dc.xsd https://purl.org/dc/terms/ https://dublincore.org/schemas/xmls/qdc/2006/01/06/dcterms.xsd"
+    schema_locations = "http://purl.org/dc/elements/1.1/ https://dublincore.org/schemas/xmls/qdc/2006/01/06/dc.xsd http://purl.org/dc/terms/ https://dublincore.org/schemas/xmls/qdc/2006/01/06/dcterms.xsd"
 
     dc_root = xml.dc(
-                 'xmlns' => 'https://purl.org/dc/elements/1.1/',
-                 "xmlns:dcterms" => "https://purl.org/dc/terms/",
-                 "xmlns:xlink" => "https://www.w3.org/1999/xlink",
-                 'xmlns:xsi' => 'https://www.w3.org/2001/XMLSchema-instance',
+                 'xmlns' => 'http://purl.org/dc/elements/1.1/',
+                 "xmlns:dcterms" => "http://purl.org/dc/terms/",
+                 "xmlns:xlink" => "http://www.w3.org/1999/xlink",
+                 'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
                  'xsi:schemaLocation' => schema_locations) {
 
 

--- a/backend/app/exporters/serializers/eac.rb
+++ b/backend/app/exporters/serializers/eac.rb
@@ -59,9 +59,9 @@ class EACSerializer < ASpaceExport::Serializer
   def _eac(obj, xml)
     json = obj.json
     xml.send('eac-cpf', { 'xmlns' => 'urn:isbn:1-931666-33-4',
-                          'xmlns:html' => 'https://www.w3.org/1999/xhtml',
-                          'xmlns:xlink' => 'https://www.w3.org/1999/xlink',
-                          'xmlns:xsi' => 'https://www.w3.org/2001/XMLSchema-instance',
+                          'xmlns:html' => 'http://www.w3.org/1999/xhtml',
+                          'xmlns:xlink' => 'http://www.w3.org/1999/xlink',
+                          'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
                           'xsi:schemaLocation' => 'urn:isbn:1-931666-33-4 https://eac.staatsbibliothek-berlin.de/schema/cpf.xsd',
                           'xml:lang' => 'eng' }) do
       _control(json, xml)

--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -148,9 +148,9 @@ class EADSerializer < ASpaceExport::Serializer
 
     doc = Nokogiri::XML::Builder.new(:encoding => "UTF-8") do |xml|
       ead_attributes = {
-        'xmlns:xsi' => 'https://www.w3.org/2001/XMLSchema-instance',
+        'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
         'xsi:schemaLocation' => 'urn:isbn:1-931666-22-9 https://www.loc.gov/ead/ead.xsd',
-        'xmlns:xlink' => 'https://www.w3.org/1999/xlink'
+        'xmlns:xlink' => 'http://www.w3.org/1999/xlink'
       }
 
       if data.publish === false

--- a/backend/app/exporters/serializers/marc21.rb
+++ b/backend/app/exporters/serializers/marc21.rb
@@ -33,10 +33,10 @@ class MARCSerializer < ASpaceExport::Serializer
   private
 
   def _root(marc, xml)
-    xml.collection('xmlns'              => 'https://www.loc.gov/MARC21/slim',
-                   'xmlns:marc'         => 'https://www.loc.gov/MARC21/slim',
-                   'xmlns:xsi'          => 'https://www.w3.org/2001/XMLSchema-instance',
-                   'xsi:schemaLocation' => 'https://www.loc.gov/MARC21/slim https://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd') {
+    xml.collection('xmlns'              => 'http://www.loc.gov/MARC21/slim',
+                   'xmlns:marc'         => 'http://www.loc.gov/MARC21/slim',
+                   'xmlns:xsi'          => 'http://www.w3.org/2001/XMLSchema-instance',
+                   'xsi:schemaLocation' => 'http://www.loc.gov/MARC21/slim https://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd') {
 
       xml.record {
 

--- a/backend/app/exporters/serializers/marc_auth.rb
+++ b/backend/app/exporters/serializers/marc_auth.rb
@@ -15,10 +15,10 @@ class MARCAuthSerializer < ASpaceExport::Serializer
   def _marc(obj, xml)
     json = obj.json
     xml.collection(
-      'xmlns' => 'https://www.loc.gov/MARC21/slim',
-      'xmlns:marc' => 'https://www.loc.gov/MARC21/slim',
-      'xmlns:xsi' => 'https://www.w3.org/2001/XMLSchema-instance',
-      'xsi:schemaLocation' => 'https://www.loc.gov/MARC21/slim https://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'
+      'xmlns' => 'http://www.loc.gov/MARC21/slim',
+      'xmlns:marc' => 'http://www.loc.gov/MARC21/slim',
+      'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+      'xsi:schemaLocation' => 'http://www.loc.gov/MARC21/slim https://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'
     ) do
       xml.record do
         _leader(json, xml)

--- a/backend/app/exporters/serializers/mets.rb
+++ b/backend/app/exporters/serializers/mets.rb
@@ -24,12 +24,12 @@ class METSSerializer < ASpaceExport::Serializer
   private
 
   def mets(data, xml, dmd = "mods")
-    xml.mets('xmlns' => 'https://www.loc.gov/METS/',
-             'xmlns:mods' => 'https://www.loc.gov/mods/v3',
-             'xmlns:dc' => 'https://purl.org/dc/elements/1.1/',
-             'xmlns:xlink' => 'https://www.w3.org/1999/xlink',
-             'xmlns:xsi' => "https://www.w3.org/2001/XMLSchema-instance",
-             'xsi:schemaLocation' => "https://www.loc.gov/METS/ https://www.loc.gov/standards/mets/mets.xsd") {
+    xml.mets('xmlns' => 'http://www.loc.gov/METS/',
+             'xmlns:mods' => 'http://www.loc.gov/mods/v3',
+             'xmlns:dc' => 'http://purl.org/dc/elements/1.1/',
+             'xmlns:xlink' => 'http://www.w3.org/1999/xlink',
+             'xmlns:xsi' => "http://www.w3.org/2001/XMLSchema-instance",
+             'xsi:schemaLocation' => "http://www.loc.gov/METS/ https://www.loc.gov/standards/mets/mets.xsd") {
       xml.metsHdr(:CREATEDATE => Time.now.iso8601) {
         xml.agent(:ROLE => data.header_agent_role, :TYPE => data.header_agent_type) {
           xml.name data.header_agent_name

--- a/backend/app/exporters/serializers/mods.rb
+++ b/backend/app/exporters/serializers/mods.rb
@@ -13,7 +13,7 @@ class MODSSerializer < ASpaceExport::Serializer
 
   def serialize_mods(mods, xml)
     root_args = {'version' => '3.4'}
-    root_args['xmlns'] = 'https://www.loc.gov/mods/v3'
+    root_args['xmlns'] = 'http://www.loc.gov/mods/v3'
 
     xml.mods(root_args) {
       serialize_mods_inner(mods, xml)


### PR DESCRIPTION
Fix for ANW-2025, partially reverting ANW-1671

This rolls back the replacement of http with https in serializer XML namespaces, but leaves the updates to the schema locations intact.

Tested locally by doing exports of EAD, EAC, MARCXML, DC, MODS, and METS and making sure that the changes were reverted properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
