### PR TITLE
ANW-2014: Remove InfiniteRecords waypoint url extra slash

### DIFF
--- a/public/app/assets/javascripts/InfiniteRecords.js
+++ b/public/app/assets/javascripts/InfiniteRecords.js
@@ -163,7 +163,7 @@
         query.append('urls[]', uri);
       });
 
-      const url = `${this.appUrlPrefix}/${this.resourceUri}/infinite/waypoints?${query}`;
+      const url = `${this.appUrlPrefix}${this.resourceUri}/infinite/waypoints?${query}`;
 
       try {
         const response = await fetch(url);


### PR DESCRIPTION
An extra `'/'` was added to the infinite records waypoint URL during the [recent app proxy prefix work](https://github.com/archivesspace/archivesspace/commit/753ba2d17e5749e1a0b3c55696a123eb6bfa7002#diff-aaa915a88594ef3b73cbcf501c58d26cdde05fb8b93d500e398cf6479c1c93b8R166). However this did not break the PUI Collection Org infinite view from fetching waypoints both in local development and in production on the test server.

More recently on the test server fetching now throws an error and the PUI Collection Org loading spinner hangs ([see here for example](https://test.archivesspace.org/repositories/2/resources/32/collection_organization)), while local development still works as expected.

It may have something to do with the recent jruby updates (#3271).

<img width="1498" alt="broke fetch" src="https://github.com/user-attachments/assets/d0459e41-5906-4c10-8d71-e81ba8f6c6a7">

## Testing this solution on the test server right now

This fix can be tested on the test server before merging this PR by removing the slash from the failed GET request and entering the url in the browser which returns a successful GET request,  ie: `https://test.archivesspace.org//repositories/2/resources/32/infinite/waypoints?urls%5B%5D=%2Frepositories%2F2%2Fresources%2F32&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14008&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14010&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14011&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14015&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14017&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14020&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14013&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14007&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14012&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14016&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14018&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14009&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14021&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F24514&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14022&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14023&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14025&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14026&urls%5B%5D=%2Frepositories%2F2%2Farchival_objects%2F14027`