### PR TITLE
ANW-1509 reproduce search "Found In" column in CSV exports

### DIFF
--- a/frontend/app/helpers/export_helper.rb
+++ b/frontend/app/helpers/export_helper.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 module ExportHelper
 
   def csv_response(request_uri, params = {}, filename_prefix = '')
@@ -23,5 +25,82 @@ module ExportHelper
     end
   end
 
+  # This is meant to be used by the search controller to be able to fill in the derived "context" column,
+  # since JSONModel can't do that as it isn't stored/indexed.
+  def csv_export_with_context(request_uri, params = {})
+    params["dt"] = "csv"
+    JSONModel::HTTP::stream(request_uri, params) do |response|
+      old_csv = CSV.parse(response.body)
+      new_csv = ContextConverter.new.convert_ancestors_to_context old_csv
+
+      # convert arrays back CSV string
+      return new_csv.map(&:to_csv).join
+    end
+  end
+
+  # Creates a "context" string intended to match what is displayed in the Staff UI for search results.
+  class ContextConverter
+
+    # There are several different fields that 'context' data may potentially be drawn from
+    def self.ancestor_fields
+      ['ancestors', 'linked_instance_uris', 'linked_record_uris', 'collection_uri_u_sstr', 'digital_object']
+    end
+
+    def initialize
+      # Fetching JSONModel records from the backend creates a lot of overhead, and it's likely that many records have
+      # the same ancestor(s), so we'll cache the titles to mitigate that.
+      @title_cache = {}
+    end
+
+    def convert_ancestors_to_context(old_csv)
+      # we want all the columns from the search except for the various ancestor fields, which will all end up in context
+      new_csv = [old_csv[0].reject {|header| self.class.ancestor_fields.include? header}]
+      new_csv[0].append 'context'
+      new_row_length = new_csv[0].length
+      context_column_index = new_csv[0].index 'context'
+
+      column_map = []
+      old_csv[0].each_with_index do |old_column, old_column_index|
+        new_column_index = new_csv[0].index(old_column)
+        if new_column_index
+          column_map[old_column_index] = new_column_index
+        else
+          column_map[old_column_index] = context_column_index
+        end
+      end
+
+      old_csv[1...old_csv.length].each do |old_row|
+        new_row = Array.new(new_row_length)
+        column_map.each_with_index do |new_column_index, old_column_index|
+          if new_column_index == context_column_index
+            # these ones need to be moved to the context column if they exist
+            uris = old_row[old_column_index]
+            new_row[new_column_index] = context_string(uris.split ',') unless uris.blank?
+          else
+            new_row[new_column_index] = old_row[old_column_index]
+          end
+        end
+        new_csv.append new_row
+      end
+
+      new_csv
+    end
+
+    private
+
+    # given a list of ancestor URIs, look up record titles and construct context string that matches the frontend display
+    def context_string(ancestor_uris)
+      ancestor_context = ''
+      ancestor_uris.reverse.each_with_index do |ancestor_uri, i|
+        title = @title_cache.fetch(ancestor_uri) do |uri|
+          @title_cache[uri] = JSONModel::HTTP.get_json(ancestor_uri)['title']
+        end
+        ancestor_context += title
+        ancestor_context += ' > ' if i < ancestor_uris.length - 1
+      end
+      ancestor_context
+    end
+
+  end
 
 end

--- a/frontend/spec/helpers/export_helper_spec.rb
+++ b/frontend/spec/helpers/export_helper_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_helper'
+
+describe ExportHelper do
+  before :all do
+    @repo = create :repo, repo_code: "exporthelper_test_#{Time.now.to_i}"
+    set_repo @repo
+  end
+
+  it 'can convert the ancestor refs from a search to a user-friendly context column for CSV downloads' do
+    collection = create(:resource, title: 'ExportHelper collection', level: 'collection')
+    series = create(:archival_object, title: 'ExportHelper series', level: 'series', resource: {ref: collection.uri})
+    top_container = create(:top_container, type: 'box')
+    item = create(:archival_object,
+      title: 'ExportHelper item',
+      level: 'item',
+      resource: {ref: collection.uri}, parent: {ref: series.uri}
+    )
+    digital_object = create(:digital_object, title: 'ExportHelper digital object')
+    digital_object_component = create(:digital_object_component, title: 'ExportHelper digital object component', digital_object: {ref: digital_object.uri})
+
+    run_index_round
+
+    criteria = {'fields[]' => ['primary_type', 'title', 'ancestors'], 'q' => '*', 'page' => '1'}
+    export = csv_export_with_context "#{@repo.uri}/search", Search.build_filters(criteria)
+    expect(export).to include('archival_object,ExportHelper series,ExportHelper collection')
+    expect(export).to include('archival_object,ExportHelper item,ExportHelper collection > ExportHelper series')
+    expect(export).to include('digital_object_component,ExportHelper digital object component,ExportHelper digital object')
+  end
+end


### PR DESCRIPTION
The "Found In" column in the search results table in the Staff UI is generated by the frontend, and unlike the other columns is not indexed so it doesn't show up in CSV exports. This is because the CSV export helper actually has to re-run the search in order to get the full results set (not just the currently displayed page), and is just given the field names displayed in the results table to include in the search. Since "context" is not an actual field in any record, it comes back blank.

I've added a class to the ExportHelper that mimics the way the "Found In" column results are constructed. Since the various fields that indicate the ancestors for different record types only provide URI refs, they need to be grabbed from the backend in order to get the actual title string. This introduces a lot of overhead, so the titles are cached as they are retreived to avoid having to make this a background job. Since most ancestors are likely to be parents to many of the records in the search results, this should be effective.