### PR TITLE
ANW-2417: Fix staff readonly display of notes with mixed content

### DIFF
--- a/frontend/app/assets/javascripts/notes.crud.js.erb
+++ b/frontend/app/assets/javascripts/notes.crud.js.erb
@@ -360,17 +360,17 @@ $(function () {
 
         var truncate_note_content = function (content_inputs) {
           if (content_inputs.length === 0) {
-            return '&hellip;';
+            return '…';
           }
 
           var text = $(content_inputs.get(0)).val();
           if (text.length <= 200) {
-            return text + (content_inputs.length > 1 ? '<br/>&hellip;' : '');
+            return text + (content_inputs.length > 1 ? '<br/>…' : '');
           }
 
           return (
             $.trim(text).substring(0, 200).split(' ').slice(0, -1).join(' ') +
-            '&hellip;'
+            '…'
           );
         };
 

--- a/frontend/app/assets/javascripts/utils.js
+++ b/frontend/app/assets/javascripts/utils.js
@@ -455,6 +455,37 @@ AS.encodeForAttribute = function (string) {
   return $.trim(string.replace(/"/g, '&quot;').replace(/(\r\n|\n|\r)/gm, ''));
 };
 
+/**
+ * ANW-2417 Copy the bootstrap-select.js plugin's function for escaping HTML
+ * via frontend/vendor/assets/javascripts/bootstrap-select.js, or
+ * https://github.com/snapappointments/bootstrap-select/blob/v1.6.5/js/bootstrap-select.js#L170-L186
+ * @param {string} html
+ * @returns {string}
+ */
+AS.htmlEscape = function (html) {
+  if (html === null || html === undefined) {
+    return '';
+  }
+
+  const escapeMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#x27;',
+    '`': '&#x60;',
+  };
+
+  const source = `(?:${Object.keys(escapeMap).join('|')})`;
+  const testRegexp = new RegExp(source);
+  const replaceRegexp = new RegExp(source, 'g');
+  const string = `${html}`;
+
+  return testRegexp.test(string)
+    ? string.replace(replaceRegexp, match => escapeMap[match])
+    : string;
+};
+
 AS.openQuickModal = function (title, message) {
   AS.openCustomModal(
     'quickModal',

--- a/frontend/app/views/notes/_template.html.erb
+++ b/frontend/app/views/notes/_template.html.erb
@@ -114,14 +114,14 @@
     <div class="tabbable tabs-below">
       <div class="tab-content">
         <div class="tab-pane active" id="<%= form.id_for("item") %>_raw">
-          <span class="note-content-raw"><%= form.textarea(nil, item, { :escape => false, :class => "mixed-content" }) %></span>
+          <p class="note-content-raw"><%= item %></p>
         </div>
         <div class="tab-pane note-content-formatted" id="<%= form.id_for("item") %>_parsed">
           <%= clean_note(item).html_safe %>
         </div>
       </div>
       <ul class="nav nav-tabs">
-        <li class="active nav-item"><a class="nav-link" href="#<%= form.id_for("item") %>_raw" data-toggle="tab" title="<%= I18n.t("note._frontend.preview.raw_title") %>"><%= I18n.t("note._frontend.preview.raw") %></a></li>
+        <li class="nav-item"><a class="active nav-link" href="#<%= form.id_for("item") %>_raw" data-toggle="tab" title="<%= I18n.t("note._frontend.preview.raw_title") %>"><%= I18n.t("note._frontend.preview.raw") %></a></li>
         <li class="nav-item"><a class="nav-link" href="#<%= form.id_for("item") %>_parsed" data-toggle="tab" title="<%= I18n.t("note._frontend.preview.parsed_title") %>"><%= I18n.t("note._frontend.preview.parsed") %></a></li>
       </ul>
     </div>
@@ -912,14 +912,14 @@
           <div class="tabbable tabs-below">
             <div class="tab-content">
               <div class="tab-pane active" id="<%= form.id_for("content") %>_raw">
-                <span class="note-content-raw"><%= form.textarea(nil, form["content"], :class => "mixed-content") %></span>
+                <p class="note-content-raw"><%= form["content"] %></p>
               </div>
               <div class="tab-pane note-content-formatted" id="<%= form.id_for("content") %>_parsed">
                 <%= clean_note(form["content"]).html_safe %>
               </div>
             </div>
             <ul class="nav nav-tabs">
-              <li class="active nav-item"><a class="nav-link" href="#<%= form.id_for("content") %>_raw" data-toggle="tab" title="<%= I18n.t("note._frontend.preview.raw_title") %>"><%= I18n.t("note._frontend.preview.raw") %></a></li>
+              <li class="nav-item"><a class="active nav-link" href="#<%= form.id_for("content") %>_raw" data-toggle="tab" title="<%= I18n.t("note._frontend.preview.raw_title") %>"><%= I18n.t("note._frontend.preview.raw") %></a></li>
               <li class="nav-item"><a class="nav-link" href="#<%= form.id_for("content") %>_parsed" data-toggle="tab" title="<%= I18n.t("note._frontend.preview.parsed_title") %>"><%= I18n.t("note._frontend.preview.parsed") %></a></li>
             </ul>
           </div>

--- a/frontend/app/views/shared/_templates.html.erb
+++ b/frontend/app/views/shared/_templates.html.erb
@@ -329,7 +329,7 @@
   </div>
   {if summary.length > 0}
   <div class="subrecord-summary-content">
-    ${summary}
+    ${AS.htmlEscape(summary)}
   </div>
   {/if}
 --></div>


### PR DESCRIPTION
This PR fixes a bug where note summaries containing mixed content were not being handled properly. The readonly summaries are present in both show and edit views.

The fix here is a bit different than most mixed content fixes. In particular the edit view creates a "truncated note summary" at run time via JS code and the outdated JS templating system. This solution adds a global helper for escaping HTML to the `AS` utility object, which the template can then use. This helper was essentially copied from the [bootstrap-select.js plugin's code](https://github.com/archivesspace/archivesspace/blob/0ff3a67c323450766360d8840f0deb3c3edca0d5/frontend/vendor/assets/javascripts/bootstrap-select.js#L176-L192) which provides a similar helper.

In the case of the show view, where the notes are shown in both raw and formatted versions of mixed content, the code was cleaned up a bit. Previously the [`form.textarea`](https://github.com/archivesspace/archivesspace/blob/e99d895dd03092ec73b44e7e607b817c2771d103/frontend/app/helpers/aspace_form_helper.rb#L438) helper was being used to display the note content, not by creating a new textarea field (which is an edit-mode behavior), but just to pass through the note content to get the text out of the other side.

This PR also fixes a Softserv-related bug regarding how the "Raw" and "Formatted" tabs in the note summary in the show view are displayed.

[ANW-2417](https://archivesspace.atlassian.net/browse/ANW-2417)

## Screenshots

### `show` view

<img width="1492" alt="ANW-2417-show-view" src="https://github.com/user-attachments/assets/208ceb37-4aee-4c8c-bf7d-b65af038d520" />

### `edit` view

<img width="1449" alt="ANW-2417 edit view" src="https://github.com/user-attachments/assets/04c2a177-2e1b-49ed-b4d2-be47fd54de9a" />


[ANW-2417]: https://archivesspace.atlassian.net/browse/ANW-2417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ