### PR TITLE
ANW-2272: Fix duplicate too-many-records alert for the record link linker on the Classifications form

### DIFF
--- a/frontend/app/views/classifications/_form_container.html.erb
+++ b/frontend/app/views/classifications/_form_container.html.erb
@@ -32,10 +32,9 @@
       <% form.push("creator", form["creator"] || {}) do %>
         <%= render_aspace_partial :partial => "agents/linker", :locals => {:form => form, :linker_label => t("classification.creator"), :optional => true, :multiplicity => "one"} %>
       <% end %>
-
-      <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "linked_records"} %>
-
     </section>
+
+    <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "linked_records"} %>
   <% end %>
 
   <% form.emit_template("classification") %>


### PR DESCRIPTION
This PR fixes the duplicate "too many records alert" for the record links linker, when there are more than 4 links, on the Classifications form. This bug was found when reviewing #3471.

[ANW-2272](https://archivesspace.atlassian.net/browse/ANW-2272)

## Solution

<img width="1495" alt="ANW-2272-solution" src="https://github.com/user-attachments/assets/2b53d597-7d53-4b77-8d8f-d0d11e78c3b5" />

## Problem

<img width="1501" alt="ANW-2270-classification-record-linker-bug" src="https://github.com/user-attachments/assets/e8af2d51-909e-46bd-a8e5-5498a76cf446" />


[ANW-2272]: https://archivesspace.atlassian.net/browse/ANW-2272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ