### PR TITLE
ANW-2173: Fix digital object notes id and anchor links

### DIFF
--- a/frontend/app/views/digital_objects/_form_container.html.erb
+++ b/frontend/app/views/digital_objects/_form_container.html.erb
@@ -46,7 +46,7 @@
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "linked_agents", :template => "digital_object_linked_agent"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "subjects", :template => "subrecord_subject"} %>
 
-  <%= render_aspace_partial :partial => "notes/form", :locals => { :section_id => "digital_object_notes", :form => form, :all_note_types => note_types_for(form['jsonmodel_type'])} %>
+  <%= render_aspace_partial :partial => "notes/form", :locals => { :section_id => "digital_object_notes_", :form => form, :all_note_types => note_types_for(form['jsonmodel_type'])} %>
 
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "rights_statements"} %>

--- a/frontend/app/views/digital_objects/_show_inline.html.erb
+++ b/frontend/app/views/digital_objects/_show_inline.html.erb
@@ -87,7 +87,7 @@
         <% end %>
 
         <% if digital_object.notes.length > 0 %>
-          <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => digital_object.notes, :context => readonly } %>
+          <%= render_aspace_partial :partial => "notes/show", :locals => { :notes => digital_object.notes, :context => readonly, :section_id => "digital_object_notes_" } %>
         <% end %>
 
         <% if digital_object.external_documents.length > 0 %>

--- a/frontend/app/views/digital_objects/_sidebar.html.erb
+++ b/frontend/app/views/digital_objects/_sidebar.html.erb
@@ -15,7 +15,7 @@
     <%= sidebar.render_for_view_only(:subrecord_type => 'linked_record', :property => 'linked_instances') %>
 
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'subject', :property => 'subjects') %>
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'note', :property => 'notes', :anchor => 'digital_object_notes') %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'note', :property => 'notes', :anchor => 'digital_object_notes_') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_document', :property => 'external_documents') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'rights_statement', :property => 'rights_statements') %>
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'metadata_rights_declaration', :property => 'metadata_rights_declarations') %>


### PR DESCRIPTION
This PR solves [ANW-2173](https://archivesspace.atlassian.net/browse/ANW-2173) by fixing the `id` of the Digital Object Notes section in both `show` and `edit` views, and the corresponding `sidebar` anchor link.

![ANW-2173-notes](https://github.com/user-attachments/assets/3925cb6c-7cce-45d4-ba55-bc47e92ce9c6)


[ANW-2173]: https://archivesspace.atlassian.net/browse/ANW-2173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ