### PR TITLE
ANW-2074 update for git client lib log changes

### DIFF
--- a/scripts/tasks/doc.thor
+++ b/scripts/tasks/doc.thor
@@ -39,7 +39,7 @@ class Doc < Thor
     end
 
     git = Git.open('./')
-    log = ReleaseNotes.parse_log(git.log('a').between(previous_tag, current_tag))
+    log = ReleaseNotes.parse_log(git.log.max_count(:all).between(previous_tag, current_tag))
     log.reject! { |log_entry| log_entry[:desc].match(/^Merge pull request/) }
     pulls_page = 1
     while((log.select { |log_entry| log_entry[:pr_number].nil? }.size > 0) && (pulls_page < options[:max_pr_pages] + 1)) do


### PR DESCRIPTION
It seems that around v1.15.0 the git library client methods got changed up a bit and the log method now takes different arguments. This should hopefully restore the ability for the release process to automatically pull PRs for the release notes.