### PR TITLE
ANW-2168: Fix PUI accessibility errors

### DIFF
--- a/frontend/app/views/file_versions/_file_uri.html.erb
+++ b/frontend/app/views/file_versions/_file_uri.html.erb
@@ -1,5 +1,5 @@
-<div class="form-group">
-  <div class="control-label col-sm-2"><%= t("file_version.file_uri") %></div>
+<div class="form-group d-flex">
+  <div class="control-label col-sm-2 text-md-right"><%= t("file_version.file_uri") %></div>
   <div class="controls label-only col-sm-8">
     <% if file_uri.respond_to?(:scheme) && FileEmbedHelper.supported_scheme?(file_uri.scheme) %>
   	<%= link_to file_uri.to_s, file_uri.to_s %>

--- a/public/app/assets/javascripts/ReadMoreNotes.js
+++ b/public/app/assets/javascripts/ReadMoreNotes.js
@@ -11,8 +11,7 @@
     constructor(readmoreElement) {
       this.readmore = readmoreElement;
       this.state = this.readmore.querySelector('.readmore__state');
-      this.more = this.readmore.querySelector('.readmore__more-label');
-      this.less = this.readmore.querySelector('.readmore__less-label');
+      this.label = this.readmore.querySelector('.readmore__label');
 
       this.listen();
     }
@@ -25,27 +24,15 @@
         this.setAriaExpanded(this.state.checked);
       });
 
-      this.readmore.addEventListener('keydown', e => {
-        if (e.target === this.more && (e.key === 'Enter' || e.key === ' ')) {
+      this.label.addEventListener('keydown', e => {
+        if (!this.state.checked && (e.key === 'Enter' || e.key === ' ')) {
           e.preventDefault();
-          const x = window.scrollX;
-          const y = window.scrollY;
-
           this.state.checked = true;
           this.setAriaExpanded(this.state.checked);
-
-          this.less.focus();
-
-          window.scrollTo(x, y); // Don't scroll down to this.less
-        } else if (
-          e.target === this.less &&
-          (e.key === 'Enter' || e.key === ' ')
-        ) {
+        } else if (this.state.checked && (e.key === 'Enter' || e.key === ' ')) {
           e.preventDefault();
           this.state.checked = false;
           this.setAriaExpanded(this.state.checked);
-
-          this.more.focus();
         }
       });
     }

--- a/public/app/assets/stylesheets/archivesspace/bootstrap-overrides.scss
+++ b/public/app/assets/stylesheets/archivesspace/bootstrap-overrides.scss
@@ -37,3 +37,17 @@
   color: $body-color;
   background-color: var(--light);
 }
+
+.btn-primary {
+  background-color: $primary-color;
+  border-color: $primary-color;
+}
+
+.page-link {
+  color: $primary-color;
+}
+
+.page-item.active .page-link {
+  background-color: $primary-color;
+  border-color: $primary-color;
+}

--- a/public/app/assets/stylesheets/archivesspace/read-more-notes.scss
+++ b/public/app/assets/stylesheets/archivesspace/read-more-notes.scss
@@ -1,5 +1,4 @@
-.readmore__more-label,
-.readmore__less-label {
+.readmore__label {
   padding: 0.25rem 0.5rem;
   font-size: 0.875rem;
   border: 1px solid $primary-color;
@@ -16,19 +15,19 @@
   }
 }
 
-.readmore__more-label {
+.readmore__label--more {
   display: inline-block;
 }
 
-.readmore__less-label {
+.readmore__label--less {
   display: none;
 }
 
-.readmore__state:checked ~ .readmore__more-label {
+.readmore__state:checked ~ .readmore__label .readmore__label--more {
   display: none;
 }
 
-.readmore__state:checked ~ .readmore__less-label {
+.readmore__state:checked ~ .readmore__label .readmore__label--less {
   display: inline-block;
 }
 

--- a/public/app/views/shared/_navigation.html.erb
+++ b/public/app/views/shared/_navigation.html.erb
@@ -2,6 +2,7 @@
   <nav class="navbar navbar-expand-lg navbar-light navbar-default bg-light p-0" aria-label="<%= I18n.t("navigation.top_level") %>">
       <button type="button" class="navbar-toggler m-2 ml-auto" data-toggle="collapse" data-target="#collapsemenu" aria-expanded="false">
         <div class="container">
+          <span class="sr-only"><%= t('navigation.mobile_menu') %></span>
           <span class="navbar-toggler-icon"></span>
         </div>
       </button>

--- a/public/app/views/shared/_note_content.html.erb
+++ b/public/app/views/shared/_note_content.html.erb
@@ -20,8 +20,10 @@
         aria-expanded="false"
         aria-controls="<%= type %>_readmore_content"
       />
-      <label for="<%= state_id %>" class="readmore__more-label order-1" tabindex="0"><%= t('readmore.see_more') %> <i class="fa fa-chevron-down"></i></label>
-      <label for="<%= state_id %>" class="readmore__less-label order-1" tabindex="0"><%= t('readmore.see_less') %> <i class="fa fa-chevron-up"></i></label>
+      <label for="<%= state_id %>" class="readmore__label order-1" tabindex="0">
+        <span class="readmore__label--more"><%= t('readmore.see_more') %> <i class="fa fa-chevron-down"></i></span>
+        <span class="readmore__label--less"><%= t('readmore.see_less') %> <i class="fa fa-chevron-up"></i></span>
+      </label>
       <section
         id="<%= type %>_readmore_content"
         class="readmore__content order-0"

--- a/public/config/locales/de.yml
+++ b/public/config/locales/de.yml
@@ -193,6 +193,7 @@ de:
   navigation:
     hierarchical: hierarchische Navigation
     top_level: oberste Navigationsebene
+    mobile_menu: Navigationsmenü für kleinere Geräte
   advanced_search:
     operator_label: Verknüpfer
     operator:

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -228,6 +228,7 @@ en:
   navigation:
     hierarchical: hierarchical navigation
     top_level: top-level navigation
+    mobile_menu: Navigation menu for smaller devices
 
   internal_links:
     main: Main Content

--- a/public/config/locales/es.yml
+++ b/public/config/locales/es.yml
@@ -197,6 +197,11 @@ es:
     search_placeholder: Introduzca sus términos de búsqueda
     error_no_term: No se han introducido términos de búsqueda.
     toggle_navigation: Alternar navegación
+  
+  navigation:
+    hierarchical: Navegación jerárquica
+    top_level: Navegación de nivel superior
+    mobile_menu: Menú de navegación para dispositivos más pequeños
 
   internal_links:
     main: Principales elementos

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -217,6 +217,11 @@ fr:
     search_placeholder: Saisissez les termes de votre recherche
     error_no_term: Aucun terme saisi.
     toggle_navigation: Basculer la navigation
+  
+  navigation:
+    hierarchical: Navigation hiérarchique
+    top_level: Navigation de haut niveau
+    mobile_menu: Menu de navigation pour les petits appareils
 
   internal_links:
     main: Contenu principal

--- a/public/config/locales/ja.yml
+++ b/public/config/locales/ja.yml
@@ -184,6 +184,10 @@ ja:
     search_placeholder: 検索用語を入力してください
     error_no_term: 検索語が入力されていません。
     toggle_navigation: Toggle Navigation
+  navigation:
+    hierarchical: 階層ナビゲーション
+    top_level: トップレベルナビゲーション
+    mobile_menu: 小型デバイス向けのナビゲーションメニュー
   internal_links:
     main: メインコンテンツ
     filter: 結果をフィルタリングする

--- a/public/config/locales/pt.yml
+++ b/public/config/locales/pt.yml
@@ -104,6 +104,10 @@ pt:
     welcome_page_title: Interface pública do ArchivesSpace
     welcome_message: "<p> Pesquisar nas nossas colecções, materiais digitais, e muito mais. </p>\n"
   page_actions: Ações da página
+  navigation:
+    hierarchical: navegação hierárquica
+    top_level: navegação de nível superior
+    mobile_menu: Menu de navegação para dispositivos menores
   request:
     email_header: Obrigado por seu solicitação
     user_name: Seu nome

--- a/public/spec/features/read_more_notes_spec.rb
+++ b/public/spec/features/read_more_notes_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 require 'rails_helper'
 
-def test_expand_collapse(content, see_more, see_less, mode = 'click')
+def test_expand_collapse(content, label, see_more, see_less, mode = 'click')
   initial_height = page.evaluate_script("arguments[0].clientHeight;", content.native)
 
   if mode == 'click'
-    see_more.click
+    label.click
   elsif mode == 'keyboard'
-    see_more.send_keys(:tab)
-    see_more.send_keys(:space)
+    label.send_keys(:tab)
+    label.send_keys(:space)
   end
 
   expect(page.evaluate_script("arguments[0].clientHeight;", content.native)).to be > initial_height
@@ -16,10 +16,10 @@ def test_expand_collapse(content, see_more, see_less, mode = 'click')
   expect(see_less).to be_visible
 
   if mode == 'click'
-    see_less.click
+    label.click
   elsif mode == 'keyboard'
-    see_less.send_keys(:tab)
-    see_less.send_keys(:space)
+    label.send_keys(:tab)
+    label.send_keys(:space)
   end
 
   expect(page.evaluate_script("arguments[0].clientHeight;", content.native)).to eq(initial_height)
@@ -27,13 +27,13 @@ def test_expand_collapse(content, see_more, see_less, mode = 'click')
   expect(see_less).to_not be_visible
 
   if mode == 'keyboard'
-    see_more.send_keys(:tab)
-    see_more.send_keys(:enter)
+    label.send_keys(:tab)
+    label.send_keys(:enter)
 
     expect(page.evaluate_script("arguments[0].clientHeight;", content.native)).to be > initial_height
 
-    see_less.send_keys(:tab)
-    see_less.send_keys(:enter)
+    label.send_keys(:tab)
+    label.send_keys(:enter)
 
     expect(page.evaluate_script("arguments[0].clientHeight;", content.native)).to eq(initial_height)
   end
@@ -96,10 +96,11 @@ describe 'Read More Notes', js: true do
 
     within(scope_and_contents_read_mores[0]) do
       content = find('.upper-record-details .abstract.single_note .readmore__content')
-      see_more = find('.upper-record-details .abstract.single_note .readmore__more-label')
-      see_less = find('.upper-record-details .abstract.single_note .readmore__less-label', visible: false)
+      label = find('.upper-record-details .abstract.single_note .readmore__label')
+      see_more = find('.upper-record-details .abstract.single_note .readmore__label--more')
+      see_less = find('.upper-record-details .abstract.single_note .readmore__label--less', visible: false)
 
-      test_expand_collapse(content, see_more, see_less)
+      test_expand_collapse(content, label, see_more, see_less)
     end
   end
 
@@ -108,18 +109,20 @@ describe 'Read More Notes', js: true do
 
     within(scope_and_contents_read_mores[0]) do
       content = find('.upper-record-details .abstract.single_note .readmore__content')
-      see_more = find('.upper-record-details .abstract.single_note .readmore__more-label')
-      see_less = find('.upper-record-details .abstract.single_note .readmore__less-label', visible: false)
+      label = find('.upper-record-details .abstract.single_note .readmore__label')
+      see_more = find('.upper-record-details .abstract.single_note .readmore__label--more')
+      see_less = find('.upper-record-details .abstract.single_note .readmore__label--less', visible: false)
 
-      test_expand_collapse(content, see_more, see_less)
+      test_expand_collapse(content, label, see_more, see_less)
     end
 
     within(scope_and_contents_read_mores[1]) do
       content = find('.upper-record-details .abstract.single_note .readmore__content')
-      see_more = find('.upper-record-details .abstract.single_note .readmore__more-label')
-      see_less = find('.upper-record-details .abstract.single_note .readmore__less-label', visible: false)
+      label = find('.upper-record-details .abstract.single_note .readmore__label')
+      see_more = find('.upper-record-details .abstract.single_note .readmore__label--more')
+      see_less = find('.upper-record-details .abstract.single_note .readmore__label--less', visible: false)
 
-      test_expand_collapse(content, see_more, see_less)
+      test_expand_collapse(content, label, see_more, see_less)
     end
   end
 
@@ -128,10 +131,11 @@ describe 'Read More Notes', js: true do
 
     within(scope_and_contents_read_mores[0]) do
       content = find('.upper-record-details .abstract.single_note .readmore__content')
-      see_more = find('.upper-record-details .abstract.single_note .readmore__more-label')
-      see_less = find('.upper-record-details .abstract.single_note .readmore__less-label', visible: false)
+      label = find('.upper-record-details .abstract.single_note .readmore__label')
+      see_more = find('.upper-record-details .abstract.single_note .readmore__label--more')
+      see_less = find('.upper-record-details .abstract.single_note .readmore__label--less', visible: false)
 
-      test_expand_collapse(content, see_more, see_less, 'keyboard')
+      test_expand_collapse(content, label, see_more, see_less, 'keyboard')
     end
   end
 
@@ -140,8 +144,8 @@ describe 'Read More Notes', js: true do
 
     within(scope_and_contents_read_mores[0]) do
       state = find('.upper-record-details .abstract.single_note .readmore__state[aria-expanded="false"]')
-      see_more = find('.upper-record-details .abstract.single_note .readmore__more-label')
-      see_less = find('.upper-record-details .abstract.single_note .readmore__less-label', visible: false)
+      see_more = find('.upper-record-details .abstract.single_note .readmore__label--more')
+      see_less = find('.upper-record-details .abstract.single_note .readmore__label--less', visible: false)
 
       see_more.click
 


### PR DESCRIPTION
[ANW-2168](https://archivesspace.atlassian.net/browse/ANW-2168)

This PR fixes some PUI accessibility errors reported in the following Wave report: https://app.pope.tech/organization/lyrasis/accessibility/f14898cf-9345-4c9b-aea1-69282315e524

This PR should solve all of the reported errors except the image-related† errors:

- Color contrast: solution is to override Bootstrap
- Empty button: solution is to add i18n text
- Form labels: solution is to adjust the markup

This PR also fixes a minor frontend Softserv layout bug

† The image-related errors are arbitrary and dependent on whether or not a caption is provided for a digital object's file version in the frontend.

[ANW-2168]: https://archivesspace.atlassian.net/browse/ANW-2168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ