### PR TITLE
ANW-1770: Add alt text to images in Digital Object search listing

### DIFF
--- a/frontend/app/views/search/_representative_file_version_cell.html.erb
+++ b/frontend/app/views/search/_representative_file_version_cell.html.erb
@@ -1,11 +1,7 @@
 <%
   json = ASUtils.json_parse(record["json"])
   file_uri = json['representative_file_version'] ? json['representative_file_version']['file_uri'] : nil
-  file_caption = json['representative_file_version'] &&
-    json['representative_file_version']['caption'] &&
-    !json['representative_file_version']['caption'].empty? ?
-      clean_mixed_content(json['representative_file_version']['caption']) :
-      nil
+  file_caption = json.dig('representative_file_version', 'caption').presence
 %>
 
 <% if file_uri %>

--- a/frontend/app/views/search/_representative_file_version_cell.html.erb
+++ b/frontend/app/views/search/_representative_file_version_cell.html.erb
@@ -1,8 +1,15 @@
 <%
   json = ASUtils.json_parse(record["json"])
   file_uri = json['representative_file_version'] ? json['representative_file_version']['file_uri'] : nil
+  file_caption = json['representative_file_version'] &&
+    json['representative_file_version']['caption'] &&
+    !json['representative_file_version']['caption'].empty? ?
+      clean_mixed_content(json['representative_file_version']['caption']) :
+      nil
 %>
 
 <% if file_uri %>
-<img src="<%= file_uri %>"/>
+<img
+  src="<%= file_uri %>"
+  <% if file_caption %>alt="<%= file_caption %>"<% end %>/>
 <% end %>

--- a/frontend/spec/features/representative_file_version_spec.rb
+++ b/frontend/spec/features/representative_file_version_spec.rb
@@ -20,7 +20,8 @@ describe 'Representative File Version', js: true do
             publish: true,
             is_representative: true,
             file_uri: @good_img,
-            use_statement: 'image-thumbnail'
+            use_statement: 'image-thumbnail',
+            caption: 'This is a good image'
           }
         ]
       )
@@ -51,9 +52,9 @@ describe 'Representative File Version', js: true do
       click_button('Save')
     end
 
-    xit 'is shown when a supported image format is available' do
+    xit 'is shown when a supported image format is available and includes alt text from its caption' do
       visit '/digital_objects'
-      expect(page).to have_css("#tabledSearchResults .representative_file_version > img[src='#{@good_img}']", visible: :visible)
+      expect(page).to have_css("#tabledSearchResults .representative_file_version > img[src='#{@good_img}'][alt='This is a good image']", visible: :visible)
     end
     it 'is hidden when a supported image format is not available' do
       visit '/digital_objects'


### PR DESCRIPTION
This PR fixes [ANW-1770](https://archivesspace.atlassian.net/browse/ANW-1770) which reports that the images in the Image Thumbnail column of the Staff Digital Object search listing table does not provide the image caption as `alt` text as happens in the PUI.

The accompanying spec is ignored due to the representative file version spec being a common flaky test in CI but not locally. The spec was unignored to test locally, which passed. The test was then re-ignored for this PR.

## Solution

<img width="1447" alt="ANW-1770" src="https://github.com/user-attachments/assets/fdf34ecb-6a7b-4c54-ac38-4cc1571f4a1a">


[ANW-1770]: https://archivesspace.atlassian.net/browse/ANW-1770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ