### PR TITLE
ANW-2215 Fix Softserv help tooltip multi close button bug

### DIFF
--- a/frontend/app/assets/javascripts/utils.js
+++ b/frontend/app/assets/javascripts/utils.js
@@ -349,10 +349,10 @@ $(function () {
           $this.off('mouseleave');
 
           $this.tooltip('show');
-          $('.tooltip-inner', $this.data('bs.tooltip').$tip).prepend(
+          $('.tooltip-inner', $this.data('bs.tooltip').tip).prepend(
             '<span class="tooltip-close glyphicon glyphicon-remove-circle icon-white"></span>'
           );
-          $('.tooltip-close', $this.data('bs.tooltip').$tip).click(function () {
+          $('.tooltip-close', $this.data('bs.tooltip').tip).click(function () {
             $this.trigger('click');
           });
           openedViaClick = true;

--- a/frontend/spec/features/help_tooltips_spec.rb
+++ b/frontend/spec/features/help_tooltips_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Help Tooltips', js: true do
+  context 'attached to subrecord form headings' do
+    before(:each) do
+      login_admin
+      visit '/resources/new'
+      @body = page.find('body')
+      @example_heading = page.find('h3.subrecord-form-heading > span', text: 'Languages')
+      expect(@body).to_not have_selector('.tooltip:last-child')
+    end
+
+    it 'are shown and removed when the heading has mouseenter and mouseleave events respectively' do
+      @example_heading.hover
+      tooltip = page.find('body > .tooltip:last-child')
+      expect(@example_heading['aria-describedby']).to eq(tooltip[:id])
+      @body.hover
+      expect(page).to_not have_selector('body > .tooltip:last-child')
+      expect(@example_heading['aria-describedby']).to be_nil
+    end
+
+    it 'are shown and removed when the heading is clicked regardless of a mouseleave event' do
+      @example_heading.click
+      tooltip = page.find('body > .tooltip:last-child')
+      expect(@example_heading['aria-describedby']).to eq(tooltip[:id])
+      @body.hover
+      expect(page).to have_selector('body > .tooltip:last-child')
+      expect(@example_heading['aria-describedby']).to eq(tooltip[:id])
+      @example_heading.click
+      expect(page).to_not have_selector('body > .tooltip:last-child')
+      expect(@example_heading['aria-describedby']).to be_nil
+    end
+
+    it 'that are shown from clicking the heading are also removed by clicking the tooltip close button' do
+      @example_heading.click
+      tooltip = page.find('body > .tooltip:last-child')
+      expect(@example_heading['aria-describedby']).to eq(tooltip[:id])
+      close_button = tooltip.find('.tooltip-close')
+      close_button.click
+      expect(page).to_not have_selector('body > .tooltip:last-child')
+      expect(@example_heading['aria-describedby']).to be_nil
+    end
+
+    it 'that are shown from clicking the heading only have one close button regardless '\
+    'of how many other tooltips are open from heading clicks' do
+      @example_heading.click
+      tooltip = page.find('body > .tooltip:last-child')
+      expect(@example_heading['aria-describedby']).to eq(tooltip[:id])
+      page.find('h3.subrecord-form-heading > span', text: 'Dates').click
+      expect(page).to have_selector('body > .tooltip', count: 2)
+      expect(tooltip).to have_selector('.tooltip-close', count: 1)
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes a Softserv-related bug where "help tooltips" attached to subrecord form headings in the Staff app, which remain visible if the heading is clicked (as opposed to disappearing from the user moving their mouse off of the heading), would have their number of close buttons incremented each time another heading's tooltip was shown by click.

The bug does not appear to have occurred as a result of the Softserv manual code changes, but rather merely by virtue of updating the underlying versions of jQuery and/or Bootstrap. It appears that earlier versions of jQuery and/or Bootstrap were more lenient than the versions introduced by the Softserv upgrades in allowing the tooltip object's `tip` key to be accessed via `$tip` 🤦🏼 

## Problem

![ANW-2215-problem](https://github.com/user-attachments/assets/894925a8-3cad-4aa9-98ff-271b0e184a89)

## Solution

![ANW-2215-tooltip-multi-close-btn-bug](https://github.com/user-attachments/assets/70b1d908-ffcd-49e0-ad8e-e2309cfa6070)
