### PR TITLE
Remove unused print pdf backend controller and ead xml export frontend

### DIFF
--- a/backend/app/controllers/exports.rb
+++ b/backend/app/controllers/exports.rb
@@ -317,7 +317,7 @@ class ArchivesSpaceService < Sinatra::Base
         curl -s -F password="admin" "http://localhost:8089/users/admin/login"
         set SESSION="session_id"
         curl -H "X-ArchivesSpace-Session: $SESSION" \\
-        "http://localhost:8089/repositories/2/resource_descriptions/577.xml?include_unpublished=false&include_daos=true&numbered_cs=true&print_pdf=false&ead3=false" //
+        "http://localhost:8089/repositories/2/resource_descriptions/577.xml?include_unpublished=false&include_daos=true&numbered_cs=true&ead3=false" //
         --output ead.xml
       SHELL
     end
@@ -334,7 +334,6 @@ class ArchivesSpaceService < Sinatra::Base
                              params={"include_unpublished": False,
                                      "include_daos": True,
                                      "numbered_cs": True,
-                                     "print_pdf": False,
                                      "ead3": False})
         # replace 2 for your repository ID and 577 with your resource ID. Find these at the URI on the staff interface
         # set parameters to True or False
@@ -353,88 +352,18 @@ class ArchivesSpaceService < Sinatra::Base
              "Include digital objects in dao tags", :optional => true],
             ["numbered_cs", BooleanParam,
              "Use numbered <c> tags in ead", :optional => true],
-            ["print_pdf", BooleanParam,
-             "Print EAD to pdf", :optional => true],
             ["repo_id", :repo_id],
             ["ead3", BooleanParam,
              "Export using EAD3 schema", :optional => true])
     .permissions([:view_repository])
     .returns([200, "(:resource)"]) \
   do
-    if params[:print_pdf]
-      redirect to("/repositories/#{params[:repo_id]}/resource_descriptions/#{params[:id]}.pdf?#{params.map { |k, v| "#{k}=#{v}" }.join('&')}")
-    end
     ead_stream = generate_ead(params[:id],
                               (params[:include_unpublished] || false),
                               (params[:include_daos] || false),
                               (params[:numbered_cs] || false),
                               (params[:ead3] || false))
     stream_response(ead_stream)
-  end
-
-  Endpoint.get('/repositories/:repo_id/resource_descriptions/:id.pdf')
-    .description("Get a PDF representation of a Resource")
-    .example("shell") do
-      <<~SHELL
-        curl -s -F password="admin" "http://localhost:8089/users/admin/login"
-        set SESSION="session_id"
-        curl -H "X-ArchivesSpace-Session: $SESSION" \\
-        "http://localhost:8089/repositories/2/resource_descriptions/577.pdf?include_unpublished=false&include_daos=true&numbered_cs=true&print_pdf=false&ead3=false" //
-        --output ead.pdf
-      SHELL
-    end
-    .example("python") do
-      <<~PYTHON
-        from asnake.client import ASnakeClient  # import the ArchivesSnake client
-
-        client = ASnakeClient(baseurl="http://localhost:8089", username="admin", password="admin")
-        # replace http://localhost:8089 with your ArchivesSpace API URL and admin for your username and password
-
-        client.authorize()  # authorizes the client
-
-        ead_pdf = client.get("repositories/2/resource_descriptions/577.pdf",
-                              params={"include_unpublished": False,
-                                      "include_daos": True,
-                                      "numbered_cs": True,
-                                      "print_pdf": True,
-                                      "ead3": False})
-        # replace 2 for your repository ID and 577 with your resource ID. Find these at the URI on the staff interface
-        # set parameters to True or False
-
-        with open("ead.pdf", "wb") as file:  # save the file
-            file.write(ead_pdf.content)  # write the file content to our file.
-            file.close()
-
-        # For error handling, print or log the returned value of client.get with .json() - print(ead_pdf.json())
-      PYTHON
-    end
-    .params(["id", :id],
-            ["include_unpublished", BooleanParam,
-             "Include unpublished records", :optional => true],
-            ["include_daos", BooleanParam,
-             "Include digital objects in dao tags", :optional => true],
-            ["numbered_cs", BooleanParam,
-             "Use numbered <c> tags in ead", :optional => true],
-            ["print_pdf", BooleanParam,
-             "Print EAD to pdf", :optional => true],
-            ["repo_id", :repo_id],
-            ["ead3", BooleanParam,
-             "Export using EAD3 schema", :optional => true])
-    .permissions([:view_repository])
-    .returns([200, "(:resource)"]) \
-  do
-    ead_stream = generate_ead(params[:id],
-                              (params[:include_unpublished] || false),
-                              (params[:include_daos] || false),
-                              (params[:numbered_cs] || false),
-                              (params[:ead3] || false))
-
-    repo = resolve_references(Repository.get_or_die(params[:repo_id]), params[:resolve])
-
-    image_for_pdf = (repo['image_url'])
-
-    pdf = generate_pdf_from_ead(ead_stream, image_for_pdf)
-    pdf_response(pdf)
   end
 
   Endpoint.get('/repositories/:repo_id/resource_descriptions/:id.:fmt/metadata')

--- a/frontend/app/assets/javascripts/export_dropdown.js.erb
+++ b/frontend/app/assets/javascripts/export_dropdown.js.erb
@@ -7,7 +7,7 @@ $(function () {
       e.stopPropagation();
     });
     $('.record-toolbar').on('click', 'a.download-ead-action', function(e) {
-      var url = AS.quickTemplate(decodeURIComponent($("#download-ead-dropdown").data("download-ead-url")), { testme: true,  include_unpublished: $("input#include-unpublished").is(':checked'), include_daos: $("input#include-daos").is(':checked'), numbered_cs: $("input#numbered-cs").is(':checked'), print_pdf: $("input#print-pdf").is(':checked'), ead3: $("input#ead3").is(':checked')});
+      var url = AS.quickTemplate(decodeURIComponent($("#download-ead-dropdown").data("download-ead-url")), { testme: true,  include_unpublished: $("input#include-unpublished").is(':checked'), include_daos: $("input#include-daos").is(':checked'), numbered_cs: $("input#numbered-cs").is(':checked'), ead3: $("input#ead3").is(':checked')});
       location.href = url;
     });
     $('.record-toolbar').on('click', 'a.download-marc-action', function(e) {

--- a/frontend/app/controllers/exports_controller.rb
+++ b/frontend/app/controllers/exports_controller.rb
@@ -40,15 +40,10 @@ class ExportsController < ApplicationController
 
 
   def download_ead
-    if params[:print_pdf] == "true"
-      url = "/repositories/#{JSONModel::repository}/resource_descriptions/#{params[:id]}.pdf"
-    else
-      url = "/repositories/#{JSONModel::repository}/resource_descriptions/#{params[:id]}.xml"
-    end
+    url = "/repositories/#{JSONModel::repository}/resource_descriptions/#{params[:id]}.xml"
 
     download_export(url,
                     :include_unpublished => (params[:include_unpublished] ? params[:include_unpublished] : false),
-                    :print_pdf => (params[:print_pdf] ? params[:print_pdf] : false),
                     :include_daos => (params[:include_daos] ? params[:include_daos] : false),
                     :numbered_cs => (params[:numbered_cs] ? params[:numbered_cs] : false),
                     :ead3 => (params[:ead3] ? params[:ead3] : false))

--- a/frontend/app/views/resources/_toolbar.html.erb
+++ b/frontend/app/views/resources/_toolbar.html.erb
@@ -12,8 +12,7 @@
           for export needs that this alt approach was easiest. %>
       <li class="dropdown-item p-0 dropdown-submenu" id="download-ead-dropdown" data-download-ead-url="<%= url_for(:controller => :exports,
         :action => :download_ead, :id => @resource.id, :include_unpublished => "${include_unpublished}",
-        :include_daos => "${include_daos}", :numbered_cs => "${numbered_cs}", :print_pdf => "${print_pdf}",
-        :ead3 => "${ead3}" )%>">
+        :include_daos => "${include_daos}", :numbered_cs => "${numbered_cs}", :ead3 => "${ead3}" )%>">
         <%# The following <a> triggers a download on click and shows the sub dropdown menu
             below it on hover; the sub dropdown menu repositions weirdly (via popper.js)
             after the download in the same page session, so `data-display="static"` is

--- a/frontend/config/locales/de.yml
+++ b/frontend/config/locales/de.yml
@@ -416,7 +416,6 @@ de:
     include_unpublished: Unveröffentlichte einschließen
     include_daos: '&lt;dao&gt; Tags einschließen'
     numbered_cs: Nummerierte &lt;c&gt; Tags verwenden
-    print_pdf: In PDF drucken
     ead3: EAD3 Schema
     use_mods: MODS verwenden
     use_dc: Dublin Core verwenden

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -162,7 +162,6 @@ en:
     include_unpublished: Include unpublished
     include_daos: Include &lt;dao&gt; tags
     numbered_cs: Use numbered &lt;c&gt; tags
-    print_pdf: Print to PDF
     ead3: EAD3 schema
     use_mods: Use MODS
     use_dc: Use Dublin Core

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -203,7 +203,6 @@ es:
     include_unpublished: Incluir sin publicar
     include_daos: Incluir etiquetas &lt; dao &gt;
     numbered_cs: Utilice etiquetas numeradas &lt; c &gt;
-    print_pdf: Imprimir en PDF
     ead3: EAD3 esquema
     use_mods: Utilizar MODS
     use_dc: Utilizar Dublin Core

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -205,7 +205,6 @@ fr:
     include_unpublished: Inclure non publié
     include_daos: Inclure balises &lt;dao&gt;
     numbered_cs: Utiliser balises numérotées &lt;c&gt;
-    print_pdf: Imprimer en PDF
     ead3: Schéma EAD3
     use_mods: Utiliser MODS
     use_dc: Utiliser Dublin Core

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -169,7 +169,6 @@ ja:
     include_unpublished: 未発表を含める
     include_daos: "&lt;dao&gt;タグを含める"
     numbered_cs: 番号付きの&lt;c&gt;タグを使用する
-    print_pdf: PDFへの印刷
     ead3: EAD3スキーマ
     use_mods: MODSを使用する
     use_dc: ダブリンコアを使用する


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The pdf export for a resource used to be in a checkbox inside the Export -> Download EAD menu, and we could directly download the EAD using a backend controller.

At some point, the print pdf was moved inside a job, in a separate section in the Export menu, so the controller on the backend and anything related to directly printing pdf on the frontend is not used anymore.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
