### PR TITLE
ANW-2037: Fix staff plugins dropdown submenu in repo settings

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/submenu.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/submenu.scss
@@ -12,6 +12,12 @@
   margin-left: 0;
   border-radius: 4px;
 }
+.dropdown-submenu.dropleft > .dropdown-menu {
+  right: 100%;
+  left: auto;
+  margin-top: -9px; // Align hovered first child dropdown-item with parent dropdown-item
+  margin-right: 0;
+}
 .dropdown-submenu:hover > .dropdown-menu {
   display: block;
 }

--- a/frontend/app/views/shared/_header_repository.html.erb
+++ b/frontend/app/views/shared/_header_repository.html.erb
@@ -167,15 +167,17 @@
                     <% end %>
 
                     <% if Plugins.repository_menu_items.any? {|plugin| has_permission_for_controller?(session, plugin)} %>
-                      <li class="dropdown-submenu dropdown-item">
-                        <a href="javascript:void(0);"><%= t("navbar.plugins") %></a>
-                        <ul class="dropdown-menu">
-                          <% Plugins.repository_menu_items.each do |plugin| %>
-                            <% if has_permission_for_controller?(session, plugin) %>
-                              <li><%= link_to t("plugins.#{plugin}.label"), {:controller => plugin.intern, :action => :index}, :class => "dropdown-item" %></li>
+                      <li>
+                        <div class="btn-group dropdown-item dropdown-submenu dropleft px-0">
+                          <button type="button" class="btn dropdown-toggle py-0 border-0 rounded-0 text-left" data-toggle="dropdown"><%= t("navbar.plugins") %></button>
+                          <ul class="dropdown-menu">
+                            <% Plugins.repository_menu_items.each do |plugin| %>
+                              <% if has_permission_for_controller?(session, plugin) %>
+                                <li><%= link_to t("plugins.#{plugin}.label"), {:controller => plugin.intern, :action => :index}, :class => "dropdown-item px-4 py-1" %></li>
+                              <% end %>
                             <% end %>
-                          <% end %>
-                        </ul>
+                          </ul>
+                        </div>
                       </li>
                     <% end %>
                   </ul>


### PR DESCRIPTION
Fix the positioning and improve markup for the plugins dropdown submenu under the repo settings dropdown menu in the global header of the Staff app.

[ANW-2037](https://archivesspace.atlassian.net/browse/ANW-2037)

## Before

<img width="1512" alt="plugins-dropdown-bug" src="https://github.com/archivesspace/archivesspace/assets/3411019/27aa4b87-b6ba-44a1-8abb-aaa2adff8863">

## After

<img width="1496" alt="ANW-2037-after" src="https://github.com/archivesspace/archivesspace/assets/3411019/575bbbac-5fe1-488d-bfe9-ced3686a884c">

[ANW-2037]: https://archivesspace.atlassian.net/browse/ANW-2037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ