### PR TITLE
ANW-2015 export leading mixed content in revisiondesc

### DIFF
--- a/backend/app/exporters/serializers/ead.rb
+++ b/backend/app/exporters/serializers/ead.rb
@@ -977,7 +977,7 @@ class EADSerializer < ASpaceExport::Serializer
       if export_rs.length > 0
         xml.revisiondesc {
           export_rs.each do |rs|
-            if rs['description'] && rs['description'].strip.start_with?('<')
+            if rs['description'] && (rs['description'].strip.start_with?('<change') || rs['description'].strip.start_with?('<list'))
               xml.text (fragments << escape_content(rs['description']) )
             else
               xml.change(rs['publish'] ? nil : {:audience => 'internal'}) {

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1323,6 +1323,33 @@ describe "EAD export mappings" do
       expect(serializer.remove_smart_quotes(note_with_smart_quotes)).to eq("This note has \"smart quotes\" and \'smart apostrophes\' from MSWord.")
     end
 
+    context 'when revision statement starts with mixed content' do
+      let(:resource) do
+        create(:json_resource,
+          :publish => true,
+          :revision_statements => [
+            {
+              :date => '1999-9-9',
+              :description => '<change><date>9/9/99</date><item>mixed content revision</item></change>',
+              :publish => true
+            },
+            {
+              :date => '1999-9-9',
+              :description => '<name>revision name</name> that made some changes',
+              :publish => true
+            }
+          ]
+        )
+      end
+
+      it "properly exports revisiondesc starting with mixed content" do
+        document = get_xml("/repositories/#{$repo_id}/resource_descriptions/#{resource.id}.xml")
+        document.remove_namespaces!
+        
+        expect(document.xpath('//revisiondesc/change').length).to eq(2)
+      end
+    end
+
     context 'when revision statement fields contain ampersand' do
       let(:resource) do
         create(:json_resource,

--- a/backend/spec/export_ead_spec.rb
+++ b/backend/spec/export_ead_spec.rb
@@ -1345,7 +1345,6 @@ describe "EAD export mappings" do
       it "properly exports revisiondesc starting with mixed content" do
         document = get_xml("/repositories/#{$repo_id}/resource_descriptions/#{resource.id}.xml")
         document.remove_namespaces!
-        
         expect(document.xpath('//revisiondesc/change').length).to eq(2)
       end
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
If the Description of a Revision Description note starts with `<`, the entire note will bypass the `<change>` wrapper when exported as EAD.  This makes sense if the leading XML is specifically `<change>` or `<list>` (the only two valid children of `<revisiondesc>`).  However, other XML tags are allowed in `change/item`; for example, `<change><item><name>Alex</name> revised this</item>[..]` is valid EAD.  The current exporter would just drop `<name>Alex</name> revised this` directly under `revisiondesc`, which makes the document invalid.

This PR makes the check for `<change>` and `<list>` in Revision Description more explicit, so other leading mixed content won't invalidate the document.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-2015

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a new unit test to the EAD specs to verify that the correct number of `<change>` are present under different mixed content scenarios.

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
