### PR TITLE
changes user_defined date help wording

### DIFF
--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -28,11 +28,11 @@ en:
     text_4: Text 4
     text_5: Text 5
     date_1: Date 1
-    date_1_inline_help: e.g. YYYY-MM-DD
+    date_1_inline_help: YYYY-MM-DD Format Required
     date_2: Date 2
-    date_2_inline_help: e.g. YYYY-MM-DD
+    date_2_inline_help: YYYY-MM-DD Format Required
     date_3: Date 3
-    date_3_inline_help: e.g. YYYY-MM-DD
+    date_3_inline_help: YYYY-MM-DD Format Required
     enum_1: Controlled Value 1
     enum_2: Controlled Value 2
     enum_3: Controlled Value 3

--- a/common/locales/es.yml
+++ b/common/locales/es.yml
@@ -30,11 +30,11 @@ es:
     text_4: Texto 4
     text_5: Texto 5
     date_1: Fecha 1
-    date_1_inline_help: e.g. YYYY-MM-DD
+    date_1_inline_help: YYYY-MM-DD Formato Necesario
     date_2: Fecha 2
-    date_2_inline_help: e.g. YYYY-MM-DD
+    date_2_inline_help: YYYY-MM-DD Formato Necesario
     date_3: Fecha 3
-    date_3_inline_help: e.g. YYYY-MM-DD
+    date_3_inline_help: YYYY-MM-DD Formato Necesario
     enum_1: Valor controlado 1
     enum_2: Valor controlado 2
     enum_3: Valor controlado 3


### PR DESCRIPTION
This help text "e.g." reads more like a suggestion when it's actually required to be exactly that format. I think this change makes that more clear.