### PR TITLE
Fixes Plugin Partial Render Memory Leak

### DIFF
--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -16,6 +16,7 @@ class ApplicationController < ActionController::Base
 
   # Allow overriding of templates via the local folder(s)
   if not ASUtils.find_local_directories.blank?
+    append_view_path(File.absolute_path(ASUtils.plugin_base_directory))
     ASUtils.find_local_directories.map {|local_dir| File.join(local_dir, 'frontend', 'views')}.reject { |dir| !Dir.exist?(dir) }.each do |template_override_directory|
       prepend_view_path(template_override_directory)
     end

--- a/frontend/app/helpers/plugin_helper.rb
+++ b/frontend/app/helpers/plugin_helper.rb
@@ -61,13 +61,19 @@ module PluginHelper
     result.html_safe
   end
 
+  # calculate a relative path from the incoming partial to the plugin directory
+  def self.relative_plugin_view_path(partial)
+    rel_path = Pathname.new(File.absolute_path(partial)).relative_path_from(File.absolute_path(ASUtils.plugin_base_directory)).to_s
+    File.join(File.dirname(rel_path), File.basename(rel_path).split('.')[0])
+  end
+
   def render_plugin_partials(name, locals = {})
     result = ''
 
     ASUtils.find_local_directories("frontend/views/_#{name}.html.erb").each do |partial|
       next unless File.exist?(partial)
 
-      result << render(:inline => File.read(partial), :locals => locals)
+      result << render(:template => PluginHelper.relative_plugin_view_path(partial), :locals => locals)
     end
 
     result.html_safe

--- a/frontend/app/views/layouts/application.html.erb
+++ b/frontend/app/views/layouts/application.html.erb
@@ -38,7 +38,7 @@
   <% ASUtils.order_plugins(ASUtils.find_local_directories('frontend/views/layout_head.html.erb')).each do |layout| %>
     <% if File.exist?(layout) %>
       <!-- Begin plugin layout -->
-      <%= render :inline => File.read(layout) %>
+      <%= render :template => PluginHelper.relative_plugin_view_path(layout) %>
       <!-- End plugin layout -->
     <% end %>
   <% end %>
@@ -66,7 +66,7 @@
     <% ASUtils.order_plugins(ASUtils.find_local_directories('frontend/views/_shared_templates.html.erb')).each do |layout| %>
       <% if File.exist?(layout) %>
         <!-- Begin plugin layout -->
-        <%= render :inline => File.read(layout) %>
+        <%= render :template => PluginHelper.relative_plugin_view_path(layout) %>
         <!-- End plugin layout -->
       <% end %>
     <% end %>

--- a/public/app/controllers/application_controller.rb
+++ b/public/app/controllers/application_controller.rb
@@ -31,6 +31,7 @@ class ApplicationController < ActionController::Base
 
   # Allow overriding of templates via the local folder(s)
   if not ASUtils.find_local_directories.blank?
+    append_view_path(File.absolute_path(ASUtils.plugin_base_directory))
     ASUtils.find_local_directories.map {|local_dir| File.join(local_dir, 'public', 'views')}.reject { |dir| !Dir.exist?(dir) }.each do |template_override_directory|
       prepend_view_path(template_override_directory)
     end

--- a/public/app/helpers/view_helper.rb
+++ b/public/app/helpers/view_helper.rb
@@ -199,4 +199,11 @@ module ViewHelper
 
     return url
   end
+
+  # calculate a relative path from the incoming partial to the plugin directory
+  def self.relative_plugin_view_path(partial)
+    rel_path = Pathname.new(File.absolute_path(partial)).relative_path_from(File.absolute_path(ASUtils.plugin_base_directory)).to_s
+    File.join(File.dirname(rel_path), File.basename(rel_path).split('.')[0])
+  end
+
 end

--- a/public/app/views/layouts/application.html.erb
+++ b/public/app/views/layouts/application.html.erb
@@ -25,11 +25,9 @@
 	<%= render partial: 'shared/metadata' %>
 
 	<% ASUtils.find_local_directories('public/views/layout_head.html.erb').each do |template| %>
-		<% if File.exists?(template) %>
-			<!-- Begin plugin layout -->
-      <%= render :template => ViewHelper.relative_plugin_view_path(template) %>
-			<!-- End plugin layout -->
-		<% end %>
+		<!-- Begin plugin layout -->
+		<%= render :template => ViewHelper.relative_plugin_view_path(template) if File.exists?(template) %>
+		<!-- End plugin layout -->
 	<% end %>
 
 <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->

--- a/public/app/views/layouts/application.html.erb
+++ b/public/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
 	<% ASUtils.find_local_directories('public/views/layout_head.html.erb').each do |template| %>
 		<% if File.exists?(template) %>
 			<!-- Begin plugin layout -->
-			<%= render :inline => File.read(template) %>
+      <%= render :template => ViewHelper.relative_plugin_view_path(template) %>
 			<!-- End plugin layout -->
 		<% end %>
 	<% end %>
@@ -43,11 +43,9 @@
 <body class="min-h-screen d-flex flex-column">
 
 	<% ASUtils.find_local_directories('public/views/body_top.html.erb').each do |template| %>
-		<% if File.exists?(template) %>
-			<!-- Begin plugin layout -->
-			<%= render :inline => File.read(template) %>
-			<!-- End plugin layout -->
-		<% end %>
+		<!-- Begin plugin layout -->
+		<%= render :template => ViewHelper.relative_plugin_view_path(template) if File.exists?(template) %>
+		<!-- End plugin layout -->
 	<% end %>
 
 	<%= render partial: 'shared/skipnav' %>

--- a/public/app/views/pdf/_archival_object.html.erb
+++ b/public/app/views/pdf/_archival_object.html.erb
@@ -160,7 +160,7 @@ end
                 <% end %>
 
                 <% ASUtils.find_local_directories('public/views/_pdf_archival_object.html.erb').each do |template| %>
-                    <%= render(:inline => File.read(template), :locals => {:record => record}) if File.exists?(template) %>
+                    <%= render(:template => ViewHelper.relative_plugin_view_path(template), :locals => {:record => record}) if File.exists?(template) %>
                 <% end %>
 
             </dl>

--- a/public/app/views/pdf/_digital_object_links.html.erb
+++ b/public/app/views/pdf/_digital_object_links.html.erb
@@ -10,6 +10,6 @@
       <% end %>
     <% end %>
     <% ASUtils.find_local_directories('public/views/_pdf_digital_object_links.html.erb').each do |template| %>
-        <%= render(:inline => File.read(template), :locals => {:instance => instance}) if File.exists?(template) %>
+        <%= render(:template => ViewHelper.relative_plugin_view_path(template), :locals => {:instance => instance}) if File.exists?(template) %>
     <% end %>
 <% end %>

--- a/public/app/views/pdf/_header.html.erb
+++ b/public/app/views/pdf/_header.html.erb
@@ -376,7 +376,7 @@ li::before {
 
         </style>
         <% ASUtils.find_local_directories('public/views/_pdf_header.html.erb').each do |template| %>
-            <%= render(:inline => File.read(template), :locals => {:record => record}) if File.exists?(template) %>
+            <%= render(:template => ViewHelper.relative_plugin_view_path(template), :locals => {:record => record}) if File.exists?(template) %>
         <% end %>
     </head>
     <body>

--- a/public/app/views/pdf/_resource.html.erb
+++ b/public/app/views/pdf/_resource.html.erb
@@ -310,7 +310,7 @@
 
 
 <% ASUtils.find_local_directories('public/views/_pdf_resource.html.erb').each do |template| %>
-    <%= render(:inline => File.read(template), :locals => {:record => record}) if File.exists?(template) %>
+    <%= render(:template => ViewHelper.relative_plugin_view_path(template), :locals => {:record => record}) if File.exists?(template) %>
 <% end %>
 
 <div class="collection-inventory">

--- a/public/app/views/pdf/_titlepage.html.erb
+++ b/public/app/views/pdf/_titlepage.html.erb
@@ -40,7 +40,7 @@
     </div>
     
     <% ASUtils.find_local_directories('public/views/_pdf_titlepage.html.erb').each do |template| %>
-        <%= render(:inline => File.read(template), :locals => {:record => record}) if File.exists?(template) %>
+        <%= render(:template => ViewHelper.relative_plugin_view_path(template), :locals => {:record => record}) if File.exists?(template) %>
     <% end %>
 
     <% if record.resolved_repository && 

--- a/public/app/views/shared/_record_innards.html.erb
+++ b/public/app/views/shared/_record_innards.html.erb
@@ -58,7 +58,7 @@
     <% end %>
 
     <% ASUtils.find_local_directories('public/views/_upper_record_innards.html.erb').each do |template| %>
-      <%= render :inline => File.read(template) if File.exists?(template) %>
+      <%= render :template => ViewHelper.relative_plugin_view_path(template) if File.exists?(template) %>
     <% end %>
 </div>
 
@@ -148,7 +148,7 @@
         <% end %>
       </div>
       <% ASUtils.find_local_directories('public/views/_lower_record_innards.html.erb').each do |template| %>
-        <%= render :inline => File.read(template) if File.exists?(template) %>
+        <%= render :template => ViewHelper.relative_plugin_view_path(template) if File.exists?(template) %>
       <% end %>
     </div>
     <script type="text/javascript" >initialize_accordion(".note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>", <%= AppConfig[:pui_expand_all] %>);

--- a/public/app/views/welcome/show.html.erb
+++ b/public/app/views/welcome/show.html.erb
@@ -26,5 +26,5 @@
     } %>
 
     <% ASUtils.find_local_directories('public/views/_welcome_addition.html.erb').each do |template| %>
-        <%= render(:inline => File.read(template)) if File.exists?(template) %>
+        <%= render(:template => ViewHelper.relative_plugin_view_path(template)) if File.exists?(template) %>
     <% end %>


### PR DESCRIPTION
- adds new helper methods for frontend and public
- adds plugin base directory to Rails view path(s)
- changes `render :inline` to `render :template` for plugin partials

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
As discovered by @marktriggs, the `render :inline` used in the initial release of ArchivesSpace 4.0 creates a memory leak for instances that are running plugins with specific partials.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
See #3508 for full explanation, discussion, and resolution

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing. Mac OS 15, mariadb, solr 9.8.0 and local containerized dev environment. Tested with local (not public) custom plugins and the following public plugins

- https://github.com/dartmouth-dltg/local_contexts_projects
- https://github.com/dartmouth-dltg/aspace_content_warnings
- https://github.com/dartmouth-dltg/aspace_custom_restrictions_and_context
- https://github.com/dartmouth-dltg/aspace_reparative_descriptions
- https://github.com/dartmouth-dltg/aspace_analytics

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
