### PR TITLE
ANW-2107 Allow owner repo to be imported via CSV

### DIFF
--- a/backend/app/converters/converter.rb
+++ b/backend/app/converters/converter.rb
@@ -55,6 +55,7 @@ class Converter
   def initialize(input_file)
     @input_file = input_file
     @batch = ASpaceImport::RecordBatch.new
+    @import_options = {}
   end
 
 
@@ -77,6 +78,16 @@ class Converter
         end
       end
     end
+  end
+
+
+  def import_options
+    self.class.import_options
+  end
+
+
+  def self.import_options
+    @import_options
   end
 
 
@@ -124,24 +135,14 @@ class Converter
 
       if converter
         if converter.respond_to?(:set_import_options)
-          import_events   = nil
-          import_subjects = nil
+          import_events = opts[:import_events]
+          import_subjects = opts[:import_subjects]
+          import_repository = opts[:import_repository]
 
-          if opts[:import_events]
-            import_events = true
-          else
-            import_events = false
-          end
-
-          if opts[:import_subjects]
-            import_subjects = true
-          else
-            import_subjects = false
-          end
-
-          unless import_events == nil && import_subjects == nil
+          unless [import_events, import_subjects, import_repository].all?(&:nil?)
             converter.set_import_options({:import_events   => import_events,
-                                          :import_subjects => import_subjects})
+                                          :import_subjects => import_subjects,
+                                          :import_repository => import_repository})
           end
         end
 

--- a/backend/app/converters/location_converter.rb
+++ b/backend/app/converters/location_converter.rb
@@ -14,7 +14,12 @@ class LocationConverter < Converter
   end
 
   def self.instance_for(type, input_file)
+    @import_options = {}
     new(input_file) if type == 'location_csv'
+  end
+
+  def set_import_options(opts)
+    self.import_options&.merge!(opts)
   end
 
   def self.configure
@@ -32,6 +37,14 @@ class LocationConverter < Converter
       'location_coordinate_3_label' => 'location.coordinate_3_label',
       'location_coordinate_3_indicator' => 'location.coordinate_3_indicator',
       'location_temporary' => 'location.temporary',
+
+      :location => {
+        :on_create => Proc.new {|data, obj|
+          if @import_options && @import_options[:import_repository]
+            obj.owner_repo = {'ref' => JSONModel(:repository).uri_for(Thread.current[:request_context][:repo_id])}
+          end
+        }
+      },
     }
   end
 end

--- a/backend/app/lib/job_runners/batch_import_runner.rb
+++ b/backend/app/lib/job_runners/batch_import_runner.rb
@@ -27,6 +27,7 @@ class BatchImportRunner < JobRunner
     filenames = @json.job['filenames'] || []
     import_maint_events = @json.job["import_events"]   == "1" ? true : false
     import_subjects     = @json.job["import_subjects"] == "1" ? true : false
+    import_repository     = @json.job["import_repository"] == "1" ? true : false
 
     # Wrap the import in a transaction if the DB supports MVCC
     begin
@@ -36,7 +37,7 @@ class BatchImportRunner < JobRunner
         begin
           @job.job_files.each_with_index do |input_file, i|
             ticker.log(("=" * 50) + "\n#{filenames[i]}\n" + ("=" * 50)) if filenames[i]
-            converter = Converter.for(@json.job['import_type'], input_file.full_file_path, {:import_events => import_maint_events, :import_subjects => import_subjects})
+            converter = Converter.for(@json.job['import_type'], input_file.full_file_path, {:import_events => import_maint_events, :import_subjects => import_subjects, :import_repository => import_repository})
             begin
               RequestContext.open(:create_enums => true,
                                   :current_username => @job.owner.username,

--- a/backend/app/lib/job_runners/batch_import_runner.rb
+++ b/backend/app/lib/job_runners/batch_import_runner.rb
@@ -27,7 +27,7 @@ class BatchImportRunner < JobRunner
     filenames = @json.job['filenames'] || []
     import_maint_events = @json.job["import_events"]   == "1" ? true : false
     import_subjects     = @json.job["import_subjects"] == "1" ? true : false
-    import_repository     = @json.job["import_repository"] == "1" ? true : false
+    import_repository   = @json.job["import_repository"] == "1" ? true : false
 
     # Wrap the import in a transaction if the DB supports MVCC
     begin

--- a/backend/spec/lib_location_converter_spec.rb
+++ b/backend/spec/lib_location_converter_spec.rb
@@ -26,7 +26,7 @@ describe 'Location converter' do
       my_converter.instance_variable_set(:@import_options, {})
     end
 
-    it 'creates location records with owner repo' do
+    it 'creates location records without owner repo' do
       locations = convert(test_file).select {|r| r['jsonmodel_type'] == 'location' }
       expect(locations.select { |l| l['owner_repo'] }).to be_empty
     end

--- a/backend/spec/lib_location_converter_spec.rb
+++ b/backend/spec/lib_location_converter_spec.rb
@@ -9,17 +9,38 @@ describe 'Location converter' do
     LocationConverter
   end
 
-  before(:all) do
+  let(:test_file) do
     test_file = File.expand_path(
       '../../backend/spec/examples/aspace_location_import_template.csv',
       File.dirname(__FILE__)
     )
-    @records = convert(test_file)
-    @locations = @records.select {|r| r['jsonmodel_type'] == 'location' }
   end
 
-  it 'created one Location record for each row in the CSV file' do
-    expect(@locations.count).to eq(3)
+  it 'creates one location record for each row in the CSV file' do
+    locations = convert(test_file).select {|r| r['jsonmodel_type'] == 'location' }
+    expect(locations.count).to eq(3)
+  end
+
+  context 'when import repository is not checked' do
+    before do
+      my_converter.instance_variable_set(:@import_options, {})
+    end
+
+    it 'creates location records with owner repo' do
+      locations = convert(test_file).select {|r| r['jsonmodel_type'] == 'location' }
+      expect(locations.select { |l| l['owner_repo'] }).to be_empty
+    end
+  end
+
+  context 'when import repository is checked' do
+    before do
+      my_converter.instance_variable_set(:@import_options, {:import_repository => true})
+    end
+
+    it 'creates location records with owner repo' do
+      locations = convert(test_file).select {|r| r['jsonmodel_type'] == 'location' }
+      expect(locations.select { |l| l['owner_repo'] }).not_to be_empty
+    end
   end
 
 end

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -2564,6 +2564,7 @@ en:
     _singular: Import Job
     import_events: Import Maintenance Events?
     import_subjects: Import and Link related Subjects?
+    import_repository: Link imported locations to current repository?
     filenames: Files
     import_type: Import Type
     import_type_ead_xml: EAD

--- a/common/schemas/import_job.rb
+++ b/common/schemas/import_job.rb
@@ -28,6 +28,10 @@
         "type" => "string"
       },
 
+      "import_repository" => {
+        "type" => "string"
+      }
+
     }
   }
 }

--- a/frontend/app/assets/javascripts/jobs.crud.js
+++ b/frontend/app/assets/javascripts/jobs.crud.js
@@ -487,6 +487,18 @@ var init = function () {
     });
   };
 
+  var hideImportRepositoryOption = function () {
+    $('#js-import-repository').hide();
+
+    $('#job_import_type_').change(function () {
+      if ($('#job_import_type_').val() == 'location_csv') {
+        $('#js-import-repository').show();
+      } else {
+        $('#js-import-repository').hide();
+      }
+    });
+  };
+
   var type = $('#job_type').val();
 
   $('.linker:not(.initialised)').linker();
@@ -508,6 +520,7 @@ var init = function () {
 
   hideImportEventsOption();
   hideImportSubjectsOption();
+  hideImportRepositoryOption();
 };
 
 $(init);

--- a/frontend/app/views/jobs/_form.html.erb
+++ b/frontend/app/views/jobs/_form.html.erb
@@ -56,6 +56,9 @@
     <fieldset id='js-import-subjects'>
         <%= form.label_and_boolean("import_subjects", {}, false, true) %>
     </fieldset>
+    <fieldset id='js-import-repository'>
+        <%= form.label_and_boolean("import_repository") %>
+    </fieldset>
   </section>
 
   <section id="job_filenames_">


### PR DESCRIPTION
Adds a checkbox to the location CSV importer that allows for the imported location(s) to be linked to the current repo.

## Description
Allows for locations to be imported with an associated repo from the start, rather than requiring additional steps after import.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-2107

## How Has This Been Tested?
Some tests added to the backend test suite, as well as manually testing.  Happy to add additional tests based off the guidance/review of the dev team.

## Screenshots (if appropriate):
Adds the following checkbox:

<img width="793" alt="Screenshot 2024-08-08 at 5 09 33 PM" src="https://github.com/user-attachments/assets/20c1cf02-dd23-4fba-b2bf-fe4f8861c531">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
