### PR TITLE
ANW-2392 ensure empty title subrecord appears on new record

### DIFF
--- a/common/schemas/archival_object.rb
+++ b/common/schemas/archival_object.rb
@@ -8,6 +8,9 @@
     "parent" => "abstract_archival_object",
     "uri" => "/repositories/:repo_id/archival_objects",
     "properties" => {
+      # Titles (overrides abstract schema)
+      "titles" => {"type" => "array", "minItems" => 1, "items" => {"type" => "JSONModel(:title) object"}},
+
       "ref_id" => {"type" => "string", "maxLength" => 255, "pattern" => "\\A[a-zA-Z0-9\\-_:\\.]*\\z"},
       "component_id" => {"type" => "string", "maxLength" => 255, "required" => false, "default" => ""},
 

--- a/common/schemas/resource.rb
+++ b/common/schemas/resource.rb
@@ -8,6 +8,8 @@
     "parent" => "abstract_archival_object",
     "uri" => "/repositories/:repo_id/resources",
     "properties" => {
+      # Titles (overrides abstract schema)
+      "titles" => {"type" => "array", "ifmissing" => "error", "minItems" => 1, "items" => {"type" => "JSONModel(:title) object"}},
 
       "id_0" => {"type" => "string", "ifmissing" => "error", "maxLength" => 255},
       "id_1" => {"type" => "string", "maxLength" => 255},

--- a/frontend/app/controllers/archival_objects_controller.rb
+++ b/frontend/app/controllers/archival_objects_controller.rb
@@ -22,6 +22,7 @@ class ArchivalObjectsController < ApplicationController
       flash[:success] = t("archival_object._frontend.messages.duplicated", archival_object_display_string: clean_mixed_content(@archival_object.display_string))
     else
       @archival_object = ArchivalObject.new._always_valid!
+      @archival_object.titles = [{title: ""}]
       @archival_object.parent = {'ref' => ArchivalObject.uri_for(params[:archival_object_id])} if params.has_key?(:archival_object_id)
       @archival_object.resource = {'ref' => Resource.uri_for(params[:resource_id])} if params.has_key?(:resource_id)
       @archival_object.position = params[:position]

--- a/frontend/app/controllers/resources_controller.rb
+++ b/frontend/app/controllers/resources_controller.rb
@@ -46,7 +46,7 @@ class ResourcesController < ApplicationController
   end
 
   def new
-    @resource = Resource.new(:title => t("resource.title_default", :default => ""))._always_valid!
+    @resource = Resource.new(:titles => [{:title => t("resource.title_default", :default => "")}])._always_valid!
     defaults = user_defaults('resource')
     if defaults
       @resource.update(defaults.values)


### PR DESCRIPTION
Updates controllers to spawn the new record with the default title or an empty title in the titles list, which will cause the subrecord form to show an empty title subrecord. Also updated titles list in the schema to match other fields by overriding the abstract schema and specifying a minimum of 1 item, though this did not fix the problem on its own.