### PR TITLE
ANW-2168 Change hidden text color for valid contrast

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/infinite-records.scss
+++ b/public/app/assets/stylesheets/archivesspace/infinite-records.scss
@@ -120,6 +120,7 @@ $indent-width: 20px;
   display: inline-block;
   text-indent: -9999px;
   background: #006e99;
+  color: white;
   border-radius: 100px;
   cursor: pointer;
 }


### PR DESCRIPTION
This PR adds to #3352 which fixes Wave-reported accessibility errors. This PR fixes the contrast error on the load-all-records feature's toggle switch. The error relates to the color of the toggle `<input>`'s hidden text used as an input label for screen readers but which is hidden visually. Instead of ignoring the error in Wave, let's just fix the error in the code.