### PR TITLE
ANW-2126 Fix location profile badge and layout issues

### DIFF
--- a/frontend/app/views/location_profiles/edit.html.erb
+++ b/frontend/app/views/location_profiles/edit.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for @location_profile, :as => "location_profile", :url => {:action => :update}, :html => {:class => 'form-horizontal aspace-record-form'}.merge(update_monitor_params(@location_profile)) do |f| %>
   <%= form_context :location_profile, @location_profile do |form| %>
-    <div class="row">
+    <div class="d-flex">
       <div class="col-md-3">
         <%= render_aspace_partial :partial => "sidebar" %>
       </div>
@@ -13,7 +13,7 @@
           <h2><%= @location_profile.name %>  <span class="label label-info badge"><%= t("location_profile._singular") %></span></h2>
 
           <%= render_aspace_partial :partial => "location_profiles/form", :locals => {:form => form} %>
-          <div class="form-actions">
+          <div class="form-actions pl-0">
             <button type="submit" class="btn btn-primary"><%= t("location_profile._frontend.action.save") %></button>
             <%= link_to t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>

--- a/frontend/app/views/location_profiles/new.html.erb
+++ b/frontend/app/views/location_profiles/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for @location_profile, :as => "location_profile", :url => {:action => :create}, :html => {:class => 'form-horizontal aspace-record-form'} do |f| %>
   <%= form_context :location_profile, @location_profile do |form| %>
-    <div class="row">
+    <div class="d-flex">
       <div class="col-md-3">
         <%= render_aspace_partial :partial => "sidebar" %>
       </div>

--- a/frontend/app/views/location_profiles/show.html.erb
+++ b/frontend/app/views/location_profiles/show.html.erb
@@ -1,13 +1,13 @@
 <%= setup_context :object => @location_profile, :title => @location_profile.name %>
 
-<div class="row">
+<div class="d-flex">
    <div class="col-md-3">
      <%= render_aspace_partial :partial => "sidebar" %>
    </div>
   <div class="col-md-9">
     <%= render_aspace_partial :partial => "toolbar" %>
     <div class="record-pane">
-      <h2><%= @location_profile.name %>  <span class=" badge"><%= t("location_profile._singular") %></span></h2>
+      <h2><%= @location_profile.name %>  <span class="label label-info badge"><%= t("location_profile._singular") %></span></h2>
       <%= readonly_context :location_profile, @location_profile do |readonly| %>
         <%= render_aspace_partial :partial => "location_profiles/form", :locals => {:form => readonly} %>
       <% end %>


### PR DESCRIPTION
This PR fixes minor Softserv bugs where the staff location profile badge was not properly resized, and multiple view layouts were misaligned.

[ANW-2126](https://archivesspace.atlassian.net/browse/ANW-2126)

## Before

<img width="1409" alt="Screen Shot 2024-09-09 at 2 07 16 PM" src="https://github.com/user-attachments/assets/3a04326c-8172-4007-ac5f-8d06f1149c7b">

## After

<img width="1448" alt="Screen Shot 2024-09-09 at 2 07 51 PM" src="https://github.com/user-attachments/assets/fd713529-b703-463c-9899-52f2a03f48da">


[ANW-2126]: https://archivesspace.atlassian.net/browse/ANW-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ