### PR TITLE
ANW 2445: Extend launcher to allow log appending

### DIFF
--- a/launcher/archivesspace.sh
+++ b/launcher/archivesspace.sh
@@ -92,6 +92,10 @@ if [ "$ARCHIVESSPACE_LOGS" = "" ]; then
     ARCHIVESSPACE_LOGS="logs/archivesspace.out"
 fi
 
+if [ "$ARCHIVESSPACE_APPEND_LOGS" = "" ]; then
+    ARCHIVESSPACE_APPEND_LOGS=
+fi
+
 export JAVA_OPTS="-Darchivesspace-daemon=yes $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom"
 
 # Wow.  Not proud of this!
@@ -141,10 +145,15 @@ case "$1" in
             shellcmd="su $ARCHIVESSPACE_USER"
         fi
 
+        redirect="&>"
+        if [ "$ARCHIVESSPACE_APPEND_LOGS" != "" ]; then
+            redirect="&>>"
+        fi
+
         $shellcmd -c "cd '$ASPACE_LAUNCHER_BASE';
           (
              exec 0<&-; exec 1>&-; exec 2>&-;
-             $startup_cmd &> \"$ARCHIVESSPACE_LOGS\" &
+             $startup_cmd $redirect \"$ARCHIVESSPACE_LOGS\" &
              echo \$! > \"$ASPACE_PIDFILE\"
           ) &
           disown $!"


### PR DESCRIPTION
Adds the environment variable `ARCHIVESSPACE_APPEND_LOGS` that toggles between overwriting and appending log output.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-2445

## How Has This Been Tested?
Manual deployment with an ArchivesSpace 4.1.0 instance.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

 (I'm not positive about "My change requires a change to the documentation." It seems like it ought to be documented, but the configuration for `ARCHIVESSPACE_USER` and `ARCHIVESSPACE_LOGS` don't appear to be documented in the code)