### PR TITLE
ANW-2334: Add bibliography notes to PUI pdf generation

### DIFF
--- a/public/app/views/pdf/_resource.html.erb
+++ b/public/app/views/pdf/_resource.html.erb
@@ -90,7 +90,7 @@
 
 </dl>
 
-    <a href="#toc">Return to Table of Contents</a>
+    <a href="#toc"><%= I18n.t('pdf_reports.return_to_table_of_contents') %></a>
 
     <% record.notes.each do |note_type, note| %>
         <% if note_type == 'prefercite' %>
@@ -118,7 +118,7 @@
     <% end %>
   <% end %>
 
-  <a href="#toc">Return to Table of Contents</a>
+  <a href="#toc"><%= I18n.t('pdf_reports.return_to_table_of_contents') %></a>
 </div>
 
 
@@ -136,7 +136,7 @@
     <p><%== process_mixed_content(n['note_text']) %></p>
   <% end %>
 
-  <a href="#toc">Return to Table of Contents</a>
+  <a href="#toc"><%= I18n.t('pdf_reports.return_to_table_of_contents') %></a>
 <% end %>
 
 <a id="note-arrangement"></a>
@@ -153,7 +153,7 @@
     <p><%== process_mixed_content(n['note_text']) %></p>
   <% end %>
 
-  <a href="#toc">Return to Table of Contents</a>
+  <a href="#toc"><%= I18n.t('pdf_reports.return_to_table_of_contents') %></a>
 <% end %>
 
 
@@ -233,7 +233,7 @@
   <% end %>
 <% end %>
 
-<a href="#toc">Return to Table of Contents</a>
+<a href="#toc"><%= I18n.t('pdf_reports.return_to_table_of_contents') %></a>
 
 <a id="note-relatedmaterial"></a>
 
@@ -273,7 +273,7 @@
 
   </ul>
 
-  <a href="#toc">Return to Table of Contents</a>
+  <a href="#toc"><%= I18n.t('pdf_reports.return_to_table_of_contents') %></a>
 <% end %>
 
 
@@ -289,7 +289,23 @@
     <p><%== process_mixed_content(n['note_text']) %></p>
   <% end %>
 
-  <a href="#toc">Return to Table of Contents</a>
+  <a href="#toc"><%= I18n.t('pdf_reports.return_to_table_of_contents') %></a>
+<% end %>
+
+<% unless record.notes['note_bibliography'].nil? %>
+  <a id="note-note_bibliography"></a>
+  <% record.notes['note_bibliography'].each do |n| %>
+    <h3>
+      <% if n['label'] %>
+          <%== process_mixed_content(n['label']) %>
+      <% else %>
+          <%= I18n.t("enumerations._note_types.note_bibliography") %>
+      <% end %>
+    </h3>
+    <p><%== process_mixed_content(n['note_text']) %></p>
+  <% end %>
+
+  <a href="#toc"><%= I18n.t('pdf_reports.return_to_table_of_contents') %></a>
 <% end %>
 
 

--- a/public/app/views/pdf/_toc.html.erb
+++ b/public/app/views/pdf/_toc.html.erb
@@ -83,6 +83,23 @@
           <li class="level-1"><a href="#controlled-access-headings"><%= I18n.t('pdf_reports.controlled_access_headings') %></a></li>
         <% end %>
 
+        <% unless resource.notes['note_bibliography'].nil? %>
+          <li class="level-1">
+            <a href="#note-note_bibliography">
+              <% labels = [] %>
+
+              <% resource.notes['note_bibliography'].each do |n| %>
+                <% if n['label'] %>
+                    <% labels << n['label'] %>
+                <% else %>
+                    <% labels <<  I18n.t("enumerations._note_types.note_bibliography") %>
+                <% end %>
+              <% end %>
+              <%== process_mixed_content(labels.uniq.join(", ")) %>
+            </a>
+          </li>
+        <% end %>
+
         <% if has_children %>
             <li class="level-1"><a href="#collection-inventory"><%= I18n.t('pdf_reports.collection_inventory') %></a></li>
         <% end %>

--- a/public/config/locales/de.yml
+++ b/public/config/locales/de.yml
@@ -410,6 +410,7 @@ de:
     collection_inventory: Sammlungs-Verzeichnis
     summary_information: Zusammengefasste Informationen
     table_of_contents: Inhalt
+    return_to_table_of_contents: Zurück zum Inhalt
     publication_statement: Veröffentlichungs-Bezeichnung
     controlled_access_headings: Überschriften für geregelten Zugang
     finding_aid_date_prefix: Dieses Findmittel wurde erstellt mit ArchivesSpace am

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -487,6 +487,7 @@ en:
     collection_inventory: Collection Inventory
     summary_information: Summary Information
     table_of_contents: Table Of Contents
+    return_to_table_of_contents: Return to Table of Contents
     publication_statement: Publication Statement
     controlled_access_headings: Controlled Access Headings
     finding_aid_date_prefix: This finding aid was produced using ArchivesSpace on

--- a/public/config/locales/es.yml
+++ b/public/config/locales/es.yml
@@ -459,6 +459,7 @@ es:
     collection_inventory: Inventario de la colección
     summary_information: Información de resumen
     table_of_contents: Tabla de contenidos
+    return_to_table_of_contents: Volver a la tabla de contenidos
     publication_statement: Declaración de publicación
     controlled_access_headings: Encabezados de acceso controlado
     finding_aid_date_prefix: Esta ayuda de búsqueda se elaboró utilizando ArchivesSpace en

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -485,6 +485,7 @@ fr:
     collection_inventory: Inventaire des collections
     summary_information: Résumé informatif
     table_of_contents: Table des matières
+    return_to_table_of_contents: Retour à la table des matières
     publication_statement: Mention de publication
     controlled_access_headings: En-têtes de confidentialité
     finding_aid_date_prefix: Instrument de recherche élaboré à l'aide d'ArchivesSpace sur

--- a/public/config/locales/ja.yml
+++ b/public/config/locales/ja.yml
@@ -405,6 +405,7 @@ ja:
     collection_inventory: コレクションインベントリ
     summary_information: 要約情報
     table_of_contents: 目次
+    return_to_table_of_contents: 目次に戻る
     publication_statement: 出版物
     controlled_access_headings: 制御されたアクセス見出し
     finding_aid_date_prefix: この発見支援は、ArchivesSpace on

--- a/public/config/locales/pt.yml
+++ b/public/config/locales/pt.yml
@@ -166,3 +166,11 @@ pt:
       browse_number_digital_objects_in_collection:
         one: Pesquisar %{num} objeto digital na coleção
         other: Pesquisar %{num} objetos digitais na coleção
+
+  pdf_reports:
+    administrative_information: Informação administrativa
+    collection_inventory: Inventário da coleção
+    summary_information: Informação resumida
+    table_of_contents: Índice
+    return_to_table_of_contents: Voltar ao índice
+    publication_statement: Declaração de publicação


### PR DESCRIPTION
This PR adds any existing bibliography notes that a resource might have to the to the pdf generated by the PUI.

[ANW-2334](https://archivesspace.atlassian.net/browse/ANW-2334)

## Solution

Here are 2 relevant pages exported from https://test.archivesspace.org/repositories/2/resources/32:

![wag_354-toc](https://github.com/user-attachments/assets/e90dd100-2cd9-4a19-bee6-81e808f2e63e)

![wag_354-biblio](https://github.com/user-attachments/assets/4764fff2-15ab-4bbd-9e48-084a1cc092c0)


[ANW-2334]: https://archivesspace.atlassian.net/browse/ANW-2334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ