### PR TITLE
ANW-2422: Fix Suppressed badge in staff tree bug

### DIFF
--- a/frontend/app/assets/javascripts/tree_renderers.js.erb
+++ b/frontend/app/assets/javascripts/tree_renderers.js.erb
@@ -294,7 +294,7 @@ function build_node_title(node) {
  * @return {htmlString}
  */
 function recordTitleHandler(suppressed, title) {
-  const suppressedMarkup = `<span class="label label-info"><%= I18n.t("states.suppressed") %></span>`;
+  const suppressedMarkup = `<span class="badge badge-warning"><%= I18n.t("states.suppressed") %></span>`;
 
   return suppressed ? `${suppressedMarkup} ${title}` : title;
 }

--- a/frontend/spec/features/trees_spec.rb
+++ b/frontend/spec/features/trees_spec.rb
@@ -258,10 +258,8 @@ describe 'Tree UI', js: true do
   end
 
   it 'shows the suppressed tag only for suppressed records' do
-    elements = all('#tree-container > .table.root > .table-row-group > div > .title > a.record-title > span.label.label-info')
+    elements = all('#tree-container .record-title .badge', text: 'Suppressed')
     expect(elements.length).to eq(1)
-
-    element = find("div[title=\"#{@archival_object_4.title}\"]")
-    expect(element).to have_text 'Suppressed'
+    expect(elements[0].find(:xpath, '..')['title']).to eq(@archival_object_4.title)
   end
 end


### PR DESCRIPTION
Fixes a softserv bug where the suppressed label in the staff tree used a deprecated Bootstrap css class

[ANW-2422](https://archivesspace.atlassian.net/browse/ANW-2422)

## Solution

<img width="1493" alt="ANW-2422 solution" src="https://github.com/user-attachments/assets/143fdc1e-9f44-45a2-87da-c33de1c1438c" />


[ANW-2442]: https://archivesspace.atlassian.net/browse/ANW-2442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ANW-2422]: https://archivesspace.atlassian.net/browse/ANW-2422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ