### PR TITLE
ANW-1351: Handle error on preference page without a repository

### DIFF
--- a/frontend/app/controllers/preferences_controller.rb
+++ b/frontend/app/controllers/preferences_controller.rb
@@ -5,13 +5,21 @@ class PreferencesController < ApplicationController
   def edit
     opts, user_scope = setup_defaults
 
+    # Check if we have any repositories before proceeding
+    repos = JSONModel::HTTP.get_json("/repositories")
+    if repos.empty?
+      flash[:error] = I18n.t("preference._frontend.messages.no_access_to_preferences")
+      redirect_to(:controller => :welcome, :action => :index)
+      return
+    end
+
     if @current_prefs[user_scope]
       pref = JSONModel(:preference).from_hash(@current_prefs[user_scope])
     else
       pref = JSONModel(:preference).new({
-                                          :defaults => {},
-                                          :user_id => params['repo'] ? nil : JSONModel(:user).id_for(session[:user_uri])
-                                        })
+                                        :defaults => {},
+                                        :user_id => params['repo'] ? nil : JSONModel(:user).id_for(session[:user_uri])
+                                      })
       pref.save(opts)
     end
 

--- a/frontend/config/locales/de.yml
+++ b/frontend/config/locales/de.yml
@@ -1477,6 +1477,7 @@ de:
         reset: Voreinstellungen auf Anwendungs-Standards gesetzt
         reset_error: 'Konnte Voreinstellungen wegen einem Fehler nicht zurücksetzen:
           %{exception}'
+        no_access_to_preferences: "Sie müssen mindestens einen Aufbewahrungsort erstellen, bevor Sie Voreinstellungen verwalten können"
       action:
         save: Einstellungen speichern
   rights_statement:

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1355,6 +1355,7 @@ en:
         updated: Preferences updated
         reset: Preferences set to application defaults
         reset_error: "Unable to reset preferences due to an error: %{exception}"
+        no_access_to_preferences: "You must create at least one repository before managing preferences"
       action:
         save: Save Preferences
 

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -1315,6 +1315,7 @@ es:
         reset: Preferencias establecidas en los valores predeterminados de la aplicación
         reset_error: "No se pueden restablecer las preferencias debido a un error:
           %{exception}"
+        no_access_to_preferences: "Debe crear al menos un repositorio antes de administrar las preferencias"
       action:
         save: Guardar preferencias
 

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -1338,6 +1338,7 @@ fr:
         reset: Préférences définies sur les valeurs par défaut de l'application
         reset_error: "Impossible de réinitialiser les préférences en raison d'une
           erreur: %{exception}"
+        no_access_to_preferences: "Vous devez créer au moins un service d'archives avant de pouvoir gérer les préférences"
       action:
         save: Enregistrer les préférences
 

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -1219,6 +1219,7 @@ ja:
         updated: プリファレンスの更新
         reset: アプリケーションのデフォルトに設定されたプリファレンス
         reset_error: "エラーのために設定をリセットできません：％{exception}"
+        no_access_to_preferences: "少なくとも1つのリポジトリを作成する前に、プリファレンスを管理できません"
       action:
         save: 設定を保存
 

--- a/frontend/spec/controllers/preferences_controller_spec.rb
+++ b/frontend/spec/controllers/preferences_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe PreferencesController, type: :controller do
+  render_views
+
+  before(:each) do
+    set_repo($repo)
+    session = User.login('admin', 'admin')
+    User.establish_session(controller, session, 'admin')
+    controller.session[:repo_id] = JSONModel.repository
+  end
+
+  describe 'GET edit' do
+    it 'redirects to welcome page when no repositories exist' do
+      # Ensure no repositories exist
+      allow(JSONModel::HTTP).to receive(:get_json).with("/repositories").and_return([])
+
+      get :edit, params: { id: 0 }
+      expect(response).to redirect_to(controller: :welcome, action: :index)
+      expect(flash[:error]).to eq(I18n.t("preference._frontend.messages.no_access_to_preferences"))
+    end
+
+    it 'shows preferences page when repositories exist' do
+      # Mock the existence of at least one repository
+      allow(JSONModel::HTTP).to receive(:get_json).with("/repositories").and_return([{"uri" => "/repositories/1"}])
+
+      get :edit, params: { id: 0 }
+      expect(response).not_to redirect_to(controller: :welcome, action: :index)
+      expect(response.status).to eq(200)
+      expect(flash[:error]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix error when accessing preferences page on Staff UI when there is no repository

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1351

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before
<img width="500" alt="accessing-preference-without-repo" src="https://github.com/user-attachments/assets/b6123ca3-f3b8-44e1-9bd9-49ba6493b6ee" />


After
<img width="500" alt="handle-preferences-without-repo" src="https://github.com/user-attachments/assets/6b304dad-bb15-4c0d-9a9d-426de6111a8a" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
