### PR TITLE
ANW-2069 Shift PUI More Facets negative assertion

### DIFF
--- a/public/spec/features/more_facets_spec.rb
+++ b/public/spec/features/more_facets_spec.rb
@@ -8,7 +8,7 @@ describe 'More Facets', js: true do
 
   it 'are shown when a facet type has more than 5 facets' do
     expect(page).to have_selector('#language-facet .more-facets')
-    expect(page).to_not have_selector('#repository-facet .more-facets')
+    expect(page).to_not have_selector('#subject-facet .more-facets')
   end
 
   it 'are shown/hidden on click' do


### PR DESCRIPTION
Running the individual spec associated with #3238 passed, but it failed in aggregate with the rest of the specs since the number of repos eventually grew beyond 5, causing the spec here to fail. This PR passes the buck by, instead of figuring out how to control the creation of facets, relies on the aggregate tests _not_ creating more than 5 Subject facets, just like the earlier reliance on the aggregate not creating more than 5 repository facets. The author of this PR needs more understanding of how facets get created in order to provide a more robust solution to this issue.