### PR TITLE
ANW-2363: Enable lightmode on Agent Required Fields form

### DIFF
--- a/frontend/app/views/agents/_form_required.html.erb
+++ b/frontend/app/views/agents/_form_required.html.erb
@@ -12,23 +12,23 @@
     </div>
   </section>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_record_identifiers", help_topic: "agent_record_identifiers", type: :agent_record_identifier, field_names: ["record_identifier", "source", "identifier_type"]} %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_record_identifiers", help_topic: "agent_record_identifiers", type: :agent_record_identifier, field_names: ["record_identifier", "source", "identifier_type"], lightmode_toggle: false} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_record_controls", help_topic: "agent_record_controls",  type: :agent_record_control, field_names: ["maintenance_status", "publication_status", "maintenance_agency", "agency_name", "maintenance_agency_note", "language", "script", "language_note", "romanization", "government_agency_type", "reference_evaluation", "name_type", "level_of_detail", "modified_record", "cataloging_source"] } %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_record_controls", help_topic: "agent_record_controls",  type: :agent_record_control, field_names: ["maintenance_status", "publication_status", "maintenance_agency", "agency_name", "maintenance_agency_note", "language", "script", "language_note", "romanization", "government_agency_type", "reference_evaluation", "name_type", "level_of_detail", "modified_record", "cataloging_source"], lightmode_toggle: true} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_other_agency_codes", help_topic: "agent_other_agency_codes", type: :agent_other_agency_codes, field_names: ["maintenance_agency", "agency_code_type"] } %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_other_agency_codes", help_topic: "agent_other_agency_codes", type: :agent_other_agency_codes, field_names: ["maintenance_agency", "agency_code_type"], lightmode_toggle: true} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name:  "agent_conventions_declarations", help_topic: "agent_conventions_declarations", type: :agent_conventions_declaration, field_names: ["name_rule", "citation", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute", "last_verified_date"]} %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name:  "agent_conventions_declarations", help_topic: "agent_conventions_declarations", type: :agent_conventions_declaration, field_names: ["name_rule", "citation", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute", "last_verified_date"], lightmode_toggle: true} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "metadata_rights_declarations", help_topic: "metadata_rights_declarations", type: :metadata_rights_declaration, field_names: ["license", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute", "last_verified_date"]} %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "metadata_rights_declarations", help_topic: "metadata_rights_declarations", type: :metadata_rights_declaration, field_names: ["license", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute", "last_verified_date"], lightmode_toggle: true} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_maintenance_histories", help_topic: "agent_maintenance_histories", type: :agent_maintenance_history, field_names: ["maintenance_event_type", "event_date", "agent", "maintenance_agent_type", "descriptive_note"] } %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_maintenance_histories", help_topic: "agent_maintenance_histories", type: :agent_maintenance_history, field_names: ["maintenance_event_type", "event_date", "agent", "maintenance_agent_type", "descriptive_note"], lightmode_toggle: true} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_sources", help_topic: "agent_sources", type: "agent_sources", field_names: ["source_entry", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute",  "last_verified_date"]} %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_sources", help_topic: "agent_sources", type: "agent_sources", field_names: ["source_entry", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute",  "last_verified_date"], lightmode_toggle: true} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_alternate_sets", help_topic: "agent_alternate_sets", type: "agent_alternate_set", field_names: ["set_component", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute", "last_verified_date"]}  %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_alternate_sets", help_topic: "agent_alternate_sets", type: "agent_alternate_set", field_names: ["set_component", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute", "last_verified_date"], lightmode_toggle: true}  %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_identifiers", help_topic: "agent_identifiers", type: "agent_identifier", field_names: ["entity_identifier", "identifier_type"]} %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_identifiers", help_topic: "agent_identifiers", type: "agent_identifier", field_names: ["entity_identifier", "identifier_type"], lightmode_toggle: false} %>
 
   <%
      name_type = @agent.agent_type.to_s.sub('agent', 'name')
@@ -47,23 +47,23 @@
                     end
    %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "names", help_topic: "#{@agent.agent_type}_names", type: name_type.intern, field_names: name_fields, section_id: "#{@agent.agent_type}_names" } %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "names", help_topic: "#{@agent.agent_type}_names", type: name_type.intern, field_names: name_fields, section_id: "#{@agent.agent_type}_names", lightmode_toggle: false} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "dates_of_existence", :heading_text => t("agent._frontend.section.dates_of_existence"), :help_topic => "#{@agent.agent_type}_dates_of_existence", type: :structured_date_label, i18n_type: :structured_date_label_common_fields, field_names: ["date_label", "date_type_structured", "date_certainty", "date_era", "date_calendar"], section_id: "#{@agent.agent_type}_dates_of_existence" } %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "dates_of_existence", :heading_text => t("agent._frontend.section.dates_of_existence"), :help_topic => "#{@agent.agent_type}_dates_of_existence", type: :structured_date_label, i18n_type: :structured_date_label_common_fields, field_names: ["date_label", "date_type_structured", "date_certainty", "date_era", "date_calendar"], section_id: "#{@agent.agent_type}_dates_of_existence", lightmode_toggle: false} %>
 
   <% if @agent.agent_type.to_s == "agent_person" %>
-    <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_genders", help_topic: "agent_genders", :property => "agent_genders", type: "agent_gender", field_names: ["gender"]}  %>
+    <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_genders", help_topic: "agent_genders", :property => "agent_genders", type: "agent_gender", field_names: ["gender"], lightmode_toggle: true}  %>
   <% end %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_places", help_topic: "agent_places", :property => "agent_places", type: "agent_place", field_names: ["place_role"]} %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_places", help_topic: "agent_places", :property => "agent_places", type: "agent_place", field_names: ["place_role"], lightmode_toggle: true} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "used_languages",  help_topic: "used_languages", type: "used_language", field_names: ["language", "script"] } %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "used_languages",  help_topic: "used_languages", type: "used_language", field_names: ["language", "script"], lightmode_toggle: true} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_contacts", help_topic: "#{@agent.agent_type}_contact_details", type: :agent_contact, field_names: ["name", "salutation", "address_1", "address_2", "address_3", "city", "region", "country", "post_code", "email", "note"], section_id: "#{@agent.agent_type}_contact_details" } %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_contacts", help_topic: "#{@agent.agent_type}_contact_details", type: :agent_contact, field_names: ["name", "salutation", "address_1", "address_2", "address_3", "city", "region", "country", "post_code", "email", "note"], section_id: "#{@agent.agent_type}_contact_details", lightmode_toggle: false} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "external_documents", help_topic: "#{@agent.agent_type}_external_documents", type: :external_document, field_names: ["title", "location"], section_id: "#{@agent.agent_type}_external_documents" } %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "external_documents", help_topic: "#{@agent.agent_type}_external_documents", type: :external_document, field_names: ["title", "location"], section_id: "#{@agent.agent_type}_external_documents", lightmode_toggle: false} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_resources", help_topic: "agent_resources", type: :agent_resource, field_names: ["linked_agent_role", "linked_resource", "linked_resource_description", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute",  "last_verified_date"] } %>
+  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_resources", help_topic: "agent_resources", type: :agent_resource, field_names: ["linked_agent_role", "linked_resource", "linked_resource_description", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute",  "last_verified_date"], lightmode_toggle: true} %>
 
   <%= form_plugins_for(@agent.agent_type.to_s, form) %>
 

--- a/frontend/app/views/agents/_required_sidebar.html.erb
+++ b/frontend/app/views/agents/_required_sidebar.html.erb
@@ -6,46 +6,46 @@
            }) do |sidebar| %>
 
 
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_record_identifier', :property => 'agent_record_identifiers', :anchor => "#{@agent.agent_type}_agent_record_identifier") %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_record_identifier', :property => 'agent_record_identifiers', :anchor => "#{@agent.agent_type}_agent_record_identifier", :lightmode_toggle => false) %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_record_control', :property => 'agent_record_controls', :anchor => "#{@agent.agent_type}_agent_record_control") %>
+     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_record_control', :property => 'agent_record_controls', :anchor => "#{@agent.agent_type}_agent_record_control", :lightmode_toggle => true) %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_other_agency_code', :property => 'agent_other_agency_codes', :anchor => "#{@agent.agent_type}_agent_other_agency_codes") %>
+     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_other_agency_code', :property => 'agent_other_agency_codes', :anchor => "#{@agent.agent_type}_agent_other_agency_codes", :lightmode_toggle => true) %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_conventions_declaration', :property => 'agent_conventions_declarations', :anchor => "#{@agent.agent_type}_agent_conventions_declaration") %>
+     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_conventions_declaration', :property => 'agent_conventions_declarations', :anchor => "#{@agent.agent_type}_agent_conventions_declaration", :lightmode_toggle => true) %>
 
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'metadata_rights_declaration', :property => 'metadata_rights_declarations', :anchor => "#{@agent.agent_type}_metadata_rights_declaration") %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'metadata_rights_declaration', :property => 'metadata_rights_declarations', :anchor => "#{@agent.agent_type}_metadata_rights_declaration", :lightmode_toggle => true) %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_maintenance_history', :property => 'agent_maintenance_histories', :anchor => "#{@agent.agent_type}_agent_maintenance_history") %>
+     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_maintenance_history', :property => 'agent_maintenance_histories', :anchor => "#{@agent.agent_type}_agent_maintenance_history", :lightmode_toggle => true) %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_source', :property => 'agent_sources', :anchor => "#{@agent.agent_type}_agent_sources") %>
+     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_source', :property => 'agent_sources', :anchor => "#{@agent.agent_type}_agent_sources", :lightmode_toggle => true) %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_alternate_set', :property => 'agent_alternate_sets', :anchor => "#{@agent.agent_type}_agent_alternate_set") %>
+     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_alternate_set', :property => 'agent_alternate_sets', :anchor => "#{@agent.agent_type}_agent_alternate_set", :lightmode_toggle => true) %>
 
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_identifier', :property => 'agent_identifiers', :anchor => "#{@agent.agent_type}_agent_identifier") %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_identifier', :property => 'agent_identifiers', :anchor => "#{@agent.agent_type}_agent_identifier", :lightmode_toggle => false) %>
 
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_name', :property => 'names', :anchor => "#{@agent.agent_type}_names") %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_name', :property => 'names', :anchor => "#{@agent.agent_type}_names", :lightmode_toggle => false) %>
 
 
 
 
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'dates_of_existence', :property => 'dates_of_existence',
-                                         :anchor => "#{@agent.agent_type}_dates_of_existence") %>
+                                         :anchor => "#{@agent.agent_type}_dates_of_existence", :lightmode_toggle => false) %>
 
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_place', :property => 'agent_places',
-                                         :anchor => "#{@agent.agent_type}_agent_place") %>
+                                         :anchor => "#{@agent.agent_type}_agent_place", :lightmode_toggle => true) %>
 
     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'used_language', :property => 'used_languages',
-                                         :anchor => "#{@agent.agent_type}_used_language") %>
+                                         :anchor => "#{@agent.agent_type}_used_language", :lightmode_toggle => true) %>
     <% if user_can?('view_agent_contact_record') %>
-      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_contact', :property => 'agent_contacts', :anchor => "#{@agent.agent_type}_contact_details") %>
+      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_contact', :property => 'agent_contacts', :anchor => "#{@agent.agent_type}_contact_details", :lightmode_toggle => false) %>
     <% end %>
 
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_document', :property => "external_documents", :anchor => "#{@agent.agent_type}_external_documents") %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_document', :property => "external_documents", :anchor => "#{@agent.agent_type}_external_documents", :lightmode_toggle => false) %>
 
 
      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_resource', :property => 'agent_resources',
-                                         :anchor => "#{@agent.agent_type}_agent_resource") %>
+                                         :anchor => "#{@agent.agent_type}_agent_resource", :lightmode_toggle => true) %>
 
     <%= sidebar.render_for_view_only(:subrecord_type => 'search_embedded', :property => :none, :anchor => 'search_embedded') %>
     <% if @agent.agent_type == 'agent_person' %>

--- a/frontend/app/views/agents/required.html.erb
+++ b/frontend/app/views/agents/required.html.erb
@@ -1,4 +1,4 @@
-<%= setup_context :object => @agent, :controller => :agents,  :agent_type => @agent.agent_type, :title => "#{t("actions.required")} #{t("agent.agent_type.#{@agent.agent_type}")}" %>
+<%= setup_context :object => @agent, :controller => :agents, :agent_type => @agent.agent_type, :title => "#{t("actions.required")} #{t("agent.agent_type.#{@agent.agent_type}")}" %>
 
 <%= form_for @agent, :as => "agent", :url => {:action => :update_required}, :html => {:class => 'form-horizontal aspace-record-form', :id => "agent_form"} do |f| %>
   <%= form_context :agent, @agent do |form| %>

--- a/frontend/app/views/shared/_required_subrecord_form.html.erb
+++ b/frontend/app/views/shared/_required_subrecord_form.html.erb
@@ -7,6 +7,7 @@
   heading_text = t("#{i18n_prefix}#{singular}._plural") if heading_text.blank?
 
   section_classes = ['subrecord-form']
+  section_classes << 'lightmode_toggle' if local_assigns[:lightmode_toggle]
   if defined?(section_class)
     section_classes << section_class
   end


### PR DESCRIPTION
This PR fixes a bug (going back to at least v3.5.1) where lightmode didn't work when editing Agent Required Fields.

[ANW-2363](https://archivesspace.atlassian.net/browse/ANW-2363)

## Forthcoming spec

The spec is forthcoming and will be included with the PR for [ANW-2366](https://archivesspace.atlassian.net/browse/ANW-2366) which will focus on the sidebar structure and will finalize the subforms that show/hide for lightmode.

## Solution

![ANW-2363-lightmode-required-fields](https://github.com/user-attachments/assets/cd4d349b-cf44-494d-856a-71d20806dd8d)


[ANW-2363]: https://archivesspace.atlassian.net/browse/ANW-2363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-2366]: https://archivesspace.atlassian.net/browse/ANW-2366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ