### PR TITLE
ANW-2113: Don't create pre-1970 authority record creation event_dates in authority maintenance events

### DIFF
--- a/backend/app/converters/lib/marcxml_auth_agent_base_map.rb
+++ b/backend/app/converters/lib/marcxml_auth_agent_base_map.rb
@@ -530,7 +530,13 @@ module MarcXMLAuthAgentBaseMap
         "parent::record/controlfield[@tag='008']" => proc { |amh, node|
           tag8_content = node.inner_text
 
-          amh['event_date'] = '19' + tag8_content[0..5]
+          # The MARC Authority format was not developed until the 1970s, and the
+          #   first 2 digits of the authority 008 are specifically defined as a
+          #   computer-generated date representing the creation of the MARC
+          #   record. Therefore, “19” should never be the prefix if the decade
+          #   is represented by a number less than 7
+          century = tag8_content[0].to_i < 7 ? '20' : '19'
+          amh['event_date'] = century + tag8_content[0..5]
           amh['maintenance_event_type'] = 'created'
           amh['maintenance_agent_type'] = 'machine'
         },

--- a/backend/spec/lib_marcxml_auth_agent_converter_spec.rb
+++ b/backend/spec/lib_marcxml_auth_agent_converter_spec.rb
@@ -281,6 +281,16 @@ describe 'MARCXML Auth Agent converter' do
       expect(record['agent_maintenance_histories'][0]['agent']).to eq('DLC')
     end
 
+    it 'does not create pre-1970 agent_maintenance_history event_dates' do
+      record = convert(authority_agent_other_standard_identifier_a, true)
+        .select { |r| r['jsonmodel_type'] == 'agent_person' }.first
+
+      expect(record['agent_maintenance_histories'][0]['event_date']).to eq('20090721')
+      expect(record['agent_maintenance_histories'][0]['maintenance_event_type']).to eq('created')
+      expect(record['agent_maintenance_histories'][0]['maintenance_agent_type']).to eq('machine')
+      expect(record['agent_maintenance_histories'][0]['agent']).to eq('Missing in File')
+    end
+
     it 'does not import agent_maintenance_histories if option not set' do
       record = convert(person_agent_1, false).select { |r| r['jsonmodel_type'] == 'agent_person' }.first
 


### PR DESCRIPTION
## Description
The problem is described in ANW-2113. The fix proposed in that issue is implemented. 

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-2113

## How Has This Been Tested?
I added a test to the spec file modified in this PR to verify that "09" will get treated as 2009 and not 1909. I verified that an existing test covered that "89" gets treated as 1989.

I verified that my new test failed before implementing the change. 

I worked in a development environment set up using [these instructions](https://docs.archivesspace.org/development/dev/#_top) and I ran the entire backend specs. There were no failures.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project. (No rubocop offenses detected!)
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
