### PR TITLE
ANW-2316: Handle mixed content in titles especially the title tag

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -833,7 +833,6 @@ span.component {
 
 span.title {
   font-style: italic;
-  font-variant: small-caps;
 }
 
 span.required {

--- a/public/app/views/shared/_idbadge.html.erb
+++ b/public/app/views/shared/_idbadge.html.erb
@@ -41,10 +41,10 @@ end
 <%= (props.fetch(:full,false)? '<h1>' : '<h3>').html_safe %>
   <% if !props.fetch(:full,false) %>
     <a class="record-title" href="<%= app_prefix(url) %>">
-      <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>
+      <%== props.fetch(:infinite_item, false) ? process_mixed_content(result.parse_full_title(true)) : process_mixed_content(result.display_string) %>
     </a>
   <% else %>
-    <%== result.display_string %>
+    <%== process_mixed_content(result.display_string)%>
   <% end %>
 <%= (props.fetch(:full,false)? '</h1>' : '</h3>').html_safe %>
 

--- a/public/app/views/subjects/_terms.html.erb
+++ b/public/app/views/subjects/_terms.html.erb
@@ -1,6 +1,6 @@
 <dl>
   <% terms.each do |term|  %>
     <dt><%= t("enumerations.subject_term_type.#{term['term_type']}") %></dt>
-    <dd><%= term['term'] %></dd>
+    <dd><%== process_mixed_content(term['term']) %></dd>
   <% end %>
 </dl>

--- a/public/app/views/subjects/show.html.erb
+++ b/public/app/views/subjects/show.html.erb
@@ -19,7 +19,7 @@
       <%= render partial: 'shared/results', locals: {:results => @results, :pager => @pager} %>
     </div>
     <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
-      <h3><%= t('more_about') %> '<%= @result.display_string %>'</h3>
+      <h3><%= t('more_about') %> '<%== process_mixed_content(@result.display_string) %>'</h3>
       <div class="acc_holder clear" >
         <div class="panel-group" id="res_accordion">
           <% if !(terms = ASUtils.wrap(@result['json']['terms'])).empty? %>

--- a/public/spec/features/idbadge_spec.rb
+++ b/public/spec/features/idbadge_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'ID Badge component', js: true do
+  before(:all) do
+    @repo = create(:repo, repo_code: "idbadge_test_#{Time.now.to_i}")
+    set_repo(@repo)
+
+    @accession = create(:accession,
+      title: 'This is a <title>mixed content</title> accession',
+      publish: true
+    )
+
+    @subject = create(:subject,
+      terms: [build(:term, {term: "This is a <title>mixed content</title> subject", term_type: 'temporal'})]
+    )
+
+    @resource = create(:resource,
+      title: 'This is a <title>mixed content</title> resource',
+      publish: true,
+      subjects: [{'ref' => @subject.uri}]
+    )
+
+    @ao = create(:archival_object,
+      resource: {'ref' => @resource.uri},
+      title: 'This is a <title>mixed content</title> archival object',
+      publish: true
+    )
+
+    @do = create(:digital_object,
+      title: 'This is a <title>mixed content</title> digital object',
+      publish: true
+    )
+
+    @doc = create(:digital_object_component,
+      digital_object: { ref: @do.uri },
+      title: 'This is a <title>mixed content</title> digital object component',
+      publish: true
+    )
+
+    run_indexers
+  end
+
+  context 'when displaying mixed content in titles' do
+    shared_examples 'a mixed content title' do |record_var|
+      let(:record_type_names) do
+        {
+          '@ao' => 'archival object',
+          '@do' => 'digital object',
+          '@doc' => 'digital object component'
+        }
+      end
+
+      it 'displays the full title with properly rendered mixed content' do
+        visit instance_variable_get(record_var).uri
+        idbadge_title = find('#info_row h1')
+        record_name = record_type_names[record_var.to_s] || record_var.to_s.delete('@')
+        expect(idbadge_title).to have_content("This is a mixed content #{record_name}")
+        expect(idbadge_title).to have_css('span.title', text: 'mixed content')
+      end
+    end
+
+    it_behaves_like 'a mixed content title', :@accession
+    it_behaves_like 'a mixed content title', :@resource
+    it_behaves_like 'a mixed content title', :@ao
+    it_behaves_like 'a mixed content title', :@do
+    it_behaves_like 'a mixed content title', :@doc
+    it_behaves_like 'a mixed content title', :@subject
+  end
+end


### PR DESCRIPTION
This PR solves a regression bug in v4.0.0 that, in the PUI, did not show text in record titles wrapped in mixed content `<title>` tags. This bug did not exist in v3.5.1. I'm not sure where the break happened, the files changed herein were the first I checked and it appears to be fixed, even though the file bits hadn't been updated in 3+ years. Possibly related to recent mixed content work, or softserv?

[ANW-2316](https://archivesspace.atlassian.net/browse/ANW-2316)

## Problem

<img width="1495" alt="ANW-2316 problem" src="https://github.com/user-attachments/assets/99eb8b7d-86d2-4c5e-be58-ebf09860f2e0" />

## Solution

<img width="1490" alt="ANW-2316 solution" src="https://github.com/user-attachments/assets/acb3d72b-f91b-42d4-9201-46653002a501" />



[ANW-2316]: https://archivesspace.atlassian.net/browse/ANW-2316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ