### PR TITLE
ANW-2333 Adjust PUI font-awesome path for url prefix

### DIFF
--- a/public/vendor/assets/stylesheets/font-awesome/scss/_variables.scss
+++ b/public/vendor/assets/stylesheets/font-awesome/scss/_variables.scss
@@ -1,7 +1,7 @@
 // Variables
 // --------------------------
 
-$fa-font-path:        "../assets/font-awesome" !default;
+$fa-font-path:        "assets/font-awesome" !default;
 $fa-font-size-base:   14px !default;
 $fa-line-height-base: 1 !default;
 //$fa-font-path:        "//netdna.bootstrapcdn.com/font-awesome/4.7.0/fonts" !default; // for referencing Bootstrap CDN font files directly


### PR DESCRIPTION
This PR is attempting to fix a problem where the PUI Font Awesome font assets are not being found when the app has a url prefix.

[ANW-2333](https://archivesspace.atlassian.net/browse/ANW-2333)

[ANW-2333]: https://archivesspace.atlassian.net/browse/ANW-2333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ