### PR TITLE
ANW-2154 Bulk AO Updater job disable submit button until valid file input

### DIFF
--- a/frontend/app/views/bulk_archival_object_updater_job/_form.html.erb
+++ b/frontend/app/views/bulk_archival_object_updater_job/_form.html.erb
@@ -8,6 +8,7 @@
         type="file"
         name="files[]"
         accept=".csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel"
+        autocomplete="off"
         required
       />
     </label>
@@ -20,7 +21,20 @@
 </section>
 
 <script>
-$('#job_file_input').on('change', function (e) {
-  $('#job_filename').text(e.target.files[0].name);
+$(document).ready(function () {
+  const $jobSubmitBtn = $('#job_file_input')
+    .closest('.record-pane')
+    .find('.form-actions .btn-primary[type="submit"]');
+  $jobSubmitBtn.prop('disabled', true);
+
+  $('#job_file_input').on('change', function (e) {
+    if (e.target.files.length > 0) {
+      $('#job_filename').text(e.target.files[0].name);
+      $jobSubmitBtn.prop('disabled', false);
+    } else {
+      $('#job_filename').text('');
+      $jobSubmitBtn.prop('disabled', true);
+    }
+  });
 });
 </script>

--- a/frontend/spec/features/resources_spec.rb
+++ b/frontend/spec/features/resources_spec.rb
@@ -284,6 +284,8 @@ describe 'Resources', js: true do
     click_on 'Background Job'
     click_on 'Bulk Archival Object Updater'
 
+    expect(page).to have_button('Start Job', disabled: true)
+
     attach_file(
       'job_file_input',
       downloaded_spreadsheet_filename,


### PR DESCRIPTION
This PR fixes [ANW-2154](https://archivesspace.atlassian.net/browse/ANW-2154) which [reports](https://archivesspace.atlassian.net/browse/ANW-2154?focusedCommentId=40857) that the Bulk AO Updater job can be submitted before a valid file has been selected for the job.

This PR disables the "Start Job" button until a valid file has been selected via the file input, which is consistent with the way the "Load via Spreadsheet" input works.

## Solution

![ANW-2154-bulk-ao-updater](https://github.com/user-attachments/assets/991b2a5f-cb5d-4423-b1f3-2340402918c2)


[ANW-2154]: https://archivesspace.atlassian.net/browse/ANW-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ