### PR TITLE
ANW-2017: Fix agent merge preview page

### DIFF
--- a/frontend/app/assets/javascripts/agents.merge_selector.js
+++ b/frontend/app/assets/javascripts/agents.merge_selector.js
@@ -18,7 +18,7 @@ $(function () {
       'mergePreviewModal',
       $(this).text(),
       "<div class='alert alert-info'>Loading...</div>",
-      {},
+      'xl',
       this
     );
     $.ajax({

--- a/frontend/app/assets/javascripts/utils.js
+++ b/frontend/app/assets/javascripts/utils.js
@@ -788,12 +788,8 @@ AS.initSubRecordSorting = function ($list) {
         // Manually duplicate frontend/app/views/shared/_fa_grip_svg.html.erb here
         // instead of renaming this file .erb
         const fa_grip_svg = `
-<svg xmlns="http://www.w3.org/2000/svg" height="16" width="10" viewBox="0 0 320 512"><path d="M40 352l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40zm192 0l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40zM40 320c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0zM232 192l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40zM40 160c-22.1 0-40-17.9-40-40L0 72C0 49.9 17.9 32 40 32l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0zM232 32l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" class="fa-grip" height="16" width="10" viewBox="0 0 320 512"><path d="M40 352l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40zm192 0l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40zM40 320c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0zM232 192l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40zM40 160c-22.1 0-40-17.9-40-40L0 72C0 49.9 17.9 32 40 32l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0zM232 32l48 0c22.1 0 40 17.9 40 40l0 48c0 22.1-17.9 40-40 40l-48 0c-22.1 0-40-17.9-40-40l0-48c0-22.1 17.9-40 40-40z"/></svg>
 `;
-        // LEFT OFF IMPROVING THE drag handle here used on record edit sub forms
-        // My question is does this change have any unintended impacts elsewhere?
-        // Perhaps not given the css for this drag-handle nested under a subform class:
-        // `ul.subrecord-form-list .drag-handle`
         var $handle = $(`<div class='drag-handle'>${fa_grip_svg}</div>`);
         if ($list.parent().hasClass('controls')) {
           $handle.addClass('inline');
@@ -1018,7 +1014,6 @@ $(function () {
       switch (String.fromCharCode(event.which).toLowerCase()) {
         case 's':
           event.preventDefault();
-          console.log('ctrl-s');
           break;
       }
     }

--- a/frontend/app/assets/stylesheets/archivesspace/merge_selector.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/merge_selector.scss
@@ -13,6 +13,10 @@
   color: black;
 }
 
+#merge-target svg.fa-grip {
+  display: none;
+}
+
 .merge-group {
   margin-top: 20px;
   margin-bottom: 20px;

--- a/frontend/app/helpers/aspace_form_helper.rb
+++ b/frontend/app/helpers/aspace_form_helper.rb
@@ -887,7 +887,7 @@ module AspaceFormHelper
         if replace
           html << '<label class="replace-control">'
           html << form.merge_checkbox('replace')
-          html << '<small>'
+          html << '<small class="fs-14px">'
           html << I18n.t("actions.merge_replace").to_s
           html << '</small>'
           html << '</label>'
@@ -896,7 +896,7 @@ module AspaceFormHelper
         if append
           html << '<label class="append-control">'
           html << form.merge_checkbox('append')
-          html << '<small>'
+          html << '<small class="fs-14px">'
           html << I18n.t("actions.merge_add").to_s
           html << '</small>'
           html << '</label>'

--- a/frontend/app/views/agent_alternate_sets/_show.html.erb
+++ b/frontend/app/views/agent_alternate_sets/_show.html.erb
@@ -5,10 +5,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <% agent_alternate_sets.each_with_index do | agent_alternate_set, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_alternate_set_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_contact_details/_show.html.erb
+++ b/frontend/app/views/agent_contact_details/_show.html.erb
@@ -5,7 +5,7 @@
 
 <section id="<%= section_id %>">
   <h3><%= t("agent_contact._plural") %></h3>
-  <div class="accordion details" id="agent_contact_accordion">
+  <div class="accordion details my-3" id="agent_contact_accordion">
     <%= context.list_for(context["agent_contacts"], "agent_contacts[]") do |contact, index| %>
       <div class="panel panel-default">
         <div class="panel-heading">

--- a/frontend/app/views/agent_conventions_declarations/_show.html.erb
+++ b/frontend/app/views/agent_conventions_declarations/_show.html.erb
@@ -5,10 +5,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <% agent_conventions_declarations.each_with_index do | agent_conventions_declaration, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_conventions_declaration_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_functions/_show.html.erb
+++ b/frontend/app/views/agent_functions/_show.html.erb
@@ -6,10 +6,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <%= context.list_for(context["agent_functions"], "agent_functions[]") do |agent_function, index| %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_function_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_genders/_show.html.erb
+++ b/frontend/app/views/agent_genders/_show.html.erb
@@ -5,10 +5,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <%= context.list_for(context["agent_genders"], "agent_genders[]") do |agent_gender, index| %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_gender_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_identifiers/_show.html.erb
+++ b/frontend/app/views/agent_identifiers/_show.html.erb
@@ -5,10 +5,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <% agent_identifiers.each_with_index do | agent_identifier, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_identifier_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_maintenance_histories/_show.html.erb
+++ b/frontend/app/views/agent_maintenance_histories/_show.html.erb
@@ -5,10 +5,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <% agent_maintenance_histories.each_with_index do | agent_maintenance_history, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_maintenance_history_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_names/_show.html.erb
+++ b/frontend/app/views/agent_names/_show.html.erb
@@ -5,10 +5,10 @@
 
 <section id="<%= @agent.agent_type %>_names">
   <h3><%= t("agent_name._plural") %></h3>
-  <div class="panel-group details" id="agent_name_accordion">
+  <div class="details my-3" id="agent_name_accordion">
     <% @agent.names.each_with_index do | name, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#agent_name_accordion" href="#agent_name_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_occupations/_show.html.erb
+++ b/frontend/app/views/agent_occupations/_show.html.erb
@@ -6,10 +6,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <%= context.list_for(context["agent_occupations"], "agent_occupations[]") do |agent_occupation, index| %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_occupation_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_other_agency_codes/_show.html.erb
+++ b/frontend/app/views/agent_other_agency_codes/_show.html.erb
@@ -5,10 +5,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <% agent_other_agency_codes.each_with_index do | agent_other_agency_code, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_other_agency_code_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_parallel_names/_show.html.erb
+++ b/frontend/app/views/agent_parallel_names/_show.html.erb
@@ -7,10 +7,10 @@
 
 <section id="<%= section_title + rand(1000000).to_s %>">
   <h4><%= t("agent_parallel_name._plural") %></h4>
-  <div class="panel-group details" id="agent_parallel_name_accordion_<%= parent_index %>">
+  <div class="details my-3" id="agent_parallel_name_accordion_<%= parent_index %>">
     <% names.each_with_index do | name, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#agent_parallel_name_accordion_<%= parent_index %>" href="#agent_parallel_name_<%= parent_index %>_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_parallel_names/_show_inline.html.erb
+++ b/frontend/app/views/agent_parallel_names/_show_inline.html.erb
@@ -7,10 +7,10 @@
 
 <section id="<%= section_title + rand(1000000).to_s %>">
   <h4><%= t("agent_parallel_name._plural") %></h4>
-  <div class="panel-group details" id="agent_parallel_name_accordion_<%= parent_index %>">
+  <div class="details my-3" id="agent_parallel_name_accordion_<%= parent_index %>">
     <% names.each_with_index do | name, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row">
             <div class="col-md-1">
               &nbsp;

--- a/frontend/app/views/agent_places/_show.html.erb
+++ b/frontend/app/views/agent_places/_show.html.erb
@@ -6,10 +6,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <%= context.list_for(context["agent_places"], "agent_places[]") do |agent_place, index| %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_place_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_record_controls/_show.html.erb
+++ b/frontend/app/views/agent_record_controls/_show.html.erb
@@ -5,10 +5,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <% agent_record_controls.each_with_index do | agent_record_control, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_record_control_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_record_identifiers/_show.html.erb
+++ b/frontend/app/views/agent_record_identifiers/_show.html.erb
@@ -5,10 +5,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <% agent_record_identifiers.each_with_index do | agent_record_identifier, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_record_identifier_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_resources/_show.html.erb
+++ b/frontend/app/views/agent_resources/_show.html.erb
@@ -6,10 +6,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <% agent_resources.each_with_index do | agent_resource, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_resource_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_sources/_show.html.erb
+++ b/frontend/app/views/agent_sources/_show.html.erb
@@ -5,10 +5,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <% agent_sources.each_with_index do | agent_source, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_source_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agent_topics/_show.html.erb
+++ b/frontend/app/views/agent_topics/_show.html.erb
@@ -6,10 +6,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <%= context.list_for(context["agent_topics"], "agent_topics[]") do |agent_topic, index| %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_agent_topic_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/agents/_merge_selector.html.erb
+++ b/frontend/app/views/agents/_merge_selector.html.erb
@@ -1,14 +1,14 @@
 <%= setup_context :object => @agent, :controller => :agents,  :agent_type => @agent.agent_type, :title => "#{t("actions.merge")} #{t("agent.agent_type.#{@agent.agent_type}")}" %>
 
-<div class="form-actions row mb-3">
-  <div class='col d-flex'>
-    <button type="button" class="btn preview-merge btn bg-white border mr-2"><%= t("agent._frontend.action.preview") %></button>
+<div class="form-actions d-flex mb-3">
+  <div class='col d-flex gap-x-2'>
+    <button type="button" class="btn btn-default preview-merge"><%= t("agent._frontend.action.preview") %></button>
     <button type="button" class="btn btn-primary do-merge"><%= t("actions.merge") %></button>
-    <%= link_to t("actions.cancel"), {:controller => :agents, :action => :show, :id => @agent.id}, :class => "btn btn-cancel btn-default ml-auto bg-white border" %>
+    <%= link_to t("actions.cancel"), {:controller => :agents, :action => :show, :id => @agent.id}, :class => "btn btn-cancel btn-default ml-auto" %>
   </div>
 </div>
-<div id="merge-selector-root" class="row">
-  <div class="col-md-6">
+<div id="merge-selector-root" class="d-flex">
+  <div id="merge-target" class="col-md-6">
     <h2><%= t("agent._frontend.section.target_record") %></h2>
     <div class="record-pane">
       <%= form_for @agent, :as => "agent", :url => {:action => :merge_detail}, :html => {:class => 'form-horizontal aspace-record-form', :id => "agent_form"} do |f| %>
@@ -224,8 +224,7 @@
       <% end %>
     </div>
   </div>
-  <%# VICTIM SIDE %>
-  <div class="col-md-6">
+  <div id="merge-victim" class="col-md-6">
     <h2>
       <%= t("agent._frontend.section.victim_record") %>
       <span class='ml-auto'>
@@ -448,8 +447,8 @@
     </div>
   </div>
 </div>
-<div class="form-actions row p-3">
-  <button type="button" class="btn preview-merge"><%= t("agent._frontend.action.preview") %></button>
+<div class="form-actions d-flex gap-x-2 p-3">
+  <button type="button" class="btn btn-default preview-merge"><%= t("agent._frontend.action.preview") %></button>
   <button type="button" class="btn btn-primary do-merge"><%= t("actions.merge") %></button>
-  <%= link_to t("actions.cancel"), {:controller => :agents, :action => :show, :id => @agent.id}, :class => "btn btn-cancel btn-default ml-auto ml-auto border bg-white" %>
+  <%= link_to t("actions.cancel"), {:controller => :agents, :action => :show, :id => @agent.id}, :class => "btn btn-cancel btn-default ml-auto" %>
 </div>

--- a/frontend/app/views/deaccessions/_show.html.erb
+++ b/frontend/app/views/deaccessions/_show.html.erb
@@ -6,9 +6,9 @@
 
 <section id="<%= section_id %>">
   <h3><%= t("deaccession._plural") %></h3>
-  <div class="accordion details" id="deaccessions_accordion">
+  <div class="accordion details my-3" id="deaccessions_accordion">
     <%= context.list_for(context["deaccessions"], "deaccessions[]") do |deaccession, index| %>
-      <div class="card">
+      <div class="card mb-3">
         <div class="card-header panel-heading">
           <div class="row collapsed accordion-toggle" data-toggle="collapse" data-parent="#deaccessions_accordion" href="#deaccession_<%= index %>">
             <div class="col-md-1">

--- a/frontend/app/views/file_versions/_show.html.erb
+++ b/frontend/app/views/file_versions/_show.html.erb
@@ -4,7 +4,7 @@
 
 <section id="<%= section_id %>">
   <h3><%= t("file_version._plural") %></h3>
-  <div class="accordion details" id="<%= section_id %>_accordion">
+  <div class="accordion details my-3" id="<%= section_id %>_accordion">
     <% file_versions.each_with_index do | file_version, index | %>
       <div class="card border">
         <div class="panel-heading card-header">

--- a/frontend/app/views/lang_materials/_show.html.erb
+++ b/frontend/app/views/lang_materials/_show.html.erb
@@ -4,7 +4,7 @@
 
 <section id="<%= section_id %>">
   <h3><%= t('lang_material._plural') %></h3>
-  <div class="accordion details" id="lang_materials_accordion">
+  <div class="accordion details my-3" id="lang_materials_accordion">
     <% lang_materials.each_with_index do | lang_material, index | %>
       <div class="card border">
         <div class="panel-heading card-header">

--- a/frontend/app/views/metadata_rights_declarations/_show.html.erb
+++ b/frontend/app/views/metadata_rights_declarations/_show.html.erb
@@ -5,11 +5,11 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <% metadata_rights_declarations.each_with_index do | metadata_rights_declaration, index | %>
       <% license = metadata_rights_declaration['license'] || "other" %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_metadata_rights_declaration_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/revision_statements/_show.html.erb
+++ b/frontend/app/views/revision_statements/_show.html.erb
@@ -4,10 +4,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= t("revision_statement._plural") %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <% revision_statements.each_with_index do | rs, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_revision_statement_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/rights_statements/_show.html.erb
+++ b/frontend/app/views/rights_statements/_show.html.erb
@@ -4,7 +4,7 @@
 
 <section id="<%= section_id %>">
   <h3><%= t("rights_statement._plural") %></h3>
-  <div class="accordion details" id="rights_statements_accordion">
+  <div class="accordion details my-3" id="rights_statements_accordion">
     <% rights_statements.each_with_index do | rights_statement, index | %>
       <div class="panel panel-default">
         <div class="panel-heading">

--- a/frontend/app/views/structured_dates/_show.html.erb
+++ b/frontend/app/views/structured_dates/_show.html.erb
@@ -7,10 +7,10 @@
 
 <section id="<%= section_id %>">
   <<%= heading_size %>><%= section_title %></<%= heading_size %>>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <% dates.each_with_index do | date, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/structured_dates/_show_inline.html.erb
+++ b/frontend/app/views/structured_dates/_show_inline.html.erb
@@ -7,10 +7,10 @@
 
 <section id="<%= section_id %>">
   <<%= heading_size %>><%= section_title %></<%= heading_size %>>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <% dates.each_with_index do | date, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row">
             <div class="col-md-1">
               &nbsp;

--- a/frontend/app/views/used_languages/_show.html.erb
+++ b/frontend/app/views/used_languages/_show.html.erb
@@ -5,10 +5,10 @@
 
 <section id="<%= section_id %>">
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <%= context.list_for(context["used_languages"], "used_languages[]") do |used_language, index| %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card mb-3">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_used_language_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/spec/features/agents_spec.rb
+++ b/frontend/spec/features/agents_spec.rb
@@ -53,7 +53,7 @@ describe 'System Information', js: true do
 
       within '#mergePreviewModal' do
         within '#agent_corporate_entity_agent_record_identifier_accordion' do
-          elements = all('.panel.panel-default')
+          elements = all('.card')
           elements.last.click
           expect(elements.last).to have_text agent_b['agent_record_identifiers'][0]['record_identifier']
         end
@@ -101,7 +101,7 @@ describe 'System Information', js: true do
 
       within '#mergePreviewModal' do
         within '#agent_corporate_entity_agent_record_identifier_accordion' do
-          elements = all('.panel.panel-default')
+          elements = all('.card')
           elements.last.click
           expect(elements.last).to have_text agent_b['agent_record_identifiers'][0]['record_identifier']
         end
@@ -149,7 +149,7 @@ describe 'System Information', js: true do
 
       within '#mergePreviewModal' do
         within '#agent_corporate_entity_agent_place' do
-          elements = all('.panel.panel-default')
+          elements = all('.card')
           elements.last.click
           expect(elements.last).to have_text I18n.t("enumerations.place_role.#{agent_b['agent_places'][0]['place_role']}")
         end
@@ -197,7 +197,7 @@ describe 'System Information', js: true do
 
       within '#mergePreviewModal' do
         within '#agent_name_accordion' do
-          elements = all('.panel.panel-default')
+          elements = all('.card')
           elements.last.click
           expect(elements.last).to have_text agent_b['agent_places'][0]['primary_name']
         end


### PR DESCRIPTION
This PR fixes the Agent merge preview page and modal layouts, spacing, sizes, and more.

Includes replacing the pattern used for accordion instances across multiple `show` views.

[ANW-2017](https://archivesspace.atlassian.net/browse/ANW-2017)

## Before

![ANW-2017-before](https://github.com/archivesspace/archivesspace/assets/3411019/c34e7901-9d70-4c41-bc7a-12652ba3708f)

<img width="1481" alt="ANW-2017-modal-before" src="https://github.com/archivesspace/archivesspace/assets/3411019/fe99d05e-e2de-428e-883a-8e6f5e0d042a">

## After

<img width="1462" alt="ANW-2017-modal-after" src="https://github.com/archivesspace/archivesspace/assets/3411019/5c0fd21c-d5b3-4161-aa60-edcdb5d33893">

![ANW-2017-after](https://github.com/archivesspace/archivesspace/assets/3411019/05d96735-4c1c-4878-9ce6-7d745d184f22)

[ANW-2017]: https://archivesspace.atlassian.net/browse/ANW-2017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ