### PR TITLE
ANW-2048 Fix Jobs status layouts

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/form.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/form.scss
@@ -814,12 +814,13 @@ label {
 }
 
 .audit-display-wide {
+  margin: 0 auto;
+  padding: 4px;
+  display: flex;
+  justify-content: center;
+  line-height: $baseLineHeight;
   border: 1px solid #f6f6f6;
   background-color: #f1f1f1;
-  padding: 4px;
-  margin-right: 4px;
-  float: right;
-  line-height: $baseLineHeight;
 }
 
 .transfer-form,

--- a/frontend/app/views/jobs/_show_templates.html.erb
+++ b/frontend/app/views/jobs/_show_templates.html.erb
@@ -2,25 +2,25 @@
   <section id="job_status" data-poll-url="<%= url_for(:controller => :jobs, :action => :status, :id => job.id) %>" data-current-status="<%= @job.status %>">
     <h3><%= t("job._frontend.section.status") %></h3>
 
-    <div class="job-status form-group">
-      <label class="col-sm-3 control-label"><%= t("job.status") %></label>
+    <div class="job-status form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("job.status") %></label>
       <div class="col-sm-9 controls label-only">
         <%= t("job.status_#{job.status}", :default => job.status) %>
       </div>
     </div>
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("job.time_submitted") %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("job.time_submitted") %></label>
       <div class="col-sm-9 controls label-only"><%= Time.parse(job.time_submitted).getlocal %></div>
     </div>
     <% if job.time_started %>
-      <div class="form-group">
-        <label class="col-sm-3 control-label"><%= t("job.time_started") %></label>
+      <div class="form-group d-flex">
+        <label class="col-sm-3 control-label text-right"><%= t("job.time_started") %></label>
         <div class="col-sm-9 controls label-only"><%= Time.parse(job.time_started).getlocal %></div>
       </div>
     <% end %>
     <% if job.time_finished %>
-      <div class="form-group">
-        <label class="col-sm-3 control-label"><%= t("job.time_finished") %></label>
+      <div class="form-group d-flex">
+        <label class="col-sm-3 control-label text-right"><%= t("job.time_finished") %></label>
         <div class="col-sm-9 controls label-only"><%= Time.parse(job.time_finished).getlocal %></div>
       </div>
     <% end %>
@@ -40,20 +40,20 @@
     <%= form.label_with_field "import_type", job['import_type'] %>
 
     <% if job["job_type"] != 'generate_slugs_job' && job["job_type"] != 'generate_arks_job' %>
-      <div class="form-group">
-        <label class="col-sm-3 control-label"><%= t("repository._singular") %></label>
+      <div class="form-group d-flex">
+        <label class="col-sm-3 control-label text-right"><%= t("repository._singular") %></label>
         <div class="col-sm-9 controls label-only"><%= resolve_readonly_link_to job.repository['_resolved']['repo_code'], job.repository['ref'] %></div>
       </div>
     <% end %>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("job.owner") %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("job.owner") %></label>
       <div class="col-sm-9 controls label-only"><%= job.owner %></div>
     </div>
 
     <% if job.job.key?('import_type') %>
-      <div class="form-group">
-        <label class="col-sm-3 control-label"><%= t("import_job.import_type") %></label>
+      <div class="form-group d-flex">
+        <label class="col-sm-3 control-label text-right"><%= t("import_job.import_type") %></label>
         <div class="col-sm-9 controls label-only"><%= t("import_job.import_type_#{job.job['import_type']}") %></div>
       </div>
     <% end %>
@@ -72,8 +72,8 @@
 
 <% define_template "container_labels_job", jsonmodel_definition(:container_labels_job) do |form, job| %>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("actions.container_labels")  %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("actions.container_labels")  %></label>
       <div class="col-sm-9 controls label-only"><%= job['source'] %></div>
     </div>
 
@@ -82,8 +82,8 @@
 
 <% define_template "import_job", jsonmodel_definition(:import_job) do |form, job| %>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("import_job.filenames") %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("import_job.filenames") %></label>
       <div class="col-sm-9 controls label-only"><%= job['filenames'].join("<br/>").html_safe %></div>
     </div>
 
@@ -92,13 +92,13 @@
 
 <% define_template "find_and_replace_job", jsonmodel_definition(:find_and_replace_job) do |form, job| %>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("find_and_replace_job.find") %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("find_and_replace_job.find") %></label>
       <div class="col-sm-9 controls label-only"><%= job['find'] %></div>
     </div>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("find_and_replace_job.replace") %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("find_and_replace_job.replace") %></label>
       <div class="col-sm-9 controls label-only"><%= job['replace'] %></div>
     </div>
 
@@ -106,13 +106,13 @@
 
 <% define_template "print_to_pdf_job", jsonmodel_definition(:print_to_pdf_job) do |form, job| %>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("actions.resource_to_pdf")  %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("actions.resource_to_pdf")  %></label>
       <div class="col-sm-9 controls label-only"><%= job['source'] %></div>
     </div>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("print_to_pdf_job.include_unpublished")  %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("print_to_pdf_job.include_unpublished")  %></label>
       <div class="col-sm-9 controls label-only"><%= t("boolean.#{job['include_unpublished']}") %></div>
     </div>
 
@@ -120,18 +120,18 @@
 
 <% define_template "bulk_import_job", jsonmodel_definition(:bulk_import_job) do |form, job| %>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("actions.bulk_import")  %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("actions.bulk_import")  %></label>
       <div class="col-sm-9 controls label-only"><%= job['filename'].html_safe %></div>
     </div>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("bulk_import_job.load_type")  %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("bulk_import_job.load_type")  %></label>
       <div class="col-sm-9 controls label-only"><%= t("bulk_import_job.type.#{job['load_type']}") %></div>
     </div>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("bulk_import_job.content_type")  %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("bulk_import_job.content_type")  %></label>
       <div class="col-sm-9 controls label-only"><%= t("bulk_import_job.type.#{job['content_type']}") %></div>
     </div>
 
@@ -139,8 +139,8 @@
 
 <% define_template "report_job", jsonmodel_definition(:report_job) do |form, job| %>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("report_job.report_type")  %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("report_job.report_type")  %></label>
       <div class="col-sm-9 controls label-only"><%= t("reports.#{job['report_type']}.title", :default => job['report_type']) %></div>
       <label class="col-sm-3 control-label"><%= t("report_job.format")  %></label>
       <div class="col-sm-9 controls label-only"><%= t("reports.formats.#{job['format']}", :default => job['format']) %></div>
@@ -150,18 +150,18 @@
 
 <% define_template "top_container_linker_job", jsonmodel_definition(:top_container_linker_job) do |form, job| %>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("actions.bulk_import")  %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("actions.bulk_import")  %></label>
       <div class="col-sm-9 controls label-only"><%= job['filename'].html_safe %></div>
     </div>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("top_container_linker_job.load_type")  %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("top_container_linker_job.load_type")  %></label>
       <div class="col-sm-9 controls label-only"><%= t("top_container_linker_job.type.#{job['load_type']}") %></div>
     </div>
 
-    <div class="form-group">
-      <label class="col-sm-3 control-label"><%= t("top_container_linker_job.content_type")  %></label>
+    <div class="form-group d-flex">
+      <label class="col-sm-3 control-label text-right"><%= t("top_container_linker_job.content_type")  %></label>
       <div class="col-sm-9 controls label-only"><%= t("bulk_import_job.type.#{job['content_type']}") %></div>
     </div>
 

--- a/frontend/app/views/jobs/new.html.erb
+++ b/frontend/app/views/jobs/new.html.erb
@@ -19,7 +19,7 @@
           <br/>
           <div class="form-actions pl-0">
             <div class="btn-group">
-              <button type="submit" class="btn btn-primary btn-sm"><%= t("job._frontend.actions.save") %></button>
+              <button type="submit" class="btn btn-primary"><%= t("job._frontend.actions.save") %></button>
             </div>
             <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>

--- a/frontend/app/views/shared/_templates.html.erb
+++ b/frontend/app/views/shared/_templates.html.erb
@@ -233,7 +233,7 @@
 <div id="subform_remove_confirmation_template"><!--
    <div class="ml-auto subrecord-form-removal-confirmation float-right">
     <div class="btn-group m-2">
-      <button class="btn fuck btn-sm btn-default cancel-removal"><%= I18n.t "actions.cancel" %></button>
+      <button class="btn btn-sm btn-default cancel-removal"><%= I18n.t "actions.cancel" %></button>
       <button class="btn btn-sm btn-danger confirm-removal"><%= I18n.t "actions.confirm_removal" %></button>
      </div>
    </div>


### PR DESCRIPTION
This PR fixes the layout for Jobs status sections.

This is part of [ANW-2048](https://archivesspace.atlassian.net/browse/ANW-2048), outstanding Softserv updates fixes.

## After

![Screen Shot 2024-06-05 at 06 52 38-fullpage](https://github.com/archivesspace/archivesspace/assets/3411019/217ea7b5-56ae-43b0-bb3d-87b0ed36f501)


[ANW-2048]: https://archivesspace.atlassian.net/browse/ANW-2048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ