### PR TITLE
Remove stranded code from old required field system.

### DIFF
--- a/frontend/app/helpers/aspace_form_helper.rb
+++ b/frontend/app/helpers/aspace_form_helper.rb
@@ -422,13 +422,10 @@ module AspaceFormHelper
         opts[:"aria-label"] = I18n.t(i18n_for(name))
       end
       selection = obj[name]
-      selection = selection[0...-4] if selection.is_a? String and selection.end_with?("_REQ")
       @forms.select_tag(path(name), @forms.options_for_select(options, selection || default_for(name) || opts[:default]), {:id => id_for(name)}.merge!(opts))
     end
 
     def textarea(name = nil, value = "", opts = {})
-      value = value[0...-4] if value.is_a? String and value.end_with?("_REQ")
-      value = nil if value === "REQ"
       options = {:id => id_for(name), :rows => 3}
 
       placeholder = I18n.t("#{i18n_for(name)}_placeholder", :default => '')
@@ -450,10 +447,6 @@ module AspaceFormHelper
 
     def textfield(name = nil, value = nil, opts = {})
       value ||= obj[name] if !name.nil?
-
-      value = value[0...-4] if value.is_a? String and value.end_with?("_REQ")
-      value = nil if value === "REQ"
-
       options = {:id => id_for(name), :type => "text", :value => h(value), :name => path(name)}
 
       placeholder = I18n.t("#{i18n_for(name)}_placeholder", :default => '')


### PR DESCRIPTION
Required fields for the agent form were originally implemented by appending the string "_REQ" to values in the form and somehow tracking required fields that way. It was refactored a while back, but it looks like some code stuck around in the form helper. See: https://github.com/archivesspace/archivesspace/pull/2703

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
