### PR TITLE
ANW-2073 Add search result highlighting translations

### DIFF
--- a/public/config/locales/de.yml
+++ b/public/config/locales/de.yml
@@ -76,6 +76,8 @@ de:
       role_enum_s: Rollen
       linked_agent_roles: Verknüpfte Agentenrollen
       notes_published: Anmerkungen
+      finding_aid_title: Titel des Findmittels
+      finding_aid_filing_title: Findmittel Ablagetitel
     result: Ergebnis
     results: Ergebnisse
     search_for: Suche %{type} wobei %{conditions}

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -106,6 +106,8 @@ en:
       role_enum_s: Roles
       linked_agent_roles: Linked Agent Roles
       notes_published: Notes
+      finding_aid_title: Finding Aid Title
+      finding_aid_filing_title: Finding Aid Filing Title
     page_title: "Found %{count} Results"
     results_head: "Showing %{type}: %{start} - %{end} of %{total}"
     result: Result

--- a/public/config/locales/es.yml
+++ b/public/config/locales/es.yml
@@ -86,6 +86,8 @@ es:
       role_enum_s: Roles
       linked_agent_roles: Roles de agente vinculada
       notes_published: Notas
+      finding_aid_title: Título del instrumento de descripción
+      finding_aid_filing_title: Título abreviado del instrumento de descripción
     page_title: "Encontrado %{count} resultados"
     results_head: "Mostrando %{type}: %{start} - %{end} of %{total}"
     result: Resultado

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -105,6 +105,8 @@ fr:
       role_enum_s: Les rôles
       linked_agent_roles: Rôles d'agent liés
       notes_published: Remarques
+      finding_aid_title: Titre de l'instrument de recherche
+      finding_aid_filing_title: Titre de classement de l'aide
     page_title: "%{count} résultats trouvés"
     results_head: "%{type} affichés : %{start} - %{end} de %{total}"
     result: Résultats

--- a/public/config/locales/ja.yml
+++ b/public/config/locales/ja.yml
@@ -78,6 +78,8 @@ ja:
       role_enum_s: 役割
       linked_agent_roles: リンクされたエージェントの役割
       notes_published: ノート
+      finding_aid_title: 援助のタイトルを見つける
+      finding_aid_filing_title: 援助申請のタイトルを探す
     page_title: 見つかった%{count}結果
     results_head: "%{type} ： %{start} - %{end}の%{total}"
     result: 結果


### PR DESCRIPTION
This is a follow up from #3239 that adds missing translations.

## Before

<img width="1430" alt="ANW-2073-highlight-translations before" src="https://github.com/archivesspace/archivesspace/assets/3411019/57886aec-b526-4736-bba1-f9e42db970e2">

## After

<img width="1443" alt="ANW-2073 after" src="https://github.com/archivesspace/archivesspace/assets/3411019/410d7a50-241c-4ff7-a7dd-af3f6e9d4b90">
