### PR TITLE
ANW-2028 upgrade Jruby to 9.4.8.0 targeting ruby 3.1 compatibility with compatible jetty version

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -19,10 +19,10 @@
   <property name="jruby_rack_file" value="jruby-rack-${jruby_rack_version}.jar" />
   <property name="jruby_rack_url" value="https://repo1.maven.org/maven2/org/jruby/rack/jruby-rack/${jruby_rack_version}/jruby-rack-${jruby_rack_version}.jar" />
 
-  <property name="jettyrunner_url" value="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-runner/11.0.22/jetty-runner-11.0.22.jar" />
-  <property name="jettyrunner_file" value="jetty-runner-11.0.22.jar" />
-  <property name="jettywebapp_url" value="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-webapp/11.0.22/jetty-webapp-11.0.22.jar" />
-  <property name="jettywebapp_file" value="jetty-webapp-11.0.22.jar" />
+  <property name="jettyrunner_url" value="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-runner/10.0.22/jetty-runner-10.0.22.jar" />
+  <property name="jettyrunner_file" value="jetty-runner-10.0.22.jar" />
+  <property name="jettywebapp_url" value="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-webapp/10.0.22/jetty-webapp-10.0.22.jar" />
+  <property name="jettywebapp_file" value="jetty-webapp-10.0.22.jar" />
 
   <property name="gem_home" location="gems" />
   <property name="aspace.backend.port" value="4567" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is fixing the broken and reverted: https://github.com/archivesspace/archivesspace/pull/3247

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
  - Upgraded to the latest version of https://github.com/code4lib/ruby-oai
- [x] Breaking change: 
  - After upgrade of the oai gem (https://github.com/code4lib/ruby-oai/releases/tag/v1.0.0) oai identifiers are now being generated/expected with a colon between namespace and prefix, rather than slash. So oai URIs that used to be:     `/oai?verb=GetRecord&identifier=oai:archivesspace/#{@test_resource_record}&metadataPrefix=oai_dcterms` now become: `/oai?verb=GetRecord&identifier=oai:archivesspace:#{@test_resource_record}&metadataPrefix=oai_dcterms`
 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
