### PR TITLE
ANW-1780: Display hyperlinks in classification description on PUI

### DIFF
--- a/public/app/models/classification.rb
+++ b/public/app/models/classification.rb
@@ -35,6 +35,15 @@ class Classification < Record
     raw['has_classification_terms'] == true
   end
 
+  def parsed_description
+    return '' if description.blank?
+
+    # Convert URLs to clickable links
+    description.gsub(/(https?:\/\/[^\s<>]+)/) do |url|
+      "<a href='#{url}' target='_blank' rel='noopener noreferrer'>#{url}</a>"
+    end.html_safe
+  end
+
   private
 
   def parse_linked_records

--- a/public/app/views/classifications/show.html.erb
+++ b/public/app/views/classifications/show.html.erb
@@ -10,7 +10,7 @@
   <div class="row">
     <div class="information w-100">
       <%= render partial: 'shared/breadcrumbs' %>
-      <div class="description px-3"><%= @result.description %></div>
+      <div class="description px-3"><%= @result.parsed_description %></div>
       <% if @result.creator %>
         <div class="creator clear">
           <span class="inline-label clear"><%= t('classification.creator') %>: </span>

--- a/public/spec/features/classifications_spec.rb
+++ b/public/spec/features/classifications_spec.rb
@@ -33,4 +33,34 @@ describe 'Classifications', js: true do
 
     expect(page).to_not have_text repository_uri
   end
+
+  describe 'classification with links' do
+    before do
+      @classification = create(:classification, {
+        :title => "Research Guides",
+        :identifier => "RG-#{rand(1000)}",
+        :description => "Check our LibGuide at https://example.edu/guide1 and https://example.edu/guide2",
+        :publish => true
+      })
+
+      run_indexers
+    end
+
+    it 'displays clickable links in description field' do
+      visit @classification.uri
+
+      within '.description' do
+        expect(page).to have_link('https://example.edu/guide1',
+          href: 'https://example.edu/guide1')
+        expect(page).to have_link('https://example.edu/guide2',
+          href: 'https://example.edu/guide2')
+
+        # Check link attributes
+        all('a').each do |link|
+          expect(link[:target]).to eq('_blank')
+          expect(link[:rel]).to include('noopener')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Display clickable hyperlinks in the Classifications Description field on PUI

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1780

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="528" alt="Screenshot 2024-11-24 at 08 14 27" src="https://github.com/user-attachments/assets/ab4b6544-f196-451b-bfe1-c00b6858fb8d">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
