### PR TITLE
ANW-2361 - Put back intended uses of the word "target"

### DIFF
--- a/frontend/app/views/shared/_templates.html.erb
+++ b/frontend/app/views/shared/_templates.html.erb
@@ -335,7 +335,7 @@
 --></div>
 
 <div id="template_load_via_spreadsheet_help_icon"><!--
-  <a merge_destination='_blank' class='btn btn-sm btn-default border-left-0 has-tooltip initialised' id='load_via_spreadsheet_help_icon' href="<%= ArchivesSpaceHelp.url_for_topic('resource_load_via_spreadsheet') %>" data-toggle="tooltip" data-placement="top" title="<%= t("help.topics.resource_load_via_spreadsheet")%>" data-container="body">
+  <a target='_blank' class='btn btn-sm btn-default border-left-0 has-tooltip initialised' id='load_via_spreadsheet_help_icon' href="<%= ArchivesSpaceHelp.url_for_topic('resource_load_via_spreadsheet') %>" data-toggle="tooltip" data-placement="top" title="<%= t("help.topics.resource_load_via_spreadsheet")%>" data-container="body">
     <span class='context-help-icon glyphicon glyphicon-question-sign'></span>
   </a>
 --></div>

--- a/frontend/config/locales/de.yml
+++ b/frontend/config/locales/de.yml
@@ -2718,6 +2718,6 @@ de:
     _singular: Eingangs-Verknüpfung
   footer:
     public_interface: <a href="%{public_url}">Zum öffentlichen Katalog</a>
-    feedback: <a id='aspaceFeedbackLink' href='%{feedback_url}' merge_destination='_blank'>Rückmeldung
+    feedback: <a id='aspaceFeedbackLink' href='%{feedback_url}' target='_blank'>Rückmeldung
       geben oder ein Problem melden</a>
     archivesspace_home: Besuchen Sie <a href='http://archivesspace.org'>ArchivesSpace.org</a>

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -3320,6 +3320,6 @@ es:
       recursos, objetos de archivo u objetos digitales existentes.
   footer:
     archivesspace_home: Visitar <a href='http://archivesspace.org'>ArchivesSpace.org</a>
-    feedback: <a id='aspaceFeedbackLink' href='%{feedback_url}' merge_destination='_blank'>Enviar
+    feedback: <a id='aspaceFeedbackLink' href='%{feedback_url}' target='_blank'>Enviar
       comentarios o informar un problema</a>
     public_interface: Vistar <a href="%{public_url}">Interfaz Pública</a>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
There are a few places where it looks like a find and replace for "target" (or equivalent) incorrectly replaced that word with the new merge terminology. I did not see this in the Japanese yml (someone may need to check) and had previously corrected the French one.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-2361

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
