### PR TITLE
refactor(factories): update resource and archival_object factories to…

### DIFF
--- a/frontend/app/views/resources/_form_container.html.erb
+++ b/frontend/app/views/resources/_form_container.html.erb
@@ -1,7 +1,7 @@
 <%= link_to_help :topic => "resource" %>
 
 <h2>
-  <%= @form_title ? @form_title : @resource.titles.empty? ? "#{t("resource.new_title")}" : clean_mixed_content(MultipleTitlesHelper.determine_primary_title(@resource.titles, I18n.locale))  %>  
+  <%= @form_title ? @form_title : @resource.titles.empty? ? "#{t("resource.new_title")}" : clean_mixed_content(MultipleTitlesHelper.determine_primary_title(@resource.titles, I18n.locale))  %>
   <span class="label label-info badge"><%= t("resource._singular") %></span>
 </h2>
 
@@ -44,7 +44,7 @@
     </fieldset>
   </section>
 
-  <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "titles"} %>
+  <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "titles", :required => true} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "lang_materials", :custom_action_template => "lang_materials/subrecord_form_action"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "dates", :template => "archival_record_date"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "extents"} %>

--- a/frontend/spec/factories.rb
+++ b/frontend/spec/factories.rb
@@ -85,7 +85,7 @@ module Factories
       end
 
       factory :resource, class: JSONModel(:resource) do
-        title { generate(:resource_title) }
+        titles { [build(:title, title: title)] }
         id_0 { generate(:generic_id) }
         id_1 { generate(:generic_id) }
         extents { [build(:extent)] }
@@ -94,6 +94,14 @@ module Factories
         lang_materials { [build(:json_lang_material)] }
         finding_aid_language { 'eng' }
         finding_aid_script { 'Latn' }
+
+        transient do
+          title { generate(:generic_title) }
+        end
+      end
+
+      factory :title, class: JSONModel(:title) do
+        title { generate(:generic_title) }
       end
 
       factory :extent, class: JSONModel(:extent) do
@@ -111,9 +119,14 @@ module Factories
       end
 
       factory :archival_object, class: JSONModel(:archival_object) do
+        titles { [build(:title, title: title)] }
         ref_id { generate(:ref_id) }
         level { 'item' }
         lang_materials { [build(:json_lang_material)] }
+
+        transient do
+          title { generate(:generic_title) }
+        end
       end
 
       factory :digital_object, class: JSONModel(:digital_object) do


### PR DESCRIPTION
… use titles association

Updated the `resource` and `archival_object` factories to include a `titles` association, replacing the previous `title` attribute. Added a new `title` factory for generating title objects. Introduced transient attributes for customizing titles in `resource` and `archival_object` factories.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
