### PR TITLE
ANW-1340 Escape ampersand characters on pdf export

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -954,7 +954,7 @@ class EADSerializer < ASpaceExport::Serializer
         xml.creation { sanitize_mixed_content( creation, xml, fragments) }
 
         if (val = data.finding_aid_language_note)
-          xml.langusage (fragments << val)
+          xml.langusage (fragments << escape_content(val))
         else
           xml.langusage() {
             xml.text(I18n.t("resource.finding_aid_langusage_label"))
@@ -977,12 +977,12 @@ class EADSerializer < ASpaceExport::Serializer
         xml.revisiondesc {
           export_rs.each do |rs|
             if rs['description'] && rs['description'].strip.start_with?('<')
-              xml.text (fragments << rs['description'] )
+              xml.text (fragments << escape_content(rs['description']) )
             else
               xml.change(rs['publish'] ? nil : {:audience => 'internal'}) {
                 rev_date = rs['date'] ? rs['date'] : ""
-                xml.date (fragments <<  rev_date )
-                xml.item (fragments << rs['description']) if rs['description']
+                xml.date (fragments <<  escape_content(rev_date))
+                xml.item (fragments << escape_content(rs['description'])) if rs['description']
               }
             end
           end


### PR DESCRIPTION
For fields in revision statements and finding_aid_language_note in  a resource

<!--- Provide a general summary of your changes in the Title above -->

## Description
I was unable to reproduce the issue on the PUI pdf. 

I was able to reproduce the issue only on the pdf generated on the staff UI by including ampersands in fields:
- Finding Aid Status 
- the fields inside Revision Statements.


<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
[ANW-1340]
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[ANW-1340]: https://archivesspace.atlassian.net/browse/ANW-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ