### PR TITLE
ANW-2154: Bring bulk updater file input component into parity with load via spreadsheet

### DIFF
--- a/frontend/app/views/bulk_archival_object_updater_job/_form.html.erb
+++ b/frontend/app/views/bulk_archival_object_updater_job/_form.html.erb
@@ -1,18 +1,26 @@
 <section id="job_filenames_">
   <div class="form-group required">
-    <label class="col-sm-2 control-label" for="job_file_input">Spreadsheet File</label>
-    <div class="col-sm-9">
+    <label class="btn btn-success btn-sm fileinput-button" for="job_file_input">
+      <span class="glyphicon glyphicon-plus icon-white"></span>
+      <span><%= t("job._frontend.actions.add_file") %></span>
       <input
-          id="job_file_input"
-          type="file"
-          name="files[]"
-          accept=".csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel"
-          required
+        id="job_file_input"
+        type="file"
+        name="files[]"
+        accept=".csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel"
+        required
       />
-    </div>
+    </label>
+    <span id="job_filename"></span>
   </div>
   <%= form.label_and_boolean "create_missing_top_containers",
     {},
     AppConfig.has_key?(:bulk_archival_object_updater_create_missing_top_containers) && AppConfig[:bulk_archival_object_updater_create_missing_top_containers]
   %>
 </section>
+
+<script>
+$('#job_file_input').on('change', function (e) {
+  $('#job_filename').text(e.target.files[0].name);
+});
+</script>

--- a/frontend/spec/features/resources_spec.rb
+++ b/frontend/spec/features/resources_spec.rb
@@ -275,7 +275,11 @@ describe 'Resources', js: true do
     click_on 'Background Job'
     click_on 'Bulk Archival Object Updater'
 
-    attach_file('job_file_input', downloaded_spreadsheet_filename)
+    attach_file(
+      'job_file_input',
+      downloaded_spreadsheet_filename,
+      make_visible: true
+    )
 
     click_on 'Start Job'
 


### PR DESCRIPTION
This PR updates the bulk updater file input's design and behavior by making it consistent with the load via spreadsheet file input.

[ANW-2154](https://archivesspace.atlassian.net/browse/ANW-2154)

## Before

<img width="1346" alt="ANW-2154 before" src="https://github.com/user-attachments/assets/9ca5d253-1e7e-4359-9ffe-f60f614d1691">

## After

<img width="1408" alt="ANW-2154 after" src="https://github.com/user-attachments/assets/ac7376a2-8ed0-4447-8621-235ddd32a0fa">


[ANW-2154]: https://archivesspace.atlassian.net/browse/ANW-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ