### PR TITLE
ANW-1844: Render request modal conditionally based on `pui_page_actions_request`

### DIFF
--- a/public/app/views/shared/_modal_actions.html.erb
+++ b/public/app/views/shared/_modal_actions.html.erb
@@ -9,9 +9,9 @@
   } %>
 <script type ="text/javascript" >setupCite()</script>
 <% end %>
-<% if defined?(@request) && !@request.nil? %>
+<% if AppConfig[:pui_page_actions_request] && defined?(@request) && !@request.nil? %>
   <% req = render partial: 'shared/request_form' %>
   <%= render partial: 'shared/modal', locals: {:modal_id => 'request_modal', :title => t('actions.request'),
       :modal_body => req } %>
-<script type ="text/javascript" >setupRequest("request_modal",  "<%= t('actions.request') %>")</script>
+  <script type ="text/javascript" >setupRequest("request_modal",  "<%= t('actions.request') %>")</script>
 <% end %>

--- a/public/app/views/shared/_request_page_action.html.erb
+++ b/public/app/views/shared/_request_page_action.html.erb
@@ -1,4 +1,4 @@
-<% if defined?(@request) && !@request.nil? && pass_email_requirements?(@result) %>
+<% if AppConfig[:pui_page_actions_request] && defined?(@request) && !@request.nil? && pass_email_requirements?(@result) %>
   <%= form_tag "#{app_prefix(@request[:request_uri])}/request", :id => 'request_sub' do |f| %>
     <%= render partial: 'shared/request_hiddens' %>
     <button type="submit" class="btn page_action request  btn-default" title="<%= t('actions.request') %>">

--- a/public/spec/features/request_spec.rb
+++ b/public/spec/features/request_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Request feature', js: true do
+  before(:all) do
+    @resource = create(:resource, publish: true)
+    run_indexers
+  end
+
+  before(:each) do
+    allow(AppConfig).to receive(:[]).and_call_original
+  end
+
+  context 'when AppConfig[:pui_page_actions_request] is set to true' do
+    before :each do
+      allow(AppConfig).to receive(:[]).with(:pui_page_actions_request) { true }
+      visit(@resource.uri)
+      wait_for_jquery
+    end
+
+    it 'shows the request button' do
+      expect(page).to have_button('Request')
+    end
+
+    it 'hides the modal by default' do
+      expect(page).to have_css('#request_modal', visible: false)
+      expect(page).to have_css('#request_form', visible: false)
+    end
+
+    context 'when the Request button is clicked' do
+      before :each do
+        click_button 'Request'
+        wait_for_jquery
+      end
+
+      it 'the modal becomes visible' do
+        expect(page).to have_css('#request_modal', visible: true)
+        expect(page).to have_css('#request_form', visible: true)
+      end
+    end
+  end
+
+  context 'when AppConfig[:pui_page_actions_request] is set to false' do
+    before :each do
+      allow(AppConfig).to receive(:[]).with(:pui_page_actions_request) { false }
+    end
+
+    it 'does not include the request button or modal in the DOM' do
+      visit(@resource.uri)
+      expect(page).not_to have_button('Request')
+      expect(page).not_to have_css('#request_modal')
+      expect(page).not_to have_css('#request_form')
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes [ANW-1844](https://archivesspace.atlassian.net/browse/ANW-1844) by not adding the PUI request modal to the DOM when `AppConfig[:pui_page_actions_request]` is `false`.

## Solution

The following screenshot shows that the "Request" button is not present in the toolbar towards the top of the page. It also shows the browser dev tools confirming that `#request_modal`, the CSS selector for the modal element containing the request form, is not present in the DOM.

<img width="1470" alt="ANW-1844-solution" src="https://github.com/user-attachments/assets/9d954ba6-064b-4d84-8052-f426de172c07" />

[ANW-1844]: https://archivesspace.atlassian.net/browse/ANW-1844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ