### PR TITLE
Fixing controlled value lists translation column

### DIFF
--- a/frontend/app/views/enumerations/_list.html.erb
+++ b/frontend/app/views/enumerations/_list.html.erb
@@ -25,7 +25,7 @@
       <% @enumeration["enumeration_values"].each_with_index do |enum_value, i| %>
         <tr>
           <td><%= enum_value["value"] %></td>
-          <td><%= t({:enumeration => @enumeration['name'], :value => enum_value['value']}, :default => enum_value['value']) %></td>
+          <td><%= I18n.t("enumerations.#{@enumeration["name"]}.#{enum_value["value"]}", :default => enum_value['value']) %></td>
           <td>
             <%= enum_value["position"] %>
             <% unless i == 0 %>

--- a/frontend/spec/controllers/enumerations_controller_spec.rb
+++ b/frontend/spec/controllers/enumerations_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe EnumerationsController, type: :controller do
+  render_views
+
+  let(:enum_id) { JSONModel(:enumeration).all.select {|enum| enum.name == "language_iso639_2" }.first.id }
+
+  it "translates the label for an enumeration value" do
+    apply_session_to_controller(controller, 'admin', 'admin')
+    get :index, params: { id: enum_id }
+    result = Capybara.string(response.body)
+    first_row = result.first(".enumeration-list").first("tbody").first("tr")
+    key_cell = first_row.find("td[1]")
+    value_cell = first_row.find("td[2]")
+    expect(key_cell.text).to eq "aar"
+    expect(value_cell.text).to eq "Afar"
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This reverts commit 204c48109a994c6a99ef743b2c6d0abf5197b712.
The commit was submitted in [PR 301](https://github.com/archivesspace/archivesspace/pull/301)
There was no explanation other than supporting I18n keys
with '.' in the string. I could find no examples with a '.'
in the key in any of the enumerations in the ArchivesSpace
repository, and this alternate way of calling `translate`
appears not to work in current versions of I18n. So while
previous versions of ArchivesSpace do show translated values
correctly in the controlled value list table, v4.0.0-RC1 does
not. 

<!--- Why is this change required? What problem does it solve? -->
Translated labels are not appearing on Controlled Value List table in 
v4.0.0.-RC1

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See first commit in this PR, which includes a new Rails controller test for the `EnumerationsController`

## Screenshots (if appropriate):
<img width="1460" alt="image" src="https://github.com/user-attachments/assets/127637b4-7d00-451e-9c23-c4b5557c80b9" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
