### PR TITLE
Core Code Plugin Support - Changes for 4.0

### DIFF
--- a/frontend/app/helpers/plugin_helper.rb
+++ b/frontend/app/helpers/plugin_helper.rb
@@ -67,7 +67,7 @@ module PluginHelper
     ASUtils.find_local_directories("frontend/views/_#{name}.html.erb").each do |partial|
       next unless File.exist?(partial)
 
-      result << render(:file => partial, :locals => locals)
+      result << render(:inline => File.read(partial), :locals => locals)
     end
 
     result.html_safe

--- a/frontend/app/views/layouts/application.html.erb
+++ b/frontend/app/views/layouts/application.html.erb
@@ -62,6 +62,14 @@
    </footer>
 
    <%= render "shared/templates" %>
+   
+    <% ASUtils.order_plugins(ASUtils.find_local_directories('frontend/views/_shared_templates.html.erb')).each do |layout| %>
+      <% if File.exist?(layout) %>
+        <!-- Begin plugin layout -->
+        <%= render :inline => File.read(layout) %>
+        <!-- End plugin layout -->
+      <% end %>
+    <% end %>
 
   </div>
 </body>

--- a/public/app/views/layouts/application.html.erb
+++ b/public/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
 	<% ASUtils.find_local_directories('public/views/body_top.html.erb').each do |template| %>
 		<% if File.exists?(template) %>
 			<!-- Begin plugin layout -->
-			<%= render :file => template %>
+			<%= render :inline => File.read(template) %>
 			<!-- End plugin layout -->
 		<% end %>
 	<% end %>

--- a/public/app/views/pdf/_archival_object.html.erb
+++ b/public/app/views/pdf/_archival_object.html.erb
@@ -160,7 +160,7 @@ end
                 <% end %>
 
                 <% ASUtils.find_local_directories('public/views/_pdf_archival_object.html.erb').each do |template| %>
-                    <%= render(:file => template, :locals => {:record => record}) if File.exists?(template) %>
+                    <%= :inline => File.read(template) => template, :locals => {:record => record}) if File.exists?(template) %>
                 <% end %>
 
             </dl>

--- a/public/app/views/pdf/_archival_object.html.erb
+++ b/public/app/views/pdf/_archival_object.html.erb
@@ -160,7 +160,7 @@ end
                 <% end %>
 
                 <% ASUtils.find_local_directories('public/views/_pdf_archival_object.html.erb').each do |template| %>
-                    <%= :inline => File.read(template) => template, :locals => {:record => record}) if File.exists?(template) %>
+                    <%= render(:inline => File.read(template), :locals => {:record => record}) if File.exists?(template) %>
                 <% end %>
 
             </dl>

--- a/public/app/views/pdf/_digital_object_links.html.erb
+++ b/public/app/views/pdf/_digital_object_links.html.erb
@@ -10,6 +10,6 @@
       <% end %>
     <% end %>
     <% ASUtils.find_local_directories('public/views/_pdf_digital_object_links.html.erb').each do |template| %>
-        <%= render(:file => template, :locals => {:record => record}) if File.exists?(template) %>
+        <%= :inline => File.read(template) => template, :locals => {:record => record}) if File.exists?(template) %>
     <% end %>
 <% end %>

--- a/public/app/views/pdf/_digital_object_links.html.erb
+++ b/public/app/views/pdf/_digital_object_links.html.erb
@@ -10,6 +10,6 @@
       <% end %>
     <% end %>
     <% ASUtils.find_local_directories('public/views/_pdf_digital_object_links.html.erb').each do |template| %>
-        <%= render(:inline => File.read(template), :locals => {:record => record}) if File.exists?(template) %>
+        <%= render(:inline => File.read(template), :locals => {:instance => instance}) if File.exists?(template) %>
     <% end %>
 <% end %>

--- a/public/app/views/pdf/_digital_object_links.html.erb
+++ b/public/app/views/pdf/_digital_object_links.html.erb
@@ -10,6 +10,6 @@
       <% end %>
     <% end %>
     <% ASUtils.find_local_directories('public/views/_pdf_digital_object_links.html.erb').each do |template| %>
-        <%= :inline => File.read(template) => template, :locals => {:record => record}) if File.exists?(template) %>
+        <%= render(:inline => File.read(template), :locals => {:record => record}) if File.exists?(template) %>
     <% end %>
 <% end %>

--- a/public/app/views/pdf/_header.html.erb
+++ b/public/app/views/pdf/_header.html.erb
@@ -376,7 +376,7 @@ li::before {
 
         </style>
         <% ASUtils.find_local_directories('public/views/_pdf_header.html.erb').each do |template| %>
-            <%= render(:file => template, :locals => {:record => record}) if File.exists?(template) %>
+            <%= :inline => File.read(template) => template, :locals => {:record => record}) if File.exists?(template) %>
         <% end %>
     </head>
     <body>

--- a/public/app/views/pdf/_header.html.erb
+++ b/public/app/views/pdf/_header.html.erb
@@ -376,7 +376,7 @@ li::before {
 
         </style>
         <% ASUtils.find_local_directories('public/views/_pdf_header.html.erb').each do |template| %>
-            <%= :inline => File.read(template) => template, :locals => {:record => record}) if File.exists?(template) %>
+            <%= render(:inline => File.read(template), :locals => {:record => record}) if File.exists?(template) %>
         <% end %>
     </head>
     <body>

--- a/public/app/views/pdf/_resource.html.erb
+++ b/public/app/views/pdf/_resource.html.erb
@@ -294,7 +294,7 @@
 
 
 <% ASUtils.find_local_directories('public/views/_pdf_resource.html.erb').each do |template| %>
-    <%= render(:file => template, :locals => {:record => record}) if File.exists?(template) %>
+    <%= :inline => File.read(template) => template, :locals => {:record => record}) if File.exists?(template) %>
 <% end %>
 
 <div class="collection-inventory">

--- a/public/app/views/pdf/_resource.html.erb
+++ b/public/app/views/pdf/_resource.html.erb
@@ -294,7 +294,7 @@
 
 
 <% ASUtils.find_local_directories('public/views/_pdf_resource.html.erb').each do |template| %>
-    <%= :inline => File.read(template) => template, :locals => {:record => record}) if File.exists?(template) %>
+    <%= render(:inline => File.read(template), :locals => {:record => record}) if File.exists?(template) %>
 <% end %>
 
 <div class="collection-inventory">

--- a/public/app/views/pdf/_titlepage.html.erb
+++ b/public/app/views/pdf/_titlepage.html.erb
@@ -40,7 +40,7 @@
     </div>
     
     <% ASUtils.find_local_directories('public/views/_pdf_titlepage.html.erb').each do |template| %>
-        <%= render(:file => template, :locals => {:record => record}) if File.exists?(template) %>
+        <%= :inline => File.read(template) => template, :locals => {:record => record}) if File.exists?(template) %>
     <% end %>
 
     <% if record.resolved_repository && 

--- a/public/app/views/pdf/_titlepage.html.erb
+++ b/public/app/views/pdf/_titlepage.html.erb
@@ -40,7 +40,7 @@
     </div>
     
     <% ASUtils.find_local_directories('public/views/_pdf_titlepage.html.erb').each do |template| %>
-        <%= :inline => File.read(template) => template, :locals => {:record => record}) if File.exists?(template) %>
+        <%= render(:inline => File.read(template), :locals => {:record => record}) if File.exists?(template) %>
     <% end %>
 
     <% if record.resolved_repository && 

--- a/public/app/views/shared/_record_innards.html.erb
+++ b/public/app/views/shared/_record_innards.html.erb
@@ -55,7 +55,7 @@
     <% end %>
 
     <% ASUtils.find_local_directories('public/views/_upper_record_innards.html.erb').each do |template| %>
-      <%= render :file => template if File.exists?(template) %>
+      <%= render :inline => File.read(template) if File.exists?(template) %>
     <% end %>
 </div>
 
@@ -145,7 +145,7 @@
         <% end %>
       </div>
       <% ASUtils.find_local_directories('public/views/_lower_record_innards.html.erb').each do |template| %>
-        <%= render :file => template if File.exists?(template) %>
+        <%= render :inline => File.read(template) if File.exists?(template) %>
       <% end %>
     </div>
     <script type="text/javascript" >initialize_accordion(".note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>", <%= AppConfig[:pui_expand_all] %>);

--- a/public/app/views/welcome/show.html.erb
+++ b/public/app/views/welcome/show.html.erb
@@ -26,5 +26,5 @@
     } %>
 
     <% ASUtils.find_local_directories('public/views/_welcome_addition.html.erb').each do |template| %>
-        <%= :inline => File.read(template) => template) if File.exists?(template) %>
+        <%= render(:inline => File.read(template)) if File.exists?(template) %>
     <% end %>

--- a/public/app/views/welcome/show.html.erb
+++ b/public/app/views/welcome/show.html.erb
@@ -26,5 +26,5 @@
     } %>
 
     <% ASUtils.find_local_directories('public/views/_welcome_addition.html.erb').each do |template| %>
-        <%= render(:file => template) if File.exists?(template) %>
+        <%= :inline => File.read(template) => template) if File.exists?(template) %>
     <% end %>


### PR DESCRIPTION
- properly render plugin layouts inline for both staff and public frontends and public pdf exports
- allow plugins to add their own shared/templates equivalents - due to changes in `ActionView::PartialRenderer render` method
- fix public pdf locals for digital object links

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Some plugin partials were not rendering inline properly. Additionally, changes to `ActionView::PartialRenderer` necessitated the inclusion of an additional plugin file (`frontend/views/_shared_templates.html.erb`) to allow plugins to add their own templates for the frontend.

Also fixes local variable for plugins which use a plugin supplied `_pdf_digital_object_links` partial
## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local tests. Mac OS 14, MariaDB 10.11.4, Solr 8.11.2
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
