### PR TITLE
ANW-2238: Fix Softserv bugs in Staff reorder mode and RDE

### DIFF
--- a/frontend/app/assets/javascripts/tree_toolbar.js.erb
+++ b/frontend/app/assets/javascripts/tree_toolbar.js.erb
@@ -24,7 +24,7 @@ var SHARED_TOOLBAR_ACTIONS = [
         },
         onClick: function(event, btn, node, tree, toolbarRenderer) {
             $(tree.large_tree.elt).toggleClass('drag-enabled');
-            $(event.target).toggleClass('btn-success');
+            $(event.target).toggleClass(['btn-success', 'active']);
 
             if ($(tree.large_tree.elt).is('.drag-enabled')) {
                 $(btn).text('<%= I18n.t('actions.reorder_active') %>');

--- a/frontend/app/assets/stylesheets/archivesspace/tree.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/tree.scss
@@ -153,3 +153,29 @@
     }
   }
 }
+
+.spinner:not(:required) {
+  animation: spinner 1500ms infinite linear;
+  border-radius: 0.5em;
+  box-shadow: rgba(0, 0, 51, 0.3) 1.5em 0 0 0,
+    rgba(0, 0, 51, 0.3) 1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) 0 1.5em 0 0,
+    rgba(0, 0, 51, 0.3) -1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) -1.5em 0 0 0,
+    rgba(0, 0, 51, 0.3) -1.1em -1.1em 0 0, rgba(0, 0, 51, 0.3) 0 -1.5em 0 0,
+    rgba(0, 0, 51, 0.3) 1.1em -1.1em 0 0;
+  display: inline-block;
+  font-size: 10px;
+  width: 1em;
+  height: 1em;
+  margin: 1.5em;
+  overflow: hidden;
+  text-indent: 100%;
+}
+
+@keyframes spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/app/views/shared/_rde.html.erb
+++ b/frontend/app/views/shared/_rde.html.erb
@@ -65,8 +65,8 @@
 
         <div class="fill-column-form rde-inline-form" style="display: none;">
           <ul class="nav nav-tabs">
-            <li class="active nav-item"><a class="nav-link" href="#fill_basic" data-toggle="tab"><%= t("rde.fill_column.basic") %></a></li>
-            <li CLASS="nav-item"><a class="nav-link" href="#fill_sequence" data-toggle="tab"><%= t("rde.fill_column.sequence") %></a></li>
+            <li class="nav-item"><a class="nav-link active" href="#fill_basic" data-toggle="tab"><%= t("rde.fill_column.basic") %></a></li>
+            <li class="nav-item"><a class="nav-link" href="#fill_sequence" data-toggle="tab"><%= t("rde.fill_column.sequence") %></a></li>
           </ul>
           <div class="tab-content">
             <div class="tab-pane active" id="fill_basic">
@@ -83,9 +83,9 @@
                     <div class="alert alert-info"><%= t("rde.fill_column.select_a_column") %></div>
                   </div>
                 </div>
-                <div class="form-actions">
+                <div class="form-actions pl-0">
                   <button class="btn btn-primary btn-sm disabled" disabled="disabled"><%= t("rde.fill_column.apply_basic_fill") %></button>
-                  <button class="btn btn-sm btn-cancel"><%= t("actions.cancel") %></button>
+                  <button class="btn btn-sm btn-default"><%= t("actions.cancel") %></button>
                 </div>
               </fieldset>
             </div>
@@ -114,9 +114,9 @@
                 <div class="form-group">
                   <div class="controls sequence-preview"></div>
                 </div>
-                <div class="form-actions">
+                <div class="form-actions pl-0">
                   <button class="btn btn-primary btn-sm disabled" disabled="disabled"><%= t("rde.fill_column.apply_sequence_fill") %></button>
-                  <button class="btn btn-sm btn-cancel"><%= t("actions.cancel") %></button>
+                  <button class="btn btn-sm btn-default btn-cancel"><%= t("actions.cancel") %></button>
                 </div>
               </fieldset>
             </div>
@@ -134,7 +134,7 @@
           <div class="form-group">
             <div class="col-sm-2"></div>
             <button class="btn btn-primary btn-sm disabled" disabled="disabled"><%= t("rde.save_template.save_template") %></button>
-            <button class="btn btn-sm btn-cancel"><%= t("actions.cancel") %></button>
+            <button class="btn btn-sm btn-default btn-cancel"><%= t("actions.cancel") %></button>
           </div>
         </div>
 
@@ -156,9 +156,9 @@
           <select id="columnOrder" multiple="multiple"></select>
           <a href="JavaScript:void(0);" id="columnOrderUp" class="btn btn-sm btn-default"><span class="glyphicon glyphicon-arrow-up"></span></a>
           <a href="JavaScript:void(0);" id="columnOrderDown" class="btn btn-sm btn-default"><span class="glyphicon glyphicon-arrow-down"></span></a>
-          <div class="form-actions">
+          <div class="form-actions pl-0">
             <button class="btn btn-primary btn-sm disabled" disabled="disabled"><%= t("rde.reorder_columns.apply_order") %></button>
-            <button class="btn btn-sm btn-cancel"><%= t("actions.cancel") %></button>
+            <button class="btn btn-sm btn-default btn-cancel"><%= t("actions.cancel") %></button>
           </div>
         </div>
 


### PR DESCRIPTION
This PR fixes Softserv related bugs in the Staff reorder mode and RDE features:

- Fix reorder mode loading spinner
- Fix 'disable reorder mode' btn bg color
- Fix RDE 'fill column' nav tabs and various cancel btns

[ANW-2238](https://archivesspace.atlassian.net/browse/ANW-2238)

## Solution screenshots

<img width="1497" alt="ANW-2238-reorder" src="https://github.com/user-attachments/assets/cbdedb18-72ae-4dd3-84ad-6a7092074327" />

<img width="1497" alt="ANW-2238-RDE" src="https://github.com/user-attachments/assets/a14f143c-3021-4859-9c5d-b5a212278a15" />

[ANW-2238]: https://archivesspace.atlassian.net/browse/ANW-2238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ