### PR TITLE
fixes missing enum instance_type_enum_s on highlighting

### DIFF
--- a/public/config/locales/de.yml
+++ b/public/config/locales/de.yml
@@ -78,6 +78,7 @@ de:
       notes_published: Anmerkungen
       finding_aid_title: Titel des Findmittels
       finding_aid_filing_title: Findmittel Ablagetitel
+      instance_type_enum_s: Exemplar-Typ
     result: Ergebnis
     results: Ergebnisse
     search_for: Suche %{type} wobei %{conditions}

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -108,6 +108,7 @@ en:
       notes_published: Notes
       finding_aid_title: Finding Aid Title
       finding_aid_filing_title: Finding Aid Filing Title
+      instance_type_enum_s: Instance type
     page_title: "Found %{count} Results"
     results_head: "Showing %{type}: %{start} - %{end} of %{total}"
     result: Result

--- a/public/config/locales/es.yml
+++ b/public/config/locales/es.yml
@@ -91,6 +91,7 @@ es:
       notes_published: Notas
       finding_aid_title: Título del instrumento de descripción
       finding_aid_filing_title: Título abreviado del instrumento de descripción
+      instance_type_enum_s: Tipo de representación
     page_title: "Encontrado %{count} resultados"
     results_head: "Mostrando %{type}: %{start} - %{end} of %{total}"
     result: Resultado

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -110,6 +110,7 @@ fr:
       notes_published: Remarques
       finding_aid_title: Titre de l'instrument de recherche
       finding_aid_filing_title: Titre de classement de l'aide
+      instance_type_enum_s: Type d'instance
     page_title: "%{count} résultats trouvés"
     results_head: "%{type} affichés : %{start} - %{end} de %{total}"
     result: Résultats

--- a/public/config/locales/ja.yml
+++ b/public/config/locales/ja.yml
@@ -81,6 +81,7 @@ ja:
       notes_published: ノート
       finding_aid_title: 援助のタイトルを見つける
       finding_aid_filing_title: 援助申請のタイトルを探す
+      instance_type_enum_s: インスタンスの種類
     page_title: 見つかった%{count}結果
     results_head: "%{type} ： %{start} - %{end}の%{total}"
     result: 結果


### PR DESCRIPTION
As seen on the mailing list last week, this enum throws an error in search results like this one https://test.archivesspace.org/search?utf8=%E2%9C%93&op%5B%5D=&q%5B%5D=books&limit=&field%5B%5D=&from_year%5B%5D=&to_year%5B%5D=&commit=Search