### PR TITLE
ANW-2149, ANW-2148: Fix frontend missing badge styles

### DIFF
--- a/frontend/app/assets/stylesheets/themes/default/default.scss
+++ b/frontend/app/assets/stylesheets/themes/default/default.scss
@@ -47,7 +47,15 @@ body {
 }
 
 // Bootstrap badge styles are overriden due to ../../archivesspace.scss,
-// copy .btn-warning styles instead of reordering imports for quick fix
+// so copy .btn-* styles instead of reordering imports for quick fix
+.badge-danger {
+  color: #fff;
+  background-color: #9d261d;
+}
+.badge-success {
+  color: #fff;
+  background-color: #398439;
+}
 .badge-warning {
   color: #212529;
   background-color: #ffc40d;

--- a/frontend/app/assets/stylesheets/themes/default/default.scss
+++ b/frontend/app/assets/stylesheets/themes/default/default.scss
@@ -46,6 +46,13 @@ body {
   color: white;
 }
 
+// Bootstrap badge styles are overriden due to ../../archivesspace.scss,
+// copy .btn-warning styles instead of reordering imports for quick fix
+.badge-warning {
+  color: #212529;
+  background-color: #ffc40d;
+}
+
 .sidebar .badge {
   border-radius: 20px;
 }

--- a/frontend/app/views/extent_calculator/_show_calculation.html.erb
+++ b/frontend/app/views/extent_calculator/_show_calculation.html.erb
@@ -4,7 +4,7 @@
       <%= results['resource']['title']  %> --
     <% end %>
     <%= results['object']['title'] %>
-    <span class="label label-info"><%= t("#{results['object']['jsonmodel_type']}._singular") %>
+    <span class="label label-info badge"><%= t("#{results['object']['jsonmodel_type']}._singular") %>
   </h3>
   <span id="required_fields_alert_message" message="<%= t('extent_calculator.required_fields_alert_message') %>" />
   <div>

--- a/frontend/app/views/jobs/_job_records.html.erb
+++ b/frontend/app/views/jobs/_job_records.html.erb
@@ -22,7 +22,7 @@
             <%= resolve_readonly_link_to record_title, result["record"]["ref"] %>
           <% else %>
             <%= resolve_readonly_link_to "#{record_title} (#{result["record"]["ref"]})", result["record"]["ref"], false %>
-            <span class="label label-warning">
+            <span class="badge badge-warning">
              <%= t("job._frontend.external_repo") %>
             </span>
           <% end %>

--- a/frontend/app/views/linked_agents/_show.html.erb
+++ b/frontend/app/views/linked_agents/_show.html.erb
@@ -47,7 +47,7 @@
                     <dt><%= t("linked_agent.terms") %></dt>
 
                     <% ASUtils.wrap(link['terms']).each do |term| %>
-                      <dd class="label label-info" title="<%= t("enumerations.subject_term_type.#{term["term_type"]}") %>">
+                      <dd class="label label-info badge" title="<%= t("enumerations.subject_term_type.#{term["term_type"]}") %>">
                         <%= term['term'] %>
                       </dd>
                     <% end %>

--- a/frontend/app/views/search/_title_cell.html.erb
+++ b/frontend/app/views/search/_title_cell.html.erb
@@ -1,13 +1,13 @@
 <% if record['primary_type'] === "repository" and session[:repo] === record['id'] %>
-	<span class="label label-success"><%= t("repository._frontend.messages.selected_short") %></span>
+	<span class="badge badge-success"><%= t("repository._frontend.messages.selected_short") %></span>
 <% end %>
 
 <% if record["suppressed"] %>
-	<span class="label label-info"><%= t("states.suppressed") %></span>
+	<span class="badge badge-warning"><%= t("states.suppressed") %></span>
 <% end %>
 
 <% if deleted(record) %>
-	<span class="label label-important"><%= t("states.deleted") %></span>
+	<span class="badge badge-danger"><%= t("states.deleted") %></span>
 <% end %>
 
 <%= clean_mixed_content(record["title"]).html_safe || clean_mixed_content(record['display_string']).html_safe %>

--- a/frontend/app/views/shared/_header_repository.html.erb
+++ b/frontend/app/views/shared/_header_repository.html.erb
@@ -128,7 +128,7 @@
                   <span class="repository-label has-popover" tabindex="0" data-trigger="focus hover" data-placement="bottom" data-html='true' data-toggle='popover' data-title="<span class='icomoon icon-repository'>&#160;</span><%= CGI::escapeHTML(current_repo['repo_code']) %>" data-content="<%= CGI::escapeHTML(current_repo['name']) %>">
                     <span class="icomoon icon-repository"></span><span class="current-repository-id"><% if current_repo %><%= current_repo['repo_code'] %><% end %></span>
                     <% unless current_repo.publish %>
-                      <span class="label label-warning"><%= t("navbar.unpublished") %></span>
+                      <span class="badge badge-warning"><%= t("navbar.unpublished") %></span>
                     <% end %>
                   </span>
                 </a>

--- a/frontend/app/views/shared/_header_user.html.erb
+++ b/frontend/app/views/shared/_header_user.html.erb
@@ -5,7 +5,7 @@
     <li class="dropdown select-a-repository">
       <button type="button" class="btn d-flex align-items-center gap-x-1 dropdown-toggle" style="padding: .875rem;" data-toggle="dropdown"><%= t("repository._frontend.action.select") %></button>
       <ul class="dropdown-menu dropdown-menu-right" style="padding: 15px;">
-        <li class='dropdown-item'>
+        <li>
           <%= form_tag({:controller => :repositories, :action => :select}) do |f| %>
             <fieldset>
               <label for="id" class="sr-only"><%= t('repository._frontend.action.select') %></label>


### PR DESCRIPTION
This PR provides two commits:

## ANW-2149:  Fix two minor Softserv style bugs:

- Fix the unpublished repo warning label by quick and dirty copying of Bootstrap styles instead of addressing the underlying order of SCSS imports in frontend/app/assets/stylesheets/archivesspace.scss, which awards higher specificity for frontend/app/assets/stylesheets/themes/default/default.scss over Bootstrap
- Remove a conventional `.dropdown-item` class on the select repo menu to remove unintentional padding and hover effect

[ANW-2149](https://archivesspace.atlassian.net/browse/ANW-2149)

### Problem

<img width="1469" alt="ANW-2149 problem" src="https://github.com/user-attachments/assets/6436e028-d298-43df-8931-cd1cfa5d2b75">

### Solution

<img width="1488" alt="ANW-2149" src="https://github.com/user-attachments/assets/f205b724-0a04-41b9-88eb-45832f64ebc4">

## ANW-2148: "Fix" broader Softserv frontend badge issues

All of Bootstrap's bade styles are overridden due to the problem listed above. This commit "fixes" the problem by copying more Bootstrap styles into default.scss, and updating the badge markup across multiple files.

The problems above stem from the fact that Softserv kept the deprecated `.label.label-*` class combinations. In the case where `.label.label-info` was used, `.badge` was added, and the default.scss file provided a hardcoded dark blue background color. This works out okay for the `.badge-info` variant since it is intended as a dark blue background color, so this PR only the Softserv approach since there are 10s of examples of this pattern littered all around the codebase. The fixes provided herein are for those use cases that Softserv missed.

[ANW-2148](https://archivesspace.atlassian.net/browse/ANW-2148)

### Solution

<img width="1393" alt="ANW-2148" src="https://github.com/user-attachments/assets/727984cb-56af-4b87-8948-7fda21daf1a9">

[ANW-2149]: https://archivesspace.atlassian.net/browse/ANW-2149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-2148]: https://archivesspace.atlassian.net/browse/ANW-2148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ