### PR TITLE
ANW-2366 Make Agent Required Fields form consistent with their counterpart Agent form

### DIFF
--- a/frontend/app/views/agents/_form_required.html.erb
+++ b/frontend/app/views/agents/_form_required.html.erb
@@ -12,58 +12,110 @@
     </div>
   </section>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_record_identifiers", help_topic: "agent_record_identifiers", type: :agent_record_identifier, field_names: ["record_identifier", "source", "identifier_type"], lightmode_toggle: false} %>
+  <% unless @agent.agent_type.to_s == "agent_software" %>
+    <section id="record_control_information" class="agents-subsection subrecord-form-section">
+      <h3 class='subrecord-form-heading-label d-flex py-2 align-items-center'>
+        <%= wrap_with_tooltip(
+          t("agent._frontend.section.record_control_information"),
+          "section_headings.record_control_information_tooltip",
+          "subrecord-form-heading-label"
+        ) %>
+      </h3>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_record_controls", help_topic: "agent_record_controls",  type: :agent_record_control, field_names: ["maintenance_status", "publication_status", "maintenance_agency", "agency_name", "maintenance_agency_note", "language", "script", "language_note", "romanization", "government_agency_type", "reference_evaluation", "name_type", "level_of_detail", "modified_record", "cataloging_source"], lightmode_toggle: true} %>
+      <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_record_identifiers", help_topic: "agent_record_identifiers", type: :agent_record_identifier, field_names: ["record_identifier", "source", "identifier_type"], lightmode_toggle: false} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_other_agency_codes", help_topic: "agent_other_agency_codes", type: :agent_other_agency_codes, field_names: ["maintenance_agency", "agency_code_type"], lightmode_toggle: true} %>
+      <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_record_controls", help_topic: "agent_record_controls", type: :agent_record_control, field_names: ["maintenance_status", "publication_status", "maintenance_agency", "agency_name", "maintenance_agency_note", "language", "script", "language_note", "romanization", "government_agency_type", "reference_evaluation", "name_type", "level_of_detail", "modified_record", "cataloging_source"], lightmode_toggle: true} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name:  "agent_conventions_declarations", help_topic: "agent_conventions_declarations", type: :agent_conventions_declaration, field_names: ["name_rule", "citation", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute", "last_verified_date"], lightmode_toggle: true} %>
+      <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_other_agency_codes", help_topic: "agent_other_agency_codes", type: :agent_other_agency_codes, field_names: ["maintenance_agency", "agency_code_type"], lightmode_toggle: true} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "metadata_rights_declarations", help_topic: "metadata_rights_declarations", type: :metadata_rights_declaration, field_names: ["license", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute", "last_verified_date"], lightmode_toggle: true} %>
+      <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_conventions_declarations", help_topic: "agent_conventions_declarations", type: :agent_conventions_declaration, field_names: ["name_rule", "citation", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute", "last_verified_date"], lightmode_toggle: true} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_maintenance_histories", help_topic: "agent_maintenance_histories", type: :agent_maintenance_history, field_names: ["maintenance_event_type", "event_date", "agent", "maintenance_agent_type", "descriptive_note"], lightmode_toggle: true} %>
+      <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "metadata_rights_declarations", help_topic: "metadata_rights_declarations", type: :metadata_rights_declaration, field_names: ["license", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute", "last_verified_date"], lightmode_toggle: true} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_sources", help_topic: "agent_sources", type: "agent_sources", field_names: ["source_entry", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute",  "last_verified_date"], lightmode_toggle: true} %>
+      <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_maintenance_histories", help_topic: "agent_maintenance_histories", type: :agent_maintenance_history, field_names: ["maintenance_event_type", "event_date", "agent", "maintenance_agent_type", "descriptive_note"], lightmode_toggle: true} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_alternate_sets", help_topic: "agent_alternate_sets", type: "agent_alternate_set", field_names: ["set_component", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute", "last_verified_date"], lightmode_toggle: true}  %>
+      <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_sources", help_topic: "agent_sources", type: "agent_sources", field_names: ["source_entry", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute", "last_verified_date"], lightmode_toggle: true} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_identifiers", help_topic: "agent_identifiers", type: "agent_identifier", field_names: ["entity_identifier", "identifier_type"], lightmode_toggle: false} %>
-
-  <%
-     name_type = @agent.agent_type.to_s.sub('agent', 'name')
-     name_fields = ["authority_id", "source", "rules"]
-     name_fields += case name_type
-                    when 'name_person'
-                      ["name_order", "prefix", "title", "primary_name", "rest_of_name", "suffix", "fuller_form", "number", "dates", "language", "script", "transliteration", "qualifier"]
-                    when 'name_corporate_entity'
-                      ["primary_name", "subordinate_name_1", "subordinate_name_2", "number", "dates", "location", "language", "script", "transliteration", "qualifier"]
-                    when 'name_family'
-                      ["prefix", "family_name", "dates", "family_type", "location", "language", "script", "transliteration", "qualifier"]
-                    when 'name_software'
-                      ["software_name", "version", "manufacturer", "dates", "language", "script", "transliteration", "qualifier"]
-                    else
-                      []
-                    end
-   %>
-
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "names", help_topic: "#{@agent.agent_type}_names", type: name_type.intern, field_names: name_fields, section_id: "#{@agent.agent_type}_names", lightmode_toggle: false} %>
-
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "dates_of_existence", :heading_text => t("agent._frontend.section.dates_of_existence"), :help_topic => "#{@agent.agent_type}_dates_of_existence", type: :structured_date_label, i18n_type: :structured_date_label_common_fields, field_names: ["date_label", "date_type_structured", "date_certainty", "date_era", "date_calendar"], section_id: "#{@agent.agent_type}_dates_of_existence", lightmode_toggle: false} %>
-
-  <% if @agent.agent_type.to_s == "agent_person" %>
-    <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_genders", help_topic: "agent_genders", :property => "agent_genders", type: "agent_gender", field_names: ["gender"], lightmode_toggle: true}  %>
+      <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_alternate_sets", help_topic: "agent_alternate_sets", type: "agent_alternate_set", field_names: ["set_component", "descriptive_note", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute", "last_verified_date"], lightmode_toggle: true} %>
+    </section>
   <% end %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_places", help_topic: "agent_places", :property => "agent_places", type: "agent_place", field_names: ["place_role"], lightmode_toggle: true} %>
+  <section id="identity_information" class="agents-subsection subrecord-form-section">
+    <h3 class='subrecord-form-heading-label d-flex py-2 align-items-center'>
+      <%= wrap_with_tooltip(
+        t("agent._frontend.section.identity_information"),
+        "section_headings.identity_information_tooltip",
+        "subrecord-form-heading-label"
+      ) %>
+    </h3>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "used_languages",  help_topic: "used_languages", type: "used_language", field_names: ["language", "script"], lightmode_toggle: true} %>
+    <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_identifiers", help_topic: "agent_identifiers", type: "agent_identifier", field_names: ["entity_identifier", "identifier_type"], lightmode_toggle: false} %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_contacts", help_topic: "#{@agent.agent_type}_contact_details", type: :agent_contact, field_names: ["name", "salutation", "address_1", "address_2", "address_3", "city", "region", "country", "post_code", "email", "note"], section_id: "#{@agent.agent_type}_contact_details", lightmode_toggle: false} %>
+    <%
+       name_type = @agent.agent_type.to_s.sub('agent', 'name')
+       name_fields = ["authority_id", "source", "rules"]
+       name_fields += case name_type
+                      when 'name_person'
+                        ["name_order", "prefix", "title", "primary_name", "rest_of_name", "suffix", "fuller_form", "number", "dates", "language", "script", "transliteration", "qualifier"]
+                      when 'name_corporate_entity'
+                        ["primary_name", "subordinate_name_1", "subordinate_name_2", "number", "dates", "location", "language", "script", "transliteration", "qualifier"]
+                      when 'name_family'
+                        ["prefix", "family_name", "dates", "family_type", "location", "language", "script", "transliteration", "qualifier"]
+                      when 'name_software'
+                        ["software_name", "version", "manufacturer", "dates", "language", "script", "transliteration", "qualifier"]
+                      else
+                        []
+                      end
+     %>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "external_documents", help_topic: "#{@agent.agent_type}_external_documents", type: :external_document, field_names: ["title", "location"], section_id: "#{@agent.agent_type}_external_documents", lightmode_toggle: false} %>
+    <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "names", help_topic: "#{@agent.agent_type}_names", type: name_type.intern, field_names: name_fields, section_id: "#{@agent.agent_type}_names", lightmode_toggle: false} %>
+  </section>
 
-  <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_resources", help_topic: "agent_resources", type: :agent_resource, field_names: ["linked_agent_role", "linked_resource", "linked_resource_description", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute",  "last_verified_date"], lightmode_toggle: true} %>
+  <section id="description_information" class="agents-subsection subrecord-form-section">
+    <h3 class='subrecord-form-heading-label d-flex py-2 align-items-center'>
+      <%= wrap_with_tooltip(
+        t("agent._frontend.section.description_information"),
+        "section_headings.description_information_tooltip",
+        "subrecord-form-heading-label"
+      ) %>
+    </h3>
+
+    <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "dates_of_existence", :heading_text => t("agent._frontend.section.dates_of_existence"), :help_topic => "#{@agent.agent_type}_dates_of_existence", type: :structured_date_label, i18n_type: :structured_date_label_common_fields, field_names: ["date_label", "date_type_structured", "date_certainty", "date_era", "date_calendar"], section_id: "#{@agent.agent_type}_dates_of_existence", lightmode_toggle: false} %>
+
+    <% if @agent.agent_type.to_s == "agent_person" %>
+      <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_genders", help_topic: "agent_genders", :property => "agent_genders", type: "agent_gender", field_names: ["gender"], lightmode_toggle: true} %>
+    <% end %>
+
+    <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_places", help_topic: "agent_places", :property => "agent_places", type: "agent_place", field_names: ["place_role"], lightmode_toggle: true} %>
+
+    <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_occupations", help_topic: "agent_occupations", type: "agent_occupation", field_names: ["occupation"], lightmode_toggle: true} %>
+
+    <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_functions", help_topic: "agent_functions", type: "agent_function", field_names: ["function"], lightmode_toggle: true} %>
+
+    <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_topics", help_topic: "agent_topics", type: "agent_topic", field_names: ["topic"], lightmode_toggle: true} %>
+
+    <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "used_languages", help_topic: "used_languages", type: "used_language", field_names: ["language", "script"], lightmode_toggle: true} %>
+
+    <% if user_can?('view_agent_contact_record') %>
+      <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_contacts", help_topic: "#{@agent.agent_type}_contact_details", type: :agent_contact, field_names: ["name", "salutation", "address_1", "address_2", "address_3", "city", "region", "country", "post_code", "email", "note"], section_id: "#{@agent.agent_type}_contact_details", lightmode_toggle: false} %>
+    <% end %>
+
+    <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "external_documents", help_topic: "#{@agent.agent_type}_external_documents", type: :external_document, field_names: ["title", "location"], section_id: "#{@agent.agent_type}_external_documents", lightmode_toggle: false} %>
+  </section>
+
+  <% unless @agent.agent_type.to_s == "agent_software" %>
+    <section id="relation_information" class="agents-subsection subrecord-form-section">
+      <h3 class='subrecord-form-heading-label d-flex py-2 align-items-center'>
+        <%= wrap_with_tooltip(
+          t("agent._frontend.section.relation_information"),
+          "section_headings.relation_information_tooltip",
+          "subrecord-form-heading-label"
+        ) %>
+      </h3>
+
+      <%= render_aspace_partial :partial => "shared/required_subrecord_form", :locals => {form: form, name: "agent_resources", help_topic: "agent_resources", type: :agent_resource, field_names: ["linked_agent_role", "linked_resource", "linked_resource_description", "file_uri", "file_version_xlink_actuate_attribute", "file_version_xlink_show_attribute", "xlink_title_attribute", "xlink_role_attribute", "xlink_arcrole_attribute", "last_verified_date"], lightmode_toggle: true} %>
+    </section>
+  <% end %>
 
   <%= form_plugins_for(@agent.agent_type.to_s, form) %>
 

--- a/frontend/app/views/agents/_required_sidebar.html.erb
+++ b/frontend/app/views/agents/_required_sidebar.html.erb
@@ -5,51 +5,86 @@
              :save_button_text => t("#{@agent.agent_type}._frontend.action.save")
            }) do |sidebar| %>
 
+    <% unless @agent.agent_type.to_s == "agent_software" %>
+      <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => 'record_control_information',
+        :property => 'record_control_information',
+        :anchor => "record_control_information",
+        :sidebar_heading => true,
+        :sidebar_children => [:agent_record_identifiers,
+                            :agent_record_controls,
+                            :agent_other_agency_codes,
+                            :agent_conventions_declarations,
+                            :metadata_rights_declarations,
+                            :agent_maintenance_histories,
+                            :agent_sources,
+                            :agent_alternate_sets]) %>
 
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_record_identifier', :property => 'agent_record_identifiers', :anchor => "#{@agent.agent_type}_agent_record_identifier", :lightmode_toggle => false) %>
+      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_record_identifier', :property => 'agent_record_identifiers', :anchor => "#{@agent.agent_type}_agent_record_identifier", :lightmode_toggle => false, :subentry => true) %>
+      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_record_control', :property => 'agent_record_controls', :anchor => "#{@agent.agent_type}_agent_record_control", :lightmode_toggle => true, :subentry => true) %>
+      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_other_agency_code', :property => 'agent_other_agency_codes', :anchor => "#{@agent.agent_type}_agent_other_agency_codes", :lightmode_toggle => true, :subentry => true) %>
+      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_conventions_declaration', :property => 'agent_conventions_declarations', :anchor => "#{@agent.agent_type}_agent_conventions_declaration", :lightmode_toggle => true, :subentry => true) %>
+      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'metadata_rights_declaration', :property => 'metadata_rights_declarations', :anchor => "#{@agent.agent_type}_metadata_rights_declaration", :lightmode_toggle => true, :subentry => true) %>
+      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_maintenance_history', :property => 'agent_maintenance_histories', :anchor => "#{@agent.agent_type}_agent_maintenance_history", :lightmode_toggle => true, :subentry => true) %>
+      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_source', :property => 'agent_sources', :anchor => "#{@agent.agent_type}_agent_sources", :lightmode_toggle => true, :subentry => true) %>
+      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_alternate_set', :property => 'agent_alternate_sets', :anchor => "#{@agent.agent_type}_agent_alternate_set", :lightmode_toggle => true, :subentry => true) %>
+    <% end %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_record_control', :property => 'agent_record_controls', :anchor => "#{@agent.agent_type}_agent_record_control", :lightmode_toggle => true) %>
+    <%= sidebar.render_for_view_and_edit(
+      :subrecord_type => "identity_information",
+      :property => "identity_information",
+      :anchor => "identity_information",
+      :sidebar_heading => true,
+      :sidebar_children => [:agent_identifiers,
+                          :names]) %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_other_agency_code', :property => 'agent_other_agency_codes', :anchor => "#{@agent.agent_type}_agent_other_agency_codes", :lightmode_toggle => true) %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_identifier', :property => 'agent_identifiers', :anchor => "#{@agent.agent_type}_agent_identifier", :lightmode_toggle => false, :subentry => true) %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_conventions_declaration', :property => 'agent_conventions_declarations', :anchor => "#{@agent.agent_type}_agent_conventions_declaration", :lightmode_toggle => true) %>
+    <% name_type = @agent.agent_type.to_s.sub('agent', 'name') %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_name', :property => 'names', :anchor => "#{@agent.agent_type}_names", :lightmode_toggle => false, :subentry => true) %>
 
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'metadata_rights_declaration', :property => 'metadata_rights_declarations', :anchor => "#{@agent.agent_type}_metadata_rights_declaration", :lightmode_toggle => true) %>
+    <%= sidebar.render_for_view_and_edit(
+      :subrecord_type => "description_information",
+      :property => "description_information",
+      :anchor => "description_information",
+      :sidebar_heading => true,
+      :sidebar_children => [:dates_of_existence,
+                          :agent_genders,
+                          :agent_places,
+                          :agent_occupations,
+                          :agent_functions,
+                          :agent_topics,
+                          :used_languages,
+                          :agent_contacts,
+                          :external_documents]) %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_maintenance_history', :property => 'agent_maintenance_histories', :anchor => "#{@agent.agent_type}_agent_maintenance_history", :lightmode_toggle => true) %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'dates_of_existence', :property => 'dates_of_existence', :anchor => "#{@agent.agent_type}_dates_of_existence", :lightmode_toggle => false, :subentry => true) %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_source', :property => 'agent_sources', :anchor => "#{@agent.agent_type}_agent_sources", :lightmode_toggle => true) %>
+    <% if @agent.agent_type.to_s == "agent_person" %>
+      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_gender', :property => 'agent_genders', :anchor => "agent_person_agent_gender", :lightmode_toggle => true, :subentry => true) %>
+    <% end %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_alternate_set', :property => 'agent_alternate_sets', :anchor => "#{@agent.agent_type}_agent_alternate_set", :lightmode_toggle => true) %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_place', :property => 'agent_places', :anchor => "#{@agent.agent_type}_agent_place", :lightmode_toggle => true, :subentry => true) %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_occupation', :property => 'agent_occupations', :anchor => "#{@agent.agent_type}_agent_occupation", :lightmode_toggle => true, :subentry => true) %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_function', :property => 'agent_functions', :anchor => "#{@agent.agent_type}_agent_function", :lightmode_toggle => true, :subentry => true) %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_topic', :property => 'agent_topics', :anchor => "#{@agent.agent_type}_agent_topic", :lightmode_toggle => true, :subentry => true) %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'used_language', :property => 'used_languages', :anchor => "#{@agent.agent_type}_used_language", :lightmode_toggle => true, :subentry => true) %>
 
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_identifier', :property => 'agent_identifiers', :anchor => "#{@agent.agent_type}_agent_identifier", :lightmode_toggle => false) %>
-
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_name', :property => 'names', :anchor => "#{@agent.agent_type}_names", :lightmode_toggle => false) %>
-
-
-
-
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'dates_of_existence', :property => 'dates_of_existence',
-                                         :anchor => "#{@agent.agent_type}_dates_of_existence", :lightmode_toggle => false) %>
-
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_place', :property => 'agent_places',
-                                         :anchor => "#{@agent.agent_type}_agent_place", :lightmode_toggle => true) %>
-
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'used_language', :property => 'used_languages',
-                                         :anchor => "#{@agent.agent_type}_used_language", :lightmode_toggle => true) %>
     <% if user_can?('view_agent_contact_record') %>
-      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_contact', :property => 'agent_contacts', :anchor => "#{@agent.agent_type}_contact_details", :lightmode_toggle => false) %>
+      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_contact', :property => 'agent_contacts', :anchor => "#{@agent.agent_type}_contact_details", :lightmode_toggle => false, :subentry => true) %>
     <% end %>
 
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_document', :property => "external_documents", :anchor => "#{@agent.agent_type}_external_documents", :lightmode_toggle => false) %>
+    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'external_document', :property => "external_documents", :anchor => "#{@agent.agent_type}_external_documents", :lightmode_toggle => false, :subentry => true) %>
 
+    <% unless @agent.agent_type.to_s == "agent_software" %>
+      <%= sidebar.render_for_view_and_edit(
+        :subrecord_type => "relation_information",
+        :property => "relation_information",
+        :anchor => "relation_information",
+        :sidebar_heading => true,
+        :sidebar_children => [:agent_resources]) %>
 
-     <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_resource', :property => 'agent_resources',
-                                         :anchor => "#{@agent.agent_type}_agent_resource", :lightmode_toggle => true) %>
-
-    <%= sidebar.render_for_view_only(:subrecord_type => 'search_embedded', :property => :none, :anchor => 'search_embedded') %>
-    <% if @agent.agent_type == 'agent_person' %>
-      <%= sidebar.render_for_view_only(:title => t('assessment._frontend.linked_records.linked_via_assessment_surveyed_by'), :subrecord_type => 'assessment', :property => :none, :anchor => 'linked_assessments_surveyed_by') %>
-      <%= sidebar.render_for_view_only(:title => t('assessment._frontend.linked_records.linked_via_assessment_reviewer'), :subrecord_type => 'assessment', :property => :none, :anchor => 'linked_assessments_reviewer') %>
+      <%= sidebar.render_for_view_and_edit(:subrecord_type => 'agent_resource', :property => 'agent_resources', :anchor => "#{@agent.agent_type}_agent_resource", :lightmode_toggle => true, :subentry => true) %>
     <% end %>
+
 <% end %>

--- a/frontend/spec/features/agents_required_fields_spec.rb
+++ b/frontend/spec/features/agents_required_fields_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Agents Required Fields', js: true do
+  before(:each) do
+    login_admin
+  end
+
+  let(:all_possible_items) do
+    [
+      'Basic Information',
+      'Record Control Information',
+      'Record IDs',
+      'Record Info',
+      'Other Agency Codes',
+      'Convention Declarations',
+      'Metadata Rights Declarations',
+      'Maintenance History',
+      'Sources',
+      'Alternate Sets',
+      'Identity Information',
+      'Entity IDs',
+      'Name Forms',
+      'Description Information',
+      'Dates of Existence',
+      'Genders',
+      'Places',
+      'Occupations',
+      'Functions',
+      'Topics',
+      'Languages Used',
+      'Contact Details',
+      'External Documents',
+      'Relation Information',
+      'Related External Resources'
+    ]
+  end
+
+  let(:light_mode_common_items) do
+    [
+      'Basic Information',
+      'Identity Information',
+      'Entity IDs',
+      'Name Forms',
+      'Description Information',
+      'Dates of Existence',
+      'Contact Details',
+      'External Documents'
+    ]
+  end
+
+  def expect_sidebar_items(agent_type, expected_items, unexpected_items = [])
+    visit "/agents/#{agent_type}/required"
+    sidebar = find('#archivesSpaceSidebar')
+
+    expected_items.each do |item|
+      expect(sidebar).to have_link(item)
+    end
+
+    unexpected_items.each do |item|
+      expect(sidebar).not_to have_link(item)
+    end
+  end
+
+  def expect_form_sections(agent_type, expected_items, unexpected_items = [])
+    visit "/agents/#{agent_type}/required"
+
+    expected_items.each do |item|
+      expect(page).to have_selector('h3, h4', text: item)
+    end
+
+    unexpected_items.each do |item|
+      expect(page).not_to have_selector('h3, h4', text: item)
+    end
+  end
+
+  shared_examples 'agent sidebar items' do |agent_type, unexpected_items|
+    it "shows the correct items for #{agent_type}" do
+      expected_items = all_possible_items - unexpected_items
+      expect_sidebar_items(agent_type, expected_items, unexpected_items)
+    end
+  end
+
+  shared_examples 'light mode agent sidebar items' do |agent_type, additional_items = []|
+    it "shows the correct items for #{agent_type} in light mode" do
+      visit "/agents/#{agent_type}/required"
+      check 'Light Mode'
+
+      expected_items = light_mode_common_items + additional_items
+      sidebar = find('#archivesSpaceSidebar')
+
+      expected_items.each do |item|
+        expect(sidebar).to have_link(item)
+      end
+
+      (all_possible_items - expected_items).each do |item|
+        expect(sidebar).not_to have_link(item)
+      end
+    end
+  end
+
+  shared_examples 'agent form sections' do |agent_type, unexpected_items|
+    it "shows the correct form sections for #{agent_type}" do
+      expected_items = all_possible_items - unexpected_items
+      expect_form_sections(agent_type, expected_items, unexpected_items)
+    end
+  end
+
+  shared_examples 'light mode agent form sections' do |agent_type, additional_items = []|
+    it "shows the correct form sections for #{agent_type} in light mode" do
+      visit "/agents/#{agent_type}/required"
+      check 'Light Mode'
+      expected_items = light_mode_common_items + additional_items
+      expected_items.each do |item|
+        expect(page).to have_selector('h3, h4', text: item)
+      end
+
+      (all_possible_items - expected_items).each do |item|
+        expect(page).not_to have_selector('h3, h4', text: item)
+      end
+    end
+  end
+
+  context 'when lightmode is off' do
+    describe 'the sidebar' do
+      include_examples 'agent sidebar items', 'agent_person', []
+      include_examples 'agent sidebar items', 'agent_family', ['Genders']
+      include_examples 'agent sidebar items', 'agent_corporate_entity', ['Genders']
+      include_examples 'agent sidebar items', 'agent_software', [
+        'Record Control Information',
+        'Record IDs',
+        'Record Info',
+        'Other Agency Codes',
+        'Convention Declarations',
+        'Metadata Rights Declarations',
+        'Maintenance History',
+        'Sources',
+        'Alternate Sets',
+        'Genders',
+        'Relation Information',
+        'Related External Resources'
+      ]
+    end
+
+    describe 'the form' do
+      include_examples 'agent form sections', 'agent_person', []
+      include_examples 'agent form sections', 'agent_family', ['Genders']
+      include_examples 'agent form sections', 'agent_corporate_entity', ['Genders']
+      include_examples 'agent form sections', 'agent_software', [
+        'Record Control Information',
+        'Record IDs',
+        'Record Info',
+        'Other Agency Codes',
+        'Convention Declarations',
+        'Metadata Rights Declarations',
+        'Maintenance History',
+        'Sources',
+        'Alternate Sets',
+        'Genders',
+        'Relation Information',
+        'Related External Resources'
+      ]
+    end
+  end
+
+  context 'when lightmode is on' do
+    describe 'the sidebar' do
+      include_examples 'light mode agent sidebar items', 'agent_person', [
+        'Record Control Information',
+        'Record IDs',
+        'Relation Information'
+      ]
+      include_examples 'light mode agent sidebar items', 'agent_family', [
+        'Record Control Information',
+        'Record IDs',
+        'Relation Information'
+      ]
+      include_examples 'light mode agent sidebar items', 'agent_corporate_entity', [
+        'Record Control Information',
+        'Record IDs',
+        'Relation Information'
+      ]
+      include_examples 'light mode agent sidebar items', 'agent_software'
+    end
+
+    describe 'the form' do
+      include_examples 'light mode agent form sections', 'agent_person', [
+        'Record Control Information',
+        'Record IDs',
+        'Relation Information'
+      ]
+      include_examples 'light mode agent form sections', 'agent_family', [
+        'Record Control Information',
+        'Record IDs',
+        'Relation Information'
+      ]
+      include_examples 'light mode agent form sections', 'agent_corporate_entity', [
+        'Record Control Information',
+        'Record IDs',
+        'Relation Information'
+      ]
+      include_examples 'light mode agent form sections', 'agent_software'
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes a long standing bug where the Agent Required Fields forms were inconsistent with their Agent forms counterpart with respect to the page's sidebar and sub forms:

- updates the required fields sidebar to look just like their agent form counterpart with regard to sidebar items present and visual hierarchy
- updates subforms to match the subforms had by their agent counterpart

⚠️⚠️ This PR keeps the status quo of the Agent Required Fields form NOT providing a "Notes" or "Related Agent" section, due to possible unsolved implementations of making notes and/or related agents required. ⚠️⚠️

[ANW-2366](https://archivesspace.atlassian.net/browse/ANW-2366)

## Screenshot examples

### Person Agent Required Fields form lightmode

![Screen Shot 2025-04-23 at 06 03 01-fullpage](https://github.com/user-attachments/assets/db8008f5-c89e-46b4-ba32-36b928272933)

### Person Agent Required Fields form

![Screen Shot 2025-04-23 at 06 02 48-fullpage](https://github.com/user-attachments/assets/3ec4feca-2085-4da3-8212-04f2fbecdc15)

[ANW-2366]: https://archivesspace.atlassian.net/browse/ANW-2366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ