### PR TITLE
Remove Dynamic _relator_sort Fields from Solr Schema

### DIFF
--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -212,22 +212,6 @@ class IndexerCommon
       # index the creators only
       creators = record['record']['linked_agents'].select{|link| link['role'] === 'creator'}
       doc['creators'] = creators.collect{|link| link['_resolved']['display_name']['sort_name']} if not creators.empty?
-
-      # make a special sort field for each agent
-      # creator > subject > source
-      seen = {}
-      record['record']['linked_agents'].each do |link|
-        if seen[link['ref']] == 'creator'
-          # do nothing
-        elsif seen[link['ref']] == 'subject' && link['role'] != 'creator'
-          # do nothing
-        else
-          relator_label = link['relator'] ? I18n.t("enumerations.linked_agent_archival_record_relators.#{link['relator']}") : ''
-
-          doc["#{link['ref'].gsub(/\//, '_')}_relator_sort"] = "#{link['role']} #{relator_label}"
-          seen[link['ref']] = link['role']
-        end
-      end
     end
   end
 

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -165,7 +165,6 @@
     <dynamicField name="*_u_typeahead_utext" type="text_general" indexed="true" stored="true" multiValued="false" />
     <dynamicField name="*_u_sortdate" type="date" indexed="true" stored="false" multiValued="false" />
     <dynamicField name="*_u_ssortdate" type="date" indexed="true" stored="true" multiValued="false" />
-    <dynamicField name="*_relator_sort" type="sort_string" indexed="true" stored="true" multiValued="false" />
     <dynamicField name="*_int_sort" type="int" indexed="true" stored="false" multiValued="false" />
   </fields>
   <uniqueKey>id</uniqueKey>


### PR DESCRIPTION
Many moons ago there was a PR which introduced some PUI functionality which apparently depended or was thought to depend on being able to sort a record's related agents by their role.
https://github.com/archivesspace/archivesspace/pull/429 None of this appears to be in use or ever to have been in use in the public app, but the indexer is still creating dynamic fields with keys like:

_agents_corporate_entities_102_relator_sort
_agents_corporate_entities_103_relator_sort
_agents_corporate_entities_104_relator_sort

In fact, for an instance with 1000 agent records - each appearing in at least 1 related_agents relationship - the Solr schema will contain 1000 of these unused, unnecessary fields in the dynamic schema. (Try it by looking at the "Schema" pane in the Solr admin panel after indexing some resource records with related agents.) I don't know how much this has been affecting Solr performance, but removing all these spam fields can surely only help.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
