### PR TITLE
ANW-769: Allow PUI Collection Organization sidebar to be positioned to the left or right of content; display it to the left by default

### DIFF
--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -511,10 +511,14 @@ AppConfig[:pui_hide][:container_inventory] = false
 # Whether to display linked deaccessions
 AppConfig[:pui_display_deaccessions] = true
 
+# Where to position the PUI Collection Organization sidebar
+# Options: 'left' or 'right'
+AppConfig[:pui_collection_org_sidebar_position] = 'left'
+
 # Whether to display archival record identifiers in the PUI collection organization tree
 AppConfig[:pui_display_identifiers_in_resource_tree] = false
 
-#The number of characters to truncate before showing the 'Read More' link on notes
+# The number of characters to truncate before showing the 'Read More' link on notes
 AppConfig[:pui_readmore_max_characters] = 1000
 
 # Whether to expand all additional information blocks at the bottom of record pages by default. `true` expands all blocks, `false` collapses all blocks.

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -749,11 +749,13 @@ i.giant {
 
 /* record details */
 .available-digital-objects {
-  float: right;
-  max-width: 50%;
+  width: 100%;
+  display: flex;
+  justify-content: end;
 }
 
 .objectimage {
+  max-width: 50%;
   display: block;
   margin: 0 0 1em 1em;
 }
@@ -917,7 +919,19 @@ span.head {
 @media (min-width: 992px) {
   #sidebar.resizable-sidebar {
     position: relative;
-    padding-left: 18px; // margin-right (10) + handle width (8)
+    padding-left: 18px; // padding-right (10) + handle width (8)
+
+    &.resizable-sidebar-left {
+      padding-left: 0.625rem;
+      padding-right: 18px;
+
+      .resizable-sidebar-handle {
+        left: unset;
+        right: 0;
+        border-right: none;
+        border-left: 1px solid #ccc;
+      }
+    }
 
     .resizable-sidebar-handle {
       background-color: #eee;
@@ -1019,6 +1033,12 @@ span.head {
 
 @media (min-width: 992px) {
   #sidebar.resizable-sidebar {
+    &.resizable-sidebar-left {
+      .resizable-sidebar-handle {
+        left: unset;
+        right: 0;
+      }
+    }
     .resizable-sidebar-handle {
       background-color: #eee;
       position: absolute;

--- a/public/app/assets/stylesheets/archivesspace/infinite-scroll.scss
+++ b/public/app/assets/stylesheets/archivesspace/infinite-scroll.scss
@@ -17,12 +17,6 @@
   }
 }
 
-.infinite-record-scrollbar {
-  overflow: scroll;
-  position: absolute;
-  width: 15px;
-}
-
 .infinite-tree-view {
   height: 600px;
   padding: 1em;

--- a/public/app/views/resources/infinite.html.erb
+++ b/public/app/views/resources/infinite.html.erb
@@ -20,23 +20,14 @@
   content_waypoint_size = 20
   sidebar_waypoint_size = 200
   num_records = @ordered_records.count
+  sidebar_position = AppConfig[:pui_collection_org_sidebar_position]
 %>
-<div class="row" style="overflow: hidden;">
+<div class="row overflow-hidden">
   <div
-    class="infinite-records-container col-sm-9"
-    data-waypoint-size="<%= content_waypoint_size %>"
-    data-total-records="<%= num_records %>">
-    <div class="root">
-      <% @ordered_records.each_slice(content_waypoint_size).each_with_index do |refs, i| %>
-        <div
-          class="waypoint"
-          data-waypoint-number="<%= i %>"
-          data-uris="<%= refs.map {|r| r['ref']}.join(';') %>"
-        >&nbsp;</div>
-      <% end %>
-    </div>
-  </div>
-  <div id="sidebar" class="sidebar sidebar-container col-sm-3 resizable-sidebar infinite-tree-sidebar">
+    id="sidebar"
+    class="sidebar sidebar-container col-sm-3 resizable-sidebar <%= sidebar_position == 'left' ? 'resizable-sidebar-left' : 'order-1' %> infinite-tree-sidebar"
+    data-sidebar-position="<%= sidebar_position %>"
+  >
     <% if AppConfig[:pui_search_collection_from_collection_organization] %>
       <%= render partial: 'shared/search_collection_form', :locals => {:resource_uri => @result['uri'], :action_text => t('actions.search_in', :type => t('resource._singular'))} %>
     <% end %>
@@ -48,6 +39,20 @@
       data-repo-id="<%= @result['uri'].split('/')[2] %>"
       data-resource-id="<%= @result['uri'].split('/')[4] %>"
     >
+    </div>
+  </div>
+  <div
+    class="infinite-records-container col-sm-9 resizable-content-pane"
+    data-waypoint-size="<%= content_waypoint_size %>"
+    data-total-records="<%= num_records %>">
+    <div class="root">
+      <% @ordered_records.each_slice(content_waypoint_size).each_with_index do |refs, i| %>
+        <div
+          class="waypoint"
+          data-waypoint-number="<%= i %>"
+          data-uris="<%= refs.map {|r| r['ref']}.join(';') %>"
+        >&nbsp;</div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/public/app/views/shared/_only_facets.html.erb
+++ b/public/app/views/shared/_only_facets.html.erb
@@ -29,7 +29,7 @@
           <%= render partial: 'shared/facet_description', locals: { type: type, facet: facet } %>
         <% end %>
       <% else %>
-        <% facet_group.slice(0, max_facets_on_load - 1).each do |facet| %>
+        <% facet_group.slice(0, max_facets_on_load).each do |facet| %>
           <%= render partial: 'shared/facet_description', locals: { type: type, facet: facet } %>
         <% end %>
         <div class="more-facets">

--- a/public/spec/features/collection_organization_spec.rb
+++ b/public/spec/features/collection_organization_spec.rb
@@ -2,26 +2,32 @@ require 'spec_helper'
 require 'rails_helper'
 
 describe 'Collection Organization', js: true do
+  before(:all) do
+    @repo = create(:repo, repo_code: "collection_organization_test_#{Time.now.to_i}")
+    set_repo(@repo)
+    @resource = create(:resource,
+      title: 'This is <emph render="italic">a mixed content</emph> title',
+      publish: true
+    )
+    @ao1 = create(:archival_object,
+      resource: {'ref' => @resource.uri},
+      title: 'This is <emph render="italic">another mixed content</emph> title',
+      publish: true
+    )
+    @ao2 = create(:archival_object,
+      resource: {'ref' => @resource.uri},
+      title: 'This is not a mixed content title',
+      publish: true
+    )
+    run_indexers
+  end
+
+  before(:each) do
+    allow(AppConfig).to receive(:[]).and_call_original
+  end
+
   describe 'Infinite Tree sidebar' do
     it 'should handle titles with mixed content appropriately' do
-      @repo = create(:repo, repo_code: "infinite_tree_test_#{Time.now.to_i}")
-      set_repo(@repo)
-      @resource = create(:resource,
-        title: 'This is <emph render="italic">a mixed content</emph> title',
-        publish: true
-      )
-      @ao1 = create(:archival_object,
-        resource: {'ref' => @resource.uri},
-        title: 'This is <emph render="italic">another mixed content</emph> title',
-        publish: true
-      )
-      @ao2 = create(:archival_object,
-        resource: {'ref' => @resource.uri},
-        title: 'This is not a mixed content title',
-        publish: true
-      )
-      run_indexers
-
       visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
 
       resource = find(".infinite-tree-sidebar #resource_#{@resource.id}")
@@ -38,6 +44,170 @@ describe 'Collection Organization', js: true do
       ao2_record_title = ao2.find('.record-title')
       expect(ao2_record_title).to_not have_css('span.emph.render-italic')
       expect(ao2_record_title).to have_content('This is not a mixed content title')
+    end
+
+    it 'is positioned on the left side when AppConfig[:pui_collection_org_sidebar_position] = "left"' do
+      allow(AppConfig).to receive(:[]).with(:pui_collection_org_sidebar_position) { 'left' }
+      visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
+
+      sidebar = find('.infinite-tree-sidebar')
+      content = find('.infinite-records-container')
+
+      sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      content_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', content)
+
+      expect(sidebar_left_coordinate).to be < content_left_coordinate
+      expect(sidebar_right_coordinate).to eq content_left_coordinate
+    end
+
+    it 'is positioned on the right side when AppConfig[:pui_collection_org_sidebar_position] = "right"' do
+      allow(AppConfig).to receive(:[]).with(:pui_collection_org_sidebar_position) { 'right' }
+      visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
+
+      sidebar = find('.infinite-tree-sidebar')
+      content = find('.infinite-records-container')
+
+      sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      content_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', content)
+
+      expect(sidebar_left_coordinate).to eq content_right_coordinate
+      expect(sidebar_right_coordinate).to be > content_right_coordinate
+    end
+
+    it 'resizes appropriately via mouse drag when positioned on the left' do
+      allow(AppConfig).to receive(:[]).with(:pui_collection_org_sidebar_position) { 'left' }
+      visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
+
+      sidebar = find('.infinite-tree-sidebar')
+      sidebar_handle = find('.resizable-sidebar-handle')
+      content = find('.infinite-records-container')
+
+      sidebar_left_initial = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_initial = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+
+      sidebar_handle.drag_to(content)
+
+      sidebar_left_increase = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_increase = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      expect(sidebar_left_increase).to eq sidebar_left_initial
+      expect(sidebar_right_increase).to be > sidebar_right_initial
+
+      sidebar_handle.drag_to(sidebar)
+
+      sidebar_left_decrease = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_decrease = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      expect(sidebar_left_decrease).to eq sidebar_left_initial
+      expect(sidebar_right_decrease).to be < sidebar_right_increase
+    end
+
+    it 'resizes appropriately via mouse drag when positioned on the right' do
+      allow(AppConfig).to receive(:[]).with(:pui_collection_org_sidebar_position) { 'right' }
+      visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
+
+      sidebar = find('.infinite-tree-sidebar')
+      sidebar_handle = find('.resizable-sidebar-handle')
+      content = find('.infinite-records-container')
+
+      sidebar_right_initial = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      sidebar_left_initial = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+
+      sidebar_handle.drag_to(content)
+
+      sidebar_right_increase = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      sidebar_left_increase = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      expect(sidebar_right_increase).to eq sidebar_right_initial
+      expect(sidebar_left_increase).to be < sidebar_left_initial
+
+      sidebar_handle.drag_to(sidebar)
+
+      sidebar_right_decrease = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      sidebar_left_decrease = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      expect(sidebar_right_decrease).to eq sidebar_right_initial
+      expect(sidebar_left_decrease).to be > sidebar_left_increase
+    end
+
+    it 'resizes appropriately via keyboard arrow keys when positioned on the left' do
+      allow(AppConfig).to receive(:[]).with(:pui_collection_org_sidebar_position) { 'left' }
+      visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
+
+      sidebar = find('.infinite-tree-sidebar')
+      sidebar_handle = find('.resizable-sidebar-handle')
+      content = find('.infinite-records-container')
+
+      sidebar_left_initial = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_initial = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+
+      sidebar_handle.send_keys(:tab)
+      sidebar_handle.send_keys(:up)
+
+      sidebar_left_increase1 = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_increase1 = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      expect(sidebar_left_increase1).to eq sidebar_left_initial
+      expect(sidebar_right_increase1).to be > sidebar_right_initial
+
+      sidebar_handle.send_keys(:down)
+
+      sidebar_left_decrease1 = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_decrease1 = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      expect(sidebar_left_decrease1).to eq sidebar_left_initial
+      expect(sidebar_right_decrease1).to be < sidebar_right_increase1
+
+      sidebar_handle.send_keys(:right)
+
+      sidebar_left_increase2 = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_increase2 = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      expect(sidebar_left_increase2).to eq sidebar_left_initial
+      expect(sidebar_right_increase2).to be > sidebar_right_decrease1
+
+      sidebar_handle.send_keys(:left)
+
+      sidebar_left_decrease2 = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_decrease2 = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      expect(sidebar_left_decrease2).to eq sidebar_left_initial
+      expect(sidebar_right_decrease2).to be < sidebar_right_increase2
+    end
+
+    it 'resizes appropriately via keyboard arrow keys when positioned on the right' do
+      allow(AppConfig).to receive(:[]).with(:pui_collection_org_sidebar_position) { 'right' }
+      visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
+
+      sidebar = find('.infinite-tree-sidebar')
+      sidebar_handle = find('.resizable-sidebar-handle')
+      content = find('.infinite-records-container')
+
+      sidebar_right_initial = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      sidebar_left_initial = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+
+      sidebar_handle.send_keys(:tab)
+      sidebar_handle.send_keys(:up)
+
+      sidebar_right_increase1 = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      sidebar_left_increase1 = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      expect(sidebar_right_increase1).to eq sidebar_right_initial
+      expect(sidebar_left_increase1).to be < sidebar_left_initial
+
+      sidebar_handle.send_keys(:down)
+
+      sidebar_right_decrease1 = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      sidebar_left_decrease1 = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      expect(sidebar_right_decrease1).to eq sidebar_right_initial
+      expect(sidebar_left_decrease1).to be > sidebar_left_increase1
+
+      sidebar_handle.send_keys(:left)
+
+      sidebar_right_increase2 = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      sidebar_left_increase2 = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      expect(sidebar_right_increase2).to eq sidebar_right_initial
+      expect(sidebar_left_increase2).to be < sidebar_left_decrease1
+
+      sidebar_handle.send_keys(:right)
+
+      sidebar_right_decrease2 = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      sidebar_left_decrease2 = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      expect(sidebar_right_decrease2).to eq sidebar_right_initial
+      expect(sidebar_left_decrease2).to be > sidebar_left_increase2
     end
   end
 end


### PR DESCRIPTION
This PR:

- Moves (only) the Collection Organization sidebar to the left of the content by default
- Provides a (backend) config option for showing the Collection Org sidebar on the right or left of the content
- Changes the DOM order of the sidebar and content, where now the sidebar comes first in the DOM regardless of the backend configuration via CSS, which benefits screen readers as mentioned in the User Survey feedback report
- Improves keyboard control of the resizable sidebar when it has focus according to the following rules:
  - sidebar is increased when `Up` is pressed or `Right` when positioned on the left or `Left` when positioned on the right
  - sidebar is decreased when `Down` is pressed or `Left` when positioned on the left or `Right` when positioned on the right
- Fixes a bug where the Softserv updates removed the resizable sidebar handle on the Collection Org sidebar
- Removes unused code artifacts relating to the `infinite scroll` JavaScript component that was replaced wholly by [ANW-425 PUI Collection Organization rewrite](https://github.com/archivesspace/archivesspace/pull/3014)

[ANW-769](https://archivesspace.atlassian.net/browse/ANW-769)

## Before

![Screen Shot 2024-07-12 at 14 29 28-fullpage](https://github.com/user-attachments/assets/46df144e-e3a3-4660-9e5b-ecd9db60b27a)

## After

![ANW-769-coll-org-sidebar](https://github.com/user-attachments/assets/2dfde5a4-e436-4b82-b973-d2beaafc4a53)


[ANW-769]: https://archivesspace.atlassian.net/browse/ANW-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ