### PR TITLE
ANW-2095: Fixed error when creating a custom report when narrowing by agent type

### DIFF
--- a/reports/custom/custom_report.rb
+++ b/reports/custom/custom_report.rb
@@ -67,7 +67,8 @@ class CustomReport < AbstractReport
       if (ASUtils.present?(template['fields'][field_name]['values'])) &&
         (!template['fields'][field_name]['values'].nil?)
 
-        self.send("#{field[:data_type].downcase}_narrow", template, field_name)
+        method_name = field[:data_type].downcase.gsub('agenttype', 'agent_type') + "_narrow"
+        self.send(method_name, template, field_name)
       end
 
       if (ASUtils.present?(template['fields'][field_name]['range_start'])) &&


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Previously, when a user went to create a custom report template and designated the record type for the report as "agent" and then selected any of the agent types as a value to narrow the report, the report failed. Basically, the error showed that "agenttype_narrow" should be changed to "agent_type_narrow." 

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-2095

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I was able to set up the environment using "build/run bootstrap" but was unable to figure out the backend test suite. I have been using ArchivesSpace with this addition for close to a month now with no issues. I did not post the JIRA listing, so others must be finding this error as well.

## Screenshots (if appropriate):
What it used to say when generating a custom JSON report with an "Agents" template:
![image](https://github.com/user-attachments/assets/604f950a-1938-408f-ab58-062d75b58914)

What it says now:
![Screenshot 2024-08-13 at 2 41 48 PM](https://github.com/user-attachments/assets/06ee6a27-6934-4494-ba2e-e3beb687f3e5)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
