### PR TITLE
ANW-2257 when built with docker, skip the git commit hash when buildi…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 FROM ubuntu:22.04 as build_release
 
-# Please note: Docker is not supported as an install method.
-# Docker configuration is being used for internal purposes only.
-# Use of Docker by anyone else is "use at your own risk".
-# Docker related files may be updated at anytime without
-# warning or presence in release notes.
+# Please note: Docker is supported as an install method starting with ArchivesSpace v4.0.0, see: https://docs.archivesspace.org/administration/docker/
 
 ENV DEBIAN_FRONTEND=noninteractive \
   JDK_JAVA_OPTIONS="--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED" \
@@ -23,10 +19,10 @@ RUN apt-get update && \
 COPY . /source
 
 RUN cd /source && \
-  if [ `git symbolic-ref -q --short HEAD 2>/dev/null` ]; then \
-    ARCHIVESSPACE_VERSION="$(git symbolic-ref -q --short HEAD)-$(git rev-parse --short HEAD)"; \
+  if [ `git describe --tags --exact-match --match v* 2>/dev/null` ]; then \
+    ARCHIVESSPACE_VERSION="$(git describe --tags --match v*)" ; \
   else \
-    ARCHIVESSPACE_VERSION="$(git describe --tags --match v* 2>/dev/null)" ; \
+    ARCHIVESSPACE_VERSION="$(git symbolic-ref -q --short HEAD)-$(git rev-parse --short HEAD)"; \
   fi &&\
   ARCHIVESSPACE_VERSION=${ARCHIVESSPACE_VERSION#"heads/"} && \
   echo "Using version: $ARCHIVESSPACE_VERSION" && \


### PR DESCRIPTION
…ng tagged versions

<!--- Provide a general summary of your changes in the Title above -->

## Description
Every “official release” has a tag in the git repository (such as v4.0.0-RC1 or v4.0.0). With these changes, the footer will only show the tag and no git commit hash, if the docker image was built from a tagged version.

This means that the all of our test servers would only show the “vX.X.X” footer when hosting a tagged release and the “branch name - git commit hash” footer when hosting any non-tagged version.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
[ANW-2257]
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[ANW-2257]: https://archivesspace.atlassian.net/browse/ANW-2257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ