### PR TITLE
ANW-2169: Fix frontend accessibility errors reported by Wave

### DIFF
--- a/frontend/app/helpers/aspace_form_helper.rb
+++ b/frontend/app/helpers/aspace_form_helper.rb
@@ -547,6 +547,7 @@ module AspaceFormHelper
     def add_tooltip_options(tooltip, options)
       options[:title] = tooltip
       options['data-placement'] = 'bottom'
+      options['data-boundary'] = 'viewport'
       options['data-html'] = true
       options['data-delay'] = 500
       options['data-trigger'] = 'manual'

--- a/frontend/app/views/accession_links/_accession_linker.html.erb
+++ b/frontend/app/views/accession_links/_accession_linker.html.erb
@@ -35,7 +35,7 @@
           data-toggle="dropdown"
           aria-expanded="false"
           aria-label="<%= I18n.t("actions.link_to_record") %>"
-        ></button>
+        ><span class="sr-only"></button>
         <ul class="dropdown-menu">
           <li>
             <button

--- a/frontend/app/views/agents/_linker.html.erb
+++ b/frontend/app/views/agents/_linker.html.erb
@@ -72,11 +72,11 @@
 
       <div class="input-group-append">
         <button
-          id="dropdownMenuAgentsToggle"
           type="button"
           class="btn btn-default dropdown-toggle"
           data-toggle="dropdown"
           aria-expanded="false"
+          aria-label="<%= t('actions.toggle_dropdown_menu') %>"
         ></button>
         <ul class="dropdown-menu dropdown-menu-right" id='dropdownMenuAgents' aria-labelledby="#dropdownMenuAgents">
           <li>

--- a/frontend/config/locales/de.yml
+++ b/frontend/config/locales/de.yml
@@ -66,6 +66,7 @@ de:
     suppress_confirm_message: Obwohl eine unterdrückte Aufzeichnung in der Datenbank
       verbleibt, wird sie für die meisten Nutzer versteckt und für die meisten Funktionen
       nicht verfügbar sein.
+    toggle_dropdown_menu: Dropdown-Menü umschalten
     unsuppress: Unterdrückung aufheben
     unsuppress_confirm_message: Nein
     unable_to_move_message: Kann die Aufzeichnung nicht verschieben

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -77,6 +77,7 @@ en:
     suppress: Suppress
     suppress_confirm_title: Suppress this Record?
     suppress_confirm_message: "While a suppressed record will remain in the database, it will become hidden to most users and unavailable to most functions."
+    toggle_dropdown_menu: Toggle dropdown menu
     transfer: Transfer
     transfer_confirm_title: Transfer this record?
     transfer_confirm_message: "The record '%{target}' will be transferred to the repository you selected"

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -89,6 +89,7 @@ es:
     suppress_confirm_message: "Mientras que un registro bloqueado permanecerá en la\
       \ base de datos, se convertirá en ocultos a la mayoría de los usuarios y a la\
       \ mayoría de las funciones de carácter."
+    toggle_dropdown_menu: Alternar menú desplegable
     transfer: Transferencia
     transfer_confirm_title: ¿La transferencia de este registro?
     transfer_confirm_message: "El registro '%{merge_destination}' se transferirá en el repositorio\

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -87,6 +87,7 @@ fr:
     suppress_confirm_message: "Bien qu'une notice bloquée reste dans la base de données,\
       \ elle devient cachée à la plupart des utilisateurs et indisponible à la plupart\
       \ des fonctions."
+    toggle_dropdown_menu: Basculer le menu déroulant
     transfer: Transférer
     transfer_confirm_title: Transférer cette notice?
     transfer_confirm_message: "La notice '%{merge_destination}' sera transférée vers le service\

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -77,6 +77,7 @@ ja:
     suppress: 抑止
     suppress_confirm_title: このレコードを抑止しますか？
     suppress_confirm_message: 抑制されたレコードはデータベースに残っていますが、ほとんどのユーザーには表示されなくなり、ほとんどの機能では使用できなくなります。
+    toggle_dropdown_menu: ドロップダウンメニューを切り替える
     transfer: 転送
     transfer_confirm_title: このレコードを転送しますか？
     transfer_confirm_message: レコード '%{merge_destination}'は選択したリポジトリに転送されます

--- a/frontend/spec/features/resources_spec.rb
+++ b/frontend/spec/features/resources_spec.rb
@@ -855,7 +855,7 @@ describe 'Resources', js: true do
     click_on 'Agent Links'
     click_on 'Add Agent Link'
 
-    find('#resource_linked_agents_ #dropdownMenuAgentsToggle').click
+    find('#resource_linked_agents_ .linker-wrapper .dropdown-toggle').click
     find('#resource_linked_agents_ #dropdownMenuAgents .linker-browse-btn').click
 
     element = find('.linker-container')

--- a/frontend/vendor/assets/javascripts/bootstrap-combobox.js
+++ b/frontend/vendor/assets/javascripts/bootstrap-combobox.js
@@ -196,9 +196,13 @@
       aria-controls="${this.$source.attr('id')}_list"
     />
     <div class="input-group-append">
-      <button class="btn btn-default dropdown-toggle d-flex align-items-center" type="button" data-toggle="dropdown" aria-expanded="false">
-        <span class="glyphicon glyphicon-remove mb-1"></span>
-      </button>
+      <button
+        type="button"
+        class="btn btn-default dropdown-toggle d-flex align-items-center"
+        data-toggle="dropdown"
+        aria-expanded="false"
+        aria-label="Toggle dropdown menu"
+      ></button>
     </div>
   </div>
 </div>

--- a/frontend/vendor/assets/javascripts/codemirror/codemirror.js
+++ b/frontend/vendor/assets/javascripts/codemirror/codemirror.js
@@ -14,7 +14,7 @@ window.CodeMirror = (function() {
       if (defaults.hasOwnProperty(opt))
         options[opt] = (givenOptions && givenOptions.hasOwnProperty(opt) ? givenOptions : defaults)[opt];
 
-    var input = elt("textarea", null, null, "position: absolute; padding: 0; width: 1px; height: 1em");
+    var input = elt("textarea", null, null, "position: absolute; padding: 0; width: 1px; height: 1em", {"aria-label": "Text area input"});
     input.setAttribute("wrap", "off"); input.setAttribute("autocorrect", "off"); input.setAttribute("autocapitalize", "off");
     // Wraps and hides input textarea
     var inputDiv = elt("div", [input], null, "overflow: hidden; position: relative; width: 3px; height: 0px;");
@@ -3068,10 +3068,22 @@ window.CodeMirror = (function() {
   function posLess(a, b) {return a.line < b.line || (a.line == b.line && a.ch < b.ch);}
   function copyPos(x) {return {line: x.line, ch: x.ch};}
 
-  function elt(tag, content, className, style) {
+  /**
+   * 
+   * @param {*} tag 
+   * @param {*} content 
+   * @param {*} className 
+   * @param {*} style 
+   * @param {Object} attr Object of attributes to set on the element, ie: { 'data-foo': 'bar' }
+   * @returns 
+   */
+  function elt(tag, content, className, style, attr) {
     var e = document.createElement(tag);
     if (className) e.className = className;
     if (style) e.style.cssText = style;
+    if (attr) for (const a in attr) {
+      if (attr.hasOwnProperty(a)) e.setAttribute(a, attr[a]);
+    }
     if (typeof content == "string") setTextContent(e, content);
     else if (content) for (var i = 0; i < content.length; ++i) e.appendChild(content[i]);
     return e;


### PR DESCRIPTION
This PR is a step towards fixing [ANW-2169](https://archivesspace.atlassian.net/browse/ANW-2169) which reports frontend accessibility errors reported by Wave.

Fixing all of the errors gets into the territory of having to modify the old libraries we depend on like CodeMirror, the tooltips, etc. The same errors existed _before_ v4, so this PR stops short of a complete fix in favor of punting on the outstanding issues in favor of fixing more urgent v4 specific bugs to get the release out.


[ANW-2169]: https://archivesspace.atlassian.net/browse/ANW-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ