### PR TITLE
ANW-2000 account for potential app proxy prefix in IR code

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -102,7 +102,7 @@ jobs:
         ARCHIVESSPACE_VERSION: ${{ github.ref }}
 
       run: |
-        ./build/run rspec -Ddir="../public" -Dtag="db:accessibility" -Dspec="features" -Dorder="defined"
+        ./build/run rspec -Ddir="../public" -Dtag="db:accessibility" -Dspec="features" -Dorder="defined" -Dtest-server-url="http://127.0.0.1:13001"
 
     - name: Run Frontend accessibility tests
       env:

--- a/build/build.xml
+++ b/build/build.xml
@@ -39,6 +39,7 @@
   <property name="aspace.solr_url.test" value="http://127.0.0.1:8984/solr/archivesspace" />
   <property name="aspace.data_directory.dev" value="${basedir}/../build/dev" />
   <property name="aspace.data_directory.test" value="${basedir}/../build/test" />
+  <property name="aspace.public_url.test" value="http://127.0.0.1:13001" />
 
   <property environment="env"/>
   <!--
@@ -54,7 +55,6 @@
   <property name="env.ASPACE_TEST_SOLR_URL" value="${aspace.solr_url.test}" />
   <property name="env.ASPACE_TEST_DATA_DIRECTORY" value="${aspace.data_directory.test}" />
   <property name="env.APPCONFIG_BACKEND_LOG" value="default" />
-
 
   <condition property="java_version_compatibility"  value="--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED" else="">
     <javaversion atleast="17"/>
@@ -492,7 +492,9 @@
     <condition property="pattern-arg" value="-P &quot;${pattern}&quot;" else="">
       <isset property="pattern"/>
     </condition>
-
+    <condition property="test-server-url-arg" value="${test-server-url}" else="">
+      <isset property="test-server-url"/>
+    </condition>
 
     <echo message="Running rspec" />
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true" dir="${dir}">
@@ -505,6 +507,7 @@
       <env key="APPCONFIG_DB_URL" value="${env.ASPACE_TEST_DB_URL}" />
       <env key="APPCONFIG_SOLR_URL" value="${env.ASPACE_TEST_SOLR_URL}" />
       <env key="TEST_MODE" value="1" />
+      <env key="ASPACE_TEST_APP_SERVER_URL" value="${test-server-url-arg}" />
       <arg line="../build/gems/bin/bundle exec rspec -b --format d ${pattern-arg} ${tag-arg} ${order-arg} ${example-arg} ${spec-arg} ${extra-spec-paths}" />
     </java>
   </target>
@@ -872,6 +875,7 @@
     <antcall target="rspec">
       <param name="dir" value="../public" />
       <param name="tag" value="${tag}" />
+      <param name="test-server-url" value="${aspace.public_url.test}" />
     </antcall>
   </target>
 

--- a/public/app/assets/javascripts/InfiniteRecords.js
+++ b/public/app/assets/javascripts/InfiniteRecords.js
@@ -4,11 +4,10 @@
      * @constructor
      * @param {string} resourceUri - The URI of the root resource, e.g.
      * /repositories/2/resources/1234
-     * @param {string} js_path - The path to the js directory as returned
-     * from Rails `javascript_path` helper
+     * @param {string} appUrlPrefix - The proper app prefix
      * @returns {InfiniteRecords} - InfiniteRecords instance
      */
-    constructor(resourceUri) {
+    constructor(resourceUri, appUrlPrefix) {
       this.container = document.querySelector('.infinite-records-container');
 
       this.WAYPOINT_SIZE = parseInt(this.container.dataset.waypointSize, 10);
@@ -21,6 +20,7 @@
       );
 
       this.resourceUri = resourceUri;
+      this.appUrlPrefix = appUrlPrefix;
 
       this.wpQueue = [];
       this.wpQueueIsEmpty = () => this.wpQueue.length === 0;
@@ -163,7 +163,7 @@
         query.append('urls[]', uri);
       });
 
-      const url = `${this.resourceUri}/infinite/waypoints?${query}`;
+      const url = `${this.appUrlPrefix}/${this.resourceUri}/infinite/waypoints?${query}`;
 
       try {
         const response = await fetch(url);

--- a/public/app/assets/javascripts/InfiniteTree.js
+++ b/public/app/assets/javascripts/InfiniteTree.js
@@ -3,6 +3,7 @@
     /**
      * @constructor
      * @param {number} waypointSize - The number of nodes per waypoint
+     * @param {string} appUrlPrefix - The proper app prefix
      * @param {string} resourceUri - The URI of the collection resource
      * @param {string} identifier_separator - The i18n identifier separator
      * @param {string} date_type_bulk - The i18n date type bulk
@@ -10,11 +11,13 @@
      */
     constructor(
       waypointSize,
+      appUrlPrefix,
       resourceUri,
       identifier_separator,
       date_type_bulk
     ) {
       this.WAYPOINT_SIZE = waypointSize;
+      this.appUrlPrefix = appUrlPrefix;
       this.resourceUri = resourceUri;
       this.repoId = this.resourceUri.split('/')[2];
       this.resourceId = this.resourceUri.split('/')[4];
@@ -127,7 +130,7 @@
      */
     async fetchRootNode() {
       try {
-        const response = await fetch(this.rootUri);
+        const response = await fetch(this.appUrlPrefix + this.rootUri);
 
         return await response.json();
       } catch (err) {

--- a/public/app/views/resources/infinite.html.erb
+++ b/public/app/views/resources/infinite.html.erb
@@ -95,10 +95,12 @@ const resourceUri = '<%= @result["uri"] %>';
 const treeWaypointSize = '<%= sidebar_waypoint_size %>';
 const identifier_separator = '<%= I18n.t("resource.identifier_separator") %>';
 const date_type_bulk = '<%= I18n.t("date_type_bulk.bulk") %>';
+const appUrlPrefix = '<%= AppConfig[:public_proxy_url] %>';
 
-const infiniteRecords = new InfiniteRecords(resourceUri);
+const infiniteRecords = new InfiniteRecords(resourceUri, appUrlPrefix);
 const infiniteTree = new InfiniteTree(
   treeWaypointSize,
+  appUrlPrefix,
   resourceUri,
   identifier_separator,
   date_type_bulk

--- a/public/spec/rails_helper.rb
+++ b/public/spec/rails_helper.rb
@@ -34,6 +34,9 @@ end
 
 Capybara.raise_server_errors = false
 
+# Make sure server port used is the one AppConfig says it should be
+Capybara.server_port = URI.parse(AppConfig[:public_url]).port
+
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.include Capybara::DSL

--- a/public/spec/spec_helper.rb
+++ b/public/spec/spec_helper.rb
@@ -28,6 +28,7 @@ AppConfig[:pui_hide][:record_badge] = false
 AppConfig[:arks_enabled] = true
 app_logfile = File.join(ASUtils.find_base_directory, "ci_logs", "public_app_log.out")
 AppConfig[:pui_log] = app_logfile
+AppConfig[:public_url] = ENV['ASPACE_TEST_APP_SERVER_URL'] || AppConfig[:public_url]
 
 $backend_start_fn = proc {
   TestUtils::start_backend(URI(AppConfig[:backend_url]).port,


### PR DESCRIPTION
Passes in the public app proxy url to InfiniteTree/InfiniteRecords so they can properly fetch nodes/waypoints when a proxy is in use.

This also ends up involving some changes so that the public URL can be defined at the top level in build.xml and passed to rspec so that AppConfig can be set appropriately and various tests involving the collection organization pages will run successfully.