### PR TITLE
ANW-2099: Move Collection Org sidebar for Archival Objs and Digital Obj Components

### DIFF
--- a/public/app/views/objects/show.html.erb
+++ b/public/app/views/objects/show.html.erb
@@ -15,17 +15,14 @@
     </div>
   </section>
 
-  <div class="row" id="notes_row">
-   <div class="col-sm-9">
-    <% if  defined?(comp_id) && !comp_id && !@result['json']['ref_id'].blank? %>
-      <span class='ref_id'>[<%=  t('archival_object._public.header.ref_id') %>: <%= @result['json']['ref_id'] %>]</span>
-    <% end %>
-    <%= render partial: 'shared/digital', locals: {:dig_objs => @dig, record: @result} %>
-    <%= render partial: 'shared/record_innards' %>
-   </div>
-
-   <% if !@result.instance_of?(DigitalObject) || @has_children %>
-    <div id="sidebar" class="sidebar sidebar-container col-sm-3 resizable-sidebar">
+  <% sidebar_position = AppConfig[:pui_collection_org_sidebar_position] %>
+  <div class="row align-items-start" id="notes_row">
+  <% if !@result.instance_of?(DigitalObject) || @has_children %>
+    <div
+      id="sidebar"
+      class="sidebar sidebar-container col-sm-3 resizable-sidebar <%= sidebar_position == 'left' ? 'resizable-sidebar-left' : 'order-1' %> infinite-tree-sidebar"
+      data-sidebar-position="<%= sidebar_position %>"
+    >
       <%
         if @result.kind_of?(DigitalObject)
           heading_text = t('dig_cont_arr')
@@ -40,6 +37,14 @@
       <%= render partial: 'shared/children_tree', :locals => {:heading_text => heading_text, :root_node_uri => @result.root_node_uri, :current_node_uri => @result.uri} %>
     </div>
    <% end %>
+   <div class="col-sm-9 resizable-content-pane">
+    <% if  defined?(comp_id) && !comp_id && !@result['json']['ref_id'].blank? %>
+      <span class='ref_id'>[<%=  t('archival_object._public.header.ref_id') %>: <%= @result['json']['ref_id'] %>]</span>
+    <% end %>
+    <%= render partial: 'shared/digital', locals: {:dig_objs => @dig, record: @result} %>
+    <%= render partial: 'shared/record_innards' %>
+   </div>
+
   </div>
   <script>
     document.querySelectorAll("[data-js='readmore']").forEach((el) => {

--- a/public/spec/features/collection_organization_spec.rb
+++ b/public/spec/features/collection_organization_spec.rb
@@ -19,6 +19,11 @@ describe 'Collection Organization', js: true do
       title: 'This is not a mixed content title',
       publish: true
     )
+    @do = create(:digital_object, publish: true)
+    @doc = create(:digital_object_component,
+      publish: true,
+      digital_object: { ref: @do.uri }
+    )
     run_indexers
   end
 
@@ -46,7 +51,7 @@ describe 'Collection Organization', js: true do
       expect(ao2_record_title).to have_content('This is not a mixed content title')
     end
 
-    it 'is positioned on the left side of the show and infinite views ' \
+    it 'is positioned on the left side of the resource show and infinite views ' \
        'when AppConfig[:pui_collection_org_sidebar_position] is set to left' do
       allow(AppConfig).to receive(:[]).with(:pui_collection_org_sidebar_position) { 'left' }
 
@@ -66,6 +71,35 @@ describe 'Collection Organization', js: true do
 
       sidebar = find('.infinite-tree-sidebar')
       content = find('.infinite-records-container')
+
+      sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      content_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', content)
+
+      expect(sidebar_left_coordinate).to be < content_left_coordinate
+      expect(sidebar_right_coordinate).to eq content_left_coordinate
+    end
+
+    it 'is positioned on the left side of the objects show view ' \
+       'when AppConfig[:pui_collection_org_sidebar_position] is set to left' do
+      allow(AppConfig).to receive(:[]).with(:pui_collection_org_sidebar_position) { 'left' }
+
+      visit "/repositories/#{@repo.id}/digital_objects/#{@do.id}"
+
+      sidebar = find('.infinite-tree-sidebar')
+      content = find('.resizable-content-pane')
+
+      sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      content_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', content)
+
+      expect(sidebar_left_coordinate).to be < content_left_coordinate
+      expect(sidebar_right_coordinate).to eq content_left_coordinate
+
+      visit "/repositories/#{@repo.id}/digital_object_components/#{@doc.id}"
+
+      sidebar = find('.infinite-tree-sidebar')
+      content = find('.resizable-content-pane')
 
       sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
       sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
@@ -95,6 +129,35 @@ describe 'Collection Organization', js: true do
 
       sidebar = find('.infinite-tree-sidebar')
       content = find('.infinite-records-container')
+
+      sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      content_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', content)
+
+      expect(sidebar_left_coordinate).to eq content_right_coordinate
+      expect(sidebar_right_coordinate).to be > content_right_coordinate
+    end
+
+    it 'is positioned on the right side of the objects show view ' \
+       'when AppConfig[:pui_collection_org_sidebar_position] is set to right' do
+      allow(AppConfig).to receive(:[]).with(:pui_collection_org_sidebar_position) { 'right' }
+
+      visit "/repositories/#{@repo.id}/digital_objects/#{@do.id}"
+
+      sidebar = find('.infinite-tree-sidebar')
+      content = find('.resizable-content-pane')
+
+      sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
+      sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
+      content_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', content)
+
+      expect(sidebar_left_coordinate).to eq content_right_coordinate
+      expect(sidebar_right_coordinate).to be > content_right_coordinate
+
+      visit "/repositories/#{@repo.id}/digital_object_components/#{@doc.id}"
+
+      sidebar = find('.infinite-tree-sidebar')
+      content = find('.resizable-content-pane')
 
       sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
       sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)


### PR DESCRIPTION
This PR moves the Collection Org sidebar to the left by (a configurable) default for the children of Resources and Digital Objects. This is a follow up from ANW-2091 (#3258) and ANW-769 (#3254), and completes the moving of the Collection Org sidebar.

[ANW-2099](https://archivesspace.atlassian.net/browse/ANW-2099)

## After

![Screen Shot 2024-08-15 at 07 30 43-fullpage](https://github.com/user-attachments/assets/a7cedc5d-e3bc-48ea-909a-f4fca3096e5a)

![Screen Shot 2024-08-15 at 07 31 06-fullpage](https://github.com/user-attachments/assets/86401005-82a0-4ea9-8462-eade87880b4e)


[ANW-2099]: https://archivesspace.atlassian.net/browse/ANW-2099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ