### PR TITLE
ANW-2172: Show the set repo order button conditionally according to `AppConfig[:pui_repositories_sort]`

### DIFF
--- a/frontend/app/views/repositories/index.html.erb
+++ b/frontend/app/views/repositories/index.html.erb
@@ -10,7 +10,7 @@
     <% if user_can?('create_repository') %>
       <div class="record-toolbar d-flex justify-content-end">
         <div class="btn-group" role="group">
-          <% if user_can?('administer_system') %>
+          <% if user_can?('administer_system') && AppConfig[:pui_repositories_sort] == :position %>
             <%= link_to t("repository._frontend.action.order_for_pui"), {:controller => :repositories, :action => :reorder}, :class => "btn btn-sm btn-default" %>
           <% end %>
           <%= link_to t("repository._frontend.action.create"), {:controller => :repositories, :action => :new}, :class => "btn btn-sm btn-default" %>

--- a/frontend/spec/features/repositories_spec.rb
+++ b/frontend/spec/features/repositories_spec.rb
@@ -195,4 +195,14 @@ describe 'Repositories', js: true do
     expect(find('select', id: 'id')).to have_content(repo.repo_code)
   end
 
+  it 'will only show the Set Order in Public Interface button when configured as such' do
+    visit '/repositories'
+    expect(page).not_to have_content('Set Order in Public Interface')
+
+    allow(AppConfig).to receive(:[]).and_call_original
+    allow(AppConfig).to receive(:[]).with(:pui_repositories_sort) { :position }
+    page.refresh
+    expect(page).to have_content('Set Order in Public Interface')
+  end
+
 end


### PR DESCRIPTION
This PR conditionally shows the "Set Order in Public Interface" button in the Staff app when managing repositories if `AppConfig[:pui_repositories_sort] == :position`.

[ANW-2172](https://archivesspace.atlassian.net/browse/ANW-2172)

[ANW-2172]: https://archivesspace.atlassian.net/browse/ANW-2172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ