### PR TITLE
ANW-2122 fix empty path segment in top containers search

### DIFF
--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -371,7 +371,7 @@ class TopContainersController < ApplicationController
 
 
   def perform_search
-    JSONModel::HTTP::get_json("#{JSONModel(:top_container).uri_for("")}/search", prepare_search)
+    JSONModel::HTTP::get_json("#{JSONModel(:top_container).uri_for("")}search", prepare_search)
   end
 
   # Gather all parameters, used for HTML and CSV responses


### PR DESCRIPTION
Jetty 10 apparently decided to start complaining about "empty segments" in URIs and returning 400 errors when they are encountered. It often happens that URIs end up with double slashes in them when being constructed via string interpolation, and this is one spot where that was happening. We'll need to be more careful about that going forward.

reference: https://github.com/jetty/jetty.project/commit/b4d7e5117db6bc4ef0cb7a16eab589b83dcf0e21