### PR TITLE
ANW-1836: Add minor tweaks to load all records

### DIFF
--- a/public/app/assets/javascripts/InfiniteRecords.js
+++ b/public/app/assets/javascripts/InfiniteRecords.js
@@ -41,7 +41,7 @@
       this.isOkToObserve = true; // used to prevent jank via programmatic scrolling
 
       this.modal = new ModalManager(
-        document.querySelector('[data-loading-modal]')
+        document.querySelector('#records-loading-dialog')
       );
 
       this.waypointObserver = new IntersectionObserver(
@@ -455,6 +455,7 @@
           waypointTuples,
           resourceUri: this.resourceUri,
           MAX_CONCURRENT_FETCHES: this.WORKER_MAX_CONCURRENT_FETCHES,
+          appUrlPrefix: this.appUrlPrefix,
         });
 
         worker.onmessage = e => {

--- a/public/app/assets/javascripts/infiniteRecordsWorker.js
+++ b/public/app/assets/javascripts/infiniteRecordsWorker.js
@@ -1,6 +1,7 @@
 // Here we use ES5 syntax (to appease Uglifier) to mimic an ES6
-// async generator that fetches waypoints in batches. The smaller the
-// batch size the more frequent the user feedback re: loading progress.
+// async generator that fetches waypoints in batches.
+
+let baseUrl = '';
 
 /**
  * @typedef {array} waypointTuple - Array containing a waypoint number and an
@@ -15,11 +16,14 @@
  * @param {array} e.data.waypointTuples - Array of waypoint tuples
  * @param {string} e.data.resourceUri - The resource URI
  * @param {number} e.data.MAX_CONCURRENT_FETCHES - Max concurrent fetches
+ * @param {string} e.data.appUrlPrefix - AppConfig[:public_proxy_url]
  */
 onmessage = function (e) {
-  const { waypointTuples, resourceUri, MAX_CONCURRENT_FETCHES } = e.data;
+  const { waypointTuples, resourceUri, MAX_CONCURRENT_FETCHES, appUrlPrefix } =
+    e.data;
   const chunks = chunkGenerator(waypointTuples, MAX_CONCURRENT_FETCHES);
 
+  baseUrl = appUrlPrefix;
   iterateChunks(chunks, resourceUri, 0);
 };
 
@@ -92,14 +96,13 @@ function fetchChunks(chunk, resourceUri, callback) {
  * a waypoint number and an object of records markup keyed by URI
  */
 function fetchWaypoint(wpNum, uris, resourceUri) {
-  const origin = self.location.origin;
   const query = new URLSearchParams();
 
   uris.forEach(uri => {
     query.append('urls[]', uri);
   });
 
-  const url = `${origin}${resourceUri}/infinite/waypoints?${query}`;
+  const url = `${baseUrl}${resourceUri}/infinite/waypoints?${query}`;
 
   return fetch(url)
     .then(response => response.json())

--- a/public/app/assets/stylesheets/archivesspace/infinite-records.scss
+++ b/public/app/assets/stylesheets/archivesspace/infinite-records.scss
@@ -154,13 +154,21 @@ $indent-width: 20px;
   animation: bg-yellow-to-white 1s;
 }
 
+.loading-dialog {
+  border: none;
+}
+.loading-dialog:focus,
+.loading-dialog:active {
+  outline: 3px solid $primary-color;
+}
+
 .spinner-border {
   display: inline-block;
   width: 2rem;
   height: 2rem;
   vertical-align: -0.125em;
-  border: 0.25em solid currentcolor;
-  border-right-color: currentcolor;
+  border: 3px solid $primary-color;
+  border-right-color: $primary-color;
   border-right-color: transparent;
   border-radius: 50%;
   -webkit-animation: 0.75s linear infinite spinner-border;

--- a/public/app/views/resources/_infinite_records.html.erb
+++ b/public/app/views/resources/_infinite_records.html.erb
@@ -16,7 +16,7 @@
   </div>
 </div>
 
-<dialog data-loading-modal>
+<dialog id="records-loading-dialog" class="loading-dialog">
   <div class="spinner-border" role="status">
     <span class="visually-hidden"><%= t('resource.load_records.loading') %></span>
   </div>

--- a/public/config/environments/development.rb
+++ b/public/config/environments/development.rb
@@ -67,7 +67,7 @@ Rails.application.configure do
   config.infinite_records_waypoint_size = 20
   config.infinite_records_main_max_concurrent_waypoint_fetches = 20
   config.infinite_records_worker_max_concurrent_waypoint_fetches = 100
-  # Beware! Chromium has a limit of 1350 fetches per process, anything more and
-  # it throws a `net::ERR_INSUFFICIENT_RESOURCES` error, returning `undefined`
-  # per fetch.
+  # Beware! Don't set this number over 1350, Chromium's limit of fetches per process.
+  # Anything more and it throws `net::ERR_INSUFFICIENT_RESOURCES`, returning
+  # `undefined` per fetch.
 end

--- a/public/config/locales/pt.yml
+++ b/public/config/locales/pt.yml
@@ -143,7 +143,7 @@ pt:
     load_records:
       alert: "Esta coleção contém um grande número de registos"
       showing: "A mostrar"
-      percent_convention: " %" # Portugal Portuguese, not Brazilian Portuguese ("%")
+      percent_convention: "%" # Brazilian Portuguese, not Portugal Portuguese (" %")
       load: "Carregar registos"
       load_all: "Carregar todos os registos"
       scroll: "Ao percorrer"

--- a/public/spec/features/collection_organization_spec.rb
+++ b/public/spec/features/collection_organization_spec.rb
@@ -498,15 +498,14 @@ describe 'Collection Organization', js: true do
 
     it 'shows a spinner on state change and removes the spinner once all records are loaded' do
       visit "/repositories/#{@repo.id}/resources/#{@res_10wp.id}/collection_organization"
-      expect(page).to have_css('dialog[data-loading-modal]', visible: false)
+      expect(page).to have_css('#records-loading-dialog', visible: false)
       sleep 10
 
       # There is no dialog 'open' event so listen for 'close' which implies it was open
       page.execute_script(<<~JS)
         window.dialogClosed = false;
-        const dialog = document.querySelector('dialog[data-loading-modal]');
-        dialog.addEventListener('close', (e) => {
-          console.log('e!', e);
+        const dialog = document.querySelector('#records-loading-dialog');
+        dialog.addEventListener('close', () => {
           window.dialogClosed = true;
         });
       JS


### PR DESCRIPTION
This PR adds minor tweaks to the recent PR #3257:

- accounts for the proxy prefix when fetching from the web worker
- updates the loading spinner css
- updates the Portuguese translation file
- removes a console.log() debugger from the spec