### PR TITLE
ANW-2183 Right-align accessions 'more' dropdown menu

### DIFF
--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -53,11 +53,11 @@
           %>
         <% end %>
         <div class="btn-group" id="other-dropdown">
-          <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+          <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= t('actions.more') %>
           </button>
 
-          <ul class="dropdown-menu">
+          <ul class="dropdown-menu dropdown-menu-right">
             <li><%= render_aspace_partial :partial => "extent_calculator/toolbar_button", :locals => {:record => @accession} %></li>
             <% if user_can?('update_assessment_record') %>
               <li><%= link_to t('assessment._frontend.action.create_for_record'), {:controller => :assessments, :action => :new, :record_uri => @accession.uri}, :class => "dropdown-item" %></li>

--- a/frontend/spec/features/accessions_spec.rb
+++ b/frontend/spec/features/accessions_spec.rb
@@ -583,4 +583,16 @@ describe 'Accessions', js: true do
     click_on('Save')
     expect(page).to have_text "Accession #{accession_title} updated"
   end
+
+  describe 'toolbar' do
+    it 'has a "more" dropdown menu that is aligned to the right side of its control button' do
+      accession = create(:json_accession)
+      run_index_round
+      visit "/accessions/#{accession.id}"
+      expect(page).to have_css(
+        '#other-dropdown > .dropdown-menu.dropdown-menu-right',
+        visible: false
+      )
+    end
+  end
 end


### PR DESCRIPTION
This PR solves [ANW-2183](https://archivesspace.atlassian.net/browse/ANW-2183) by aligning the Accessions toolbar "More" dropdown menu to the right of the "More" button. Previously it was left-aligned, which would hide menu text off to the right of the viewport when the "More" button was the right-most button in the toolbar.

<img width="1489" alt="ANW-2183" src="https://github.com/user-attachments/assets/775a481d-69d4-4cf0-a74f-54b51a8576ff">



[ANW-2183]: https://archivesspace.atlassian.net/browse/ANW-2183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ