### PR TITLE
Update release notes exclude authors

### DIFF
--- a/scripts/tasks/release_notes.rb
+++ b/scripts/tasks/release_notes.rb
@@ -46,7 +46,7 @@ module ReleaseNotes
     EXCLUDE_AUTHORS = [
       'Christine Di Bella',
       'Jessica Crouch',
-      'Brian Hoffman',
+      'Thimios Dimopulos',
       'Mark Cooper',
       'Brian Zelip',
       'Donald Smith',


### PR DESCRIPTION
This PR updates the outdated list of authors to exclude from the Release Notes script.