### PR TITLE
ANW-2353: Fix more mixed content display bugs and add spec

### DIFF
--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -493,6 +493,7 @@ $(function () {
           onResult: formatResults,
           zindex: 1100,
           tokenFormatter: function (item) {
+            item.name = convertEADMarkup(item.name);
             var tokenEl = $(
               AS.renderTemplate('linker_selectedtoken_template', {
                 item: item,
@@ -507,7 +508,7 @@ $(function () {
             return tokenEl;
           },
           resultsFormatter: function (item) {
-            var string = item.name;
+            var string = convertEADMarkup(item.name);
             var $resultSpan = $(
               "<span class='" +
                 item.json.jsonmodel_type +
@@ -516,7 +517,7 @@ $(function () {
                 "'>"
             );
             var extra_class = tag_subjects_by_term_type(item);
-            $resultSpan.text(string);
+            $resultSpan.html(string);
             $resultSpan.prepend(
               "<span class='icon-token " + extra_class + "'></span>"
             );
@@ -618,6 +619,44 @@ $(function () {
       init();
     });
   };
+
+  function convertEADMarkup(text) {
+    return (
+      text
+        // Mimic MixedContentParser by matching tags to capture any render attr value and content
+        .replace(
+          /<title\s+render="([^"]+)">(.*?)<\/title>/g,
+          convertEADRenderToHTML
+        )
+        .replace(
+          /<title>(.*?)<\/title>/g,
+          '<span class="emph render-none">$1</span>'
+        )
+        .replace(
+          /<emph\s+render="([^"]+)">(.*?)<\/emph>/g,
+          convertEADRenderToHTML
+        )
+        .replace(
+          /<emph>(.*?)<\/emph>/g,
+          '<span class="emph render-none">$1</span>'
+        )
+        .replace(
+          /<unitdate\s+render="([^"]+)">(.*?)<\/unitdate>/g,
+          convertEADRenderToHTML
+        )
+        .replace(
+          /<unitdate>(.*?)<\/unitdate>/g,
+          '<span class="emph render-none">$1</span>'
+        )
+        .replace(/<lb\/>/g, '<br/>')
+    );
+
+    function convertEADRenderToHTML(match, render, content) {
+      return render === 'nonproport'
+        ? `<code class="emph render-nonproport">${content}</code>`
+        : `<span class="emph render-${render}">${content}</span>`;
+    }
+  }
 });
 
 $(document).ready(function () {

--- a/frontend/app/assets/stylesheets/archivesspace/tables.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/tables.scss
@@ -199,5 +199,5 @@ table.table-spreadsheet {
 }
 
 table .col {
-  width: min-content;
+  width: max-content;
 }

--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -432,13 +432,4 @@ module ApplicationHelper
       agent.send(subrecord).length.positive?
     end
   end
-
-  def render_linker_token(name, type, id)
-    render_token(
-      :label => clean_mixed_content(name),
-      :type => type,
-      :uri => id,
-      :inside_token_editor => true
-    )
-  end
 end

--- a/frontend/app/views/accessions/show.html.erb
+++ b/frontend/app/views/accessions/show.html.erb
@@ -22,7 +22,7 @@
                                        :form => readonly,
                                        :record => @accession) %>
 
-            <%= readonly.label_and_textarea "title" %>
+            <%= readonly.label_and_textarea "title", :field_opts => { :clean => true, :base_url => url_for(:root), :escape => false} %>
             <%= readonly.label_and_fourpartid %>
 
             <%= render_aspace_partial :partial => "shared/public_url", :locals => {:form_object => readonly} if AppConfig[:use_human_readable_urls] %>

--- a/frontend/app/views/assessments/_assessment_records_cell.html.erb
+++ b/frontend/app/views/assessments/_assessment_records_cell.html.erb
@@ -19,7 +19,7 @@
     <ul class="assessment-search-result-listing">
       <% record_titles.uniq.sort.each do |title| %>
         <li>
-          <%= title %>
+          <%= clean_mixed_content(title).html_safe %>
         </li>
       <% end %>
     </ul>

--- a/frontend/app/views/classification_terms/_show_inline.html.erb
+++ b/frontend/app/views/classification_terms/_show_inline.html.erb
@@ -18,7 +18,7 @@
             <%= form.label_and_textarea "identifier" %>
             <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @classification_term} if AppConfig[:use_human_readable_urls] %>
 
-            <%= form.label_and_textarea "title" %>
+            <%= form.label_and_textarea "title", :field_opts => { :clean => true, :base_url => url_for(:root), :escape => false} %>
             <%= form.label_and_textarea "description" %>
 
             <%= render_plugin_partials("basic_information_classification_term",

--- a/frontend/app/views/classifications/_show_inline.html.erb
+++ b/frontend/app/views/classifications/_show_inline.html.erb
@@ -17,7 +17,7 @@
                                        :record => @classification) %>
 
             <%= form.label_and_textarea "identifier" %>
-            <%= form.label_and_textarea "title" %>
+            <%= form.label_and_textarea "title", :field_opts => { :clean => true, :base_url => url_for(:root), :escape => false} %>
 
             <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @classification} if AppConfig[:use_human_readable_urls] %>
 

--- a/frontend/app/views/digital_object_components/_show_inline.html.erb
+++ b/frontend/app/views/digital_object_components/_show_inline.html.erb
@@ -18,7 +18,7 @@
                                      :record => @digital_object_component) %>
 
           <%= readonly.label_and_textfield "label" %>
-          <%= readonly.label_and_textarea "title" %>
+          <%= readonly.label_and_textarea "title", :field_opts => { :clean => true, :base_url => url_for(:root), :escape => false} %>
           <%= readonly.label_and_textfield "component_id" %>
 
           <%= readonly.label_with_field "public_url", readonly.slug_url_field("slug", session[:repo_slug], AppConfig[:repo_name_in_slugs]) if AppConfig[:use_human_readable_urls] %>

--- a/frontend/app/views/digital_objects/_show_inline.html.erb
+++ b/frontend/app/views/digital_objects/_show_inline.html.erb
@@ -17,7 +17,7 @@
                                      :form => readonly,
                                      :record => digital_object) %>
 
-          <%= readonly.label_and_textarea "title" %>
+          <%= readonly.label_and_textarea "title", :field_opts => { :clean => true, :base_url => url_for(:root), :escape => false} %>
           <%= readonly.label_and_textfield "digital_object_id" %>
 
           <%= render_aspace_partial :partial => "shared/public_url", :locals => {:form_object => readonly} if AppConfig[:use_human_readable_urls] %>

--- a/frontend/app/views/instances/_show.html.erb
+++ b/frontend/app/views/instances/_show.html.erb
@@ -18,7 +18,7 @@
             </div>
             <div class="col-md-7">
               <% if instance["instance_type"] == "digital_object" %>
-                <%= instance["digital_object"]["_resolved"]["title"] %>
+                <%= clean_mixed_content(instance["digital_object"]["_resolved"]["title"]) %>
               <% elsif instance["sub_container"] and instance["sub_container"].length > 0 %>
                 <%= instance["sub_container"]["top_container"]["_resolved"]["display_string"] %>
               <% end %>

--- a/frontend/app/views/shared/_templates.html.erb
+++ b/frontend/app/views/shared/_templates.html.erb
@@ -212,7 +212,10 @@
    <li id="${item.id.replace(/\//g,'_')}">
       <input type="hidden" name="${config.path}[_resolved]{if config.multiplicity != 'one'}[]{/if}" />
       <input type="hidden" name="${config.path}[${config.name}]{if config.multiplicity != 'one'}[]{/if}" value="${item.id}" />
-      <%= render_linker_token("${item.name}", "${item.json.jsonmodel_type}", "${item.id}") %>
+      <%= render_token :label => "${item.name}",
+                       :type => "${item.json.jsonmodel_type}",
+                       :uri => "${item.id}",
+                       :inside_token_editor => true %>
    </li>
 --></div>
 

--- a/frontend/app/views/terms/_show.html.erb
+++ b/frontend/app/views/terms/_show.html.erb
@@ -11,7 +11,7 @@
       </div>
       <% terms.each do | term | %>
         <div class="row">
-          <div class="col-md-6"><%= term["term"] %></div>
+          <div class="col-md-6"><%= clean_mixed_content(term["term"]) %></div>
           <div class="col-md-6"><%= t("enumerations.subject_term_type.#{term["term_type"]}", :default => term["term_type"]) %></div>
         </div>
       <% end %>

--- a/frontend/spec/features/mixed_content_in_title_fields_spec.rb
+++ b/frontend/spec/features/mixed_content_in_title_fields_spec.rb
@@ -1,0 +1,464 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Mixed Content in title fields', js: true do
+  before(:all) do
+    @repo = create(:repo, repo_code: "mixed_content_test_#{Time.now.to_i}")
+    set_repo(@repo)
+
+    @now = Time.now.to_i
+    @agent = create(:agent_person,
+      names: [build(
+        :name_person,
+        primary_name: "<title>Agent Person #{@now}</title>"
+      )]
+    )
+    @subject = create(:subject,
+      terms: [build(:term, {term: "<emph>Subject #{@now}</emph>", term_type: 'temporal'})]
+    )
+    @do = create(:digital_object, title: "<title>Digital object #{@now}</title>")
+    @doc = create(:digital_object_component,
+      title: "<emph render='italic'>Digital object component #{@now}</emph>",
+      digital_object: { ref: @do.uri }
+    )
+    @classification = create(:classification, title: "<emph>Classification #{@now}</emph>")
+    @acc = create(:accession, title: "<title>Accession #{@now}</title>")
+    @acc2 = create(:accession, title: "<emph>Accession 2 #{@now}</emph>")
+    @resource = create(:resource,
+      title: "<title>Mixed Content #{@now}</title>",
+      instances: [
+        {
+          instance_type: 'digital_object',
+          digital_object: { ref: @do.uri }
+        }
+      ],
+      related_accessions: [
+        {
+          ref: @acc2.uri
+        }
+      ],
+      linked_agents: [
+        {
+          ref: @agent.uri,
+          role: 'creator'
+        }
+      ],
+      subjects: [
+        {
+          ref: @subject.uri
+        }
+      ],
+      classifications: [
+        {
+          ref: @classification.uri
+        }
+      ]
+    )
+    @ao = create(:archival_object,
+      title: "<title>Archival Object #{@now}</title>",
+      resource: { ref: @resource.uri },
+      accession_links: [
+        {
+          ref: @acc2.uri
+        }
+      ]
+    )
+
+    run_indexer
+
+    @emph_selector = '.emph.render-none'
+    @emph_italic_selector = '.emph.render-italic'
+    @title_selector = '.emph.render-none'
+  end
+
+  before(:each) do
+    login_admin
+    select_repository(@repo)
+  end
+
+  describe 'should render as HTML' do
+    context 'in the main record heading' do
+      def selector(view, ead_selector)
+        if view == 'show'
+          ".record-pane > div:first-child > h2:first-child span#{ead_selector}"
+        else
+          ".record-pane > h2 > span#{ead_selector}"
+        end
+      end
+
+      def assert_heading(path, selector, expected_text)
+        visit path
+        expect(page).to have_css selector, text: expected_text
+      end
+
+      context 'for accession' do
+        before(:each) do
+          @path = "/accessions/#{@acc2.id}"
+        end
+
+        it 'show view' do
+          assert_heading @path, selector('show', @emph_selector), "Accession 2 #{@now}"
+        end
+
+        it 'edit view' do
+          assert_heading "#{@path}/edit", selector('edit', @emph_selector), "Accession 2 #{@now}"
+        end
+      end
+
+      context 'for resource' do
+        before(:each) do
+          @path = "/resources/#{@resource.id}"
+        end
+
+        it 'show view' do
+          assert_heading @path, selector('show', @title_selector), "Mixed Content #{@now}"
+        end
+
+        it 'edit view' do
+          assert_heading "#{@path}/edit", selector('edit', @title_selector), "Mixed Content #{@now}"
+        end
+      end
+
+      context 'for archival object' do
+        it 'show view' do
+          path = "/resources/#{@resource.id}/#tree::archival_object_#{@ao.id}"
+          assert_heading path, selector('show', @title_selector), "Archival Object #{@now}"
+        end
+
+        it 'edit view' do
+          path = "/resources/#{@resource.id}/edit#tree::archival_object_#{@ao.id}"
+          assert_heading path, selector('edit', @title_selector), "Archival Object #{@now}"
+        end
+      end
+
+      context 'for digital object' do
+        before(:each) do
+          @path = "/digital_objects/#{@do.id}"
+        end
+
+        it 'show view' do
+          assert_heading @path, selector('show', @title_selector), "Digital object #{@now}"
+        end
+
+        it 'edit view' do
+          assert_heading "#{@path}/edit", selector('edit', @title_selector), "Digital object #{@now}"
+        end
+      end
+
+      context 'for digital object component' do
+        it 'show view' do
+          path = "/digital_objects/#{@do.id}/#tree::digital_object_component_#{@doc.id}"
+          assert_heading path, selector('show', @emph_italic_selector), "Digital object component #{@now}"
+        end
+
+        it 'edit view' do
+          path = "/digital_objects/#{@do.id}/edit#tree::digital_object_component_#{@doc.id}"
+          assert_heading path, selector('edit', @emph_italic_selector), "Digital object component #{@now}"
+        end
+      end
+
+      context 'for subject' do
+        before(:each) do
+          @path = "/subjects/#{@subject.id}"
+        end
+
+        it 'show view' do
+          assert_heading @path, selector('show', @emph_selector), "Subject #{@now}"
+        end
+
+        it 'edit view' do
+          assert_heading "#{@path}/edit", selector('edit', @emph_selector), "Subject #{@now}"
+        end
+      end
+
+      context 'for agent' do
+        before(:each) do
+          @path = "/agents/agent_person/#{@agent.id}"
+        end
+
+        it 'show view' do
+          assert_heading @path, selector('show', @title_selector), "Agent Person #{@now}"
+        end
+
+        it 'edit view' do
+          assert_heading "#{@path}/edit", selector('edit', @title_selector), "Agent Person #{@now}"
+        end
+      end
+
+      context 'for classification' do
+        before(:each) do
+          @path = "/classifications/#{@classification.id}"
+        end
+
+        it 'show view' do
+          assert_heading @path, selector('show', @emph_selector), "Classification #{@now}"
+        end
+
+        it 'edit view' do
+          assert_heading "#{@path}/edit", selector('edit', @emph_selector), "Classification #{@now}"
+        end
+      end
+    end
+
+    context 'in the title field of the show view' do
+      it 'for accessions' do
+        visit "/accessions/#{@acc2.id}"
+        expect(page).to have_css "#basic_information span#{@emph_selector}", text: "Accession 2 #{@now}"
+      end
+
+      it 'for resources' do
+        visit "/resources/#{@resource.id}"
+        expect(page).to have_css "#basic_information span#{@title_selector}", text: "Mixed Content #{@now}"
+      end
+
+      it 'for archival objects' do
+        visit "/resources/#{@resource.id}/#tree::archival_object_#{@ao.id}"
+        expect(page).to have_css "#basic_information span#{@title_selector}", text: "Archival Object #{@now}"
+      end
+
+      it 'for digital objects' do
+        visit "/digital_objects/#{@do.id}"
+        expect(page).to have_css "#basic_information span#{@title_selector}", text: "Digital object #{@now}"
+      end
+
+      it 'for digital object components' do
+        visit "/digital_objects/#{@do.id}/#tree::digital_object_component_#{@doc.id}"
+        expect(page).to have_css "#basic_information span#{@emph_italic_selector}", text: "Digital object component #{@now}"
+      end
+
+      it 'for classifications' do
+        visit "/classifications/#{@classification.id}"
+        expect(page).to have_css "#basic_information span#{@emph_selector}", text: "Classification #{@now}"
+      end
+
+      it 'for subjects' do
+        visit "/subjects/#{@subject.id}"
+        expect(page).to have_css "#terms span#{@emph_selector}", text: "Subject #{@now}"
+      end
+
+      it 'for agents' do
+        visit "/agents/agent_person/#{@agent.id}"
+        expect(page).to have_css "#identity_information span#{@title_selector}", text: "Agent Person #{@now}"
+      end
+
+      it 'for classification terms' do
+        visit "/classifications/#{@classification.id}"
+        expect(page).to have_css "#basic_information span#{@emph_selector}", text: "Classification #{@now}"
+      end
+    end
+
+    context 'in the largetree' do
+      it 'for resources and archival objects' do
+        visit "/resources/#{@resource.id}"
+        expect(page).to have_css "#tree-container a.record-title span#{@title_selector}", text: "Mixed Content #{@now}"
+        expect(page).to have_css "#tree-container a.record-title span#{@title_selector}", text: "Archival Object #{@now}"
+      end
+
+      it 'for digital objects and digital object components' do
+        visit "/digital_objects/#{@do.id}"
+        expect(page).to have_css "#tree-container a.record-title span#{@title_selector}", text: "Digital object #{@now}"
+        expect(page).to have_css "#tree-container a.record-title span#{@emph_italic_selector}", text: "Digital object component #{@now}"
+      end
+
+      it 'for classifications and classification terms' do
+        visit "/classifications/#{@classification.id}"
+        expect(page).to have_css "#tree-container a.record-title span#{@emph_selector}", text: "Classification #{@now}"
+        expect(page).to have_css "#tree-container a.record-title span#{@emph_selector}", text: "Classification #{@now}"
+      end
+    end
+
+    context 'in search results' do
+      it 'from a search' do
+        visit "/search?q=Mixed+Content+#{@now}"
+        expect(page).to have_css "#tabledSearchResults .title > span#{@title_selector}", text: "Mixed Content #{@now}"
+      end
+
+      describe 'in an index view' do
+        it 'for accessions' do
+          visit '/accessions'
+          expect(page).to have_css "#tabledSearchResults .title > span#{@emph_selector}", text: "Accession 2 #{@now}"
+        end
+
+        it 'for resources and archival objects' do
+          visit '/resources'
+          click_link 'Show Components'
+          expect(page).to have_css "#tabledSearchResults .title > span#{@title_selector}", text: "Mixed Content #{@now}"
+          expect(page).to have_css "#tabledSearchResults .title > span#{@title_selector}", text: "Archival Object #{@now}"
+        end
+
+        it 'for digital objects and digital object components' do
+          visit '/digital_objects'
+          click_link 'Show Components'
+          expect(page).to have_css "#tabledSearchResults .title > span#{@title_selector}", text: "Digital object #{@now}"
+          expect(page).to have_css "#tabledSearchResults .title > span#{@emph_italic_selector}", text: "Digital object component #{@now}"
+        end
+
+        it 'for subjects' do
+          visit '/subjects'
+          expect(page).to have_css "#tabledSearchResults .title > span#{@emph_selector}", text: "Subject #{@now}"
+        end
+
+        it 'for agents' do
+          visit '/agents/'
+          click_link 'Person'
+          expect(page).to have_css "#tabledSearchResults .title > span#{@title_selector}", text: "Agent Person #{@now}"
+        end
+
+        it 'for classifications' do
+          visit "/classifications"
+          expect(page).to have_css "#tabledSearchResults .title > span#{@emph_selector}", text: "Classification #{@now}"
+        end
+
+        xit 'for events' do
+          # See https://archivesspace.atlassian.net/browse/ANW-2373
+        end
+
+        xit 'for assessments' do
+          # See https://archivesspace.atlassian.net/browse/ANW-2373
+        end
+      end
+    end
+
+    context 'in all linker tokens' do
+      context 'in, for example, an accession' do
+        describe 'show view' do
+          before(:each) do
+            visit "/accessions/#{@acc2.id}"
+          end
+
+          it 'for Related Resources' do
+            expect(page).to have_css '#accession_related_resources_ .token span.emph.render-none', text: "Mixed Content #{@now}"
+          end
+
+          it 'for Component Links' do
+            expect(page).to have_css '#accession_component_links_ .token span.emph.render-none', text: "Archival Object #{@now}"
+          end
+        end
+
+        describe 'edit view' do
+          before(:each) do
+            visit "/accessions/#{@acc2.id}/edit"
+          end
+
+          it 'for Related Resources' do
+            expect(page).to have_css '#accession_related_resources_ .token-input-list span.emph.render-none', text: "Mixed Content #{@now}"
+          end
+
+          it 'for Component Links' do
+            expect(page).to have_css '#accession_component_links_ .token-input-list span.emph.render-none', text: "Archival Object #{@now}"
+          end
+        end
+      end
+
+      context 'in, for example, a resource' do
+        describe 'show view' do
+          before(:each) do
+            visit "/resources/#{@resource.id}"
+          end
+
+          it 'for Related Accessions' do
+            expect(page).to have_css '#resource_related_accessions_ .token span.emph.render-none', text: "Accession 2 #{@now}"
+          end
+
+          it 'for Linked Agents' do
+            expect(page).to have_css '#resource_linked_agents_ .token span.emph.render-none', text: "Agent Person #{@now}"
+          end
+
+          it 'for Subjects' do
+            expect(page).to have_css '#resource_subjects_ .token span.emph.render-none', text: "Subject #{@now}"
+          end
+
+          it 'for Instances' do
+            expect(page).to have_css '#resource_instances_ .token span.emph.render-none', text: "Digital object #{@now}", visible: false
+          end
+
+          it 'for Classifications' do
+            expect(page).to have_css '#resource_classifications_ .token span.emph.render-none', text: "Classification #{@now}"
+          end
+        end
+
+        describe 'edit view' do
+          before(:each) do
+            visit "/resources/#{@resource.id}/edit"
+          end
+
+          it 'for Related Accessions' do
+            expect(page).to have_css '#resource_related_accessions_ .token-input-list span.emph.render-none', text: "Accession 2 #{@now}"
+          end
+
+          it 'for Linked Agents' do
+            expect(page).to have_css '#resource_linked_agents_ .token-input-list span.emph.render-none', text: "Agent Person #{@now}"
+          end
+
+          it 'for Subjects' do
+            expect(page).to have_css '#resource_subjects_ .token-input-list span.emph.render-none', text: "Subject #{@now}"
+          end
+
+          it 'for Instances' do
+            expect(page).to have_css '#resource_instances_ .token-input-list span.emph.render-none', text: "Digital object #{@now}", visible: false
+          end
+
+          it 'for Classifications' do
+            expect(page).to have_css '#resource_classifications_ .token-input-list span.emph.render-none', text: "Classification #{@now}"
+          end
+        end
+      end
+    end
+
+    context 'in flash messages' do
+      it 'for accessions' do
+        visit "/accessions/#{@acc2.id}/edit"
+        check 'Publish?'
+        click_button 'Save'
+        expect(page).to have_css "#form_messages span#{@emph_selector}", text: "Accession 2 #{@now}"
+      end
+
+      it 'for resources' do
+        visit "/resources/#{@resource.id}/edit"
+        check 'Publish?'
+        click_button 'Save'
+        expect(page).to have_css "#form_messages span#{@title_selector}", text: "Mixed Content #{@now}"
+      end
+
+      it 'for archival objects' do
+        visit "/resources/#{@resource.id}/edit#tree::archival_object_#{@ao.id}"
+        check 'Publish?'
+        click_button 'Save'
+        wait_for_ajax
+        expect(page).to have_css "#form_messages span#{@title_selector}", text: "Archival Object #{@now}"
+      end
+
+      it 'for digital objects' do
+        visit "/digital_objects/#{@do.id}/edit"
+        check 'Publish?'
+        click_button 'Save'
+        expect(page).to have_css "#form_messages span#{@title_selector}", text: "Digital object #{@now}"
+      end
+
+      it 'for digital object components' do
+        visit "/digital_objects/#{@do.id}/edit#tree::digital_object_component_#{@doc.id}"
+        check 'Publish?'
+        click_button 'Save'
+        wait_for_ajax
+        expect(page).to have_css "#form_messages span#{@emph_italic_selector}", text: "Digital object component #{@now}"
+      end
+
+      it 'for classifications' do
+        visit "/classifications/#{@classification.id}/edit"
+        fill_in 'Description', with: @now
+        click_button 'Save'
+        expect(page).to have_css "#form_messages span#{@emph_selector}", text: "Classification #{@now}"
+      end
+
+      xit 'for subjects' do
+        # Flash messages don't reference the record's title
+      end
+
+      xit 'for agents' do
+        # Flash messages don't reference the record's title
+      end
+    end
+  end
+end

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -833,6 +833,7 @@ span.component {
 
 span.title {
   font-style: italic;
+  font-variant: small-caps;
 }
 
 span.required {


### PR DESCRIPTION
This PR finalizes [ANW-2353](https://archivesspace.atlassian.net/browse/ANW-2353) by fixing more bugs related to displaying titles that contain EAD mixed content, and adds a spec to cover all of the recent work relating to this ticket (see #3534, #3509).

## Screenshots of some of the solutions presented herein

<img width="1196" alt="ANW-2353 resources show instances solution" src="https://github.com/user-attachments/assets/cabb2df5-b84d-42a5-8e1d-5c47ba52ada2" />

<img width="1453" alt="ANW-2353 assessments index solution" src="https://github.com/user-attachments/assets/82eadb02-fb57-4a8c-8a92-3f57b40963c1" />

<img width="1512" alt="ANW-2353 linker results solution" src="https://github.com/user-attachments/assets/422a7e59-3abd-40e9-a14e-86d715ecf4c1" />


[ANW-2353]: https://archivesspace.atlassian.net/browse/ANW-2353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ