### PR TITLE
ANW-2069: Fix search result filter "read more facets" feature

### DIFF
--- a/public/app/assets/javascripts/more_facets.js
+++ b/public/app/assets/javascripts/more_facets.js
@@ -7,14 +7,16 @@ function MoreFacets($more_facets_div) {
 MoreFacets.prototype.bind_events = function () {
   var self = this;
 
-  self.$more_facets_div.find('.more').on('click', function (e) {
-    $(this).siblings('.below-the-fold').show();
+  self.$more_facets_div.find('.more-facets__more').on('click', function (e) {
+    $(this).siblings('.more-facets__facets').show();
+    $(this).siblings('.more-facets__less').show();
     $(this).hide();
   });
 
-  self.$more_facets_div.find('.less').on('click', function (e) {
-    $(this).parent().hide();
-    $(this).parent().parent().find('.more').show();
+  self.$more_facets_div.find('.more-facets__less').on('click', function (e) {
+    $(this).siblings('.more-facets__facets').hide();
+    $(this).hide();
+    $(this).siblings('.more-facets__more').show();
   });
 };
 

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -99,9 +99,17 @@ a img {
 
 .more-facets {
   .btn {
-    color: $accent-color;
+    border: 1px solid $primary-color;
+    color: $primary-color;
+
+    &:hover {
+      border-color: $secondary-color;
+      background-color: $lightshade;
+      color: $secondary-color;
+    }
   }
-  .below-the-fold {
+  .more-facets__facets,
+  .more-facets__less {
     display: none;
   }
 }
@@ -562,15 +570,6 @@ ul.no-bullets {
   }
 }
 
-.recordnumber {
-  /* background-color: #ccc; */
-  padding: 0 5px;
-  font-weight: bold;
-
-  /* position: absolute; */
-
-  /* right: 20px; */
-}
 .definition {
   font-size: 0.7em;
   float: right;

--- a/public/app/views/shared/_facet_description.html.erb
+++ b/public/app/views/shared/_facet_description.html.erb
@@ -1,0 +1,8 @@
+<dd>
+  <a href="<%= app_prefix("#{@page_search}&filter_fields[]=#{type}&filter_values[]=#{CGI.escape(facet.key)}") %>"
+    rel="nofollow"
+    title="<%= t('search_results.filter_by')%> '<%= facet.label %>'">
+    <%= facet.label %>
+  </a>
+  <span class="badge badge-pill badge-dark"><%= facet.count %></span>
+</dd>

--- a/public/app/views/shared/_only_facets.html.erb
+++ b/public/app/views/shared/_only_facets.html.erb
@@ -18,29 +18,35 @@
   %>
 
   <% ordered_facet_types.each do |type| %>
-    <% facet_group = @facets.fetch(type, false) %>
-
-    <% next if facet_group.empty? %>
-    <dt class='mb-2 mt-3'><%= t("search_results.filter.#{type}") %></dt>
-    <% facet_group.each_with_index do |facet, i| %>
+    <%
+      facet_group = @facets.fetch(type, false)
+      max_facets_on_load = 5
+    %>
+    <div id="<%= t("search_results.filter.#{type}").downcase %>-facet">
+      <dt class='mb-2 mt-3'><%= t("search_results.filter.#{type}") %></dt>
+      <% if facet_group.length <= max_facets_on_load %>
+        <% facet_group.each do |facet| %>
+          <%= render partial: 'shared/facet_description', locals: { type: type, facet: facet } %>
+        <% end %>
+      <% else %>
+        <% facet_group.slice(0, max_facets_on_load - 1).each do |facet| %>
+          <%= render partial: 'shared/facet_description', locals: { type: type, facet: facet } %>
+        <% end %>
         <div class="more-facets">
-      <% if i == 5 %>
-          <span class="more btn border btn-sm">&#9663; <%= t('search_results.more_facets') %></span>
-          <div class="below-the-fold">
+          <button type="button" class="more-facets__more mb-1 btn btn-sm">
+            <%= t('search_results.more_facets') %> <i class="fa fa-chevron-down"></i>
+          </button>
+          <div class="more-facets__facets">
+            <% facet_group.slice(max_facets_on_load, facet_group.length - 1).each do |facet| %>
+              <%= render partial: 'shared/facet_description', locals: { type: type, facet: facet } %>
+            <% end %>
+          </div>
+          <button type="button" class="more-facets__less mb-1 btn btn-sm">
+            <%= t('search_results.fewer_facets') %> <i class="fa fa-chevron-up"></i>
+          </button>
+        </div>
       <% end %>
-      <dd>
-        <a href="<%= app_prefix("#{@page_search}&filter_fields[]=#{type}&filter_values[]=#{CGI.escape(facet.key)}") %>"
-           rel="nofollow"
-           title="<%= t('search_results.filter_by')%> '<%= facet.label %>'">
-          <%= facet.label %>
-        </a>
-        <span class="recordnumber"><%= facet.count %></span>
-      </dd>
-    <% end %>
-    <% if facet_group.size > 5 %>
-        <span class="less btn border btn-sm">&#9653;  <%= t('search_results.fewer_facets') %></span>
-      </div>
-    <% end %>
+    </div>
   <% end %>
 </dl>
 <% end %>

--- a/public/config/locales/de.yml
+++ b/public/config/locales/de.yml
@@ -122,7 +122,7 @@ de:
       digital_object_type_enum_s: Typ
       extent_type_enum_s: Umfang
     creators_text_contain: der <strong>Urheber</strong> enthält <span class='searchterm'>%{kw}</span>
-    fewer_facets: weniger
+    fewer_facets: Weniger
     op:
       OR: oder
       AND: und
@@ -132,7 +132,7 @@ de:
     page_title: '%{count} Ergebnisse gefunden'
     results_head: 'Zeige %{type}: %{start} - %{end} von %{total}'
     in_repository: ' in <strong>%{name}</strong>'
-    more_facets: mehr
+    more_facets: Mehr
     remove_filter: Diesen Filter entfernen
   page_actions: Seiten-Aktionen
   search-button:

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -118,8 +118,8 @@ en:
     filter_by: Filter By
     filtered_by: Filtered By
     remove_filter: Remove this filter
-    more_facets: more
-    fewer_facets: less
+    more_facets: More
+    fewer_facets: Less
     op:
       AND: and
       OR: or

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -114,8 +114,8 @@ fr:
     filter_by: Filtrer par
     filtered_by: Filtré par
     remove_filter: Ôter ce filtre
-    more_facets: plus
-    fewer_facets: moins
+    more_facets: Plus
+    fewer_facets: Moins
     op:
       AND: et
       OR: ou

--- a/public/config/locales/pt.yml
+++ b/public/config/locales/pt.yml
@@ -69,8 +69,8 @@ pt:
     filter_by: Filtrar por
     filtered_by: Filtrado por
     remove_filter: Remova esse filtro
-    more_facets: mais
-    fewer_facets: menos
+    more_facets: Mais
+    fewer_facets: Menos
     op:
       AND: e
       OR: ou

--- a/public/spec/features/more_facets_spec.rb
+++ b/public/spec/features/more_facets_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'More Facets', js: true do
+  before(:each) do
+    visit '/repositories/resources'
+  end
+
+  it 'are shown when a facet type has more than 5 facets' do
+    expect(page).to have_selector('#language-facet .more-facets')
+    expect(page).to_not have_selector('#repository-facet .more-facets')
+  end
+
+  it 'are shown/hidden on click' do
+    more_btn = find('#language-facet .more-facets__more')
+    more_facets = find('#language-facet .more-facets__facets', visible: false)
+    less_btn = find('#language-facet .more-facets__less', visible: false)
+
+    more_btn.click
+
+    expect(more_btn).to_not be_visible
+    expect(more_facets).to be_visible
+    expect(less_btn).to be_visible
+
+    less_btn.click
+
+    expect(more_btn).to be_visible
+    expect(more_facets).to_not be_visible
+    expect(less_btn).to_not be_visible
+  end
+end


### PR DESCRIPTION
This PR fixes a bug from the Softserv updates that broke the "more" / "less" buttons on the PUI sidebar of search results that expanded/collapsed a long list of facets to use for filtering.

This work also improves the more facets template, which mistakenly nested facets of different types in the markup despite the correct visual organization on the page.

*It should be noted that this was a light editing of the more facets code, and preserves the fully-JavaScript based approach. In the future this feature could be brought in line with the "read more notes" work from #3234 which is an HTML-first approach.*

[ANW-2069](https://archivesspace.atlassian.net/browse/ANW-2069)

## After screenshot and markup

![ANW-2069-more-facets](https://github.com/archivesspace/archivesspace/assets/3411019/79dbbf88-b5a9-49a2-9c09-0d32cb188e49)

<img width="1323" alt="ANW-2069-after-markup" src="https://github.com/archivesspace/archivesspace/assets/3411019/fe0058be-3907-41fe-a68c-4d2c02cdb9a3">

## Before screenshot and markup

![broke-more-less-pui-filter-btn](https://github.com/archivesspace/archivesspace/assets/3411019/ac491c4b-7453-445e-8578-aca9b4c5ac05)

<img width="1314" alt="ANW-2069-before-markup" src="https://github.com/archivesspace/archivesspace/assets/3411019/b8cc3be2-c729-485d-83bb-c1d779751dd0">



[ANW-2069]: https://archivesspace.atlassian.net/browse/ANW-2069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ