### PR TITLE
ANW-2355: Fix label `for` attributes in Agent required fields forms

### DIFF
--- a/frontend/app/views/shared/_required_subrecord_form.html.erb
+++ b/frontend/app/views/shared/_required_subrecord_form.html.erb
@@ -43,7 +43,7 @@
       <% label = t("#{i18n_type}.#{field_name}") %>
       <% form_name = "agent[#{property}][0][#{field_name}]" %>
       <div class="form-group w-100 row">
-        <label class="col-sm-2 control-label text-right" for="agent_record_identifier_" plugin=""><%=  label %></label>
+        <label class="col-sm-2 control-label text-right" for="required_fields__<%= field_name %>_" plugin=""><%=  label %></label>
         <div class="col-sm-9 label-only">
           <input id="required_fields__<%= field_name %>_" type="checkbox" name="<%= form_name %>" value="<%= type %>" col_size="1" controls_class="req_checkbox"<%= definition.required?(field_name) ? ' disabled checked=checked' : '' %><%= @required_fields.required?(property, type, field_name) ? " checked=checked" : "" %>>
         </div>

--- a/frontend/spec/features/agents_required_fields_spec.rb
+++ b/frontend/spec/features/agents_required_fields_spec.rb
@@ -123,6 +123,19 @@ describe 'Agents Required Fields', js: true do
     end
   end
 
+  shared_examples 'valid label-checkbox pairs' do |agent_type|
+    it "has matching label for and checkbox id attributes for #{agent_type}" do
+      visit "/agents/#{agent_type}/required"
+
+      all('.subrecord-form-container > .form-group.w-100.row').each do |row|
+        label = row.find('label')
+        checkbox = row.find('input[type="checkbox"]')
+
+        expect(label[:for]).to eq(checkbox[:id])
+      end
+    end
+  end
+
   context 'when lightmode is off' do
     describe 'the sidebar' do
       include_examples 'agent sidebar items', 'agent_person', []
@@ -162,6 +175,11 @@ describe 'Agents Required Fields', js: true do
         'Relation Information',
         'Related External Resources'
       ]
+
+      include_examples 'valid label-checkbox pairs', 'agent_person'
+      include_examples 'valid label-checkbox pairs', 'agent_family'
+      include_examples 'valid label-checkbox pairs', 'agent_corporate_entity'
+      include_examples 'valid label-checkbox pairs', 'agent_software'
     end
   end
 


### PR DESCRIPTION
This PR fixes an erroneously hardcoded `for` attribute in a partial used for many `<label>`s in the Agent Required Fields forms. This bug caused many mismatches between checkbox `id` values and their related `<label>`'s `for` attribute which should match.

[ANW-2355](https://archivesspace.atlassian.net/browse/ANW-2355)

[ANW-2355]: https://archivesspace.atlassian.net/browse/ANW-2355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ