### PR TITLE
ANW-2046: Undo change to Staff "Export" dropdown download buttons

### DIFF
--- a/frontend/app/assets/javascripts/export_dropdown.js.erb
+++ b/frontend/app/assets/javascripts/export_dropdown.js.erb
@@ -7,15 +7,21 @@ $(function () {
       e.stopPropagation();
     });
     $('.record-toolbar').on('click', 'a.download-ead-action', function(e) {
+      e.stopPropagation();
+      e.preventDefault();
       var url = AS.quickTemplate(decodeURIComponent($("#download-ead-dropdown").data("download-ead-url")), { testme: true,  include_unpublished: $("input#include-unpublished").is(':checked'), include_daos: $("input#include-daos").is(':checked'), include_uris: $("input#include-uris").is(':checked'), numbered_cs: $("input#numbered-cs").is(':checked'), ead3: $("input#ead3").is(':checked')});
       location.href = url;
     });
     $('.record-toolbar').on('click', 'a.download-marc-action', function(e) {
+      e.stopPropagation();
+      e.preventDefault();
       var url = AS.quickTemplate(decodeURIComponent($("#download-marc-dropdown").data("download-marc-url")), {  include_unpublished_marc: $("input#include-unpublished-marc").is(':checked')});
       console.log(url);
       location.href = url;
     });
     $('.record-toolbar').on('click', 'a.download-mets-action', function(e) {
+      e.stopPropagation();
+      e.preventDefault();
       var url = AS.quickTemplate(decodeURIComponent($("#download-mets-dropdown").data("download-mets-url")), {  dmd_scheme: $("input#js-dmd_scheme_mods").is(':checked') ? "mods" : "dc"});
       console.log(url);
       location.href = url;


### PR DESCRIPTION
The Export dropdown menu with download buttons for EAD, MARC, MODS, etc, changed inadvertently with the Softserv upgrades. Whereas the download buttons could be clicked multiple times to initiate multiple downloads without page refresh, after Softserv the download action only happened on first click and not on any subsequent clicks.

The culprit may be some change in the markup? I'm not sure exactly, but this quick change solves the issue nicely.

## Before

![ANW-2046-export-downloads-before](https://github.com/archivesspace/archivesspace/assets/3411019/b16aa923-7a95-49d2-9cc6-c611253a888b)

## After 

![ANW-2046-export-downloads-after](https://github.com/archivesspace/archivesspace/assets/3411019/5ecd1fac-b24f-4fa8-9d53-9d91361256ea)

[ANW-2046](https://archivesspace.atlassian.net/browse/ANW-2046)

[ANW-2046]: https://archivesspace.atlassian.net/browse/ANW-2046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ