### PR TITLE
Ensure Gem Group Exclusion Works By Setting BUNDLE_APP_CONFIG

### DIFF
--- a/build/.bundle/.keep
+++ b/build/.bundle/.keep
@@ -1,0 +1,1 @@
+this is where the bundler ant task writes its config

--- a/build/.bundle/.keep
+++ b/build/.bundle/.keep
@@ -1,1 +1,0 @@
-this is where the bundler ant task writes its config

--- a/build/build.xml
+++ b/build/build.xml
@@ -445,7 +445,7 @@
 
   <!-- BUNDLER -->
   <target name="bundler" depends="set-classpath" description="Run bundler against a gemfile">
-    <property name="build.home" location="."/>
+    <property name="bundle-config.home" location="./.bundle"/>
     <property name="excluded-gem-groups" value="" />
     <property name="included-gem-groups" value="" />
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true">
@@ -453,7 +453,7 @@
       <env key="GEM_HOME" value="${gem_home}" />
       <env key="GEM_PATH" value="" />
       <env key="BUNDLE_PATH" value="${gem_home}" />
-      <env key="HOME" value="${build.home}" />
+      <env key="BUNDLE_APP_CONFIG" value="${bundle-config.home}" />
       <arg line="gems/bin/bundle config unset without" />
     </java>
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true">
@@ -461,7 +461,7 @@
       <env key="GEM_HOME" value="${gem_home}" />
       <env key="GEM_PATH" value="" />
       <env key="BUNDLE_PATH" value="${gem_home}" />
-      <env key="HOME" value="${build.home}" />
+      <env key="BUNDLE_APP_CONFIG" value="${bundle-config.home}" />
       <arg line="gems/bin/bundle config unset with" />
     </java>
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true">
@@ -469,7 +469,7 @@
       <env key="GEM_HOME" value="${gem_home}" />
       <env key="GEM_PATH" value="" />
       <env key="BUNDLE_PATH" value="${gem_home}" />
-      <env key="HOME" value="${build.home}" />
+      <env key="BUNDLE_APP_CONFIG" value="${bundle-config.home}" />
       <arg line="gems/bin/bundle config without ${excluded-gem-groups}" />
     </java>
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true">
@@ -477,8 +477,14 @@
       <env key="GEM_HOME" value="${gem_home}" />
       <env key="GEM_PATH" value="" />
       <env key="BUNDLE_PATH" value="${gem_home}" />
-      <env key="HOME" value="${build.home}" />
+      <env key="BUNDLE_APP_CONFIG" value="${bundle-config.home}" />
       <arg line="gems/bin/bundle config with ${included-gem-groups}" />
+    </java>
+    <echo message="Bundler running with config:" />
+    <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true">
+      <jvmarg line="${default_java_options} ${env.JAVA_OPTS}"/>
+      <env key="BUNDLE_APP_CONFIG" value="${bundle-config.home}" />
+      <arg line="gems/bin/bundle config list" />
     </java>
     <echo message="Fetching gems for ${gemfile}" />
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true">
@@ -486,7 +492,7 @@
       <env key="GEM_HOME" value="${gem_home}" />
       <env key="GEM_PATH" value="" />
       <env key="BUNDLE_PATH" value="${gem_home}" />
-      <env key="HOME" value="${build.home}" />
+      <env key="BUNDLE_APP_CONFIG" value="${bundle-config.home}" />
       <arg line="gems/bin/bundle install --jobs=8 --gemfile='${gemfile}'" />
     </java>
   </target>

--- a/build/build.xml
+++ b/build/build.xml
@@ -199,7 +199,6 @@
       <param name="excluded-gem-groups" value="test development doc build" />
       <param name="included-gem-groups" value="" />
     </antcall>
-    <copy file="../.bundle/config" todir="../backend/.bundle" />
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true" dir="../backend">
       <jvmarg line="${default_java_options} ${env.JAVA_OPTS}"/>
       <env key="GEM_HOME" value="${gem_home}" />
@@ -207,7 +206,6 @@
       <env key="BUNDLE_PATH" value="${gem_home}" />
       <arg line="../build/${jruby_build_bin_path}/warble war" />
     </java>
-    <delete file="../backend/.bundle/config" />
   </target>
 
   <!-- BOOTSTRAP -->
@@ -237,6 +235,7 @@
     </antcall>
     <antcall target="bundler">
       <param name="gemfile" value="../_yard/Gemfile" />
+      <param name="excluded-gem-groups" value="${excluded-gem-groups}" />
     </antcall>
     <antcall target="bundler">
       <param name="gemfile" value="../public/Gemfile" />
@@ -244,9 +243,11 @@
     </antcall>
     <antcall target="bundler">
       <param name="gemfile" value="../indexer/Gemfile" />
+      <param name="excluded-gem-groups" value="${excluded-gem-groups}" />
     </antcall>
     <antcall target="bundler">
       <param name="gemfile" value="../oai/Gemfile" />
+      <param name="excluded-gem-groups" value="${excluded-gem-groups}" />
     </antcall>
   </target>
 
@@ -445,7 +446,12 @@
 
   <!-- BUNDLER -->
   <target name="bundler" depends="set-classpath" description="Run bundler against a gemfile">
-    <property name="bundle-config.home" location="./.bundle"/>
+    <!-- Make sure .bundle tracks the $gemfile location -->
+    <!-- This will break if Gemfiles are not named "Gemfile" -->
+    <exec executable="sed" inputstring="${gemfile}" outputproperty="bundle-config-path">
+      <arg value="s/Gemfile/\.bundle/g"/>
+    </exec>
+    <property name="bundle-config" value="${basedir}/${bundle-config-path}" />
     <property name="excluded-gem-groups" value="" />
     <property name="included-gem-groups" value="" />
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true">
@@ -453,7 +459,7 @@
       <env key="GEM_HOME" value="${gem_home}" />
       <env key="GEM_PATH" value="" />
       <env key="BUNDLE_PATH" value="${gem_home}" />
-      <env key="BUNDLE_APP_CONFIG" value="${bundle-config.home}" />
+      <env key="BUNDLE_APP_CONFIG" value="${bundle-config}" />
       <arg line="gems/bin/bundle config unset without" />
     </java>
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true">
@@ -461,7 +467,7 @@
       <env key="GEM_HOME" value="${gem_home}" />
       <env key="GEM_PATH" value="" />
       <env key="BUNDLE_PATH" value="${gem_home}" />
-      <env key="BUNDLE_APP_CONFIG" value="${bundle-config.home}" />
+      <env key="BUNDLE_APP_CONFIG" value="${bundle-config}" />
       <arg line="gems/bin/bundle config unset with" />
     </java>
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true">
@@ -469,7 +475,7 @@
       <env key="GEM_HOME" value="${gem_home}" />
       <env key="GEM_PATH" value="" />
       <env key="BUNDLE_PATH" value="${gem_home}" />
-      <env key="BUNDLE_APP_CONFIG" value="${bundle-config.home}" />
+      <env key="BUNDLE_APP_CONFIG" value="${bundle-config}" />
       <arg line="gems/bin/bundle config without ${excluded-gem-groups}" />
     </java>
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true">
@@ -477,13 +483,13 @@
       <env key="GEM_HOME" value="${gem_home}" />
       <env key="GEM_PATH" value="" />
       <env key="BUNDLE_PATH" value="${gem_home}" />
-      <env key="BUNDLE_APP_CONFIG" value="${bundle-config.home}" />
+      <env key="BUNDLE_APP_CONFIG" value="${bundle-config}" />
       <arg line="gems/bin/bundle config with ${included-gem-groups}" />
     </java>
     <echo message="Bundler running with config:" />
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true">
       <jvmarg line="${default_java_options} ${env.JAVA_OPTS}"/>
-      <env key="BUNDLE_APP_CONFIG" value="${bundle-config.home}" />
+      <env key="BUNDLE_APP_CONFIG" value="${bundle-config}" />
       <arg line="gems/bin/bundle config list" />
     </java>
     <echo message="Fetching gems for ${gemfile}" />
@@ -492,7 +498,6 @@
       <env key="GEM_HOME" value="${gem_home}" />
       <env key="GEM_PATH" value="" />
       <env key="BUNDLE_PATH" value="${gem_home}" />
-      <env key="BUNDLE_APP_CONFIG" value="${bundle-config.home}" />
       <arg line="gems/bin/bundle install --jobs=8 --gemfile='${gemfile}'" />
     </java>
   </target>
@@ -758,7 +763,6 @@
       <param name="excluded-gem-groups" value="test development doc build" />
       <param name="included-gem-groups" value="" />
     </antcall>
-    <copy file="../.bundle/config" todir="../oai/.bundle" />
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true" dir="../oai">
       <jvmarg line="${default_java_options} ${env.JAVA_OPTS}"/>
       <env key="GEM_HOME" value="${gem_home}" />
@@ -766,7 +770,6 @@
       <env key="BUNDLE_PATH" value="${gem_home}" />
       <arg line="../build/${jruby_build_bin_path}/warble war" />
     </java>
-    <delete file="../oai/.bundle/config" />
   </target>
 
   <!-- FRONTEND -->
@@ -981,7 +984,6 @@
       <param name="excluded-gem-groups" value="test development doc build assets" />
       <param name="included-gem-groups" value="" />
     </antcall>
-    <copy file="../.bundle/config" todir="../public/.bundle" />
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true" dir="../public">
       <jvmarg line="${default_java_options} ${env.JAVA_OPTS}"/>
       <env key="RAILS_ENV" value="production" />
@@ -990,7 +992,6 @@
       <env key="BUNDLE_PATH" value="${gem_home}" />
       <arg line="../build/${jruby_build_bin_path}/warble war" />
     </java>
-    <delete file="../public/.bundle/config" />
   </target>
 
   <!-- SETUP / SUPPORT TASKS -->


### PR DESCRIPTION
## Description
I noticed that the `v4.0.0-RC1` zip contains all the test and development gems (pry, rspec, ladle etc.). I think what happened is that after bundler was upgraded and the `--without` flag replaced with the newer `bundle config` statements, the gem group exclusions broke because in a case like this:

`bundle config set ...` 
Bundler assumes the working directory is the place to write the `config` file.

But then a command like: `bundle install --gemfile=../backend/Gemfile` causes Bundler to look for the config in `backend/.bundle`. Apparently Bundler does not look in parent directories when the config isn't there, so it ends up with nothing. 

This commit just sets the location of the config file to always be `build/.bundle`


## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
I just did some manual testing to confirm that `-Dexcluded-gem-groups` is now effective.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
