### PR TITLE
ANW-1765: added "close record" button and harmonized toolbars for all new / edit forms

### DIFF
--- a/frontend/app/assets/javascripts/tree_toolbar.js.erb
+++ b/frontend/app/assets/javascripts/tree_toolbar.js.erb
@@ -345,24 +345,6 @@ var SHARED_TOOLBAR_ACTIONS = [
             return !tree.large_tree.read_only && tree.dragdrop;
         },
     },
-
-    // go back to the read only page
-    // Close Record
-    {
-        label: '<%= I18n.t("actions.finish_editing") %>',
-        cssClasses: 'btn-success finish-editing',
-        groupCssClasses: 'ml-auto order-1',
-        onRender: function(btn, node, tree, toolbarRenderer) {
-            var readonlyPath = location.pathname.replace(/\/edit$/, '');
-            btn.attr('href', readonlyPath + location.hash);
-        },
-        isEnabled: function(node, tree, toolbarRenderer) {
-            return true;
-        },
-        isVisible: function(node, tree, toolbarRenderer) {
-            return !tree.large_tree.read_only;
-        }
-    },
 ];
 
 var EXPAND_MODE_ACTIONS = [

--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -14,6 +14,9 @@
         </div>
       <% end %>
       <% if ['edit', 'update'].include?(controller.action_name) %>
+        <div class="close-record">
+          <%= link_to t("actions.finish_editing"), {:controller => :accessions, :action => :show, :id => @accession.id}, :class => "btn btn-primary btn-sm btn-success finish-editing" %>
+        </div>
         <div class="align-items-center revert-changes">
           <%= link_to t("actions.revert"), {:controller => :accessions, :action => :edit, :id => @accession.id}, :class => "btn btn-sm btn-default flex-shrink-0" %>
         </div>

--- a/frontend/app/views/agents/_toolbar.html.erb
+++ b/frontend/app/views/agents/_toolbar.html.erb
@@ -10,6 +10,9 @@
       </div>
     <% end %>
     <% if edit_mode? %>
+      <div class="close-record">
+        <%= link_to t("actions.finish_editing"), {:controller => :agents, :action => :show, :id => @agent.id, :agent_type => @agent.agent_type}, :class => "btn btn-primary btn-sm btn-success finish-editing" %>
+      </div>
       <div class="align-items-center revert-changes">
         <%= link_to t("actions.revert"), {:controller => :agents, :action => :edit, :id => @agent.id}, :class => "btn btn-sm btn-default" %>
       </div>

--- a/frontend/app/views/assessments/_toolbar.html.erb
+++ b/frontend/app/views/assessments/_toolbar.html.erb
@@ -10,6 +10,9 @@
       <% end %>
 
       <% if ['edit', 'update'].include?(controller.action_name) %>
+        <div class="close-record">
+          <%= link_to I18n.t("actions.finish_editing"), {:controller => :assessments, :action => :show, :id => @assessment.id}, :class => "btn btn-primary btn-sm btn-success finish-editing" %>
+        </div>
         <div class="align-items-center revert-changes">
           <%= link_to I18n.t("actions.revert"), {:controller => :assessments, :action => :edit, :id => @assessment.id}, :class => "btn btn-sm btn-default flex-shrink-0" %>
         </div>

--- a/frontend/app/views/classifications/_toolbar.html.erb
+++ b/frontend/app/views/classifications/_toolbar.html.erb
@@ -12,6 +12,9 @@
         </div>
       <% end %>
       <% if ['edit', 'update'].include?(controller.action_name) %>
+        <div class="close-record">
+          <%= link_to t("actions.finish_editing"), {:controller => :classifications, :action => :show, :id => @classification.id}, :class => "btn btn-primary btn-sm btn-success finish-editing" %>
+        </div>
         <div class="revert-changes">
           <%= link_to t("actions.revert"), {:controller => :classifications, :action => :edit, :id => @classification.id}, :class => "btn btn-sm btn-default" %>
         </div>

--- a/frontend/app/views/container_profiles/_toolbar.html.erb
+++ b/frontend/app/views/container_profiles/_toolbar.html.erb
@@ -10,6 +10,9 @@
       <% end %>
 
       <% if ['edit', 'update'].include?(controller.action_name) %>
+        <div class="close-record">
+          <%= link_to I18n.t("actions.finish_editing"), {:controller => :container_profiles, :action => :show, :id => @container_profile.id}, :class => "btn btn-primary btn-sm btn-success finish-editing" %>
+        </div>
         <div class="align-items-center revert-changes">
           <%= link_to I18n.t("actions.revert"), {:controller => :container_profiles, :action => :edit, :id => @container_profile.id}, :class => "btn btn-sm btn-default flex-shrink-0" %>
         </div>

--- a/frontend/app/views/custom_report_templates/_toolbar.html.erb
+++ b/frontend/app/views/custom_report_templates/_toolbar.html.erb
@@ -10,9 +10,11 @@
     </div>
   <% end %>
   <% if ['edit', 'update'].include?(controller.action_name) %>
+    <div class="close-record">
+      <%= link_to t("actions.finish_editing"), {:controller => :custom_report_templates, :action => :show, :id => @custom_report_template.id}, :class => "btn btn-primary btn-sm btn-success finish-editing" %>
+    </div>
     <div class="revert-changes">
     <%= link_to t("actions.revert"), {:controller => :custom_report_templates, :action => :edit, :id => @custom_report_template.id}, :class => "btn btn-sm btn-default bg-white border" %>
-    <%= t("actions.toolbar_disabled_message") %>
     </div>
   <% end %>
     <div class="btn-toolbar ml-auto">
@@ -38,3 +40,9 @@
     </div>
   <div class="clearfix"></div>
 </div>
+<% if ['edit', 'update'].include?(controller.action_name) %>
+  <div id="record-toolbar-alert">
+    <p class="mb-0 pt-1 pb-2 px-2 fs-12px"><%= t("actions.toolbar_disabled_message") %></p>
+  </div>
+<% end %>
+

--- a/frontend/app/views/events/_toolbar.html.erb
+++ b/frontend/app/views/events/_toolbar.html.erb
@@ -1,31 +1,34 @@
-<% if user_can?('delete_event_record') %>
-  <section class="d-flex flex-column">
-    <div class="record-toolbar d-flex align-items-center gap-x-2" role="toolbar">
-      <% if not @event.suppressed %>
-        <% if !['edit', 'update'].include?(controller.action_name) %>
-          <%= link_to I18n.t("actions.edit"), {:controller => :events, :action => :edit, :id => @event.id}, :class => "btn btn-sm btn-primary" %>
-        <% else %>
-          <div class="save-changes">
-            <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
-          </div>
-        <% end %>
-
-        <% if ['edit', 'update'].include?(controller.action_name) %>
-          <div class="align-items-center revert-changes">
-            <%= link_to I18n.t("actions.revert"), {:controller => :events, :action => :edit, :id => @event.id}, :class => "btn btn-sm btn-default flex-shrink-0" %>
-          </div>
-        <% end %>
+<section class="d-flex flex-column">
+  <div class="record-toolbar d-flex align-items-center gap-x-2" role="toolbar">
+    <% if not @event.suppressed %>
+      <% if !['edit', 'update'].include?(controller.action_name) %>
+        <%= link_to I18n.t("actions.edit"), {:controller => :events, :action => :edit, :id => @event.id}, :class => "btn btn-sm btn-primary" %>
+      <% else %>
+        <div class="save-changes">
+          <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
+        </div>
       <% end %>
 
+      <% if ['edit', 'update'].include?(controller.action_name) %>
+        <div class="close-record">
+          <%= link_to I18n.t("actions.finish_editing"), {:controller => :events, :action => :show, :id => @event.id}, :class => "btn btn-primary btn-sm btn-success finish-editing" %>
+        </div>
+        <div class="align-items-center revert-changes">
+          <%= link_to I18n.t("actions.revert"), {:controller => :events, :action => :edit, :id => @event.id}, :class => "btn btn-sm btn-default flex-shrink-0" %>
+        </div>
+      <% end %>
+    <% end %>
+
+    <% if user_can?('delete_event_record') %>
       <div class="ml-auto btn-group" data-allow-disabled>
         <%= button_delete_action url_for(:controller => :events, :action => :delete, :id => @event.id), { :"data-title" => t("actions.delete_confirm_title", :title => record_title) } %>
       </div>
-    </div>
-
-    <% if ['edit', 'update'].include?(controller.action_name) %>
-      <div id="record-toolbar-alert">
-        <p class="mb-0 pt-1 pb-2 px-2 fs-12px"><%= t("actions.toolbar_disabled_message") %></p>
-      </div>
     <% end %>
-  </section>
-<% end %>
+  </div>
+
+  <% if ['edit', 'update'].include?(controller.action_name) %>
+    <div id="record-toolbar-alert">
+      <p class="mb-0 pt-1 pb-2 px-2 fs-12px"><%= t("actions.toolbar_disabled_message") %></p>
+    </div>
+  <% end %>
+</section>

--- a/frontend/app/views/groups/_toolbar.html.erb
+++ b/frontend/app/views/groups/_toolbar.html.erb
@@ -1,14 +1,25 @@
 <div class="row">
   <div class="col-md-12">
     <div class="record-toolbar d-flex align-items-center">
-      <div class="btn-group">
-        <div class="save-changes">
-          <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
+      <div class="save-changes">
+        <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
+      </div>
+      <% if ['edit', 'update'].include?(controller.action_name) && user_can?('manage_repository') %>
+        <div class="close-record">
+          <%= link_to I18n.t("actions.finish_editing"), {:controller => :groups, :action => :show, :id => @group.id}, :class => "btn btn-primary btn-sm btn-success finish-editing" %>
         </div>
-      </div>
-      <div class="btn-toolbar ml-auto">
-        <%= button_delete_action url_for(:controller => :groups, :action => :delete, :id => @group.id), { :"data-title" => t("actions.delete_confirm_title", :title => @group.description) } %>
-      </div>
+        <div class="align-items-center revert-changes">
+          <%= link_to t("actions.revert"), {:controller => :groups, :action => :edit, :id => @group.id}, :class => "btn btn-sm btn-default flex-shrink-0" %>
+        </div>
+        <div class="btn-grp ml-auto">
+          <%= button_delete_action url_for(:controller => :groups, :action => :delete, :id => @group.id), { :"data-title" => t("actions.delete_confirm_title", :title => @group.description) } %>
+        </div>
+      <% end %>
     </div>
+    <% if ['edit', 'update'].include?(controller.action_name) %>
+      <div id="record-toolbar-alert">
+        <p class="mb-0 pt-1 pb-2 px-2 fs-12px"><%= t("actions.toolbar_disabled_message") %></p>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/frontend/app/views/groups/new.html.erb
+++ b/frontend/app/views/groups/new.html.erb
@@ -1,17 +1,18 @@
 <%= setup_context :object => @group %>
 
-<div class="d-flex">
-  <div class="col-12">
-    <div class="record-pane">
-      <h2><%= I18n.t("actions.new_prefix") %> <%= I18n.t("group._singular") %> <span class="label label-info badge"><%= I18n.t("group._singular") %></span></h2>
+<%= form_for @group, :as => "group", :url => {:action => :create}, :html => {:class => 'aspace-record-form'} do |f| %>
+  <%= form_context :group, @group do |form| %>
+    <div class="d-flex">
+      <div class="col-12">
+        <%= render_aspace_partial :partial => "toolbar" %>
+        <div class="record-pane">
+          <h2><%= I18n.t("actions.new_prefix") %> <%= I18n.t("group._singular") %> <span class="label label-info badge"><%= I18n.t("group._singular") %></span></h2>
 
-      <%= form_for @group, :as => "group", :url => {:action => :create}, :html => {:class => 'aspace-record-form'} do |f| %>
-        <%= form_context :group, @group do |form| %>
           <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:form => form} %>
           <%= form.label_and_textfield :group_code, :required => true %>
           <%= render_aspace_partial :partial => "groups/form", :locals => {:form => form} %>
-        <% end %>
-      <% end %>
+        </div>
+      </div>
     </div>
-  </div>
-</div>
+  <% end %>
+<% end %>

--- a/frontend/app/views/locations/_toolbar.html.erb
+++ b/frontend/app/views/locations/_toolbar.html.erb
@@ -10,13 +10,16 @@
       <% end %>
 
       <% if ['edit', 'update'].include?(controller.action_name) %>
+        <div class="close-record">
+          <%= link_to I18n.t("actions.finish_editing"), {:controller => :locations, :action => :show, :id => @location.id}, :class => "btn btn-primary btn-sm btn-success finish-editing" %>
+        </div>
         <div class="align-items-center revert-changes">
           <%= link_to I18n.t("actions.revert"), {:controller => :locations, :action => :edit, :id => @location.id}, :class => "btn btn-sm btn-default flex-shrink-0" %>
         </div>
       <% end %>
 
       <div class="d-flex gap-x-2 flex-shrink-0 ml-auto" data-allow-disabled>
-        <% if user_can?('update_location_record') %>
+        <% if ['show', 'edit', 'update'].include?(controller.action_name) && user_can?('update_location_record') %>
           <%= button_delete_action url_for(:controller => :locations, :action => :delete, :id => @location.id), { :"data-title" => t("actions.delete_confirm_title", :title => @location.title) } %>
         <% end %>
       </div>

--- a/frontend/app/views/locations/new.html.erb
+++ b/frontend/app/views/locations/new.html.erb
@@ -7,6 +7,7 @@
         <%= render_aspace_partial :partial => "locations/sidebar" %>
       </div>
       <div class="col-md-9">
+        <%= render_aspace_partial :partial => "toolbar" %>
         <div class="record-pane">
           <%= link_to_help :topic => "location" %>
           <h2><%= I18n.t("location.new_title") %>  <span class="label label-info badge"><%= I18n.t("location._singular") %></span></h2>

--- a/frontend/app/views/shared/_component_toolbar.html.erb
+++ b/frontend/app/views/shared/_component_toolbar.html.erb
@@ -15,8 +15,9 @@
         <div class="save-changes">
           <button type="submit" class="btn btn-primary btn-sm"><%= t("actions.save_prefix") %></button>
         </div>
-      <% end %>
-      <% if ['edit', 'update'].include?(controller.action_name) %>
+        <div class="close-record">
+          <%= link_to t("actions.finish_editing"), {:controller => parent_link[:controller], :action => :show, :id => parent_link[:id], :anchor => parent_link[:anchor]}, :class => "btn btn-primary btn-sm btn-success finish-editing" %>
+        </div>
         <div class="align-items-center revert-changes">
           <%= link_to t("actions.revert"), parent_link, :class => "btn btn-sm btn-default flex-shrink-0" %>
         </div>
@@ -107,7 +108,7 @@
     </div>
   </div>
 
-  <% if ['edit', 'update'].include?(controller.action_name) %>
+  <% if ['new', 'create', 'edit', 'update'].include?(controller.action_name) %>
     <div id="record-toolbar-alert">
       <p class="mb-0 pt-1 pb-2 px-2 fs-12px"><%= t("actions.toolbar_disabled_message") %></p>
     </div>

--- a/frontend/app/views/shared/_resource_toolbar.html.erb
+++ b/frontend/app/views/shared/_resource_toolbar.html.erb
@@ -13,6 +13,9 @@
       </div>
     <% end %>
     <% if ['edit', 'update'].include?(controller.action_name) %>
+      <div class="close-record">
+        <%= link_to t("actions.finish_editing"), {:action => :show, :id => record.id, :anchor => "tree::#{record_type}_#{record.id}"}, :class => "btn btn-primary btn-sm btn-success finish-editing" %>
+      </div>
       <div class="align-items-center revert-changes">
         <%= link_to t("actions.revert"), {:action => :edit, :id => record.id}, :class => "btn btn-sm btn-default flex-shrink-0" %>
       </div>

--- a/frontend/app/views/subjects/_toolbar.html.erb
+++ b/frontend/app/views/subjects/_toolbar.html.erb
@@ -10,6 +10,9 @@
       <% end %>
 
       <% if ['edit', 'update'].include?(controller.action_name) %>
+        <div class="close-record">
+          <%= link_to I18n.t("actions.finish_editing"), {:controller => :subjects, :action => :show, :id => @subject.id}, :class => "btn btn-primary btn-sm btn-success finish-editing" %>
+        </div>
         <div class="align-items-center revert-changes">
           <%= link_to I18n.t("actions.revert"), {:controller => :subjects, :action => :edit, :id => @subject.id}, :class => "btn btn-sm btn-default flex-shrink-0" %>
         </div>

--- a/frontend/app/views/top_containers/_toolbar.html.erb
+++ b/frontend/app/views/top_containers/_toolbar.html.erb
@@ -12,11 +12,24 @@
         <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
       </div>
     <% end %>
+    <% if ['edit', 'update'].include?(controller.action_name) %>
+      <div class="close-record">
+        <%= link_to t("actions.finish_editing"), {:controller => :top_containers, :action => :show, :id => @top_container.id}, :class => "btn btn-primary btn-sm btn-success finish-editing" %>
+      </div>
+      <div class="align-items-center revert-changes">
+        <%= link_to t("actions.revert"), {:controller => :top_containers, :action => :edit, :id => @top_container.id}, :class => "btn btn-sm btn-default flex-shrink-0" %>
+      </div>
+    <% end %>
     <% if !['new'].include?(controller.action_name) && user_can?('manage_container_record') %>
       <div class="btn-toolbar ml-auto">
         <%= button_delete_action url_for(:controller => :top_containers, :action => :delete, :id => @top_container.id ), { :"data-title" => t("actions.delete_confirm_title", :title => @top_container.display_string) } unless @top_container.id.nil? %> 
       </div>
     <% end %>
   </div>
+  <% if ['edit', 'update'].include?(controller.action_name) %>
+    <div id="record-toolbar-alert">
+      <p class="mb-0 pt-1 pb-2 px-2 fs-12px"><%= t("actions.toolbar_disabled_message") %></p>
+    </div>
+  <% end %>
 
 <% end %>

--- a/frontend/app/views/users/_toolbar.html.erb
+++ b/frontend/app/views/users/_toolbar.html.erb
@@ -18,10 +18,17 @@
     <% end %>
   </div>
   <% if ['edit', 'update'].include?(controller.action_name) %>
+    <div class="close-record">
+      <%= link_to t("actions.finish_editing"), {:controller => :users, :action => :show, :id => @user.id}, :class => "btn btn-primary btn-sm btn-success finish-editing" %>
+    </div>
     <div class="revert-changes order-2 order-sm-1 mx-sm-2 mb-1">
       <%= link_to t("actions.revert"), {:controller => :users, :action => :edit, :id => @user.id}, :class => "btn btn-sm border bg-white rounded mr-2" %>
-      <%= t("actions.toolbar_disabled_message") %>
     </div>
   <% end %>
 </div>
+<% if ['edit', 'update'].include?(controller.action_name) %>
+  <div id="record-toolbar-alert">
+    <p class="mb-0 pt-1 pb-2 px-2 fs-12px"><%= t("actions.toolbar_disabled_message") %></p>
+  </div>
+<% end %>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR addresses and generalizes a request (https://archivesspace.atlassian.net/browse/ANW-1765) for a "close record" button on Accession records. The changes in this PR:
- add this button to all toolbars on a stable place (next to the "save" button in the toolbar)  
  Note: to this end, the "close record" button has been moved from the tree toolbar to the actual record toolbar for records with components and actual record components
- harmonize toolbars, so each record type now:
  - shows a toolbar when a new record is being created
  - provides uniform functionality, with save, close, and revert changes buttons

Updated toolbars for following record types:
- accessions
- agents
- assessments
- classifications
- container profiles
- custom report templates
- events
- user groups
- locations
- resources
- components
- subjects
- top containers
- users

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
https://archivesspace.atlassian.net/browse/ANW-1765

## How Has This Been Tested?
All changes are limited to the frontend app.

I've tested as follows:
- Forked a new branch from the master branch
- Made changes to the code
- Built a local version of ArchivesSpace with these changes 
- Checked all updated record types in the frontend app, with different user profiles

Since I'm running on Windows, with the Solr and MySQL dependencies running in a Docker container, I wasn't able to run the tests. Yet, I've tested exhaustively, and observed no errors at all.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
