### PR TITLE
Delete URI from Revision Statement Schema

### DIFF
--- a/backend/app/controllers/merge_request.rb
+++ b/backend/app/controllers/merge_request.rb
@@ -3,7 +3,7 @@ class ArchivesSpaceService < Sinatra::Base
 
   include MergeHelpers
 
-  RESOLVE_LIST = ["subjects", "related_resources", "linked_agents", "revision_statements", "container_locations", "digital_object", "classifications", "related_agents", "resource", "parent", "creator", "linked_instances", "linked_records", "related_accessions", "linked_events", "linked_events::linked_records", "linked_events::linked_agents", "top_container", "container_profile", "location_profile", "owner_repo", "agent_places", "agent_occupations", "agent_functions", "agent_topics", "agent_resources", "places"]
+  RESOLVE_LIST = ["subjects", "related_resources", "linked_agents", "container_locations", "digital_object", "classifications", "related_agents", "resource", "parent", "creator", "linked_instances", "linked_records", "related_accessions", "linked_events", "linked_events::linked_records", "linked_events::linked_agents", "top_container", "container_profile", "location_profile", "owner_repo", "agent_places", "agent_occupations", "agent_functions", "agent_topics", "agent_resources", "places"]
 
   Endpoint.post('/merge_requests/subject')
     .description("Carry out a merge request against Subject records")

--- a/common/schemas/revision_statement.rb
+++ b/common/schemas/revision_statement.rb
@@ -3,7 +3,6 @@
     "$schema" => "http://www.archivesspace.org/archivesspace.json",
     "version" => 1,
     "type" => "object",
-    "uri" => "/revision_statement",
     "properties" => {
       "uri" => {"type" => "string", "required" => false},
       "date" => {"type" => "string", "maxLength" => 255, 'ifmissing' => 'error'},


### PR DESCRIPTION
Revision Statements appear to be basic subrecords like extents, dates, etc. It appears that 'uri' was added to the json schema in error. This causes an obscure bug where if a job creates a revision statement, it will try to register it as a top-level record and will error when trying to display the list of job-created records.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
