### PR TITLE
ANW-2127 allow for lack of floor or room in a location's building data

### DIFF
--- a/backend/app/model/location.rb
+++ b/backend/app/model/location.rb
@@ -160,39 +160,32 @@ class Location < Sequel::Model(:location)
     buildings = {}
     all = self.exclude(building: nil).order_by(:building, :floor, :room, :area)
     all.each do |location|
-
-      if !buildings.has_key?(location.building)
-        buildings[location.building] = {}
-      end
-
+      # a location should always have a building
+      buildings[location.building] ||= {}
       floors = buildings[location.building]
 
-      if location.floor.nil?
-        next
-      elsif !buildings[location.building].has_key?(location.floor)
-        floors[location.floor] = {}
+      if location.floor
+        floors[location.floor] ||= {}
+        rooms = floors[location.floor]
+      else
+        floors['[no floor]'] ||= {}
+        rooms = floors['[no floor]']
       end
 
-      rooms = floors[location.floor]
-
-      if location.room.nil?
-        next
-      elsif !rooms.has_key?(location.room)
-        rooms[location.room] = []
+      if location.room
+        rooms[location.room] ||= []
+        areas = rooms[location.room]
+      else
+        rooms['[no room]'] ||= []
+        areas = rooms['[no room]']
       end
 
-      areas = rooms[location.room]
-
-      if location.area.nil?
-        next
-      elsif !areas.include?(location.area)
-        areas.push(location.area)
-      end
+      next if location.area.nil?
+      areas.push(location.area) unless areas.include? location.area
     end
 
     buildings
   end
-
 
   def self.for_building(building, floor = nil, room = nil, area = nil)
     query = {


### PR DESCRIPTION
The location model is stored in a non-hierarchical fashion, with any
variation in field values resulting in a new database row. The only
required field is Building, so users can input locations that have only
a Building and a Room, among other permutations.

However, the location model's building_data method was organizing the
flat rows from the database into a hierarchy of building->floor->
room->area. If a floor did not have any rooms defined for it, it would
move on to the next location row, thus not allowing for rooms without
floors (same for areas without rooms).

Since all buildings have at least one floor, it would be ideal for the
location creation form to require the floor field as well. However,
as a free text field, this could result in some users entering "1" while
others enter "first" or the like. Also, one can imagine a floor of a
building not having any rooms, but having areas (perhaps a warehouse),
so it makes sense not to require the room field, which also breaks the
hierarchy.

This change to the building_data method continues to process rooms
even if there is no floor, and likewise areas even if there is no room,
using simple strings to represent these cases.