### PR TITLE
ANW-2162: Filter out extra add-as-you-go buttons caused by the duplicate Note subform id bug

### DIFF
--- a/frontend/app/assets/javascripts/utils.js
+++ b/frontend/app/assets/javascripts/utils.js
@@ -674,11 +674,21 @@ AS.initAddAsYouGoActions = function ($form, $list) {
       'button[data-action], .subrecord-form-heading:first > .btn, .subrecord-form-heading:first > .custom-action > .btn',
       $form
     );
+
+    // jquery.map != Array.prototype.map
     btnsToReplicate = btnsToReplicate.map(function () {
       var $btn = $(this);
       if ($btn.hasClass('show-all') && numberOfSubRecords() < 5) return;
       else return this;
     });
+
+    /**
+     * ANW-2162: Hack around the related bug that duplicates Note subform ids
+     * resulting in extra add-as-you-go buttons
+     */
+    btnsToReplicate = btnsToReplicate.filter(
+      (i, btn) => btn.closest('section.subrecord-form') === $form[0]
+    );
 
     var fillToPercentage = 100; // full width
 


### PR DESCRIPTION
This PR addresses [ANW-2162](https://archivesspace.atlassian.net/browse/ANW-2162) which observes extraneous "add-as-you-go" buttons, while in record edit mode, at the bottom of staff subforms with zero-to-many cardinality and with nested Note suberecords.

Note data structures are different than most other structures in that they can be a top-level structure or be nested inside other structures. The problem reported by ANW-2162 stems from a bug where Note subforms duplicate HTML `id`s (ie: `rights_statement_notes`) instead of incrementing them (ie: `resource_rights_statements__0__acts_`).

⚠️ This PR does not fix the underlying problem of duplicate Note ids, rather it hacks around the underlying issue in the interest of getting the next v4 release candidate out. ⚠️

Tests are forthcoming in the interest of getting out the next v4 release candidate.

## Problem example 1

<img width="1491" alt="ANW-2162 problem 1" src="https://github.com/user-attachments/assets/6d85b495-65cd-4b22-950c-3c20b638bd86">

## Solution example 1

<img width="1491" alt="ANW-2162 solution 1" src="https://github.com/user-attachments/assets/1b6a77e4-ec55-44bd-aca5-dfeac1a2dda6">

## Problem example 2

<img width="1490" alt="ANW-2162 problem 2" src="https://github.com/user-attachments/assets/8872a949-fe81-4b4c-9a17-02c9ce84cdf2">

## Solution example 2

<img width="1467" alt="ANW-2162 solution 2" src="https://github.com/user-attachments/assets/1758aa96-5184-4386-a649-776571a32ad8">


[ANW-2162]: https://archivesspace.atlassian.net/browse/ANW-2162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ