### PR TITLE
ANW-2166: Fix PUI load-all-records accessibility errors reported by Wave

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/helpers.scss
+++ b/public/app/assets/stylesheets/archivesspace/helpers.scss
@@ -90,6 +90,10 @@
   background-color: var(--bootstrap-default-card-heading-bg-color);
 }
 
+.bg-secondary {
+  background-color: $secondary-color !important;
+}
+
 .border-top-default {
   border-top: 1px solid var(--default-border-color);
 }

--- a/public/app/assets/stylesheets/archivesspace/infinite-records.scss
+++ b/public/app/assets/stylesheets/archivesspace/infinite-records.scss
@@ -136,7 +136,7 @@ $indent-width: 20px;
   transition: 0.2s;
 }
 
-.load-all__input:checked + div > .load-all__label-toggle::after {
+.load-all__input:checked ~ .load-all__label-toggle::after {
   left: calc(100% - 0.25rem);
   transform: translateX(-100%);
 }

--- a/public/app/views/resources/_infinite_load_all.html.erb
+++ b/public/app/views/resources/_infinite_load_all.html.erb
@@ -11,7 +11,7 @@
     </p>
 
     <div class="d-flex gap-x-8">
-      <p class="align-self-center mb-0 px-2 py-1 d-flex align-items-center gap-2 bg-primary rounded">
+      <p class="align-self-center mb-0 px-2 py-1 d-flex align-items-center gap-2 bg-secondary rounded">
         <span class="text-white"><%= t('resource.load_records.showing') %></span>
         <span
           id="load-all-showing-percent"
@@ -25,15 +25,13 @@
         <div class="load-all__toggle-container d-flex align-items-center gap-2">
           <input
             id="load-all-state"
-            class="load-all__input visually-hidden order-1"
+            class="load-all__input visually-hidden"
             type="checkbox"
             autocomplete="off"
           />
-          <div class="order-1">
-            <label class="load-all__label-toggle" for="load-all-state"><%= t('resource.load_records.load_all') %></label>
-          </div>
-          <label class="mb-0 order-0 hover-pointer" for="load-all-state"><%= t('resource.load_records.scroll') %></label>
-          <label class="mb-0 order-1 hover-pointer" for="load-all-state"><%= t('resource.load_records.all') %></label>
+          <span class="mb-0"><%= t('resource.load_records.scroll') %></span>
+          <label class="load-all__label-toggle" for="load-all-state"><%= t('resource.load_records.load_all') %></label>
+          <span class="mb-0"><%= t('resource.load_records.all') %></span>
         </div>
       </div>
     </div>

--- a/public/spec/features/collection_organization_spec.rb
+++ b/public/spec/features/collection_organization_spec.rb
@@ -476,18 +476,6 @@ describe 'Collection Organization', js: true do
 
     end
 
-    it 'works by clicking on the "on scroll" and "all at once" labels' do
-      visit "/repositories/#{@repo.id}/resources/#{@res_3wp.id}/collection_organization"
-      expect(page).to have_css('input#load-all-state:not(:checked)')
-      page.find('#load-all-section label', text: 'On scroll').click
-      expect(page).to have_css('input#load-all-state:checked')
-
-      visit "/repositories/#{@repo.id}/resources/#{@res_4wp.id}/collection_organization"
-      expect(page).to have_css('input#load-all-state:not(:checked)')
-      page.find('#load-all-section label', text: 'All at once').click
-      expect(page).to have_css('input#load-all-state:checked')
-    end
-
     it 'works by keyboard' do
       visit "/repositories/#{@repo.id}/resources/#{@res_3wp.id}/collection_organization"
       input = page.find('input#load-all-state:not(:checked)')


### PR DESCRIPTION
This PR fixes the accessibility errors reported by Wave in the PUI load all records feature:

- color contrast violation
- multiple labels on an input

[ANW-2166](https://archivesspace.atlassian.net/browse/ANW-2166)

## Before

<img width="1103" alt="ANW-2166 before" src="https://github.com/user-attachments/assets/fa172aeb-39b8-408f-b1b9-28e89edde7bc">

## After

<img width="1103" alt="ANW-2166 after" src="https://github.com/user-attachments/assets/2da1e2dc-38d9-46db-b292-67adcc71d8bb">


[ANW-2166]: https://archivesspace.atlassian.net/browse/ANW-2166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ