### PR TITLE
ANW-2084: Fix Agent Type label layout

### DIFF
--- a/frontend/app/views/agents/show.html.erb
+++ b/frontend/app/views/agents/show.html.erb
@@ -20,8 +20,8 @@
                                      :form => readonly,
                                      :record => @agent) %>
 
-          <div class="form-group">
-            <label class="col-sm-2 control-label"><%= t("agent.type") %></label>
+          <div class="form-group w-100 row">
+            <label class="col-sm-2 control-label text-sm-right"><%= t("agent.type") %></label>
             <div class="col-sm-9 label-only"><%= t("agent.agent_type.#{@agent.agent_type}") %></div>
           </div>
 


### PR DESCRIPTION
This PR fixes a minor Softserv layout bug that misaligned the Agent Type label and value in the staff interface.

[ANW-2084](https://archivesspace.atlassian.net/browse/ANW-2084)

## Problem

<img width="1436" alt="ANW-2084-problem" src="https://github.com/user-attachments/assets/e9a0a3c8-84ca-4b88-acab-4a86ae03b8e5">

## Solution

<img width="1326" alt="ANW-2084" src="https://github.com/user-attachments/assets/0d8bc1a4-c6a8-49ca-8872-0d2ce253c96d">


[ANW-2084]: https://archivesspace.atlassian.net/browse/ANW-2084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ