### PR TITLE
ANW-2241: Fix Sofstserv combobox dropdown button's 'clear selection' state

### DIFF
--- a/frontend/app/assets/stylesheets/bootstrap-overrides.scss
+++ b/frontend/app/assets/stylesheets/bootstrap-overrides.scss
@@ -107,6 +107,8 @@ body {
 
 .combobox-container.combobox-selected .dropdown-toggle::after {
   border: none;
+  content: '\00D7';
+  font-weight: bold;
 }
 
 .typeahead-long {


### PR DESCRIPTION
This PR fixes a minor Softserv-related bug when a combobox item was selected and the dropdown button did not show the `⨉`, to represent "clear selection".

[ANW-2241](https://archivesspace.atlassian.net/browse/ANW-2241)

## Problem

![ANW-2241-problem](https://github.com/user-attachments/assets/491e4b0c-1b79-4f1d-a09f-82ccb663bb07)

## Solution

![ANW-2241-solution](https://github.com/user-attachments/assets/4d2baffc-e923-4e68-9fc9-c19311320076)


[ANW-2241]: https://archivesspace.atlassian.net/browse/ANW-2241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ