### PR TITLE
ANW-2091: Move Collection Overview sidebar to the left by default via config option

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -749,13 +749,12 @@ i.giant {
 
 /* record details */
 .available-digital-objects {
-  width: 100%;
-  display: flex;
-  justify-content: end;
+  float: right;
+  max-width: 40%;
 }
 
 .objectimage {
-  max-width: 50%;
+  max-width: 100%;
   display: block;
   margin: 0 0 1em 1em;
 }

--- a/public/app/assets/stylesheets/archivesspace/helpers.scss
+++ b/public/app/assets/stylesheets/archivesspace/helpers.scss
@@ -89,3 +89,7 @@
 .wrap-anywhere {
   overflow-wrap: anywhere;
 }
+
+.clear-both {
+  clear: both;
+}

--- a/public/app/views/resources/infinite.html.erb
+++ b/public/app/views/resources/infinite.html.erb
@@ -25,7 +25,7 @@
 <div class="row overflow-hidden">
   <div
     id="sidebar"
-    class="sidebar sidebar-container col-sm-3 resizable-sidebar <%= sidebar_position == 'left' ? 'resizable-sidebar-left' : 'order-1' %> infinite-tree-sidebar"
+    class="sidebar sidebar-container col-12 col-lg-3 resizable-sidebar <%= sidebar_position == 'left' ? 'resizable-sidebar-left' : 'order-1' %> infinite-tree-sidebar"
     data-sidebar-position="<%= sidebar_position %>"
   >
     <% if AppConfig[:pui_search_collection_from_collection_organization] %>
@@ -42,7 +42,7 @@
     </div>
   </div>
   <div
-    class="infinite-records-container col-sm-9 resizable-content-pane"
+    class="infinite-records-container col-12 col-lg-9 resizable-content-pane"
     data-waypoint-size="<%= content_waypoint_size %>"
     data-total-records="<%= num_records %>">
     <div class="root">

--- a/public/app/views/resources/show.html.erb
+++ b/public/app/views/resources/show.html.erb
@@ -20,7 +20,21 @@
 
 <%= render partial: 'resources/resource_alltabs' %>
 
+<% sidebar_position = AppConfig[:pui_collection_org_sidebar_position] %>
+
 <div class="row mt-5 flex-column flex-lg-row" id="notes_row">
+  <div
+    id="sidebar"
+    class="h-max col-12 col-lg-3 sidebar sidebar-container resizable-sidebar <%= sidebar_position == 'left' ? 'resizable-sidebar-left' : 'order-1' %> infinite-tree-sidebar"
+    data-sidebar-position="<%= sidebar_position %>"
+    <% unless @has_children %>style="display: none"<% end %>
+  >
+    <% if defined?(@filters) && defined?(@search) %>
+    <%= render partial: 'shared/facets' %>
+   <% end %>
+   <%= render partial: 'shared/search_collection_form', :locals => {:resource_uri => @result['uri'], :action_text => "#{t('actions.search_in', :type => t('resource._singular'))}"} %>
+   <%= render partial: 'shared/children_tree', :locals => {:heading_text => t('cont_arr'), :root_node_uri => @result.uri, :current_node_uri => @result.uri} %>
+ </div>
   <div class="col-12 col-lg-9 px-3 resizable-content-pane">
     <%= render partial: 'shared/digital', locals: {
       :dig_objs => @dig,
@@ -29,13 +43,6 @@
     } %>
     <%= render partial: 'shared/record_innards' %>
   </div>
-  <div id="sidebar" class="h-max col-12 col-lg-3 sidebar sidebar-container resizable-sidebar" <% unless @has_children %>style="display: none"<% end %>>
-    <% if defined?(@filters) && defined?(@search) %>
-    <%= render partial: 'shared/facets' %>
-   <% end %>
-   <%= render partial: 'shared/search_collection_form', :locals => {:resource_uri => @result['uri'], :action_text => "#{t('actions.search_in', :type => t('resource._singular'))}"} %>
-   <%= render partial: 'shared/children_tree', :locals => {:heading_text => t('cont_arr'), :root_node_uri => @result.uri, :current_node_uri => @result.uri} %>
- </div>
 </div>
 
 <script>

--- a/public/app/views/shared/_record_innards.html.erb
+++ b/public/app/views/shared/_record_innards.html.erb
@@ -59,7 +59,7 @@
     <% end %>
 </div>
 
-    <div class="acc_holder" >
+    <div class="acc_holder clear-both">
       <div id="res_accordion" class="accordion">
 	<% x = render partial: 'shared/multi_notes', locals: {:types => folder} %>
 	<% unless x.blank? %>

--- a/public/spec/features/accessibility_spec.rb
+++ b/public/spec/features/accessibility_spec.rb
@@ -224,14 +224,14 @@ describe 'Accessibility', js: true, db: 'accessibility' do
         end
 
         new_sidebar_width = find('div.sidebar').evaluate_script("window.getComputedStyle(this)['width']")
-        expect(new_sidebar_width).to be > sidebar_width
+        expect(new_sidebar_width).to be < sidebar_width
 
         10.times do
           handle.native.send_keys :arrow_right
         end
 
         newest_sidebar_width = find('div.sidebar').evaluate_script("window.getComputedStyle(this)['width']")
-        expect(newest_sidebar_width).to be < sidebar_width
+        expect(newest_sidebar_width).to be > sidebar_width
       end
 
       it 'should not duplicate ids' do

--- a/public/spec/features/collection_organization_spec.rb
+++ b/public/spec/features/collection_organization_spec.rb
@@ -46,8 +46,22 @@ describe 'Collection Organization', js: true do
       expect(ao2_record_title).to have_content('This is not a mixed content title')
     end
 
-    it 'is positioned on the left side when AppConfig[:pui_collection_org_sidebar_position] = "left"' do
+    it 'is positioned on the left side of the show and infinite views ' \
+       'when AppConfig[:pui_collection_org_sidebar_position] is set to left' do
       allow(AppConfig).to receive(:[]).with(:pui_collection_org_sidebar_position) { 'left' }
+
+      visit "/repositories/#{@repo.id}/resources/#{@resource.id}"
+
+      sidebar = find('.infinite-tree-sidebar')
+      content = find('.resizable-content-pane')
+
+      sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      content_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', content)
+
+      expect(sidebar_left_coordinate).to be < content_left_coordinate
+      expect(sidebar_right_coordinate).to eq content_left_coordinate
+
       visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
 
       sidebar = find('.infinite-tree-sidebar')
@@ -61,8 +75,22 @@ describe 'Collection Organization', js: true do
       expect(sidebar_right_coordinate).to eq content_left_coordinate
     end
 
-    it 'is positioned on the right side when AppConfig[:pui_collection_org_sidebar_position] = "right"' do
+    it 'is positioned on the right side of the show and infinite views ' \
+       'when AppConfig[:pui_collection_org_sidebar_position] is set to right' do
       allow(AppConfig).to receive(:[]).with(:pui_collection_org_sidebar_position) { 'right' }
+
+      visit "/repositories/#{@repo.id}/resources/#{@resource.id}"
+
+      sidebar = find('.infinite-tree-sidebar')
+      content = find('.resizable-content-pane')
+
+      sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      content_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', content)
+
+      expect(sidebar_left_coordinate).to eq content_right_coordinate
+      expect(sidebar_right_coordinate).to be > content_right_coordinate
+
       visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
 
       sidebar = find('.infinite-tree-sidebar')


### PR DESCRIPTION
This PR moves a Resource's sidebar on the show/Collection Overview view to the left by default, following ANW-769 (#3254) which moved the sidebar for a Resource's infinite/Collection Organization view.

![ANW-2091-coll-overview](https://github.com/user-attachments/assets/6ffc5cee-bfb5-43ea-81fc-966b386aa28c)

[ANW-2091](https://archivesspace.atlassian.net/browse/ANW-2091)

[ANW-2091]: https://archivesspace.atlassian.net/browse/ANW-2091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ