### PR TITLE
ANW-2030: Fix archival obj spawn from accession

### DIFF
--- a/frontend/app/assets/javascripts/archival_objects.crud.js
+++ b/frontend/app/assets/javascripts/archival_objects.crud.js
@@ -60,7 +60,7 @@ function TreeLinkingModal(config) {
     'linkResourceModal',
     config.title,
     AS.renderTemplate('linker_browsemodal_template', config),
-    'large',
+    'full',
     {},
     this
   );
@@ -240,7 +240,7 @@ function TreeLinkingModal(config) {
     // parent_uri may be undef but position should always be an int
     self.config.onLink(self.parent_uri, self.position);
     // closing this way to get proper focus back in main window
-    $('.modal-header a', self.$modal).trigger('click');
+    $('.modal-header button', self.$modal).trigger('click');
     return false;
   });
 }
@@ -258,7 +258,7 @@ function SimpleLinkingModal(config) {
     'linkResourceModal',
     self.config.title,
     AS.renderTemplate('linker_browsemodal_template', config),
-    'large',
+    'full',
     {},
     this
   );
@@ -332,7 +332,7 @@ SimpleLinkingModal.prototype.init_click_handlers = function () {
     event.preventDefault();
     if (self.currentSelected) {
       // closing this way to get proper focus back in main window
-      $('.modal-header a', self.$modal).trigger('click');
+      $('.modal-header button', self.$modal).trigger('click');
       self.config.onLink(self.currentSelected);
     }
     return false;

--- a/frontend/spec/features/spawning_spec.rb
+++ b/frontend/spec/features/spawning_spec.rb
@@ -19,10 +19,7 @@ describe 'Spawning', js: true do
     select_repository(@repo)
   end
 
-  xit "can spawn a resource component from an accession" do
-    # TODO this example was ignored to get the Softserv updates merged into master
-    # There's a bug in the code for this two-modal step process which makes this
-    # test fail, see https://archivesspace.atlassian.net/browse/ANW-2030.
+  it "can spawn a resource component from an accession" do
     set_repo(@repo)
     @resource = create(:resource)
     @parent = create(:json_archival_object,


### PR DESCRIPTION
This PR fixes the broken modal work flow for spawning an Archival Object from an Accession.

It also re-enables the related spec.

[ANW-2030](https://archivesspace.atlassian.net/browse/ANW-2030)

## Before

![broken two-step spawn modal](https://github.com/archivesspace/archivesspace/assets/3411019/d53d767b-d577-4fed-931b-f15df2573e58)

## After

![ANW-2030-broken-modal-fix](https://github.com/archivesspace/archivesspace/assets/3411019/5d5cd485-e34b-4ba4-9b19-a9cf25201d22)


[ANW-2030]: https://archivesspace.atlassian.net/browse/ANW-2030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ