### PR TITLE
ANW-2368 Fix daogrp issues in staff PDF export

### DIFF
--- a/stylesheets/as-ead-pdf.xsl
+++ b/stylesheets/as-ead-pdf.xsl
@@ -659,8 +659,8 @@
                         <xsl:apply-templates select="ead:physloc" mode="overview"/>
                         <xsl:apply-templates select="ead:langmaterial" mode="overview"/>
                         <xsl:apply-templates select="ead:materialspec" mode="overview"/>
-                        <xsl:apply-templates select="../ead:dao" mode="overview"/>
-                        <xsl:apply-templates select="../ead:daogrp" mode="overview"/>
+                        <xsl:apply-templates select="ead:dao|../ead:dao" mode="overview"/>
+                        <xsl:apply-templates select="ead:daogrp|../ead:daogrp" mode="overview"/>
                         <xsl:apply-templates select="ead:container" mode="overview"/>
                         <xsl:apply-templates select="ead:abstract" mode="overview"/>
                         <xsl:apply-templates select="ead:note" mode="overview"/>
@@ -1236,21 +1236,32 @@
         </fo:table-row>
     </xsl:template>
     <xsl:template match="ead:daogrp" mode="overview">
-        <fo:block>
-            <xsl:apply-templates/>
-        </fo:block>
+        <fo:table-row>
+            <fo:table-cell padding-bottom="8pt" padding-right="16pt" text-align="right" font-weight="bold">
+                <fo:block>
+                    <xsl:value-of select="local:tagName(.)"/>:
+                </fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+                <fo:block>
+                    <xsl:apply-templates/>
+                </fo:block>
+            </fo:table-cell>
+        </fo:table-row>
     </xsl:template>
-    <xsl:template match="ead:daoloc" mode="overview">
-        <fo:basic-link external-destination="url('{@*:href}')" xsl:use-attribute-sets="ref">
-            <xsl:choose>
-                <xsl:when test="text()">
-                    <xsl:value-of select="."/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="@*:href"/>
-                </xsl:otherwise>
-            </xsl:choose>
-        </fo:basic-link>
+    <xsl:template match="ead:daoloc">
+        <fo:block>
+            <fo:basic-link external-destination="url('{@*:href}')" xsl:use-attribute-sets="ref">
+                <xsl:choose>
+                    <xsl:when test="text()">
+                        <xsl:value-of select="."/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="@*:href"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </fo:basic-link>
+        </fo:block>
     </xsl:template>
 
     <!--Render elements -->
@@ -1566,8 +1577,8 @@
             <xsl:apply-templates select="ead:unitdate" mode="dsc"/>
             <xsl:apply-templates select="ead:physdesc" mode="dsc"/>
             <xsl:apply-templates select="ead:physloc" mode="dsc"/>
-            <xsl:apply-templates select="ead:dao"/>
-            <xsl:apply-templates select="ead:daogrp"/>
+            <xsl:apply-templates select="ead:dao" mode="dsc"/>
+            <xsl:apply-templates select="ead:daogrp" mode="dsc"/>
             <xsl:apply-templates select="ead:langmaterial" mode="dsc"/>
             <xsl:apply-templates select="ead:materialspec" mode="dsc"/>
             <xsl:apply-templates select="ead:abstract" mode="dsc"/>
@@ -1715,6 +1726,11 @@
             <fo:basic-link external-destination="url('{@*:href}')" xsl:use-attribute-sets="ref">
                 <xsl:value-of select="$title"/>
             </fo:basic-link>
+        </fo:block>
+    </xsl:template>
+    <xsl:template match="ead:daogrp" mode="dsc">
+        <fo:block xsl:use-attribute-sets="smpDsc">
+            <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
     <!-- Everything else in the dsc -->


### PR DESCRIPTION
## Description
Fixes crash described in [ANW-2368](https://archivesspace.atlassian.net/browse/ANW-2368) by adding formatting for top-level daogrp
Also added a template for daogrp dsc mode, which was being called but didn't exist
Made the daoloc template (very slightly) prettier by adding breaks between URLs
Made it so that resource-level daogrp and dao work both inside and outside of did

## Related JIRA Ticket or GitHub Issue
[<!--- Please link to the JIRA Ticket or GitHub Issue here: -->](https://archivesspace.atlassian.net/browse/ANW-2368)

## How Has This Been Tested?
Tried exporting several resources with <daogrp> at the resource level and in the <dsc>, also tried <daogrp> inside and outside of <did>

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[ANW-2368]: https://archivesspace.atlassian.net/browse/ANW-2368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ