### PR TITLE
ANW-2412 Show the current `InfiniteTree` node when its batch is initially rendered

### DIFF
--- a/public/app/assets/javascripts/InfiniteCoordinator.js
+++ b/public/app/assets/javascripts/InfiniteCoordinator.js
@@ -1,0 +1,37 @@
+(function (exports) {
+  class InfiniteCoordinator {
+    constructor() {
+      this.currentRecordUri = null;
+    }
+
+    /**
+     * @param {string} uri - eg '/repositories/2/archival_objects/4549'
+     */
+    set currentRecord(uri) {
+      this.currentRecordUri = uri;
+    }
+
+    get currentRecord() {
+      return this.currentRecordUri;
+    }
+
+    updateCurrentTreeNode() {
+      const _new = document.querySelector(
+        `#infinite-tree-container .node[data-uri="${this.currentRecordUri}"]`
+      );
+      const old = document.querySelector(
+        '#infinite-tree-container .node.current'
+      );
+
+      if (old) {
+        old.classList.remove('current');
+      }
+
+      if (_new) {
+        _new.classList.add('current');
+      }
+    }
+  }
+
+  exports.InfiniteCoordinator = InfiniteCoordinator;
+})(window);

--- a/public/app/assets/javascripts/InfiniteRecords.js
+++ b/public/app/assets/javascripts/InfiniteRecords.js
@@ -10,6 +10,7 @@
      * @param {number} mainMaxFetches - The main thread's max number of concurrent fetches
      * @param {number} workerMaxFetches - The worker's max number of concurrent fetches
      * @param {string} uriFragment - The document's URI fragment
+     * @param {Coordinator} coordinator - The coordinator instance
      * @returns {InfiniteRecords} - InfiniteRecords instance
      */
     constructor(
@@ -18,9 +19,11 @@
       workerPath,
       mainMaxFetches,
       workerMaxFetches,
-      uriFragment
+      uriFragment,
+      coordinator
     ) {
       this.uriFragment = uriFragment;
+      this.coordinator = coordinator;
       this.container = document.querySelector('#infinite-records-container');
 
       this.WAYPOINT_SIZE = parseInt(this.container.dataset.waypointSize, 10);
@@ -57,7 +60,14 @@
       );
 
       this.currentRecordObserver = new IntersectionObserver(
-        this.currentRecordScrollHandler,
+        entries => {
+          entries.forEach(entry => {
+            if (entry.isIntersecting) {
+              this.coordinator.currentRecord = entry.target.dataset.uri;
+              this.coordinator.updateCurrentTreeNode();
+            }
+          });
+        },
         {
           root: this.container,
           rootMargin: '-5px 0px -95% 0px', // only the top sliver
@@ -530,32 +540,6 @@
 
         count++;
       }
-    }
-
-    /**
-     * IntersectionObserver callback for current record observer
-     * @param {IntersectionObserverEntry[]} entries - Array of entries
-     */
-    currentRecordScrollHandler(entries) {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          const uri = entry.target.dataset.uri;
-          const _new = document.querySelector(
-            `#infinite-tree-container .node[data-uri="${uri}"]`
-          );
-          const old = document.querySelector(
-            '#infinite-tree-container .node.current'
-          );
-
-          if (old) {
-            old.classList.remove('current');
-          }
-
-          if (_new) {
-            _new.classList.add('current');
-          }
-        }
-      });
     }
 
     /**

--- a/public/app/assets/javascripts/InfiniteTree.js
+++ b/public/app/assets/javascripts/InfiniteTree.js
@@ -4,13 +4,13 @@
 (function (exports) {
   class InfiniteTree {
     /**
-     * @constructor
      * @param {number} batchSize - The number of nodes per batch of children
      * @param {string} appUrlPrefix - The proper app prefix
      * @param {string} resourceUri - The URI of the collection resource
      * @param {string} identifier_separator - The i18n identifier separator
      * @param {string} date_type_bulk - The i18n date type bulk
      * @param {string} uriFragment - The document's URI fragment
+     * @param {InfiniteCoordinator} coordinator - The coordinator instance
      * @returns {InfiniteTree} - InfiniteTree instance
      */
     constructor(
@@ -19,9 +19,11 @@
       resourceUri,
       identifier_separator,
       date_type_bulk,
-      uriFragment
+      uriFragment,
+      coordinator
     ) {
       this.uriFragment = uriFragment;
+      this.coordinator = coordinator;
       this.BATCH_SIZE = batchSize;
       this.resourceUri = resourceUri; // TODO generalize away from resource
       this.repoId = resourceUri.split('/')[2];
@@ -125,18 +127,19 @@
         listMeta.parentId,
         observeForBatch
       );
-
       const placeholder = list.querySelector(
         `li[data-batch-placeholder="${batchNumber}"]`
       );
 
-      if (!placeholder) {
-        console.error('renderBatch could not find placeholder for batch:', {
-          batchNumber,
-          parentId: listMeta.parentId,
-          listHTML: list.innerHTML,
-        });
-        return;
+      if (
+        this.coordinator.currentRecord &&
+        !this.container.querySelector('.node.current')
+      ) {
+        const currentNode = batchFragment.querySelector(
+          `[data-uri="${this.coordinator.currentRecord}"]`
+        );
+
+        if (currentNode) currentNode.classList.add('current');
       }
 
       placeholder.replaceWith(batchFragment);

--- a/public/app/views/resources/infinite.html.erb
+++ b/public/app/views/resources/infinite.html.erb
@@ -54,13 +54,16 @@ const workerPath = '<%= asset_path('infiniteRecordsWorker.js') %>';
 const mainMaxFetches = <%= Rails.configuration.infinite_records_main_max_concurrent_waypoint_fetches %>;
 const workerMaxFetches = <%= Rails.configuration.infinite_records_worker_max_concurrent_waypoint_fetches %>;
 
+const coordinator = new InfiniteCoordinator();
+
 const infiniteRecords = new InfiniteRecords(
   resourceUri,
   appUrlPrefix,
   workerPath,
   mainMaxFetches,
   workerMaxFetches,
-  uriFragment
+  uriFragment,
+  coordinator
 );
 const infiniteTree = new InfiniteTree(
   treeWaypointSize,
@@ -68,7 +71,8 @@ const infiniteTree = new InfiniteTree(
   resourceUri,
   identifier_separator,
   date_type_bulk,
-  uriFragment
+  uriFragment,
+  coordinator
 );
 
 infiniteTree.container.addEventListener('click', (e) => {

--- a/public/spec/features/collection_organization_coordinator_spec.rb
+++ b/public/spec/features/collection_organization_coordinator_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Collection Organization Infinite Coordinator', js: true do
+  before(:all) do
+    @now = Time.now.to_i
+    @repo = create(:repo, repo_code: "collection_organization_coordinatortest_#{@now}")
+    set_repo(@repo)
+    @resource = create(:resource, title: "Resource #{@now}", publish: true)
+    @ao1 = create(:archival_object,
+      resource: {'ref' => @resource.uri},
+      publish: true
+    )
+    @ao2 = create(:archival_object,
+      resource: {'ref' => @resource.uri},
+      publish: true
+    )
+
+    41.times do |i| # 3 batches
+      instance_variable_set("@ao#{i + 1}_of_ao2", create(:archival_object,
+        resource: {'ref' => @resource.uri},
+        parent: {'ref' => @ao2.uri},
+        publish: true
+      ))
+    end
+
+    run_indexers
+  end
+
+  before(:each) do
+    visit "#{@resource.uri}/collection_organization"
+    @records_container = find('#infinite-records-container')
+    @ao1_record = @records_container.find("[data-uri='#{@ao1.uri}']")
+    @ao2_record = @records_container.find("[data-uri='#{@ao2.uri}']")
+    @tree_container = find('#infinite-tree-container')
+    @ao2_expand_btn = @tree_container.find("[data-uri='#{@ao2.uri}'] .node-expand")
+  end
+
+  describe 'shares current record state between InfiniteTree and InfiniteRecords' do
+    it 'should change the current tree node when the current record changes via scroll' do
+      expect(@tree_container).to have_css('.root.current')
+      @records_container.scroll_to(@ao1_record, align: :top)
+      expect(@tree_container).to have_css("[data-uri='#{@ao1.uri}'].current")
+      expect(@tree_container).not_to have_css('.root.current')
+
+      @records_container.scroll_to(@ao2_record, align: :top)
+      expect(@tree_container).to have_css("[data-uri='#{@ao2.uri}'].current")
+      expect(@tree_container).to have_css('.current', count: 1)
+    end
+
+    describe 'helps identify the current tree node' do
+      it 'when its batch is initially rendered on parent expansion' do
+        ao1_of_ao2_record = @records_container.find("[data-uri='#{@ao1_of_ao2.uri}']")
+        @records_container.scroll_to(ao1_of_ao2_record, align: :top)
+        expect(@tree_container).not_to have_css('.current')
+        @ao2_expand_btn.click
+        expect(@tree_container).to have_css("[data-uri='#{@ao1_of_ao2.uri}'].current")
+      end
+
+      it 'when its batch is rendered on scroll' do
+        page.find('.load-all__label-toggle').click
+        ao41_of_ao2_record = @records_container.find("[data-uri='#{@ao41_of_ao2.uri}']")
+        @records_container.scroll_to(ao41_of_ao2_record, align: :top)
+        @ao2_expand_btn.click
+        observer_node = @tree_container.find('[data-observe-next-batch]')
+        expect(@tree_container).not_to have_css('.current')
+        @tree_container.scroll_to(observer_node)
+        expect(@tree_container).to have_css("[data-uri='#{@ao41_of_ao2.uri}'].current")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is related to the larger #3490 which is concerned with improving the way finding in the PUI Collection Organization's tree sidebar.

This PR adds a feature/fixes a bug where, when there is a "tree node" whose "batch" has not yet been fetched (it's not yet in the DOM), and who matches the "current record" (the top-most record viewable in the scrollable records container), then the tree node will be shown as the "current node" when its batch is fetched (either when its parent is expanded for the first time, or via the tree's `batchObserver`).

Before this PR, the current node wouldn't show up in a newly fetched batch until the user started to scroll the records container.

The solution here implements an `InfiniteCoordinator` class that sits above the `InfiniteTree` and `InfiniteRecords`. It shares state between the two, and now handles the tree DOM manipulation on current record change (instead of InfiniteRecords).

[ANW-2412](https://archivesspace.atlassian.net/browse/ANW-2412)

## Before

![ANW-2412-share-infinite-state-BEFORE](https://github.com/user-attachments/assets/2a0f791b-2928-4262-afdc-2cb646348327)

## After

![ANW-2412-share-infinite-state](https://github.com/user-attachments/assets/4312dd6d-0962-4130-ad6d-b207f416bd5d)


[ANW-2412]: https://archivesspace.atlassian.net/browse/ANW-2412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ