### PR TITLE
ANW-2041: Re-align archival object 'Publish' label text

### DIFF
--- a/frontend/app/views/archival_objects/_form_container.html.erb
+++ b/frontend/app/views/archival_objects/_form_container.html.erb
@@ -51,7 +51,7 @@
         <%= form.label_and_select "level", form.possible_options_for("level", true) %>
         <%= form.label_and_textfield "other_level", :required => true %>
         <div class="form-group w-100 row">
-          <%= form.label "publish", :class => 'control-label col-sm-2' %>
+          <%= form.label "publish", :class => 'control-label col-sm-2 text-right' %>
           <div class="col-sm-1 checkbox">
             <%= form.checkbox "publish", {}, user_prefs["publish"] %>
             <% if form.obj["has_unpublished_ancestor"] %>


### PR DESCRIPTION
This PR fixes a Softserv bug where the "Publish?" field label text not right-aligned when editing Archival Objects.

## Solution

<img width="1479" alt="ANW-2041" src="https://github.com/user-attachments/assets/e1cadd5e-2bee-43bc-9b1d-53a3af1b7b3f">
