### PR TITLE
ANW-2353 Fix mixed content display in toolbars across record types

### DIFF
--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -90,7 +90,7 @@
             <% end %>
           <% end %>
           <% if user_can?('delete_archival_record') %>
-            <%= button_delete_action url_for(:controller => :accessions, :action => :delete, :id => @accession.id), { :"data-title" => t("actions.delete_confirm_title", :title => @accession.title) } %>
+            <%= button_delete_action url_for(:controller => :accessions, :action => :delete, :id => @accession.id), { :"data-title" => t("actions.delete_confirm_title", :title => clean_mixed_content(@accession.title)) } %>
           <% end %>
         <% end %>
       </div>

--- a/frontend/app/views/agents/_merge_dropdown.html.erb
+++ b/frontend/app/views/agents/_merge_dropdown.html.erb
@@ -10,7 +10,7 @@
     </button>
     <ul class="dropdown-menu merge-form dropdown-menu-right">
       <li>
-        <p class="mb-0"><%= t("#{singular}._frontend.messages.merge_description") %> <%= record.title %></p>
+        <p class="mb-0"><%= t("#{singular}._frontend.messages.merge_description") %> <%= clean_mixed_content(record.title) %></p>
         <%= form_context :merge, {} do |form| %>
 
         <fieldset class="mt-3 mb-4 p-0">

--- a/frontend/app/views/agents/_toolbar.html.erb
+++ b/frontend/app/views/agents/_toolbar.html.erb
@@ -55,7 +55,7 @@
         %>
       <% end %>
       <% if user_can?('delete_agent_record') %>
-        <%= button_delete_action url_for(:controller => :agents, :action => :delete, :id => @agent.id), { :"data-title" => t("actions.delete_confirm_title", :title => @agent.title) } %>
+        <%= button_delete_action url_for(:controller => :agents, :action => :delete, :id => @agent.id), { :"data-title" => t("actions.delete_confirm_title", :title => clean_mixed_content(@agent.title)) } %>
       <% end %>
     </div>
   </div>

--- a/frontend/app/views/classifications/_toolbar.html.erb
+++ b/frontend/app/views/classifications/_toolbar.html.erb
@@ -18,7 +18,7 @@
       <% end %>
       <% if user_can?('delete_classification_record') %>
         <div class="ml-auto btn-group" data-allow-disabled>
-          <%= button_delete_action url_for(:controller => :classifications, :action => :delete, :id => @classification.id), { :"data-title" => t("actions.delete_confirm_title", :title => @classification.title) } %>
+          <%= button_delete_action url_for(:controller => :classifications, :action => :delete, :id => @classification.id), { :"data-title" => t("actions.delete_confirm_title", :title => clean_mixed_content(@classification.title)) } %>
         </div>
       <% end %>
     </div>

--- a/frontend/app/views/shared/_component_toolbar.html.erb
+++ b/frontend/app/views/shared/_component_toolbar.html.erb
@@ -101,7 +101,7 @@
       <% end %>
       <% if user_can?('delete_archival_record') %>
         <div class="btn btn-inline-form">
-          <%= button_delete_action url_for(:action => :delete, :id => record.id), { :"data-title" => t("actions.delete_confirm_title", :title => delete_action_title) } %>
+          <%= button_delete_action url_for(:action => :delete, :id => record.id), { :"data-title" => t("actions.delete_confirm_title", :title => clean_mixed_content(delete_action_title)) } %>
         </div>
       <% end %>
     </div>

--- a/frontend/app/views/shared/_merge_dropdown.html.erb
+++ b/frontend/app/views/shared/_merge_dropdown.html.erb
@@ -10,7 +10,7 @@
     </button>
     <ul class="dropdown-menu merge-form dropdown-menu-right" role="none">
       <li>
-        <p class="mb-0"><%= t("#{singular}._frontend.messages.merge_description") %>   <%= record.title %></p>
+        <p class="mb-0"><%= t("#{singular}._frontend.messages.merge_description") %>   <%= clean_mixed_content(record.title) %></p>
         <%= form_context :merge, {} do |form| %>
 
         <fieldset class="mt-3 mb-4 p-0">

--- a/frontend/app/views/shared/_resource_toolbar.html.erb
+++ b/frontend/app/views/shared/_resource_toolbar.html.erb
@@ -163,7 +163,7 @@
         <% end %>
       <% end %>
       <% if user_can?('delete_archival_record') %>
-        <%= button_delete_action url_for(:action => :delete, :id => record.id), { :"data-title" => t("actions.delete_confirm_title", :title => record.title) } %>
+        <%= button_delete_action url_for(:action => :delete, :id => record.id), { :"data-title" => t("actions.delete_confirm_title", :title => clean_mixed_content(record.title)) } %>
       <% end %>
     </div>
   </div>

--- a/frontend/app/views/shared/_templates.html.erb
+++ b/frontend/app/views/shared/_templates.html.erb
@@ -4,7 +4,7 @@
        <div class="modal-content">
          {if defined("title") && title.length > 0}
            <div class="modal-header align-items-start justify-content-between">
-             <h3>${title|h}</h3>
+             <h3>${title}</h3>
              <button type="button" class="btn close" data-dismiss="modal">×</button>
            </div>
          {/if}

--- a/frontend/app/views/subjects/_toolbar.html.erb
+++ b/frontend/app/views/subjects/_toolbar.html.erb
@@ -29,7 +29,7 @@
         <% end %>
 
         <% if user_can?('delete_subject_record') %>
-          <%= button_delete_action url_for(:controller => :subjects, :action => :delete, :id => @subject.id), { :"data-title" => t("actions.delete_confirm_title", :title => @subject.title) } %>
+          <%= button_delete_action url_for(:controller => :subjects, :action => :delete, :id => @subject.id), { :"data-title" => t("actions.delete_confirm_title", :title => clean_mixed_content(@subject.title)) } %>
         <% end %>
       </div>
     </div>

--- a/frontend/spec/features/mixed_content_in_title_fields_spec.rb
+++ b/frontend/spec/features/mixed_content_in_title_fields_spec.rb
@@ -249,6 +249,72 @@ describe 'Mixed Content in title fields', js: true do
       end
     end
 
+    context 'in a record toolbar' do
+      describe 'merge dropdown' do
+        def test_merge_dropdown(path, title_selector, expected_text)
+          visit path
+          expect(page).to have_css "#merge-dropdown span#{title_selector}", text: expected_text, visible: false
+        end
+
+        it 'for resources' do
+          test_merge_dropdown("/resources/#{@resource.id}/edit", @title_selector, "Mixed Content #{@now}")
+        end
+
+        it 'for digital objects' do
+          test_merge_dropdown("/digital_objects/#{@do.id}/edit", @title_selector, "Digital object #{@now}")
+        end
+
+        it 'for subjects' do
+          test_merge_dropdown("/subjects/#{@subject.id}/edit", @emph_selector, "Subject #{@now}")
+        end
+
+        it 'for agents' do
+          test_merge_dropdown("/agents/agent_person/#{@agent.id}/edit", @title_selector, "Agent Person #{@now}")
+        end
+      end
+
+      describe 'delete button' do
+        def test_delete_modal(path, title_selector, expected_text)
+          visit path
+          click_button 'Delete'
+          wait_for_ajax
+          expect(page).to have_css "#confirmChangesModal span#{title_selector}", text: expected_text
+        end
+
+        it 'for resources' do
+          test_delete_modal("/resources/#{@resource.id}/edit", @title_selector, "Mixed Content #{@now}")
+        end
+
+        it 'for archival objects' do
+          test_delete_modal("/resources/#{@resource.id}/edit#tree::archival_object_#{@ao.id}", @title_selector, "Archival Object #{@now}")
+        end
+
+        it 'for digital objects' do
+          test_delete_modal("/digital_objects/#{@do.id}/edit", @title_selector, "Digital object #{@now}")
+        end
+
+        it 'for digital object components' do
+          test_delete_modal("/digital_objects/#{@do.id}/edit#tree::digital_object_component_#{@doc.id}", @emph_italic_selector, "Digital object component #{@now}")
+        end
+
+        it 'for accessions' do
+          test_delete_modal("/accessions/#{@acc2.id}/edit", @emph_selector, "Accession 2 #{@now}")
+        end
+
+        it 'for subjects' do
+          test_delete_modal("/subjects/#{@subject.id}/edit", @emph_selector, "Subject #{@now}")
+        end
+
+        it 'for agents' do
+          test_delete_modal("/agents/agent_person/#{@agent.id}/edit", @title_selector, "Agent Person #{@now}")
+        end
+
+        it 'for classifications' do
+          test_delete_modal("/classifications/#{@classification.id}/edit", @emph_selector, "Classification #{@now}")
+        end
+      end
+    end
+
     context 'in the largetree' do
       it 'for resources and archival objects' do
         visit "/resources/#{@resource.id}"


### PR DESCRIPTION
This PR continues to fix display of mixed content in title fields across record types on the frontend, including:

- toolbar merge dropdowns
- toolbar Delete button modals

[ANW-2353](https://archivesspace.atlassian.net/browse/ANW-2353)

[ANW-2353]: https://archivesspace.atlassian.net/browse/ANW-2353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ