### PR TITLE
ANW-2048 Fix ARKs, Groups, and Custom Report views

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace.scss
+++ b/frontend/app/assets/stylesheets/archivesspace.scss
@@ -26,7 +26,6 @@
 @import 'archivesspace/embedded_files';
 @import 'archivesspace/assessments';
 @import 'archivesspace/merge_selector';
-@import 'archivesspace/custom_reports';
 @import 'archivesspace/datepicker';
 @import 'themes/default/default';
 @import 'archivesspace/print';

--- a/frontend/app/assets/stylesheets/archivesspace/common.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/common.scss
@@ -180,6 +180,10 @@ td .btn-group {
   margin-right: 36px !important; // 2.25rem
 }
 
+.ml--1px {
+  margin-left: -1px;
+}
+
 .p-12px {
   padding: 12px;
 }
@@ -210,6 +214,10 @@ td .btn-group {
 
 .gap-bs-x-15px {
   column-gap: 15px; // because bootstrap `.row`s
+}
+
+.gap-2 {
+  gap: 0.5rem;
 }
 
 @media (min-width: 992px) {
@@ -256,7 +264,7 @@ td .btn-group {
 
 .border-gray-600,
 .border-gray--secondary {
-  border-color: $gray-600;
+  border-color: $gray-600 !important;
 }
 
 .bg-asFormHeadingBg {
@@ -274,6 +282,13 @@ td .btn-group {
 
 .hover-bg-dark:hover {
   background-color: var(--dark);
+}
+
+.rounded-right-only {
+  border-top-right-radius: 0.25rem !important;
+  border-bottom-right-radius: 0.25rem !important;
+  border-bottom-left-radius: 0 !important;
+  border-top-left-radius: 0 !important;
 }
 
 .hover-no-underline:hover {

--- a/frontend/app/assets/stylesheets/archivesspace/custom_reports.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/custom_reports.scss
@@ -1,9 +1,0 @@
-.textarea-with-button {
-  textarea {
-    height: 100px;
-  }
-
-  input.user-field-clear-button {
-    display: block;
-  }
-}

--- a/frontend/app/assets/stylesheets/archivesspace/form.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/form.scss
@@ -1023,7 +1023,3 @@ div.btn-with-tooltip {
   max-width: fit-content;
   display: inline;
 }
-
-.permission-label {
-  height: auto;
-}

--- a/frontend/app/views/custom_report_templates/_form.html.erb
+++ b/frontend/app/views/custom_report_templates/_form.html.erb
@@ -4,21 +4,25 @@
 
 <% data = @custom_report_template['data'] ? ASUtils.json_parse(@custom_report_template['data']) : {} %>
 
-<fieldset>
+<fieldset class="mb-4">
 
 	<% record_types = custom_data.keys %>
 	<% record_types.delete('global') %>
 
-	<div id="template_information">
-		<h3><%= t "custom_report_template._frontend.section.template_information" %>
-		<%= link_to_help :topic => "accession_basic_information" %></h3>
+	<div id="template_information" class="mb-3">
+		<div class="d-flex align-items-center border-bottom bg-asFormHeadingBg">
+			<h3 class="flex-grow-1 mb-0 border-0">
+				<%= t "custom_report_template._frontend.section.template_information" %>
+			</h3>
+			<%= link_to_help :topic => "accession_basic_information" %>
+		</div>
 
 		<%= form.label_and_textfield "name", :required => true %>
 		<%= form.label_and_textarea "description" %>
 		<%= form.label_and_select "limit", custom_report_template_limit_options %>
 
-		<div class="form-group">
-			<%= form.label 'record_type', :class => "col-sm-2 control-label", :for => "custom_record_type" %>
+		<div class="form-group d-flex">
+			<%= form.label 'record_type', :class => "col-sm-2 control-label text-right", :for => "custom_record_type" %>
 			<div class="col-sm-9">
 				<%= select_tag "custom_report_template[data][custom_record_type]", options_for_select(record_types.collect {|record_type| [t("#{record_type}._plural"), record_type]}, data['custom_record_type']), {:id => "custom_record_type", :class => "form-control"} %>
 			</div>
@@ -48,13 +52,13 @@
 						<% {} %>
 					<% end %>
 
-					<div class="panel panel-default">
+					<div class="card mb-3">
 
-						<div class="panel-heading">
+						<div class="card-header">
 							<%= t("#{translation_scope}.#{field['alias'] || field_name}", :default => field_name) %>
 						</div>
 
-						<div style="padding-bottom: 10px;">
+						<div class="card-body">
 							<div class="form-group">
 								<%= form.label_and_boolean 'display', { :label_opts => {:for => "custom_report_template_data_#{record_type}_fields_#{field_name}_include"}, :id => "custom_report_template_data_#{record_type}_fields_#{field_name}_include", :name => "custom_report_template[data][#{record_type}][fields][#{field_name}][include]", :checked => field_data['include'] } %>
 							</div>
@@ -70,8 +74,8 @@
 							<% end %>
 
 							<% if field['data_type'] == "AgentType" %>
-								<div class="form-group">
-									<%= form.label 'values', :class => 'col-sm-2 control-label', :for => "custom_report_template_data_agent_fields_type_values" %>
+								<div class="form-group d-flex">
+									<%= form.label 'values', :class => 'col-sm-2 control-label text-right', :for => "custom_report_template_data_agent_fields_type_values" %>
 									<% agent_types = ['agent_family', 'agent_person', 'agent_corporate_entity', 'agent_software'] %>
 									<div class="col-sm-9">
 										<%= select_tag "custom_report_template[data][#{record_type}][fields][#{field_name}][values]", options_for_select(agent_types.collect {|agent_type| [t("agent.agent_type.#{agent_type}"), agent_type]}, field_data['values']), :multiple => true, :style => "width: auto; max-with: 100%;", :class=>"form-control" %>
@@ -80,8 +84,8 @@
 							<% end %>
 
 							<% if field['data_type'] == "Boolean" %>
-								<div class="form-group">
-									<%= form.label "value", :class => "col-sm-2 control-label", :for =>  "custom_report_template_data_#{record_type}_fields_#{field_name}_value" %>
+								<div class="form-group d-flex">
+									<%= form.label "value", :class => "col-sm-2 control-label text-right", :for =>  "custom_report_template_data_#{record_type}_fields_#{field_name}_value" %>
 									<div class="col-sm-9">
 										<%= select_tag "custom_report_template[data][#{record_type}][fields][#{field_name}][value]", options_for_select([["", nil], [t('custom_report_template.true'), true], [t('custom_report_template.false'), false]], field_data['value']), :style => "width: auto; max-with: 100%;", :class=>"form-control" %>
 									</div>
@@ -94,8 +98,8 @@
 								<% if enum %>
 									<% options = enum['enumeration_values'] %>
 
-									<div class="form-group">
-										<%= form.label 'values', :class => 'col-sm-2 control-label', :for =>  "custom_report_template_data_#{record_type}_fields_#{field_name}_values" %>
+									<div class="form-group d-flex">
+										<%= form.label 'values', :class => 'col-sm-2 control-label text-right', :for =>  "custom_report_template_data_#{record_type}_fields_#{field_name}_values" %>
 										<div class="col-sm-9">
 											<%= select_tag "custom_report_template[data][#{record_type}][fields][#{field_name}][values]", options_for_select(options.collect {|value| [t("enumerations.#{enum_name}.#{value['value']}", :default => value['value']), value['id']]}, field_data['values']), :multiple => true, :style => "width: auto; max-with: 100%;", :class=>"form-control" %>
 										</div>
@@ -104,18 +108,24 @@
 							<% end %>
 
 							<% if field['data_type'] == "User" %>
-								<div class="form-group">
-									    <%= form.label 'values', :class => 'col-sm-2 control-label', :for => "custom_report_template_data_#{record_type}_fields_#{field_name}_values" %>
-								    <div class="col-sm-9">
-									<%= text_field_tag "custom_report_template[data][#{record_type}][fields][#{field_name}][values]_control", nil,  :class => 'user-field form-control', :"data-label" => User, :"autocomplete" => "off", :"aria-label" => I18n.t("custom_report_template._frontend.action.search_usernames") %>
-                                                                        <div class="textarea-with-button">
-                                                                        <%= text_area_tag "custom_report_template[data][#{record_type}][fields][#{field_name}][values]", array_for_textarea(field_data["values"]), :value => field_data['values'], :readonly => true %>
-                                                                            <input type="button" value="Clear" class="user-field-clear-button">
-                                                                            </div>
+								<div class="form-group d-flex">
+									<%= form.label 'values', :class => 'col-sm-2 control-label', :for => "custom_report_template_data_#{record_type}_fields_#{field_name}_values" %>
+									<div class="col-sm-9">
+										<%= text_field_tag(
+											"custom_report_template[data][#{record_type}][fields][#{field_name}][values]_control",
+											nil,
+											:class => 'user-field form-control',
+											:"data-label" => User,
+											:"autocomplete" => "off",
+											:"aria-label" => I18n.t("custom_report_template._frontend.action.search_usernames"))
+										%>
+										<div class="mt-2 d-flex flex-column align-items-start gap-2">
+											<%= text_area_tag "custom_report_template[data][#{record_type}][fields][#{field_name}][values]", array_for_textarea(field_data["values"]), :value => field_data['values'], :readonly => true, :class => 'border border-gray--secondary rounded', :style => "height:100px" %>
+											<input type="button" class="btn btn-default" value="Clear" class="d-block user-field-clear-button">
+										</div>
 									</div>
 								</div>
 							<% end %>
-
 						</div>
 					</div>
 				<% end %>
@@ -151,8 +161,8 @@
 					<% end %>
 				<% end %>
 
-				<div class="form-group">
-					<%= form.label 'field', :class => 'col-sm-2 control-label', :for => "sort_by_#{record_type}" %>
+				<div class="d-flex form-group">
+					<%= form.label 'field', :class => 'col-sm-2 control-label text-right', :for => "sort_by_#{record_type}" %>
 					<div class="col-sm-9">
 						<%= select_tag "custom_report_template[data][#{record_type}][sort_by]", options_for_select(sortable_fields, record_data['sort_by']), {:id => "sort_by_#{record_type}", :class => "form-control"} %>
 					</div>

--- a/frontend/app/views/custom_report_templates/index.html.erb
+++ b/frontend/app/views/custom_report_templates/index.html.erb
@@ -6,7 +6,7 @@
 
 		<div class="record-toolbar d-flex justify-content-end">
 			<div class="btn-group">
-				<%= link_to I18n.t("custom_report_template._frontend.action.create"), {:controller => :custom_report_templates, :action => :new}, :class => "btn btn-sm btn-primary" %>
+				<%= link_to I18n.t("custom_report_template._frontend.action.create"), {:controller => :custom_report_templates, :action => :new}, :class => "btn btn-sm btn-default align-self-center rounded-right" %>
 				<%= link_to_help :topic => "accession_basic_information" %>
 			</div>
 		</div>

--- a/frontend/app/views/groups/_form.html.erb
+++ b/frontend/app/views/groups/_form.html.erb
@@ -21,33 +21,39 @@
 </div>
 
 <div class="form-group">
-  <fieldset>
-    <legend class="control-label col-xs-2"><%= I18n.t("group.permissions") %></legend>
-    <div class="col-xs-10">
-      <% JSONModel(:permission).all(:level => "repository").map { |permission|
-        [permission.permission_code, I18n.t("group.permission_types.#{permission.permission_code}", :default => permission.permission_code)]
-      }.sort_by { |a| a[1] }.each do |permission_code, permission_label|
-      %>
-        <div class="input-group">
-          <span class="input-group-addon">
-            <input id="<%= permission_code %>"
-               name="group[grants_permissions][]"
-               type="checkbox"
-               <% if @group.grants_permissions.include?(permission_code) %>
-                 checked="checked"
-               <% end %>
-               value="<%= permission_code %>" />
-          </span>
-          <label class="form-control permission-label" for="<%= permission_code %>" disabled>
-            <%= permission_label %>
-          </label>
-        </div>
-      <% end %>
+  <fieldset class="d-flex align-items-start">
+    <p class="control-label col-sm-2 text-right font-weight-bold"><%= t("group.permissions") %></p>
+    <div class="col-sm-10">
+      <ul class="list-unstyled">
+        <% JSONModel(:permission).all(:level => "repository").map { |permission|
+          [permission.permission_code, I18n.t("group.permission_types.#{permission.permission_code}", :default => permission.permission_code).html_safe]
+        }.sort_by { |a| a[1] }.each do |permission_code, permission_label|
+        %>
+          <li class="input-group mb-2">
+            <div class="w-100 input-group-prepend">
+              <div class="input-group-text bg-gray-400 border-gray-600">
+                <input
+                  id="<%= permission_code %>"
+                  name="group[grants_permissions][]"
+                  type="checkbox"
+                  <% if @group.grants_permissions.include?(permission_code) %>
+                    checked="checked"
+                  <% end %>
+                  value="<%= permission_code %>"
+                />
+              </div>
+              <label class="h-auto mb-0 ml--1px form-control rounded-right-only" for="<%= permission_code %>" disabled>
+                <%= permission_label %>
+              </label>
+            </div>
+          </li>
+        <% end %>
+      </ul>
     </div>
   </fieldset>
 </div>
 
-<div class="form-actions d-flex justify-content-between">
+<div class="form-actions pl-0 d-flex justify-content-between">
   <button type="submit" class="btn btn-primary">
     <% if @group.id.blank? %>
       <%= t("group._frontend.action.create") %>

--- a/frontend/app/views/groups/edit.html.erb
+++ b/frontend/app/views/groups/edit.html.erb
@@ -3,11 +3,7 @@
 <%= form_for @group, :as => "group", :url => {:action => :update, :id => @group.id}, :html => {:class => 'form-horizontal aspace-record-form'}.merge(update_monitor_params(@group)) do |f| %>
 
 <div class="d-flex">
-  <div class="col-md-3">
-  </div>
-
-
-  <div class="col-md-9">
+  <div class="col-12">
     <%= render_aspace_partial :partial => "toolbar" %>
 
     <div class="record-pane">

--- a/frontend/app/views/shared/_ark_editor.html.erb
+++ b/frontend/app/views/shared/_ark_editor.html.erb
@@ -1,4 +1,4 @@
-<a class="edit-arks-btn" href=""><%= t('arks.edit') %></a>
+<a class="dropdown-item edit-arks-btn" href=""><%= t('arks.edit') %></a>
 
 <div id="edit_arks_modal_template" style="display: none">
     <div class="modal-body edit-arks-form">
@@ -39,7 +39,7 @@
             <tr class="previous-ark-value-template" style="display: none">
                 <td class="ark-value"></td>
                 <td class="ark-actions">
-                    <button class="btn btn-sm set-ark-current"><%= t('arks.set_current') %></button>
+                    <button class="btn btn-sm btn-default set-ark-current"><%= t('arks.set_current') %></button>
                     <button class="btn btn-sm btn-danger remove-ark"><%= t('arks.remove_ark') %></button>
                 </td>
             </tr>
@@ -60,16 +60,17 @@
         <hr>
 
         <div class="form-actions">
-            <div>
-                <div style="display: inline-block">
-                    <button class="btn btn-primary btn-save-arks"><%= t('arks.save') %></button>
-                    <div class="text-muted ark-no-changes"><small><%= t('arks.no_changes') %></small></div>
-                </div>
-
-                <button class="btn btn-default btn-cancel ml-auto"><%= t('actions.cancel') %></button>
+            <div class="d-flex justify-content-between">
+                <button class="btn btn-primary btn-save-arks"><%= t('arks.save') %></button>
+                <button class="btn btn-default btn-cancel"><%= t('actions.cancel') %></button>
             </div>
             <div>
-                <small style="display: none" class="unsubmitted-input-msg text-muted"><%= t('arks.unsubmitted_input') %></small>
+                <div class="text-muted ark-no-changes">
+                    <small><%= t('arks.no_changes') %></small>
+                </div>
+                <div>
+                    <small style="display: none" class="unsubmitted-input-msg text-muted"><%= t('arks.unsubmitted_input') %></small>
+                </div>
             </div>
         </div>
     </div>
@@ -278,7 +279,7 @@
      event.preventDefault();
      var dialog_content = AS.renderTemplate("edit_arks_modal_template");
 
-     $modal = AS.openCustomModal("editArksModal", "<%= t('arks.modal_title') %>", dialog_content, 'large');
+     $modal = AS.openCustomModal("editArksModal", "<%= t('arks.modal_title') %>", dialog_content, 'xl');
 
      new EditArksForm($modal.find('.edit-arks-form'),
                       () => { window.location.reload(); },


### PR DESCRIPTION
This PR fixes:

- the "Edit ARKs" dropdown toolbar button (under the "More" dropdown)
- the edit ARKs modal
- the Groups _form view
- Custom Report views

This PR is a follow up from the Softserv upgrades.

[ANW-2048](https://archivesspace.atlassian.net/browse/ANW-2048)


## After

### ARK

![ANW-2048-arks](https://github.com/archivesspace/archivesspace/assets/3411019/d2f83a54-4969-403c-9004-65e4d286a96b)
S

### Groups

![ANW-2048-groups](https://github.com/archivesspace/archivesspace/assets/3411019/dc3ffb83-0d22-4da2-9a48-0f6ea5afeec9)


### Custom Reports

![ANW-208-custom-reports](https://github.com/archivesspace/archivesspace/assets/3411019/47c24687-9310-4933-96a0-c2498c9c128d)


[ANW-2048]: https://archivesspace.atlassian.net/browse/ANW-2048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ