### PR TITLE
ANW-2193, ANW-2194: Fix Safari rendering of table column widths for Agent Link subform and Edit Group page

### DIFF
--- a/frontend/app/views/linked_agents/_show.html.erb
+++ b/frontend/app/views/linked_agents/_show.html.erb
@@ -10,11 +10,11 @@
       <table class="table table-striped table-bordered table-condensed table-hover token-list">
         <thead>
           <tr>
-            <td class="col-md-1"><%= t("linked_agent.is_primary") %></td>
-            <td class="col-md-2"><%= t("linked_agent.role") %></td>
-            <td class="col-md-2"><%= t("linked_agent.relator") %></td>
-            <td class="col-md-4"><%= t("linked_agent.ref") %></td>
-            <td class="col-md-3"></td>
+            <td><%= t("linked_agent.is_primary") %></td>
+            <td><%= t("linked_agent.role") %></td>
+            <td><%= t("linked_agent.relator") %></td>
+            <td><%= t("linked_agent.ref") %></td>
+            <td></td>
           </tr>
         </thead>
         <tbody>

--- a/frontend/app/views/users/edit_groups.html.erb
+++ b/frontend/app/views/users/edit_groups.html.erb
@@ -21,9 +21,9 @@
                   <table class="table table-striped table-bordered table-condensed">
                     <% @groups.each do |group| %>
                       <tr>
-                        <td class="col-md-1"><%= check_box_tag("groups[]", group.uri, params.has_key?("groups") ? params["groups"].include?(group.uri) : @user.groups.include?(group.uri), :id => group.group_code) %></td>
-                        <td class="col-md-3"><%= label_tag group.group_code, group.group_code %></td>
-                        <td class="col-md-8"><%= label_tag group.group_code, group.description %></td>
+                        <td><%= check_box_tag("groups[]", group.uri, params.has_key?("groups") ? params["groups"].include?(group.uri) : @user.groups.include?(group.uri), :id => group.group_code) %></td>
+                        <td><%= label_tag group.group_code, group.group_code %></td>
+                        <td><%= label_tag group.group_code, group.description %></td>
                       </tr>
                     <% end %>
                   </table>


### PR DESCRIPTION
This PR fixes two similar bugs related to rendering tables in Safari:

- [ANW-2193](https://archivesspace.atlassian.net/browse/ANW-2193) reported "squished" columns in the Agent Links subform table in, ie: a Resource view page
- [ANW-2194](https://archivesspace.atlassian.net/browse/ANW-2194) reported "squished" columns in the user Edit Groups view

## Agent links solution

<img width="1471" alt="ANW-2193" src="https://github.com/user-attachments/assets/b7b474df-cb32-4c88-b7b5-06c33200f59b">

## Edit groups solution

<img width="1473" alt="ANW-2194" src="https://github.com/user-attachments/assets/82e9d8f0-b18d-4722-8fbf-3d98bfba4861">


[ANW-2193]: https://archivesspace.atlassian.net/browse/ANW-2193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-2194]: https://archivesspace.atlassian.net/browse/ANW-2194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ