### PR TITLE
ANW-2125 Fix public search statement buttons

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/bootstrap-overrides.scss
+++ b/public/app/assets/stylesheets/archivesspace/bootstrap-overrides.scss
@@ -8,3 +8,32 @@
   border-bottom: var(--default-border);
   border-radius: 4px;
 }
+
+/* Bootstrap v4 removed .btn-default but they were not removed or patched in
+   ArchivesSpace. frontend/ used vanilla .btn-default, but not public. Most of
+   the public .btn-defaults underwent adjustments, but not all. So here is
+   backwards compatibility with Bootstrap v3 .btn-default, but with a name change
+   so as to not override the majority of custom .btn-defaults. */
+.btn--default {
+  color: $body-color;
+  background-color: var(--white);
+  border-color: $border;
+}
+
+.btn--default:hover {
+  color: $body-color;
+  background-color: $gray-200;
+}
+
+.btn--default:focus,
+.btn--default.focus {
+  border-color: $primary-color;
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(0, 111, 155, 0.25);
+}
+
+.btn--default.disabled,
+.btn--default:disabled {
+  color: $body-color;
+  background-color: var(--light);
+}

--- a/public/app/views/search/search_results.html.erb
+++ b/public/app/views/search/search_results.html.erb
@@ -25,8 +25,8 @@
   <% unless defined?(@no_statement) %>
     <div class="searchstatement">
       <div class="btn btn-group pull-right">
-        <%= link_to I18n.t('actions.new_search'), (defined?(@new_search) ? @new_search : root_path), :class => "btn btn-sm btn-default" %>
-        <button class="btn btn-sm btn-default" id="toggleRefineSearch" aria-expanded="false" aria-controls="refineSearchPanel"><%= I18n.t('actions.refine_search') %></button>
+        <%= link_to I18n.t('actions.new_search'), (defined?(@new_search) ? @new_search : root_path), :class => "btn btn-sm btn--default" %>
+        <button class="btn btn-sm btn--default" id="toggleRefineSearch" aria-expanded="false" aria-controls="refineSearchPanel"><%= I18n.t('actions.refine_search') %></button>
       </div>
 
       <% if defined?(@search) %>

--- a/public/app/views/shared/_cite_page_action.html.erb
+++ b/public/app/views/shared/_cite_page_action.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag app_prefix("/cite"), :id => 'cite_sub' do |f| %>
   <%= hidden_field_tag 'uri', record.uri %>
   <%= hidden_field_tag 'cite', record.cite %>
-  <button type="submit" class="btn page_action request  btn-default">
+  <button type="submit" class="btn page_action request btn-default">
     <i class="fa fa-book fa-3x"></i><br/>
     <%= t('actions.cite') %>
   </button>


### PR DESCRIPTION
This PR fixes a minor Softserv styling bug for the "New Search" and "Refine Search" buttons in the top banner of a keyword search result page.

[ANW-2125](https://archivesspace.atlassian.net/browse/ANW-2125)

## Before

![Screen Shot 2024-09-09 at 12 48 32-fullpage](https://github.com/user-attachments/assets/5f7e07ad-1846-4512-acf0-0263412ac260)

## After

![Screen Shot 2024-09-09 at 12 47 13-fullpage](https://github.com/user-attachments/assets/a749f594-d8e7-48d0-aab0-61f5e6d4a2db)



[ANW-2125]: https://archivesspace.atlassian.net/browse/ANW-2125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ