### PR TITLE
Update aspace cookies

### DIFF
--- a/frontend/app/assets/javascripts/utils.js
+++ b/frontend/app/assets/javascripts/utils.js
@@ -777,6 +777,7 @@ AS.delayedTypeAhead = function (source, delay) {
 AS.prefixed_cookie = function (cookie_name, value) {
   var args = Array.prototype.slice.call(arguments, 0);
   args[0] = COOKIE_PREFIX + '_' + args[0];
+  args.push({ path: '/;SameSite=Lax', secure: location.protocol === 'https:' });
   return $.cookie.apply(this, args);
 };
 

--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -311,7 +311,12 @@ class ApplicationController < ActionController::Base
   end
 
   def set_user_repository_cookie(repository_uri)
-    cookies[user_repository_cookie_key] = repository_uri
+    cookies[user_repository_cookie_key] = {
+      value: repository_uri,
+      secure: Rails.env.production?,
+      httponly: true,
+      same_site: :lax
+    }
   end
 
   # sometimes we get exceptions that look like this: "translation missing: validation_errors.protected_read-only_list_#/dates_of_existence/0/date_type_structured._invalid_value__add_or_update_either_a_single_or_ranged_date_subrecord_to_set_.__must_be_one_of__single__range

--- a/frontend/app/models/user.rb
+++ b/frontend/app/models/user.rb
@@ -27,7 +27,12 @@ class User < JSONModel(:user)
 
 
   def self.store_permissions(permissions, context)
-    context.send(:cookies).signed[:archivesspace_permissions] = 'ZLIB:' + Zlib::Deflate.deflate(ASUtils.to_json(Permissions.pack(permissions)))
+    context.send(:cookies).signed[:archivesspace_permissions] = {
+      value: 'ZLIB:' + Zlib::Deflate.deflate(ASUtils.to_json(Permissions.pack(permissions))),
+      secure: Rails.env.production?,
+      httponly: true,
+      same_site: :lax
+    }
     context.session[:last_permission_refresh] = Time.now.to_i
   end
 

--- a/frontend/config/initializers/session_store.rb
+++ b/frontend/config/initializers/session_store.rb
@@ -1,7 +1,11 @@
 # Be sure to restart your server when you modify this file.
 
 # Use httponly because some of our AJAX handlers need access to the session too.
-ArchivesSpace::Application.config.session_store :cookie_store, key: "#{AppConfig[:cookie_prefix]}_session"
+ArchivesSpace::Application.config.session_store :cookie_store,
+  key: "#{AppConfig[:cookie_prefix]}_session",
+  secure: Rails.env.production?,
+  httponly: true,
+  same_site: :lax
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/public/config/initializers/session_store.rb
+++ b/public/config/initializers/session_store.rb
@@ -1,3 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_archivesspace-public_session'
+Rails.application.config.session_store :cookie_store,
+  key: "_archivesspace-public_session",
+  secure: Rails.env.production?,
+  httponly: true,
+  same_site: :lax


### PR DESCRIPTION
Set secure when in production (requires https).
Set SameSite lax (Rails default from v6 and the browser default when not set).
Set httponly when not js consistently.
For js set cookies just follow the url protocol.

## Screenshots (if appropriate):

Before:

![cookies-b4](https://github.com/user-attachments/assets/afbecf1c-96eb-4a6a-aa57-a232ff7fe81c)

After:

![cookies](https://github.com/user-attachments/assets/3de00cca-7176-4ba3-be2b-ca5df5c2f320)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
