### PR TITLE
ANW-2206 Do not show external repo warning for global records

### DIFF
--- a/frontend/app/helpers/jobs_helper.rb
+++ b/frontend/app/helpers/jobs_helper.rb
@@ -27,6 +27,10 @@ module JobsHelper
     end
   end
 
+  def is_global_record?(json_model)
+    json_model.match?(/agent|location|subject/)
+  end
+
   def link_for_resource(uri)
     id = JSONModel(:resource).id_for(uri)
     URI.join(

--- a/frontend/app/views/jobs/_job_records.html.erb
+++ b/frontend/app/views/jobs/_job_records.html.erb
@@ -13,9 +13,8 @@
         <span class="asicon icon-<%= result["record"]["_resolved"]["jsonmodel_type"] %>"
               title="<%= t("#{result["record"]["_resolved"]["jsonmodel_type"]}._singular") %>">
         </span>
-        <%# ANW-1519: for agents and subjects, we don't need to check what repo they belong in %>
-        <% if result["record"]["_resolved"]["jsonmodel_type"] =~ /agent/ ||
-              result["record"]["_resolved"]["jsonmodel_type"] =~ /subject/ %>
+        <%# ANW-1519, ANW-2206: Skip checking owner repo for global records (agents, subjects, locations) %>
+        <% if is_global_record?(result["record"]["_resolved"]["jsonmodel_type"]) %>
           <%= resolve_readonly_link_to record_title, result["record"]["ref"] %>
         <% else %>
           <% if result["record"]["ref"].include?(current_repo.uri) %>


### PR DESCRIPTION
Treats locations the same as other repository-less resources like agents and subjects and does not display the external_repo warning on csv import.

## Description
Even though #3275 allowed locations to be imported with an "owner repo", location records still don't actually belong to/exist within any specific repo.  Whether or not they are linked to an owning repository, they still can be viewed by all authenticated users.  Even though the issue described in ANW-2206 predates #3275, this new functionality will make the bug more visible and confusing.  So I've addressed it here.

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-2206

## How Has This Been Tested?
I've taken a stab at adding e2e tests for this and I'll PR those separately to that repo.

## Screenshots (if appropriate):
<img width="988" alt="Screenshot 2024-11-07 at 12 28 27 PM" src="https://github.com/user-attachments/assets/fbdf8171-109f-44e3-8d9d-25cdf6f8bf9c">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
ℹ️ PRed separately: https://github.com/archivesspace/e2e-tests/pull/21
- [x] All new and existing tests passed.
