### PR TITLE
Indexer State files for Trees

### DIFF
--- a/indexer/app/lib/index_state.rb
+++ b/indexer/app/lib/index_state.rb
@@ -6,14 +6,14 @@ class IndexState
   end
 
 
-  def path_for(repository_id, record_type)
+  def path_for(repository_id, record_type, state_type = nil)
     FileUtils.mkdir_p(@state_dir)
-    File.join(@state_dir, "#{repository_id}_#{record_type}")
+    File.join(@state_dir, "#{repository_id}_#{record_type}#{state_type.nil? ? '' : "_#{state_type}"}")
   end
 
 
-  def set_last_mtime(repository_id, record_type, time)
-    path = path_for(repository_id, record_type)
+  def set_last_mtime(repository_id, record_type, time, state_type = nil)
+    path = path_for(repository_id, record_type, state_type)
 
     File.open("#{path}.tmp", "w") do |fh|
       fh.puts(time.to_i)
@@ -24,8 +24,8 @@ class IndexState
   end
 
 
-  def get_last_mtime(repository_id, record_type)
-    path = path_for(repository_id, record_type)
+  def get_last_mtime(repository_id, record_type, state_type = nil)
+    path = path_for(repository_id, record_type, state_type)
 
     begin
       File.open("#{path}.dat", "r") do |fh|

--- a/indexer/app/lib/index_state_s3.rb
+++ b/indexer/app/lib/index_state_s3.rb
@@ -28,25 +28,25 @@ class IndexStateS3
     end
   end
 
-  def path_for(repository_id, record_type)
-    "#{@state_dir}#{repository_id}_#{record_type}"
+  def path_for(repository_id, record_type, state_type = nil)
+    "#{@state_dir}#{repository_id}_#{record_type}#{state_type.nil? ? '' : "_#{state_type}"}"
   end
 
-  def set_last_mtime(repository_id, record_type, time)
-    file = @bucket.files.get(path_for(repository_id, record_type))
+  def set_last_mtime(repository_id, record_type, time, state_type = nil)
+    file = @bucket.files.get(path_for(repository_id, record_type, state_type))
     if file
       file.body = StringIO.new("#{time.to_i.to_s}")
       file.save
     else
       @bucket.files.create(
-        :key  => path_for(repository_id, record_type),
+        :key  => path_for(repository_id, record_type, state_type),
         :body => StringIO.new("#{time.to_i.to_s}"),
       )
     end
   end
 
-  def get_last_mtime(repository_id, record_type)
-    file = @bucket.files.get(path_for(repository_id, record_type))
+  def get_last_mtime(repository_id, record_type, state_type = nil)
+    file = @bucket.files.get(path_for(repository_id, record_type, state_type))
     if file
       file.body.to_i
     else

--- a/indexer/app/lib/pui_indexer.rb
+++ b/indexer/app/lib/pui_indexer.rb
@@ -161,6 +161,7 @@ class PUIIndexer < PeriodicIndexer
     start = Time.now
     checkpoints = []
     update_mtimes = false
+    state_type = 'tree'
 
     tree_uris = []
 
@@ -171,8 +172,8 @@ class PUIIndexer < PeriodicIndexer
       checkpoints << [repository, root_type, start]
       checkpoints << [repository, node_type, start]
 
-      last_root_node_mtime = [@state.get_last_mtime(repository.id, root_type) - @window_seconds, 0].max
-      last_node_mtime = [@state.get_last_mtime(repository.id, node_type) - @window_seconds, 0].max
+      last_root_node_mtime = [@state.get_last_mtime(repository.id, root_type, state_type) - @window_seconds, 0].max
+      last_node_mtime = [@state.get_last_mtime(repository.id, node_type, state_type) - @window_seconds, 0].max
 
       root_node_ids = Set.new(JSONModel::HTTP.get_json(JSONModel(root_type).uri_for, :all_ids => true, :modified_since => last_root_node_mtime))
       node_ids = JSONModel::HTTP.get_json(JSONModel(node_type).uri_for, :all_ids => true, :modified_since => last_node_mtime)
@@ -217,7 +218,7 @@ class PUIIndexer < PeriodicIndexer
     @unpublished_records.clear()
 
     checkpoints.each do |repository, type, start|
-      @state.set_last_mtime(repository.id, type, start) if update_mtimes
+      @state.set_last_mtime(repository.id, type, start, state_type) if update_mtimes
     end
 
   end

--- a/indexer/spec/index_state_spec.rb
+++ b/indexer/spec/index_state_spec.rb
@@ -24,6 +24,13 @@ describe "index state" do
       s_dir = "#{AppConfig[:data_directory]}" + "/indexer_state" + "/#{repo_id}" + "_#{rec_type}"
       expect(@state.path_for(repo_id,rec_type)).to eq(s_dir)
     end
+    it "provides a path for an indexer_state file which includes a state_type" do
+      repo_id = 2
+      rec_type = 'resource'
+      state_type = 'test_state'
+      s_dir = "#{AppConfig[:data_directory]}" + "/indexer_state" + "/#{repo_id}" + "_#{rec_type}_#{state_type}"
+      expect(@state.path_for(repo_id, rec_type, state_type)).to eq(s_dir)
+    end
     it "creates directory for indexer_state files" do
       repo_id = 2
       rec_type = 'resource'
@@ -41,6 +48,15 @@ describe "index state" do
       path = @state.path_for(repo_id,rec_type)
       expect(File.mtime("#{path}.dat").utc).to be_within(1).of(start.utc)
     end
+    it "sets last mtime with a state_type" do
+      start = Time.now
+      repo_id = 3
+      rec_type = 'accession'
+      state_type = 'test_state'
+      @state.set_last_mtime(repo_id, rec_type, start, state_type)
+      path = @state.path_for(repo_id, rec_type, state_type)
+      expect(File.mtime("#{path}.dat").utc).to be_within(1).of(start.utc)
+    end
   end
   describe "get_last_mtime" do
     it "gets last mtime" do
@@ -50,8 +66,15 @@ describe "index state" do
       @state.set_last_mtime(repo_id, rec_type, start)
       expect(@state.get_last_mtime(repo_id, rec_type)).to be_within(1).of(start.to_i)
     end
-    it "returns 0 for mtime if have not indexed this repository and record_type pair" do
+    it "gets last mtime with a state_type" do
       start = Time.now
+      repo_id = 4
+      rec_type = 'archival_object'
+      state_type = 'test_state'
+      @state.set_last_mtime(repo_id, rec_type, start, state_type)
+      expect(@state.get_last_mtime(repo_id, rec_type, state_type)).to be_within(1).of(start.to_i)
+    end
+    it "returns 0 for mtime if have not indexed this repository and record_type pair" do
       repo_id = 5
       rec_type = 'digital_object'
       expect(@state.get_last_mtime(repo_id, rec_type)).to eq(0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- adds a `state_type` argument to the indexer state management
- this separates the indexer state of trees and the standard objects to prevent PUI indexer misses in some cases

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Essentially, the PUI indexer runs two types of indexes per index round - a standard object index and a tree index. The two currently share the state files that flag whether a round is complete and provide the timestamp by which to request new/changed objects.

What can happen is that a race condition develops when an index round is running and another set of objects is changed. That second set of objects will get picked up by the tree index round, and the tree indices associated with those objects will be updated, but the standard indices will not because the tree index round will update the state files with a timestamp later than those of the second batch of changed objects. A re-save of the affected/missed objects will usually fix the problem because it updates the timestamp on the objects to something later than that created by the tree index.

This PR fixes this race condition by introducing a new argument to the indexer state methods: `state_type` This allows different index run types to reference their own indexer state files preventing the race condition mentioned above. Right now, trees are the only additional `state_type`, but the code change allows for an arbitrary number of indexer types.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing. Mac O/S 15, MariaDB 10.11, Solr 9.8.1

I tested by comparing the record data in the PUI with the current index and the updated code.

1. Reindex a resource that will take more than the `AppConfig[:pui_indexing_frequency_seconds]` to complete. This can be accomplished by saving the resource without any changes.
2. Wait more than `AppConfig[:pui_indexing_frequency_seconds]` and then save a different large resource with a minor change - e.g. update the resource title.
3. Wait for the PUI index to register as complete.
4. Check the json data in the PUI (e.g. add a <%= record.json %> to the record_innards view or similar.
5. Note that the resource title has not been updated in archival objects that are children of the second resource.
6. Rebuild the indexer.war file with the changes in this PR and relaunch the app
7. Repeat steps 1-4.
8. Note that the json data in the PUI for child archival objects now includes the correct resource title.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
