### PR TITLE
ANW-2259: Refactor InfiniteTree HTML and CSS layers

### DIFF
--- a/public/app/assets/javascripts/InfiniteRecords.js
+++ b/public/app/assets/javascripts/InfiniteRecords.js
@@ -537,10 +537,10 @@
         if (entry.isIntersecting) {
           const uri = entry.target.dataset.uri;
           const _new = document.querySelector(
-            `#infinite-tree-container .table-row[data-uri="${uri}"]`
+            `#infinite-tree-container .node[data-uri="${uri}"]`
           );
           const old = document.querySelector(
-            '#infinite-tree-container .table-row.current'
+            '#infinite-tree-container .node.current'
           );
 
           if (old) {

--- a/public/app/assets/javascripts/InfiniteTree.js
+++ b/public/app/assets/javascripts/InfiniteTree.js
@@ -1,8 +1,11 @@
+//= require InfiniteTreeFetch
+//= require InfiniteTreeMarkup
+
 (function (exports) {
   class InfiniteTree {
     /**
      * @constructor
-     * @param {number} waypointSize - The number of nodes per waypoint
+     * @param {number} batchSize - The number of nodes per batch of children
      * @param {string} appUrlPrefix - The proper app prefix
      * @param {string} resourceUri - The URI of the collection resource
      * @param {string} identifier_separator - The i18n identifier separator
@@ -10,568 +13,264 @@
      * @returns {InfiniteTree} - InfiniteTree instance
      */
     constructor(
-      waypointSize,
+      batchSize,
       appUrlPrefix,
       resourceUri,
       identifier_separator,
       date_type_bulk
     ) {
-      this.WAYPOINT_SIZE = waypointSize;
-      this.appUrlPrefix = appUrlPrefix;
+      this.BATCH_SIZE = batchSize;
       this.resourceUri = resourceUri;
-      this.repoId = this.resourceUri.split('/')[2];
-      this.resourceId = this.resourceUri.split('/')[4];
-      this.baseUri = `${this.resourceUri}/tree`;
-      this.rootUri = `${this.baseUri}/root`;
-      this.nodeUri = `${this.baseUri}/node`;
-      this.waypointUri = `${this.baseUri}/waypoint`;
+      this.repoId = resourceUri.split('/')[2];
+      this.resourceId = resourceUri.split('/')[4];
       this.i18n = { sep: identifier_separator, bulk: date_type_bulk };
 
       this.container = document.querySelector('#infinite-tree-container');
 
-      this.waypointObserver = new IntersectionObserver(
-        // Wrap handler in arrow fn to preserve `this` context
+      this.fetch = new InfiniteTreeFetch(appUrlPrefix, resourceUri);
+
+      this.markup = new InfiniteTreeMarkup(resourceUri, batchSize, this.i18n);
+
+      this.batchObserver = new IntersectionObserver(
         (entries, observer) => {
-          this.waypointScrollHandler(entries, observer);
+          this.batchObserverHandler(entries, observer);
         },
         {
           root: this.container,
-          rootMargin: '-30% 0px -30% 0px',
+          rootMargin: '-30% 0px -30% 0px', // middle 40% of container
+          threshold: 0,
         }
       );
 
-      this.initTree();
+      this.renderRoot();
     }
 
     /**
-     * Initialize the large tree navigation sidebar with the collection's
-     * root node and the first waypoint of its immediate children
+     * Renders the root node and its first batch of children
      */
-    async initTree() {
-      const rootNode = await this.fetchRootNode();
-      const rootNodeDivId = `resource_${this.resourceId}`;
-      const firstWPData = rootNode.precomputed_waypoints[''][0];
+    async renderRoot() {
+      const rootData = await this.fetch.root();
+      const rootFragment = this.markup.root(this.markup.title(rootData));
+      const rootNode = rootFragment.querySelector('.root.node');
 
-      const tableRootFrag = new DocumentFragment();
+      await this.renderInitialBatch(rootNode, rootData);
 
-      const tableRoot = document.createElement('div');
-      tableRoot.setAttribute('role', 'list');
-      tableRoot.className = 'table root';
+      this.container.appendChild(rootFragment);
+    }
 
-      tableRoot.appendChild(this.rootRowMarkup(this.nodeTitle(rootNode)));
-      tableRoot.appendChild(
-        this.rootNodeWaypointsScaffold(rootNodeDivId, 1, rootNode.waypoints)
+    /**
+     * Renders the first batch of a node's children
+     * @param {HTMLElement} parent - The node element to initialize children for
+     * @param {Object} data - The node data object from the server
+     */
+    async renderInitialBatch(parent, data) {
+      const batchData = this.prepareBatch(parent, data);
+      const list = this.renderList(parent, batchData.level, data.waypoints);
+
+      this.renderBatch(list, batchData.nodes, batchData.hasNextBatch, 0);
+    }
+
+    /**
+     * Renders and returns the list element for child nodes
+     * @param {HTMLElement} parent - Parent node element
+     * @param {number} parentLevel - Tree level of the parent
+     * @param {number} numBatches - Number of batch placeholders to create
+     * @returns {HTMLElement} The rendered list element
+     */
+    renderList(parent, parentLevel, numBatches) {
+      const listFragment = this.markup.list(
+        parent.id,
+        parentLevel + 1,
+        numBatches
       );
 
-      this.populateWaypoint(
-        tableRoot.querySelector('.table-row-group'),
-        firstWPData,
-        1,
-        rootNode.waypoints > 1
-      );
+      parent.appendChild(listFragment);
 
-      tableRootFrag.appendChild(tableRoot);
-
-      this.container.appendChild(tableRootFrag);
-
-      if (rootNode.waypoints > 1) {
-        // Now that the above work has been added to the live DOM, start observing
-        // the middle node in order to populate the next empty waypoint
-        const obsSelector = `[data-parent-id="${rootNodeDivId}"][data-waypoint-number="0"] > [data-observe-next-wp]`;
-        const obsTarget = document.querySelector(obsSelector);
-
-        this.waypointObserver.observe(obsTarget);
-      }
+      return parent.querySelector('.node-children');
     }
 
     /**
-     * Build a parent node's waypoint scaffold and populate the first waypoint.
-     * This is called when any parent is expanded for the first time, then
-     * the waypointObserver takes over to populate any next empty waypoints.
-     * @param {string} nodeDivId - Div id of the parent node,
-     * ie: 'archival_object_18028'
+     * Renders a batch of child nodes into a list
+     * @param {HTMLElement} list - The list element to render into
+     * @param {array} nodes - Node objects to render
+     * @param {boolean} hasNextBatch - Whether there is another batch after this one
+     * @param {number} batchNumber - The batch number being rendered
      */
-    async initNodeChildren(nodeDivId) {
-      const nodeId = nodeDivId.split('_')[2];
-      const node = await this.fetchNode(nodeId);
-      const nodeLevel = parseInt(
-        document
-          .querySelector(`#${nodeDivId}`)
-          .closest('.table-row-group')
-          .getAttribute('data-waypoint-level'),
-        10
-      );
-      const nodeWpCount = node.waypoints;
-      const nodeUri = `/repositories/${this.repoId}/archival_objects/${nodeId}`;
-
-      this.nodeWaypointsScaffold(nodeDivId, nodeLevel + 1, nodeWpCount);
-
-      const firstWP = document.querySelector(
-        `[data-parent-id="${nodeDivId}"][data-waypoint-number="0"]`
-      );
-
-      this.populateWaypoint(
-        firstWP,
-        node.precomputed_waypoints[nodeUri][0],
-        nodeLevel + 1,
-        nodeWpCount > 1
-      );
-
-      if (nodeWpCount > 1) {
-        this.waypointObserver.observe(
-          firstWP.querySelector('[data-observe-next-wp]')
-        );
-      }
-    }
-
-    /**
-     * Fetch the root node of the tree
-     * @returns {Object} - Root node object as returned from the server
-     */
-    async fetchRootNode() {
-      try {
-        const response = await fetch(this.appUrlPrefix + this.rootUri);
-
-        return await response.json();
-      } catch (err) {
-        console.error(err);
-      }
-    }
-
-    /**
-     * Fetch the tree of the node with the given id
-     * @param {number} nodeId - ID of the node, ie: 18028
-     * @returns {Object} - Node object as returned from the server
-     */
-    async fetchNode(nodeId) {
-      const query = new URLSearchParams();
-
-      query.append(
-        'node',
-        `/repositories/${this.repoId}/archival_objects/${nodeId}`
-      );
-
-      try {
-        const response = await fetch(`${this.nodeUri}?${query}`);
-
-        return await response.json();
-      } catch (err) {
-        console.error(err);
-      }
-    }
-
-    /**
-     * Fetch the next waypoint of the given node
-     * @param {Object} params - Object of params for the ajax call with the signature:
-     * @param {string} params.node - Node URL param in the form of '' or
-     * '/repositories/X/archival_objects/Y'
-     * @param {number} params.offset - Offset URL param
-     * @returns {array} - Array of waypoint objects as returned from the server
-     */
-    async fetchWaypoint(params) {
-      const query = new URLSearchParams();
-
-      for (const key in params) {
-        query.append(key, params[key]);
+    renderBatch(list, nodes, hasNextBatch, batchNumber = 0) {
+      if (!Array.isArray(nodes)) {
+        console.error('Expected nodes to be an array, got:', nodes);
+        return;
       }
 
-      try {
-        const response = await fetch(`${this.waypointUri}?${query}`);
-        const waypoint = await response.json();
+      const listMeta = this.validateList(list);
+      if (!listMeta) return;
 
-        return waypoint;
-      } catch (err) {
-        console.error(err);
-      }
-    }
-
-    /**
-     * Append the root row to the tree container
-     * @param {string} title - Title of the root node
-     * @returns {DocumentFragment} - DocumentFragment containing the root row
-     */
-    rootRowMarkup(title) {
-      const titleContent = new MixedContent(title);
-      const rootRowFrag = new DocumentFragment();
-      const rootRow = document
-        .querySelector('#infinite-tree-root-row-template')
-        .content.cloneNode(true);
-
-      rootRow.querySelector('.table-row').id = `resource_${this.resourceId}`;
-      rootRow
-        .querySelector('.table-row')
-        .setAttribute('data-uri', this.resourceUri);
-
-      rootRow
-        .querySelector('.title')
-        .setAttribute(
-          'title',
-          titleContent.isMixed ? titleContent.derivedString : titleContent.input
-        );
-
-      rootRow.querySelector(
-        '.record-title'
-      ).href = `#tree::resource_${this.resourceId}`;
-
-      if (titleContent.isMixed) {
-        rootRow.querySelector('.record-title').innerHTML = titleContent.input;
-      } else {
-        rootRow.querySelector('.record-title').textContent = titleContent.input;
-      }
-
-      rootRowFrag.appendChild(rootRow);
-
-      return rootRowFrag;
-    }
-
-    /**
-     * Build the waypoints of a node and populate its first waypoint
-     * @param {number} nodeId - Div id of the parent node whose waypoints
-     * are being scaffolded
-     * @param {number} level - Level of the waypoints
-     * @param {number} numWPs - Number of waypoints to create
-     * @returns {DocumentFragment} - DocumentFragment containing the waypoint
-     */
-    rootNodeWaypointsScaffold(nodeId, level, numWPs) {
-      const nodeWaypointsFrag = new DocumentFragment();
-
-      for (let i = 0; i < numWPs; i++) {
-        const tableRowGroup = document.createElement('div');
-        tableRowGroup.className = 'table-row-group';
-        tableRowGroup.setAttribute('data-parent-id', nodeId);
-        tableRowGroup.setAttribute('data-waypoint-number', i);
-        tableRowGroup.setAttribute('data-waypoint-level', level);
-        tableRowGroup.setAttribute('role', 'list');
-
-        const tableRow = document.createElement('div');
-        tableRow.className = `table-row waypoint indent-level-${level}`;
-
-        tableRowGroup.appendChild(tableRow);
-
-        nodeWaypointsFrag.appendChild(tableRowGroup);
-      }
-
-      return nodeWaypointsFrag;
-    }
-
-    /**
-     * Build the markup for a node row
-     * @param {Object} node - Node data
-     * @param {number} level - Indent level of the node
-     * @param {boolean} shouldObserve - Whether or not to observe the node
-     * in order to populate the next empty waypoint
-     * @param {number} [parentId=null] - Optional ID of the node's parent; if null
-     * then parent is assumed to be the root resource
-     * @param {number} [offset=null] - Optional offset of the next waypoint to
-     * populate; required if `shouldObserve` is true
-     * @returns {DocumentFragment} - DocumentFragment containing the node row
-     */
-    nodeRowMarkup(node, level, shouldObserve, parentId = null, offset = null) {
-      const aoId = node.uri.split('/')[4];
-      const divId = `archival_object_${aoId}`;
-      const titleContent = new MixedContent(this.nodeTitle(node));
-      const aHref = `#tree::${divId}`;
-
-      const nodeRowFrag = new DocumentFragment();
-
-      const nodeRow = document
-        .querySelector('#infinite-tree-node-row-template')
-        .content.cloneNode(true);
-
-      nodeRow.querySelector('.table-row').id = divId;
-      nodeRow
-        .querySelector('.table-row')
-        .classList.add(`indent-level-${level}`);
-      nodeRow.querySelector('.table-row').setAttribute('data-uri', node.uri);
-
-      if (shouldObserve) {
-        const nodeParam = parentId.startsWith('resource')
-          ? ''
-          : `/repositories/${this.repoId}/archival_objects/${
-              parentId.split('_')[2]
-            }`;
-
-        nodeRow
-          .querySelector('.table-row')
-          .setAttribute('data-observe-next-wp', true);
-        nodeRow
-          .querySelector('.table-row')
-          .setAttribute('data-observe-node', nodeParam);
-        nodeRow
-          .querySelector('.table-row')
-          .setAttribute('data-observe-offset', offset);
-      }
-
-      nodeRow
-        .querySelector('.title')
-        .setAttribute(
-          'title',
-          titleContent.isMixed ? titleContent.derivedString : titleContent.input
-        );
-
-      if (node.child_count == 0) {
-        nodeRow.querySelector('.expandme').style.visibility = 'hidden';
-        nodeRow.querySelector('.expandme').setAttribute('aria-hidden', 'true');
-      } else if (node.child_count > 0) {
-        nodeRow
-          .querySelector('.table-row')
-          .setAttribute('data-has-expanded', false);
-        nodeRow
-          .querySelector('.table-row')
-          .setAttribute('data-is-expanded', false);
-        nodeRow
-          .querySelector('.expandme')
-          .setAttribute('aria-expanded', 'false');
-      }
-
-      nodeRow.querySelector('.sr-only').textContent = titleContent.isMixed
-        ? titleContent.derivedString
-        : titleContent.input;
-
-      if (node.has_digital_instance) {
-        const iconHtml = `<i class="has_digital_instance fa fa-file-image-o" aria-hidden="true"></i>`;
-        nodeRow
-          .querySelector('.record-title')
-          .insertAdjacentHTML('beforebegin', iconHtml);
-      }
-
-      nodeRow.querySelector('.record-title').setAttribute('href', aHref);
-
-      if (titleContent.isMixed) {
-        nodeRow.querySelector('.record-title').innerHTML = titleContent.input;
-      } else {
-        nodeRow.querySelector('.record-title').textContent = titleContent.input;
-      }
-
-      nodeRowFrag.appendChild(nodeRow);
-
-      return nodeRowFrag;
-    }
-
-    /**
-     * Append the empty set of waypoint containers belonging to a node after
-     * the node element; append elements manually because `insertAdjacentElement()`
-     * @param {number} nodeId - Div id of the parent node whose waypoints
-     * are being scaffolded
-     * @param {number} level - Level of the waypoints
-     * @param {number} numWPs - Number of waypoints to create
-     * @todo - refactor to use DocumentFragment and <template>
-     */
-    nodeWaypointsScaffold(nodeId, level, numWPs) {
-      for (let i = 0; i < numWPs; i++) {
-        const prevSibling =
-          i === 0
-            ? document.querySelector(`#${nodeId}`)
-            : document.querySelector(
-                `[data-parent-id="${nodeId}"][data-waypoint-number="${i - 1}"]`
-              );
-
-        const tableRowGroup = document.createElement('div');
-        tableRowGroup.className = 'table-row-group';
-        tableRowGroup.setAttribute('data-parent-id', nodeId);
-        tableRowGroup.setAttribute('data-waypoint-number', i);
-        tableRowGroup.setAttribute('data-waypoint-level', level);
-        tableRowGroup.setAttribute('role', 'list');
-
-        const tableRow = document.createElement('div');
-        tableRow.className = `table-row waypoint indent-level-${level}`;
-
-        prevSibling.insertAdjacentElement('afterend', tableRowGroup);
-
-        const liveTableRowGroup = document.querySelector(
-          `[data-parent-id="${nodeId}"][data-waypoint-number="${i}"]`
-        );
-
-        liveTableRowGroup.appendChild(tableRow);
-      }
-    }
-
-    /**
-     * Populate an empty waypoint with nodes
-     * @param {HTMLElement} waypoint - The empty waypoint to populate
-     * @param {array} nodes - Array of node objects to populate the waypoint with
-     * @param {number} level - Level of the waypoint
-     * @param {boolean} hasNextEmptyWP - Whether or not there is a next empty waypoint
-     */
-    populateWaypoint(waypoint, nodes, level, hasNextEmptyWP) {
-      const waypointMarker = waypoint.querySelector('.waypoint');
-      const nodeRowsFrag = new DocumentFragment();
-
-      waypointMarker.classList.add('populated');
+      const batchFragment = new DocumentFragment();
 
       nodes.forEach((node, i) => {
-        // observe the middle node if there is a next empty waypoint
         const observeThisNode =
-          i == Math.floor(this.WAYPOINT_SIZE / 2) - 1 && hasNextEmptyWP;
-        const markupArgs = [node, level, observeThisNode];
+          i == Math.floor(this.BATCH_SIZE / 2) - 1 && hasNextBatch;
+        const markupArgs = [node, listMeta.level, observeThisNode];
 
         if (observeThisNode) {
-          const nodeParentId = waypoint.getAttribute('data-parent-id');
-          const nodeWpNum = parseInt(
-            waypoint.getAttribute('data-waypoint-number'),
-            10
-          );
-
-          markupArgs.push(nodeParentId, nodeWpNum + 1);
+          markupArgs.push(listMeta.parentId, batchNumber + 1);
         }
 
-        nodeRowsFrag.appendChild(this.nodeRowMarkup(...markupArgs));
+        batchFragment.appendChild(this.markup.node(...markupArgs));
       });
 
-      waypoint.appendChild(nodeRowsFrag);
+      const placeholder = list.querySelector(
+        `li[data-batch-placeholder="${batchNumber}"]`
+      );
+
+      if (!placeholder) {
+        console.error('Could not find placeholder for batch:', {
+          batchNumber,
+          parentId: listMeta.parentId,
+          listHTML: list.innerHTML,
+        });
+        return;
+      }
+
+      placeholder.replaceWith(batchFragment);
+
+      if (hasNextBatch) {
+        const observerNode = list.querySelector('[data-observe-next-batch]');
+
+        if (observerNode) {
+          this.batchObserver.observe(observerNode);
+        }
+      }
     }
 
     /**
-     * IntersectionObserver callback for populating the next empty waypoint
+     * Prepares the data needed for rendering a batch of children
+     * @param {HTMLElement} parent - Parent node element
+     * @param {Object} data - Node data from the server
+     * @param {number} batchNumber - Which batch of children to prepare
+     * @returns {Object} Prepared batch data, {nodes:array, hasNextBatch:boolean, level:number}
+     */
+    prepareBatch(parent, data, batchNumber = 0) {
+      const isRoot = parent.classList.contains('root');
+      const wpKey = isRoot ? '' : data.uri;
+      const level = isRoot
+        ? 0
+        : Number(
+            parent.closest('.node-children').getAttribute('data-tree-level')
+          );
+
+      return {
+        nodes: data.precomputed_waypoints[wpKey][batchNumber],
+        hasNextBatch: data.waypoints > batchNumber + 1,
+        level: level,
+      };
+    }
+
+    /**
+     * Validates and returns parent data from a list
+     * @param {HTMLElement} list - The list element with data attributes to validate
+     * @returns {Object|null} List metadata if valid, null if invalid
+     */
+    validateList(list) {
+      if (!list) {
+        console.error('List element is null or undefined');
+        return null;
+      }
+
+      const parentId = list.getAttribute('data-parent-id');
+      if (!parentId) {
+        console.error('List element is missing data-parent-id attribute');
+        return null;
+      }
+
+      const level = Number(list.getAttribute('data-tree-level'));
+      if (!level) {
+        console.error('List element is missing data-tree-level attribute');
+        return null;
+      }
+
+      return { parentId, level };
+    }
+
+    /**
+     * IntersectionObserver callback for populating the next batch of children
      * @param {IntersectionObserverEntry[]} entries - Array of entries
      * @param {IntersectionObserver} observer - The observer instance
      */
-    waypointScrollHandler(entries, observer) {
+    batchObserverHandler(entries, observer) {
       entries.forEach(async entry => {
         if (entry.isIntersecting) {
-          const thisWaypoint = entry.target.closest('.table-row-group');
+          const node = entry.target;
+          const parentNodeUri = node.getAttribute('data-observe-node');
+          const siblingList = node.closest('.node-children');
+          const nextBatchNumber = Number(
+            node.getAttribute('data-observe-offset')
+          );
+          const totalBatches = Number(
+            siblingList.getAttribute('data-total-child-batches')
+          );
+          const hasNextBatch = nextBatchNumber + 1 < totalBatches;
+          const batchData = await this.fetch.batch(
+            parentNodeUri,
+            nextBatchNumber
+          );
 
-          if (!this.nextSiblingIsNextWaypoint(thisWaypoint)) {
+          if (!batchData) {
+            console.error('Failed to fetch batch');
             return;
           }
 
-          const node = entry.target.getAttribute('data-observe-node');
-          const offset = entry.target.getAttribute('data-observe-offset');
-          const nodes = await this.fetchWaypoint({ node, offset });
-          const level = thisWaypoint.getAttribute('data-waypoint-level');
-          const nextWaypoint = thisWaypoint.nextElementSibling;
-          const nextWPHasNextWP = this.nextSiblingIsNextWaypoint(nextWaypoint);
+          this.renderBatch(
+            siblingList,
+            batchData,
+            hasNextBatch,
+            nextBatchNumber
+          );
 
-          this.populateWaypoint(nextWaypoint, nodes, level, nextWPHasNextWP);
+          node.removeAttribute('data-observe-next-batch');
+          node.removeAttribute('data-observe-node');
+          node.removeAttribute('data-observe-offset');
+          observer.unobserve(node);
 
-          if (nextWPHasNextWP) {
-            const nextWPTarget = nextWaypoint.querySelector(
-              '[data-observe-next-wp="true"]'
+          if (hasNextBatch) {
+            const nextNode = siblingList.querySelector(
+              `[data-observe-next-batch][data-observe-offset="${
+                nextBatchNumber + 1
+              }"]`
             );
 
-            observer.observe(nextWPTarget);
+            if (nextNode) {
+              observer.observe(nextNode);
+            } else {
+              console.error('Could not find node to observe for next batch');
+            }
           }
-
-          entry.target.removeAttribute('data-observe-next-wp');
-          entry.target.removeAttribute('data-observe-node');
-          entry.target.removeAttribute('data-observe-offset');
-
-          observer.unobserve(entry.target);
         }
       });
     }
 
     /**
-     * Determine if the next sibling of the given waypoint is the next
-     * empty waypoint of the same parent
-     * @param {HTMLElement} waypoint - The waypoint with a possible next sibling
-     * @returns {boolean} - True if the next sibling is the next empty waypoint
-     * of the same parent
-     */
-    nextSiblingIsNextWaypoint(waypoint) {
-      const nextSibling = waypoint.nextElementSibling;
-
-      if (!nextSibling) {
-        return false;
-      }
-
-      const thisWpParent = waypoint.getAttribute('data-parent-id');
-      const thisWpNum = parseInt(
-        waypoint.getAttribute('data-waypoint-number'),
-        10
-      );
-
-      const nextSiblingParent = nextSibling.getAttribute('data-parent-id');
-      const nextSiblingWpNum = parseInt(
-        nextSibling.getAttribute('data-waypoint-number'),
-        10
-      );
-      const nextSiblingFirstChild = nextSibling.firstElementChild;
-
-      return (
-        nextSiblingParent == thisWpParent &&
-        nextSiblingWpNum == thisWpNum + 1 &&
-        nextSiblingFirstChild.classList.contains('waypoint') &&
-        !nextSiblingFirstChild.classList.contains('populated')
-      );
-    }
-
-    /**
-     * Handle click events on expandme buttons or their child icons
+     * Handles click events on expand buttons
      * @param {Event} e - Click event
      */
-    expandHandler(e) {
-      const node = e.target.closest('.largetree-node');
-      const button =
-        e.target.className === 'expandme'
-          ? e.target
-          : e.target.closest('.expandme');
-      const icon = e.target.classList.contains('expandme-icon')
-        ? e.target
-        : e.target.querySelector('.expandme-icon');
+    async expandHandler(e) {
+      const node = e.target.closest('.node');
+      const isExpanding = node.getAttribute('aria-expanded') === 'false';
+      const icon =
+        e.target.closest('.node-expand-icon') ||
+        e.target.querySelector('.node-expand-icon');
 
-      button.setAttribute(
-        'aria-expanded',
-        button.getAttribute('aria-expanded') === 'true' ? 'false' : 'true'
-      );
+      if (isExpanding && node.getAttribute('data-has-expanded') === 'false') {
+        const nodeRecordId = node.getAttribute('data-uri').split('/')[4];
+        const nodeData = await this.fetch.node(Number(nodeRecordId));
 
+        await this.renderInitialBatch(node, nodeData);
+
+        node.setAttribute('data-has-expanded', 'true');
+      }
+
+      node.setAttribute('aria-expanded', isExpanding ? 'true' : 'false');
       icon.classList.toggle('expanded');
-
-      node.setAttribute(
-        'data-is-expanded',
-        button.getAttribute('aria-expanded')
-      );
-
-      if (node.getAttribute('data-has-expanded') === 'false') {
-        this.initNodeChildren(node.id);
-
-        node.setAttribute('data-has-expanded', true);
-      }
-    }
-
-    /**
-     * Build the title of a node
-     * @param {Object} node - Node data
-     * @returns {string} - Title of the node
-     */
-    nodeTitle(node) {
-      const title = [];
-
-      if (SHOW_IDENTIFIERS_IN_TREE && node.identifier && node.parsed_title) {
-        title.push(`${node.identifier}${this.i18n.sep} ${node.parsed_title}`);
-      } else if (node.parsed_title) {
-        title.push(node.parsed_title);
-      }
-
-      if (node.label) {
-        title.push(node.label);
-      }
-
-      if (node.dates && node.dates.length > 0) {
-        node.dates.forEach(date => {
-          if (date.expression) {
-            if (date.type === 'bulk') {
-              title.push(`${this.i18n.bulk}: ${date.expression}`);
-            } else {
-              title.push(date.expression);
-            }
-          } else if (date.begin && date.end) {
-            if (date.type === 'bulk') {
-              title.push(`${this.i18n.bulk}: ${date.begin}-${date.end}`);
-            } else {
-              title.push(`${date.begin}-${date.end}`);
-            }
-          } else if (date.begin) {
-            if (date.type === 'bulk') {
-              title.push(`${this.i18n.bulk}: ${date.begin}`);
-            } else {
-              title.push(date.begin);
-            }
-          }
-        });
-      }
-
-      return title.join(', ');
     }
   }
 

--- a/public/app/assets/javascripts/InfiniteTreeFetch.js
+++ b/public/app/assets/javascripts/InfiniteTreeFetch.js
@@ -1,0 +1,79 @@
+(function (exports) {
+  class InfiniteTreeFetch {
+    /**
+     * @constructor
+     * @param {string} appUrlPrefix - The proper app prefix
+     * @param {string} resourceUri - The URI of the collection resource
+     */
+    constructor(appUrlPrefix, resourceUri) {
+      this.appUrlPrefix = appUrlPrefix;
+      this.resourceUri = resourceUri;
+      this.repoId = resourceUri.split('/')[2];
+      this.baseUri = `${this.resourceUri}/tree`;
+      this.rootUri = `${this.baseUri}/root`;
+      this.nodeUri = `${this.baseUri}/node`;
+      this.batchUri = `${this.baseUri}/waypoint`; // TODO: rename endpoint to /batch
+    }
+
+    /**
+     * Fetches the root
+     * @returns {Object} - Root object returned from the server
+     */
+    async root() {
+      try {
+        const response = await fetch(this.appUrlPrefix + this.rootUri);
+
+        return await response.json();
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    /**
+     * Fetches the node with the given id
+     * @param {number} id - ID of the node, ie: 18028
+     * @returns {Object} - Node object as returned from the server
+     */
+    async node(id) {
+      const query = new URLSearchParams();
+
+      query.append(
+        'node',
+        `/repositories/${this.repoId}/archival_objects/${id}`
+      );
+
+      try {
+        const response = await fetch(`${this.nodeUri}?${query}`);
+
+        return await response.json();
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    /**
+     * Fetches a batch of the given parent's children
+     * @param {string} parentRef - The parent reference for the endpoint; either '' for root,
+     * or the URI of the parent node, ie: '/repositories/:rid/archival_objects/:id'
+     * @param {number} offset - The `offset` URL param
+     * @returns {array} - Array of node objects as returned from the server
+     */
+    async batch(parentRef, offset) {
+      const query = new URLSearchParams();
+
+      query.append('node', parentRef);
+      query.append('offset', offset);
+
+      try {
+        const response = await fetch(`${this.batchUri}?${query}`);
+
+        return await response.json();
+      } catch (err) {
+        console.error('Error fetching batch:', err);
+        return null;
+      }
+    }
+  }
+
+  exports.InfiniteTreeFetch = InfiniteTreeFetch;
+})(window);

--- a/public/app/assets/javascripts/InfiniteTreeMarkup.js
+++ b/public/app/assets/javascripts/InfiniteTreeMarkup.js
@@ -1,0 +1,249 @@
+(function (exports) {
+  /**
+   * A tree is an ordered list, represented in the DOM as `ol.infinite-tree`.
+   * The tree has exactly one list item which is the root node.
+   * The root node has zero or more child nodes,
+   * each of which have zero or more child nodes,
+   * each of which have zero or more child nodes, etc.
+   * All nodes in the DOM are represented as `li.node`; the root as `li.root.node`.
+   * All nodes have `div.node-row` used for absolute positioning its data and
+   * allowing full-width highlighting of the current node, and containing:
+   *   - `div.node-body` a layout wrapper containing:
+   *     - `div.node-indentation` for tree level visualization via a repeating
+   *       gradient and padding, and expand/collapse button if children
+   *     - `div.node-title-container` for the node's data
+   *     - an `::after` pseudo-element to indicate the currently selected node
+   *       via the "current" InfiniteRecords record
+   * All nodes with children have a nested ordered list, `ol.node-children`, as the
+   * next sibling of `.node-row`, containing each child as `li.node`.
+   */
+
+  class InfiniteTreeMarkup {
+    /**
+     * @constructor
+     * @param {string} resourceUri - The URI of the collection resource
+     * @param {number} batchSize - The number of child nodes per batch
+     * @param {Object} i18n - Internationalization strings
+     */
+    constructor(resourceUri, batchSize, i18n) {
+      this.resourceUri = resourceUri;
+      this.repoId = resourceUri.split('/')[2];
+      this.resourceId = resourceUri.split('/')[4];
+      this.BATCH_SIZE = batchSize;
+      this.i18n = i18n;
+    }
+
+    /**
+     * Creates a tree structure with a root node
+     * @param {string} title - Display text for the root node
+     * @returns {DocumentFragment} An <ol> with a single <li>
+     */
+    root(title) {
+      const _title = new MixedContent(title);
+      const rootFrag = new DocumentFragment();
+      const rootTemplate = document
+        .querySelector('#infinite-tree-root-template')
+        .content.cloneNode(true);
+      const rootElement = rootTemplate.querySelector('li');
+      const contentWrapper = rootTemplate.querySelector('.node-body');
+      const link = rootTemplate.querySelector('.node-title');
+
+      rootElement.id = `resource_${this.resourceId}`;
+      rootElement.setAttribute('data-uri', this.resourceUri);
+      rootElement.setAttribute('aria-expanded', 'true');
+      contentWrapper.setAttribute('title', _title.cleaned);
+      link.href = `#tree::resource_${this.resourceId}`;
+
+      if (_title.isMixed) {
+        link.innerHTML = _title.input;
+      } else {
+        link.textContent = _title.cleaned;
+      }
+
+      rootFrag.appendChild(rootTemplate);
+
+      return rootFrag;
+    }
+
+    /**
+     * Creates a list of empty placeholders for batches of children
+     * @param {string} parentElementId - Value of the parent node's HTML id attribute
+     * @param {number} level - Tree level of the children (0 for root)
+     * @param {number} numBatches - Number of batch placeholders to create
+     * @returns {DocumentFragment} - An <ol> with placeholder <li>s
+     */
+    list(parentElementId, level, numBatches) {
+      const listFrag = new DocumentFragment();
+      const listTemplate = document
+        .querySelector('#infinite-tree-children-list-template')
+        .content.cloneNode(true);
+      const listElement = listTemplate.querySelector('ol');
+
+      listElement.setAttribute('data-parent-id', parentElementId);
+      listElement.setAttribute('data-tree-level', level);
+      listElement.setAttribute('data-total-child-batches', numBatches);
+
+      for (let i = 0; i < numBatches; i++) {
+        const itemTemplate = document
+          .querySelector('#infinite-tree-batch-placeholder-template')
+          .content.cloneNode(true);
+        const itemElement = itemTemplate.querySelector('li');
+
+        itemElement.setAttribute('data-batch-placeholder', i);
+
+        listElement.appendChild(itemElement);
+      }
+
+      listFrag.appendChild(listTemplate);
+
+      return listFrag;
+    }
+
+    /**
+     * Creates a node
+     * @param {Object} data - Node data object from the server
+     * @param {number} level - Tree level of the node (0 for root)
+     * @param {boolean} shouldObserve - Whether or not to observe the node
+     * in order to populate a next empty batch
+     * @param {number} [parentId=null] - Optional ID of the node's parent; if null
+     * then parent is assumed to be the root resource
+     * @param {number} [offset=null] - Optional offset of the next batch to
+     * populate; required if `shouldObserve` is true
+     * @returns {DocumentFragment} - A <li>
+     */
+    node(data, level, shouldObserve, parentId = null, offset = null) {
+      const nodeRecordId = data.uri.split('/')[4];
+      const nodeElementId = `archival_object_${nodeRecordId}`;
+      const title = new MixedContent(this.title(data));
+      const aHref = `#tree::${nodeElementId}`;
+      const nodeFrag = new DocumentFragment();
+      const nodeTemplate = document
+        .querySelector('#infinite-tree-node-template')
+        .content.cloneNode(true);
+      const nodeElement = nodeTemplate.querySelector('li');
+      const contentWrapper = nodeTemplate.querySelector('.node-body');
+      const indentation = nodeTemplate.querySelector('.node-indentation');
+      const link = nodeTemplate.querySelector('.node-title');
+
+      nodeElement.id = nodeElementId;
+      nodeElement.classList.add(`indent-level-${level}`);
+      nodeElement.setAttribute('data-uri', data.uri);
+
+      if (data.child_count > 0) {
+        const totalBatches = Math.ceil(data.child_count / this.BATCH_SIZE);
+        nodeElement.setAttribute('data-total-child-batches', totalBatches);
+        nodeElement.setAttribute('data-has-expanded', 'false');
+        nodeElement.setAttribute('aria-expanded', 'false');
+
+        indentation.appendChild(this.expandButton(title.cleaned));
+      }
+
+      if (shouldObserve) {
+        let parentUri;
+
+        if (parentId) {
+          if (parentId.startsWith('resource')) {
+            parentUri = '';
+          } else if (parentId.startsWith('archival_object')) {
+            const parentNodeId = parentId.split('_')[2];
+            parentUri = `/repositories/${this.repoId}/archival_objects/${parentNodeId}`;
+          }
+        }
+
+        nodeElement.setAttribute('data-observe-next-batch', 'true');
+        nodeElement.setAttribute('data-observe-node', parentUri);
+        nodeElement.setAttribute('data-observe-offset', offset);
+      }
+
+      contentWrapper.setAttribute('title', title.cleaned);
+
+      if (data.has_digital_instance) {
+        const iconHtml = `<i class="has_digital_instance fa fa-file-image-o" aria-hidden="true"></i>`;
+
+        nodeTemplate
+          .querySelector('.node-title')
+          .insertAdjacentHTML('beforebegin', iconHtml);
+      }
+
+      link.setAttribute('href', aHref);
+
+      if (title.isMixed) {
+        link.innerHTML = title.input;
+      } else {
+        link.textContent = title.cleaned;
+      }
+
+      nodeFrag.appendChild(nodeTemplate);
+
+      return nodeFrag;
+    }
+
+    /**
+     * Creates an expand button to show and hide a node's children
+     * @param {string} title - The node title
+     * @returns {DocumentFragment} - A <button>
+     */
+    expandButton(title) {
+      const btnFrag = new DocumentFragment();
+      const btnTemplate = document
+        .querySelector('#infinite-tree-expand-button-template')
+        .content.cloneNode(true);
+      const btn = btnTemplate.querySelector('.node-expand');
+
+      btn.querySelector('.sr-only').textContent = title;
+
+      btnFrag.appendChild(btnTemplate);
+
+      return btnFrag;
+    }
+
+    /**
+     * Builds the title of a node
+     * @param {Object} node - Node data
+     * @returns {string} - Title of the node
+     *
+     * @todo Migrate this logic to the server if possible
+     */
+    title(node) {
+      const title = [];
+
+      if (SHOW_IDENTIFIERS_IN_TREE && node.identifier && node.parsed_title) {
+        title.push(`${node.identifier}${this.i18n.sep} ${node.parsed_title}`);
+      } else if (node.parsed_title) {
+        title.push(node.parsed_title);
+      }
+
+      if (node.label) {
+        title.push(node.label);
+      }
+
+      if (node.dates && node.dates.length > 0) {
+        node.dates.forEach(date => {
+          if (date.expression) {
+            if (date.type === 'bulk') {
+              title.push(`${this.i18n.bulk}: ${date.expression}`);
+            } else {
+              title.push(date.expression);
+            }
+          } else if (date.begin && date.end) {
+            if (date.type === 'bulk') {
+              title.push(`${this.i18n.bulk}: ${date.begin}-${date.end}`);
+            } else {
+              title.push(`${date.begin}-${date.end}`);
+            }
+          } else if (date.begin) {
+            if (date.type === 'bulk') {
+              title.push(`${this.i18n.bulk}: ${date.begin}`);
+            } else {
+              title.push(date.begin);
+            }
+          }
+        });
+      }
+
+      return title.join(', ');
+    }
+  }
+
+  exports.InfiniteTreeMarkup = InfiniteTreeMarkup;
+})(window);

--- a/public/app/assets/javascripts/MixedContent.js
+++ b/public/app/assets/javascripts/MixedContent.js
@@ -50,10 +50,10 @@
     }
 
     /**
-     * @description - Get the derived string without the HTML
-     * @returns {string} - The derived string without HTML
+     * @description - Remove any HTML from the string
+     * @returns {string} - The string without HTML
      */
-    get derivedString() {
+    get cleaned() {
       if (!this.match) {
         return this.input;
       }

--- a/public/app/assets/stylesheets/archivesspace/infinite-tree.scss
+++ b/public/app/assets/stylesheets/archivesspace/infinite-tree.scss
@@ -1,31 +1,179 @@
-// pre ANW-425
-.infinite-tree-view {
+:root {
+  --tree-indent-width: 1.5rem;
+  --tree-line-color: white;
+  --tree-line-width: 1px;
+  --tree-unit-width: calc(var(--tree-indent-width) + var(--tree-line-width));
+}
+
+#infinite-tree-container {
   height: 600px;
-  padding: 1em;
+  border: 1px solid $lightshade;
+  background-color: $lightshade;
+  overflow-y: auto;
+}
 
-  .resource-level,
-  .resource-type,
-  .resource-container {
-    display: none;
+.infinite-tree,
+.node-children {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.infinite-tree {
+  font-size: 1rem;
+  background-color: $white;
+}
+
+.root.node {
+  > .node-row > .node-body {
+    padding-left: 0.25rem;
+    font-weight: normal;
+    background-color: $lightshade;
+  }
+
+  > .node-children > .node:last-child > .node-row > .node-body {
+    border-bottom: var(--tree-line-width) solid var(--tree-line-color);
   }
 }
 
-@media (max-width: 991px) {
-  .infinite-tree-sidebar {
+.node {
+  position: relative;
+
+  &:nth-child(even) > .node-row > .node-body {
+    background-color: #fafafa;
+  }
+
+  &[aria-expanded='false'] > .node-children {
     display: none;
+  }
+
+  &.current > .node-row > .node-body {
+    position: relative;
+    background-color: #effaff;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: -1px;
+      border: 1px solid $midblue;
+      pointer-events: none;
+    }
   }
 }
 
-// ANW-425 and after
-.table-row.largetree-node[data-is-expanded='false'] + .table-row-group,
-.table-row.largetree-node[data-is-expanded='false']
-  + .table-row-group
-  ~ .table-row-group {
-  display: none;
+.node-row {
+  position: relative;
+  width: 100%;
 }
-.table-row.largetree-node[data-is-expanded='true'] + .table-row-group,
-.table-row.largetree-node[data-is-expanded='true']
-  + .table-row-group
-  ~ .table-row-group {
-  display: contents;
+
+.node-body {
+  position: relative;
+  height: 2rem;
+  margin-bottom: 1px;
+  display: flex;
+  align-items: center;
+  line-height: 2rem;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.03);
+  }
+}
+
+.node-indentation {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: calc(
+    (var(--tree-unit-width) * var(--level, 1)) - var(--tree-line-width)
+  );
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  background-color: $lightshade;
+  background-image: repeating-linear-gradient(
+    90deg,
+    $lightshade,
+    $lightshade var(--tree-indent-width),
+    var(--tree-line-color) var(--tree-indent-width),
+    var(--tree-line-color) var(--tree-unit-width)
+  );
+
+  /* 
+    1. Rotate gradient horizontally for vertical line
+    2. Start background color
+    3. Extend background color to indent width
+    4. Start vertical line at indent
+    5. End vertical line at unit width
+  */
+}
+
+@for $i from 1 through 12 {
+  .node-children[data-tree-level='#{$i}'] {
+    .node-indentation {
+      --level: #{$i};
+    }
+
+    .node-title-container {
+      padding-left: calc(var(--tree-unit-width) * #{$i});
+    }
+  }
+}
+
+.node-expand {
+  height: 2rem;
+  width: var(--tree-indent-width);
+  border: none;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 0.875rem;
+  color: #555;
+  background-color: $lightshade;
+  cursor: pointer;
+
+  &:hover {
+    color: $darkest;
+  }
+}
+
+.node-expand-icon {
+  transition: transform 0.15s ease;
+
+  &.expanded {
+    transform: rotate(90deg);
+  }
+}
+
+.node-title-container {
+  min-height: var(--tree-indent-width);
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  overflow: hidden;
+}
+
+.node-title {
+  position: relative;
+  min-width: 0;
+  padding-left: 0.25rem;
+  flex-shrink: 1;
+  text-decoration: none;
+  color: $secondary-color;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  user-select: text;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+    color: $darkblue;
+  }
 }

--- a/public/app/views/resources/infinite.html.erb
+++ b/public/app/views/resources/infinite.html.erb
@@ -81,14 +81,14 @@ infiniteTree.container.addEventListener('click', (e) => {
  */
 function treeClickDelegator(event, tree, records) {
   if (
-    !event.target.classList.contains('expandme') &&
-    !event.target.classList.contains('expandme-icon') &&
-    !event.target.classList.contains('record-title')
+    !event.target.classList.contains('node-expand') &&
+    !event.target.classList.contains('node-expand-icon') &&
+    !event.target.classList.contains('node-title')
   ) return;
 
-  if (event.target.className.includes('expandme')) {
+  if (event.target.className.includes('node-expand')) {
     tree.expandHandler(event);
-  } else if (event.target.classList.contains('record-title')) {
+  } else if (event.target.classList.contains('node-title')) {
     records.treeLinkHandler(event);
   }
 }

--- a/public/app/views/shared/_infinite_tree.html.erb
+++ b/public/app/views/shared/_infinite_tree.html.erb
@@ -1,31 +1,59 @@
 <div
   id="infinite-tree-container"
-  class="infinite-tree-view largetree-container"
-  data-waypoint-size="<%= Rails.configuration.infinite_tree_waypoint_size %>"
   data-resource-uri="<%= @result['uri'] %>"
 >
 </div>
 
 <%# The <template>s below get appended to #infinite-tree-container via InfiniteTree.js %>
 
-<template id="infinite-tree-root-row-template">
-  <div id="" class="table-row root-row" role="listitem" data-uri="">
-    <div class="table-cell title" title="">
-      <a class="record-title" href=""></a>
-    </div>
-  </div>
+<template id="infinite-tree-root-template">
+  <ol class="infinite-tree" role="tree">
+    <li class="root node" role="treeitem" id data-uri aria-expanded>
+      <div class="node-row">
+        <div class="node-body" title>
+          <div class="node-title-container">
+            <a class="node-title" href></a>
+          </div>
+        </div>
+      </div>
+      <%# ol.node-children to be inserted here by JS %>
+    </li>
+  </ol>
 </template>
 
-<template id="infinite-tree-node-row-template">
-  <div id="" class="table-row largetree-node" role="listitem" data-uri="">
-    <div class="table-cell title" title="">
-      <span class="indentor">
-        <button class="expandme" aria-expanded="false">
-          <i class="expandme-icon fa fa-chevron-right"></i>
-          <span class="sr-only"></span>
-        </button>
-      </span>
-      <a class="record-title" href=""></a>
+<template id="infinite-tree-node-template">
+  <li class="node" role="treeitem" id data-uri>
+    <div class="node-row">
+      <div class="node-body" title>
+        <div class="node-indentation"></div>
+        <div class="node-title-container">
+          <a class="node-title" href></a>
+        </div>
+      </div>
     </div>
-  </div>
+    <%# ol.node-children to be inserted here by JS on expand %>
+  </li>
+</template>
+
+<template id="infinite-tree-expand-button-template">
+  <button class="node-expand" type="button">
+    <i class="node-expand-icon fa fa-chevron-right"></i>
+    <span class="sr-only"></span>
+  </button>
+</template>
+
+<template id="infinite-tree-children-list-template">
+  <ol
+    class="node-children"
+    role="group"
+    data-parent-id
+    data-tree-level
+    data-total-child-batches
+  >
+    <%# Child nodes will be inserted here by JS %>
+  </ol>
+</template>
+
+<template id="infinite-tree-batch-placeholder-template">
+  <li data-batch-placeholder style="display:none"></li>
 </template>

--- a/public/spec/aspace_helper.rb
+++ b/public/spec/aspace_helper.rb
@@ -1,0 +1,19 @@
+module ASpaceHelpers
+  include Capybara::DSL
+
+  def wait_for_jquery
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      sleep 1
+      loop until finished_all_ajax_requests?
+    end
+  end
+
+  def finished_all_ajax_requests?
+    page.evaluate_script("typeof window.jQuery != 'undefined'") &&
+      page.evaluate_script('window.jQuery !== undefined') &&
+      page.evaluate_script('jQuery.active !== undefined') &&
+      page.evaluate_script('jQuery.active')&.zero?
+  rescue Selenium::WebDriver::Error::JavascriptError
+    false
+  end
+end

--- a/public/spec/features/collection_organization_spec.rb
+++ b/public/spec/features/collection_organization_spec.rb
@@ -51,19 +51,19 @@ describe 'Collection Organization', js: true do
       visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
 
       resource = find(".infinite-tree-sidebar #resource_#{@resource.id}")
-      expect(resource).to have_css('.title[title="This is a mixed content title"]')
-      resource_mixed_content_span = resource.find('.record-title > span.emph.render-italic')
+      expect(resource).to have_css('.node-body[title="This is a mixed content title"]')
+      resource_mixed_content_span = resource.find('.root.node > .node-row span.emph.render-italic')
       expect(resource_mixed_content_span).to have_content('a mixed content')
 
       ao1 = find(".infinite-tree-sidebar #archival_object_#{@ao1.id}")
-      expect(ao1).to have_css('.title[title="This is another mixed content title"]')
-      ao1_mixed_content_span = ao1.find('.record-title > span.emph.render-italic')
+      expect(ao1).to have_css("#archival_object_#{@ao1.id} > .node-row > .node-body[title='This is another mixed content title']")
+      ao1_mixed_content_span = ao1.find("#archival_object_#{@ao1.id} > .node-row span.emph.render-italic")
       expect(ao1_mixed_content_span).to have_content('another mixed content')
 
       ao2 = find(".infinite-tree-sidebar #archival_object_#{@ao2.id}")
-      ao2_record_title = ao2.find('.record-title')
-      expect(ao2_record_title).to_not have_css('span.emph.render-italic')
-      expect(ao2_record_title).to have_content('This is not a mixed content title')
+      ao2_title = ao2.find("#archival_object_#{@ao2.id} > .node-row .node-title")
+      expect(ao2_title).to_not have_css('span.emph.render-italic')
+      expect(ao2_title).to have_content('This is not a mixed content title')
     end
 
     it 'is positioned on the left side of the resource show and infinite views ' \
@@ -78,7 +78,7 @@ describe 'Collection Organization', js: true do
       sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
       sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
       content_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', content)
-
+      sleep 5
       expect(sidebar_left_coordinate).to be < content_left_coordinate
       expect(sidebar_right_coordinate).to eq content_left_coordinate
 
@@ -90,7 +90,7 @@ describe 'Collection Organization', js: true do
       sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
       sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
       content_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', content)
-
+      sleep 5
       expect(sidebar_left_coordinate).to be < content_left_coordinate
       expect(sidebar_right_coordinate).to eq content_left_coordinate
     end
@@ -107,7 +107,7 @@ describe 'Collection Organization', js: true do
       sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
       sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
       content_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', content)
-
+      sleep 5
       expect(sidebar_left_coordinate).to be < content_left_coordinate
       expect(sidebar_right_coordinate).to eq content_left_coordinate
 
@@ -119,7 +119,7 @@ describe 'Collection Organization', js: true do
       sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
       sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
       content_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', content)
-
+      sleep 5
       expect(sidebar_left_coordinate).to be < content_left_coordinate
       expect(sidebar_right_coordinate).to eq content_left_coordinate
     end
@@ -136,7 +136,7 @@ describe 'Collection Organization', js: true do
       sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
       sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
       content_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', content)
-
+      sleep 5
       expect(sidebar_left_coordinate).to eq content_right_coordinate
       expect(sidebar_right_coordinate).to be > content_right_coordinate
 
@@ -148,7 +148,7 @@ describe 'Collection Organization', js: true do
       sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
       sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
       content_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', content)
-
+      sleep 5
       expect(sidebar_left_coordinate).to eq content_right_coordinate
       expect(sidebar_right_coordinate).to be > content_right_coordinate
     end
@@ -165,7 +165,7 @@ describe 'Collection Organization', js: true do
       sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
       sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
       content_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', content)
-
+      sleep 5
       expect(sidebar_left_coordinate).to eq content_right_coordinate
       expect(sidebar_right_coordinate).to be > content_right_coordinate
 
@@ -177,7 +177,7 @@ describe 'Collection Organization', js: true do
       sidebar_left_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().left', sidebar)
       sidebar_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', sidebar)
       content_right_coordinate = page.evaluate_script('arguments[0].getBoundingClientRect().right', content)
-
+      sleep 5
       expect(sidebar_left_coordinate).to eq content_right_coordinate
       expect(sidebar_right_coordinate).to be > content_right_coordinate
     end
@@ -323,45 +323,46 @@ describe 'Collection Organization', js: true do
 
       it 'are collapsed by default' do
         visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
-        expect(page).to have_css(".infinite-tree-sidebar ##{@parent_HTML_id}[data-is-expanded='false']:last-child")
+        expect(page).to have_css(".infinite-tree-sidebar ##{@parent_HTML_id}[aria-expanded='false']:last-child")
       end
 
-      it 'are expanded then collapsed by clicking the "expandme" button' do
+      it 'are expanded then collapsed by clicking the "expand" button' do
         visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
-        ao3_expandme = page.find(".infinite-tree-sidebar ##{@parent_HTML_id}[data-is-expanded='false']:last-child .expandme")
-        ao3_expandme.click
-        expect(page).to have_css(".infinite-tree-sidebar ##{@parent_HTML_id}[data-is-expanded='true']:nth-last-child(3)")
-        expect(page).to have_css(".infinite-tree-sidebar ##{@parent_HTML_id} + [data-parent-id='#{@parent_HTML_id}'][data-waypoint-number='0']:nth-last-child(2)")
-        expect(page).to have_css(".infinite-tree-sidebar ##{@parent_HTML_id} ~ [data-parent-id='#{@parent_HTML_id}'][data-waypoint-number='1']:last-child", visible: false)
-        ao3_expandme.click
-        expect(page).to have_css(".infinite-tree-sidebar ##{@parent_HTML_id}[data-is-expanded='false']:nth-last-child(3)")
-        expect(page).to have_css(".infinite-tree-sidebar ##{@parent_HTML_id} + [data-parent-id='#{@parent_HTML_id}'][data-waypoint-number='0']:nth-last-child(2)", visible: false)
-        expect(page).to have_css(".infinite-tree-sidebar ##{@parent_HTML_id} ~ [data-parent-id='#{@parent_HTML_id}'][data-waypoint-number='1']:last-child", visible: false)
+        expect(page).not_to have_css("##{@parent_HTML_id}.node[aria-expanded='false'] > .node-row .node-expand-icon.expanded")
+        expect(page).not_to have_css("##{@parent_HTML_id}.node[aria-expanded='false'] > .node-children")
+        ao3_expand = page.find("##{@parent_HTML_id}.node[aria-expanded='false'] > .node-row .node-expand")
+        ao3_expand.click
+        expect(page).to have_css("##{@parent_HTML_id}.node[aria-expanded='true'] > .node-row .node-expand-icon.expanded")
+        expect(page).to have_css("##{@parent_HTML_id}.node[aria-expanded='true'] > .node-children > .node", count: 200, visible: true)
+        ao3_expand.click
+        expect(page).not_to have_css("##{@parent_HTML_id}.node[aria-expanded='false'] > .node-row .node-expand-icon.expanded")
+        expect(page).to have_css("##{@parent_HTML_id}.node[aria-expanded='false'] > .node-children > .node", count: 200, visible: false)
       end
 
-      it 'children are loaded in groups of "waypoints" on scroll when the parent has more children than the configured waypoint size' do
-        visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
-        container = page.find('.infinite-tree-sidebar')
-        container.find(".infinite-tree-sidebar ##{@parent_HTML_id}[data-is-expanded='false']:last-child .expandme").click
-        expect(page).to have_css("[data-parent-id='#{@parent_HTML_id}'][data-waypoint-number='0'] > .waypoint.populated", visible: false)
-        expect(page).to have_css("[data-parent-id='#{@parent_HTML_id}'][data-waypoint-number='0'] > .largetree-node", count: 200)
-        expect(page).to have_css("[data-parent-id='#{@parent_HTML_id}'][data-waypoint-number='1'] > .waypoint:not(.populated)", visible: false)
-        observer_node = page.find('[data-observe-next-wp="true"]')
-        container.scroll_to(observer_node, align: :center)
-        expect(page).to have_css("[data-parent-id='#{@parent_HTML_id}'][data-waypoint-number='1'] > .waypoint.populated", visible: false)
-        expect(page).to have_css("[data-parent-id='#{@parent_HTML_id}'][data-waypoint-number='1'] > .largetree-node", count: 1)
-      end
-
-      it 'hide all waypoints of children when collapsed' do
+      it 'children are loaded in "batches" on scroll when the parent has more children than the configured batch size' do
         visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
         container = page.find('.infinite-tree-sidebar')
-        ao_expandme = container.find(".infinite-tree-sidebar ##{@parent_HTML_id}[data-is-expanded='false']:last-child .expandme")
-        ao_expandme.click
-        observer_node = page.find('[data-observe-next-wp="true"]')
+        container.find(".infinite-tree-sidebar ##{@parent_HTML_id}[aria-expanded='false']:last-child .node-expand").click
+        expect(page).to have_css(".node-children[data-parent-id='#{@parent_HTML_id}'] > .node", count: 200)
+        expect(page).to have_css(".node-children[data-parent-id='#{@parent_HTML_id}'] > [data-batch-placeholder='1']:last-child", visible: false)
+        observer_node = page.find('[data-observe-next-batch="true"]')
         container.scroll_to(observer_node, align: :center)
-        expect(page).to have_css("[data-parent-id='#{@parent_HTML_id}'][data-waypoint-number]", count: 2, visible: true)
-        ao_expandme.click
-        expect(page).to have_css("[data-parent-id='#{@parent_HTML_id}'][data-waypoint-number]", count: 2, visible: false)
+        sleep 5
+        expect(page).to have_css(".node-children[data-parent-id='#{@parent_HTML_id}'] > .node", count: 201)
+        expect(page).not_to have_css(".node-children[data-parent-id='#{@parent_HTML_id}'] > [data-batch-placeholder]", visible: false)
+      end
+
+      it 'hide all children when collapsed' do
+        visit "/repositories/#{@repo.id}/resources/#{@resource.id}/collection_organization"
+        container = page.find('.infinite-tree-sidebar')
+        ao_expand = container.find(".infinite-tree-sidebar ##{@parent_HTML_id}[aria-expanded='false']:last-child .node-expand")
+        ao_expand.click
+        observer_node = page.find('[data-observe-next-batch="true"]')
+        container.scroll_to(observer_node, align: :center)
+        sleep 5
+        expect(page).to have_css(".node-children[data-parent-id='#{@parent_HTML_id}'] > .node", count: 201, visible: true)
+        ao_expand.click
+        expect(page).to have_css(".node-children[data-parent-id='#{@parent_HTML_id}'] > .node", count: 201, visible: false)
       end
     end
   end
@@ -549,7 +550,7 @@ describe 'Collection Organization', js: true do
     it 'shows a spinner on state change and removes the spinner once all records are loaded' do
       visit "/repositories/#{@repo.id}/resources/#{@res_10wp.id}/collection_organization"
       expect(page).to have_css('#records-loading-dialog', visible: false)
-      sleep 10
+      sleep 5
 
       # There is no dialog 'open' event so listen for 'close' which implies it was open
       page.execute_script(<<~JS)
@@ -562,7 +563,7 @@ describe 'Collection Organization', js: true do
 
       expect(page.evaluate_script('window.dialogClosed')).to eq false
       page.find('.load-all__label-toggle').click
-      sleep 10
+      sleep 5
       expect(page.evaluate_script('window.dialogClosed')).to eq true
     end
 
@@ -570,14 +571,14 @@ describe 'Collection Organization', js: true do
       visit "/repositories/#{@repo.id}/resources/#{@res_3wp.id}/collection_organization"
       expect(page).to have_css('#load-all-section', visible: true)
       page.find('.load-all__label-toggle').click
-      sleep 10
+      sleep 5
       expect(page).to have_css('#load-all-section', visible: false)
     end
 
     it 'loads all remaining records from the main thread if the number of waypoints '\
       'does not exceed `infinite_records_main_max_concurrent_waypoint_fetches`' do
       visit "/repositories/#{@repo.id}/resources/#{@res_5wp.id}/collection_organization"
-      sleep 10
+      sleep 5
       total_records = page.find('#infinite-records-container')['data-total-records']
       num_empty_waypoints_start = page.all('#infinite-records-container .waypoint:not(.populated)').length
       expect(page).not_to have_css('#infinite-records-container .waypoint.populated .infinite-record-record', count: total_records.to_i)
@@ -596,7 +597,7 @@ describe 'Collection Organization', js: true do
 
       expect(page.evaluate_script('window.loadAllFetchCount')).to eq 0
       page.find('.load-all__label-toggle').click
-      sleep 10
+      sleep 5
       expect(page).to have_css('#infinite-records-container .waypoint.populated .infinite-record-record', count: total_records.to_i)
       expect(page.evaluate_script('window.loadAllFetchCount')).to eq num_empty_waypoints_start
     end
@@ -604,7 +605,7 @@ describe 'Collection Organization', js: true do
     it 'loads all remaining records from a background thread if the number of waypoints '\
       'exceeds `infinite_records_main_max_concurrent_waypoint_fetches`' do
       visit "/repositories/#{@repo.id}/resources/#{@res_10wp.id}/collection_organization"
-      sleep 10
+      sleep 5
       total_records = page.find('#infinite-records-container')['data-total-records']
       expect(page).not_to have_css('#infinite-records-container .waypoint.populated .infinite-record-record', count: total_records.to_i)
 
@@ -623,7 +624,7 @@ describe 'Collection Organization', js: true do
 
       expect(page.evaluate_script('window.loadAllFetchCount')).to eq 0
       page.find('.load-all__label-toggle').click
-      sleep 10
+      sleep 5
       expect(page).to have_css('#infinite-records-container .waypoint.populated .infinite-record-record', count: total_records.to_i)
       expect(page.evaluate_script('window.loadAllFetchCount')).to eq 0
     end

--- a/public/spec/rails_helper.rb
+++ b/public/spec/rails_helper.rb
@@ -1,6 +1,7 @@
 require 'capybara/rails'
 require 'capybara-screenshot/rspec'
 require 'launchy'
+require 'aspace_helper'
 
 CHROME_OPTS  = ENV.fetch('CHROME_OPTS', "--headless=new --no-sandbox --enable-logging --log-level=0 --v=1 --incognito --disable-extensions --auto-open-devtools-for-tabs --window-size=1920,1080 --disable-dev-shm-usage").split(' ')
 
@@ -23,7 +24,6 @@ Capybara.register_driver(:chrome) do |app|
   }
   Capybara::Selenium::Driver.new(app, **options)
 end
-
 
 # Firefox
 Capybara.register_driver :firefox do |app|
@@ -82,6 +82,7 @@ Capybara.server_port = URI.parse(AppConfig[:public_url]).port
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.include Capybara::DSL
+  config.include ASpaceHelpers
   config.filter_rails_from_backtrace!
 
   if Capybara.current_driver == :chrome
@@ -161,12 +162,7 @@ Capybara.register_server :as_puma do |app, port, host|
 end
 Capybara.server = :as_puma
 
-def finished_all_ajax_requests?
-  request_count = page.evaluate_script('$.active').to_i
-  request_count && request_count.zero?
-rescue Timeout::Error
-  puts 'timeout..'
-end
+Capybara.default_max_wait_time = ENV.fetch('CAPYBARA_DEFAULT_MAX_WAIT_TIME', 15).to_i
 
 cp_logger = Logger.new(File.join(ASUtils.find_base_directory, "ci_logs", "childprocess_gem.out"))
 cp_logger.level = Logger::DEBUG


### PR DESCRIPTION
This PR fixes a bug in the PUI "Collection Organization" page where collapsing a parent in the `InfiniteTree` only hid the first "waypoint" of children and left any remaining waypoints of children showing in the tree. The solution here is to rewrite the underlying HTML and CSS layers of the tree. An [earlier PR for this ticket](#3469) did not fully solve the bug.

Writing more JavaScript to hide all children was chosen against due to a [broader development goal](https://archivesspace.atlassian.net/browse/ANW-2251) of refactoring the `largetree` for drag-and-drop purposes and more, including rewriting the tree's underlying HTML and CSS.

While [ANW-425](#3014) introduced InfiniteTree.js, which replaced the `largetree` used in the PUI resources `infinite` view, its structure mimicked the largetree HTML and CSS. The largetree is characterized by a pseudo-hierarchical HTML structure assembled from unsemantic `<div>` elements and CSS declarations like `display: table` and `display: table-cell`, etc.

This PR replaces the InfiniteTree's largetree structure with more semantic, hierarchical HTML (nested ordered lists) and a simplified CSS layer. The visual appearance of the tree remains largely unchanged.

[ANW-2259](https://archivesspace.atlassian.net/browse/ANW-2259) gets fixed as a result of the new hierarchical structure (as all children are now nested in their parent).

## Manual test data

A good record to test this is ["Luis Alberto Sánchez papers" via the demo db](https://test.archivesspace.org/repositories/2/resources/19). The root's second child has 4 batches of children ("Correspondence, 1919-1991, bulk: 1930-1969").

## High level changes from largetree

- from "waypoint" to "batch"
- from div soup to nested ordered lists
- from CSS table display to absolute positioning and flexbox

## Screenshots

The new system is visually consistent with the `largetree`, and all batches of children are hidden when a parent is collapsed:

![ANW-2259-semantic-tree](https://github.com/user-attachments/assets/a61da5f4-b9f6-4bf8-bcf5-122b3713a4ee)

---

The new DOM now more accurately reflects the tree's structure. The screenshot below shows a root node with 7 nested children:

<img width="1492" alt="ANW-2259-semantic-tree-DOM" src="https://github.com/user-attachments/assets/a5b48b8a-384e-458f-be9f-ccab32175f91" />

---

The following shows the the largetree's pseudo-hierarchical structure, where children are wrapped in a sibling of their parent. In the following screenshot, a parent node is expanded showing its first of 4 waypoints of children. The parent is selected and highlighted in the dev tools inspector, and includes a `indent-level-1` class. Its children are the next 4 `div[data-waypoint-level="2"]`. The first waypoint, `[data-waypoint-number="0"]`, contains 200 children `<div>`s plus an empty waypoint data `<div>`. The next 3 waypoints contain only an empty waypoint data `<div>` which is shown here in the expanded `[data-waypoint-number="1"]`.

<img width="1452" alt="ANW-2259-old-empty-waypoints" src="https://github.com/user-attachments/assets/68bcb6df-2aae-43e8-826e-b039a8fe560b" />

---

The following shows the true hierarchical structure of, and the children placeholder mechanism for, the new InfiniteTree using the same collection as the above screenshot. The same parent node with 4 "batches" of children has been expanded, and the first batch of children are showing. In the dev tools inspector, the closing `</ol>` of the list of children is highlighted, showing a `li[data-batch-placeholder]` for each of the 3 empty batch placeholders which come at the end of the list. The placeholders get replaced by the children `<li>`s when the user scrolls near. The screenshot also shows the child `<ol>` list being nested inside the parent `<li>`.

<img width="1495" alt="ANW-2259-new-placeholder-logic" src="https://github.com/user-attachments/assets/4ec4acab-1a36-4fb2-a172-5609e42165a3" />

[ANW-2259]: https://archivesspace.atlassian.net/browse/ANW-2259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ANW-425]: https://archivesspace.atlassian.net/browse/ANW-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ