### PR TITLE
ANW-2157: Skip the asset pipeline for PUI favicon

### DIFF
--- a/public/app/views/shared/_favicon.html.erb
+++ b/public/app/views/shared/_favicon.html.erb
@@ -1,2 +1,2 @@
-<link rel="icon" type="image/png" href="<%= asset_path('favicon-AS.png') %>">
-<link rel="icon" type="image/svg+xml" href="<%= asset_path('favicon-AS.svg') %>">
+<link rel="icon" type="image/png" href="<%= asset_path('favicon-AS.png', skip_pipeline: true) %>">
+<link rel="icon" type="image/svg+xml" href="<%= asset_path('favicon-AS.svg', skip_pipeline: true) %>">


### PR DESCRIPTION
This PR is a follow up from #3331, it fixes the deprecation warning in the logs about the PUI favicons not being part of the asset pipeline:

```
[java] DEPRECATION WARNING: The asset "favicon-AS.png" is not present in the asset pipeline.
[java] Falling back to an asset that may be in the public folder.
[java] This behavior is deprecated and will be removed.
[java] To bypass the asset pipeline and preserve this behavior,
[java] use the `skip_pipeline: true` option.
```

See eg, this log from a CI run before this PR: https://github.com/archivesspace/archivesspace/actions/runs/11501086583/job/32012868739#step:8:184.