### PR TITLE
ANW-2175 fix event +1 redirecting to edit new event

### DIFF
--- a/frontend/app/views/events/new.html.erb
+++ b/frontend/app/views/events/new.html.erb
@@ -22,9 +22,7 @@
           <div class="form-actions pl-0">
             <div class="btn-group">
               <button type="submit" class="btn btn-primary"><%= t("event._frontend.action.save") %></button>
-              <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"
-                linked_record_uri="<%= params[:record_uri] %>"
-                linked_record_type="<%= params[:record_type] %>">
+              <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn">
                   <%= t("actions.save_plus_one") %>
               </button>
             </div>

--- a/frontend/spec/features/events_spec.rb
+++ b/frontend/spec/features/events_spec.rb
@@ -94,7 +94,7 @@ describe 'Events', js: true do
 
     click_button id: 'createPlusOne'
     expect(page).to have_content 'Event Created'
-    expect(page).to have_selector 'div.resource'
+    expect(page).to have_current_path '/events/new'
   end
 
   it 'creates an event and links it to an agent and an agent as a source' do


### PR DESCRIPTION
The previous change to fix the event +1 button causing a crash when
coming from the main menu Create->Event button was erroneously
redirecting to editing the newly created event; it should redirect to
a blank new event page.

This should be cleaned up now, and I've left copious comments
because this was frustratingly confusing to me and I'd like to spare
future developers from that.
