### PR TITLE
ANW-2064 preserve roles from merged agents

### DIFF
--- a/frontend/app/controllers/agents_controller.rb
+++ b/frontend/app/controllers/agents_controller.rb
@@ -267,9 +267,11 @@ class AgentsController < ApplicationController
   end
 
   def merge_detail
+    merge_destination_uri = JSONModel(@agent_type).uri_for(params[:id])
+    merge_candidate_uri = params['merge_candidate_uri']
     request = JSONModel(:merge_request_detail).new
-    request.merge_destination = { 'ref' => JSONModel(@agent_type).uri_for(params[:id]) }
-    request.merge_candidates = Array.wrap({ 'ref' => params['merge_candidate_uri'] })
+    request.merge_destination = { 'ref' => merge_destination_uri }
+    request.merge_candidates = Array.wrap({ 'ref' => merge_candidate_uri })
 
     # the backend is expecting to know how the user may have re-ordered subrecords in the merge interface. This information is encoded in the params, but will be stripped out when we clean them up unless we add them as a pseudo schema attribute.
     # add_position_to_agents_merge does exactly this.
@@ -286,7 +288,12 @@ class AgentsController < ApplicationController
       render_aspace_partial partial: 'agents/merge_preview', locals: { object: @agent }
     else
       begin
+        # For each linked resource or AO, need to remember roles to re-establish with the destination agent.
+        candidate_roles = get_merge_candidate_linked_roles(merge_candidate_uri)
+
         response = JSONModel::HTTP.post_json(URI(uri), request.to_json)
+
+        recreate_linked_record_agent_roles(candidate_roles, merge_destination_uri)
 
         flash[:success] = t('agent._frontend.messages.merged')
         resolver = Resolver.new(request.merge_destination['ref'])
@@ -431,4 +438,39 @@ class AgentsController < ApplicationController
       end
     end
   end
+
+  # gathers necessary fields to recreate agent roles in affected resources/AOs
+  def get_merge_candidate_linked_roles(merge_candidate_uri)
+    filter_term = ["{ \"agent_uris\":\"#{merge_candidate_uri}\" }"]
+    search_results = Search.all(session[:repo_id], {'filter_term[]' => filter_term})['results']
+    candidate_roles = []
+    search_results.each do |result|
+      linked_agents = JSON.parse(result['json'])['linked_agents']
+      linked_agents.select { |a| a['ref'] == merge_candidate_uri }.each do |linked_agent|
+        candidate_roles.append({
+          linked_uri: result['uri'],
+          title: linked_agent['_resolved']['title'],
+          role: linked_agent['role'],
+          relator: linked_agent['relator'],
+          terms: linked_agent['terms']
+        })
+      end
+    end
+    candidate_roles
+  end
+
+  def recreate_linked_record_agent_roles(candidate_roles, destination_agent_uri)
+    candidate_roles.each do |role|
+      linked_type = role[:linked_uri].match(/.*\/(\w+)s\/\d+$/)[1]
+      linked_record = JSONModel(linked_type.to_sym).find_by_uri(role[:linked_uri])
+      linked_record.linked_agents.append({
+        'ref' => destination_agent_uri,
+        'role' => role[:role],
+        'relator' => role[:relator],
+        'terms' => role[:terms]
+      })
+      linked_record.save
+    end
+  end
+
 end


### PR DESCRIPTION
When an agent is merged into another one, it is deleted after its
information is added to the destination agent. As a result, any resource
or archival object would lose any role linked to that agent. This update
preserves those roles by re-linking them to the destination agent for
affected resources/AOs.