### PR TITLE
Cleanup build dist bundle config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 _site
 bin
+build/.local/
 build/*.jar
 build/solr_backups/*
 *.war

--- a/build/build.xml
+++ b/build/build.xml
@@ -206,6 +206,7 @@
       <env key="BUNDLE_PATH" value="${gem_home}" />
       <arg line="../build/${jruby_build_bin_path}/warble war" />
     </java>
+    <delete file="../backend/.bundle/config" />
   </target>
 
   <!-- BOOTSTRAP -->
@@ -304,6 +305,7 @@
       <antcall target="public:war" />
     </parallel>
     <antcall target="build-zip" />
+    <delete dir=".local" failonerror="false" />
   </target>
 
   <target name="build-zip" depends="set-classpath" description="Bundle everything up into a zip file">
@@ -754,6 +756,7 @@
       <env key="BUNDLE_PATH" value="${gem_home}" />
       <arg line="../build/${jruby_build_bin_path}/warble war" />
     </java>
+    <delete file="../indexer/.bundle/config" />
   </target>
 
   <!-- OAI -->
@@ -770,6 +773,7 @@
       <env key="BUNDLE_PATH" value="${gem_home}" />
       <arg line="../build/${jruby_build_bin_path}/warble war" />
     </java>
+    <delete file="../oai/.bundle/config" />
   </target>
 
   <!-- FRONTEND -->
@@ -879,7 +883,6 @@
       <param name="excluded-gem-groups" value="test development doc build assets" />
       <param name="included-gem-groups" value="" />
     </antcall>
-    <copy file="../.bundle/config" todir="../frontend/.bundle" />
     <java classpath="${jruby_classpath}" classname="org.jruby.Main" fork="true" failonerror="true" dir="../frontend">
       <jvmarg line="${default_java_options} ${env.JAVA_OPTS}"/>
       <env key="GEM_HOME" value="${gem_home}" />
@@ -992,6 +995,7 @@
       <env key="BUNDLE_PATH" value="${gem_home}" />
       <arg line="../build/${jruby_build_bin_path}/warble war" />
     </java>
+    <delete file="../public/.bundle/config" />
   </target>
 
   <!-- SETUP / SUPPORT TASKS -->


### PR DESCRIPTION
Noticed clean builds are failing since PR: https://github.com/archivesspace/archivesspace/pull/3422 (Docker latest is out of date). Also replicated with fresh clone of ASpace and `./scripts/build_release -t`.

I made the `:war` tasks uniformly consistent with `frontend:war` (because deleting the `dist` bundle cfg seems reasonable) and removed the failing copy ref in `frontend`, which appears ok (the bundler setup is pretty complex). Local fresh builds are working (tested both standard and Docker builds & also ran the dev servers).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.