### PR TITLE
ANW-2175 fix +1 Event stuff

### DIFF
--- a/frontend/app/controllers/events_controller.rb
+++ b/frontend/app/controllers/events_controller.rb
@@ -56,10 +56,6 @@ class EventsController < ApplicationController
     end
 
     if params.has_key?(:record_uri)
-      @last_linked_record_uri = params[:record_uri]
-      @last_linked_record_type = params[:record_type]
-      @last_linked_record_path = params[:record_uri].match('\/\w+\/\d+$')[0]
-
       record = JSONModel(params[:record_type]).find_by_uri(params[:record_uri])
       @event.linked_records = []
       @event.linked_records << {'ref' => record.uri, '_resolved' => record.to_hash, 'role' => 'source'}
@@ -89,11 +85,13 @@ class EventsController < ApplicationController
                 },
                 :on_valid => ->(id) {
                   flash[:success] = t("event._frontend.messages.created")
-                  return redirect_to(
-                    :controller => :events,
-                    :action => :new,
-                    :record_uri => params[:redirect_record],
-                    :record_type => JSONModel.parse_reference(params[:redirect_record])[:type]) if params.has_key?(:plus_one)
+                  if params.has_key?(:plus_one) && params[:redirect_record]
+                    return redirect_to(
+                      :controller => :events,
+                      :action => :new,
+                      :record_uri => params[:redirect_record],
+                      :record_type => JSONModel.parse_reference(params[:redirect_record])[:type])
+                  end
 
                   # we parse the reference as a simple sanity check here...
                   if params.has_key?(:redirect_record) && JSONModel.parse_reference(params[:redirect_record])

--- a/frontend/app/views/events/new.html.erb
+++ b/frontend/app/views/events/new.html.erb
@@ -22,13 +22,17 @@
           <div class="form-actions pl-0">
             <div class="btn-group">
               <button type="submit" class="btn btn-primary"><%= t("event._frontend.action.save") %></button>
-              <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn" 
-                linked_record_uri="<%= @last_linked_record_uri %>" 
-                linked_record_type="<%= @last_linked_record_type %>">
+              <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"
+                linked_record_uri="<%= params[:record_uri] %>"
+                linked_record_type="<%= params[:record_type] %>">
                   <%= t("actions.save_plus_one") %>
               </button>
             </div>
-            <%= link_to t("actions.cancel"), @last_linked_record_path, :class => "btn btn-cancel btn-default" %>
+            <% if params[:record_uri] %>
+              <%= link_to t("actions.cancel"), params[:record_uri]&.match('\/\w+\/\d+$')[0], :class => "btn btn-cancel btn-default" %>
+            <% else %>
+              <%= link_to t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <% end %>
           </div>
         </div>
       </div>

--- a/frontend/spec/features/events_spec.rb
+++ b/frontend/spec/features/events_spec.rb
@@ -10,8 +10,8 @@ describe 'Events', js: true do
     @now = Time.now.to_i
     @repository = create :repo, repo_code: "default_values_test_#{Time.now.to_i}"
     set_repo @repository
-    @resource = create :resource
-    @accession = create(:accession, title: "Accession Title #{@now}")
+    @resource = create :resource, title: "Resource Title #{@now}"
+    @accession = create :accession, title: "Accession Title #{@now}"
 
     name_string = "Agent Name #{@now}"
 
@@ -30,7 +30,7 @@ describe 'Events', js: true do
     run_index_round
   end
 
-  it 'retains the linked resource when adding additional events via +1 button' do
+  it 'retains the linked record when adding additional events via +1 button' do
     login_admin
     select_repository @repository
     visit "/resources/#{@resource.id}"
@@ -42,15 +42,43 @@ describe 'Events', js: true do
     select 'Single', from: 'event[date][date_type]'
     fill_in 'event[date][begin]', with: '2023'
     select 'Authorizer', from: 'event[linked_agents][0][role]'
-    fill_in 'token-input-event_linked_agents__0__ref_', with: 'test'
 
     # Need to wait for evidence of dropdown populating before sending enter to select the agent.
     # This is accomplished by waiting for the aria attribute to show up. (TODO: better way?)
     # After that, click the +1, then wait for the form submission to complete, otherwise it will
     # immediately find the the linked resource div on the current page and short-circuit the test.
     # Easiest way is probably just to look for the success flash.
+    fill_in 'token-input-event_linked_agents__0__ref_', with: 'test'
     expect(page).to have_css '#token-input-event_linked_agents__0__ref_[aria-controls]'
     find(id: 'token-input-event_linked_agents__0__ref_').send_keys(:enter)
+
+    click_button id: 'createPlusOne'
+    expect(page).to have_content 'Event Created'
+    expect(page).to have_selector 'div.resource'
+  end
+
+  it 'adds an event via +1 button when using Create -> Event without a previously linked record' do
+    login_admin
+    select_repository @repository
+
+    click_button 'Create'
+    click_on 'Event'
+
+    expect(page).to have_content 'New Event'
+    select 'Single', from: 'event[date][date_type]'
+    fill_in 'event[date][begin]', with: '2023'
+    select 'Authorizer', from: 'event[linked_agents][0][role]'
+
+    # see comment in example above
+    fill_in 'token-input-event_linked_agents__0__ref_', with: 'test'
+    expect(page).to have_css '#token-input-event_linked_agents__0__ref_[aria-controls]'
+    find(id: 'token-input-event_linked_agents__0__ref_').send_keys(:enter)
+
+    select 'Source', from: 'event[linked_records][0][role]'
+    fill_in 'token-input-event_linked_records__0__ref_', with: 'Resource Title'
+    expect(page).to have_css '#token-input-event_linked_records__0__ref_[aria-controls]'
+    find(id: 'token-input-event_linked_records__0__ref_').send_keys(:enter)
+
     click_button id: 'createPlusOne'
     expect(page).to have_content 'Event Created'
     expect(page).to have_selector 'div.resource'


### PR DESCRIPTION
Some changes from #2980 broke the +1 button in cases where no resource
was previously linked. This change fixes that and reworks the code to
remove unnecessary new variables. Also adds a test for that case.