### PR TITLE
Allow Indexer Hooks to access Ancestor data in PUI Index

### DIFF
--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -103,8 +103,6 @@ class IndexerCommon
       hook.call(self)
     end
 
-    # Run the final doc rules after all the hooks have been added
-    # This allows plugins to access ancestor data in PUI records before it is removed
     final_doc_rules
   end
 

--- a/indexer/app/lib/pui_indexer.rb
+++ b/indexer/app/lib/pui_indexer.rb
@@ -73,7 +73,9 @@ class PUIIndexer < PeriodicIndexer
       end
     }
   end
-
+  
+  # Run the final doc rules after all the hooks have been added
+  # This allows plugins to access ancestor data in PUI records before it is removed
   def final_doc_rules
     # this runs after the hooks in indexer_common, so we can overwrite with confidence
     add_document_prepare_hook {|doc, record|

--- a/indexer/spec/pui_indexer_spec.rb
+++ b/indexer/spec/pui_indexer_spec.rb
@@ -2,6 +2,70 @@ require 'spec_helper'
 require_relative '../app/lib/pui_indexer'
 
 describe "PUI indexer" do
+  let (:indexer) do
+    indexer = PUIIndexer.new(AppConfig[:backend_url], nil, 'PUIIndexer')
+
+    def indexer.prepare_docs(records)
+      records.map {|rec|
+        rec_hash = rec.to_hash(:raw)
+        rec_hash['display_string'] = rec_hash['title']
+
+        {'record' => rec_hash, 'uri' => rec['uri']}
+      }
+    end
+
+    # We run the first portion of the index here so that we can separate out the 
+    # initial doc rules and the final doc rules.
+    # This is ugly because we are copy/pasting from IndexerCommon index_records
+    # with no way to know if that method changes.
+    def indexer.start_index(record)
+
+      # c/p start
+      values = record['record']
+      uri = record['uri']
+
+      reference = JSONModel.parse_reference(uri)
+      record_type = reference && reference[:type]
+
+      doc = {}
+
+      doc['id'] = uri
+      doc['uri'] = uri
+      doc['title'] = values['title']
+      doc['primary_type'] = record_type
+      doc['types'] = [record_type]
+      doc['json'] = ASUtils.to_json(sanitize_json(values))
+      doc['suppressed'] = values.has_key?('suppressed') && values['suppressed']
+      if doc['suppressed']
+        doc['publish'] = false
+      elsif is_repository_unpublished?(uri, values)
+        doc['publish'] = false
+      elsif values['has_unpublished_ancestor']
+        doc['publish'] = false
+      else
+        doc['publish'] = values.has_key?('publish') && values['publish']
+      end
+      doc['system_generated'] = values.has_key?('system_generated') ? values['system_generated'].to_s : 'false'
+      doc['repository'] = get_record_scope(uri)
+      # c/p end
+
+      doc
+    end
+
+    def indexer.run_all_but_final_doc_rules(doc, rec)
+      @document_prepare_hooks.each_with_index do |hook, idx|
+        unless idx == @document_prepare_hooks.count - 1
+          hook.call(doc, rec)
+        end
+      end
+    end
+
+    def indexer.run_final_doc_rules(doc, rec)
+      @document_prepare_hooks.last.call(doc, rec)
+    end
+
+    indexer
+  end
   describe "initialize" do
     it "initializes appropriately" do
     #    def initialize(backend = nil, state = nil, name)
@@ -55,6 +119,50 @@ describe "PUI indexer" do
   describe "stage_unpublished_for_deletion" do
     it "stages unpublished records for deletion" do
       # def stage_unpublished_for_deletion(doc_id)
+    end
+  end
+
+  describe "final_doc_rules" do
+    it "runs final PUI doc rules and removes ancestor data after all other hooks have run" do
+      res = build(:json_resource,
+                 'uri' => '/repositories/2/resources/1',
+                 'title' => "Resource",
+                 'repository' => {
+                   'ref' => '/repositories/2',
+                   '_resolved' => {
+                     'repo_code' => 'woop',
+                   },
+                 },
+                 'publish' => true,
+                 'instances' => [])
+
+      ao = build(:json_archival_object,
+                 'uri' => '/repositories/2/archival_objects/123',
+                 'title' => "AO with ancestor",
+                 'repository' => {
+                   'ref' => '/repositories/2',
+                   '_resolved' => {
+                     'repo_code' => 'woop',
+                   },
+                 },
+                 'publish' => true,
+                 'has_unpublished_ancestor' => false,
+                 'instances' => [],
+                 'ancestors' => [{
+                    "ref" => "/repositories/2/resources/1",
+                    "_resolved" => res
+                  }],
+                 'resource' => "/repositories/2/resources/1")
+
+      rec = indexer.prepare_docs([ao]).first
+      doc = indexer.start_index(rec)
+
+      indexer.run_all_but_final_doc_rules(doc, rec)
+      expect(rec['record']['ancestors'].count).to be(1)
+
+      indexer.run_final_doc_rules(doc, rec)
+      expect(rec['record']['ancestors']).to be_nil
+
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR moves the PUI indexer step that removes that ancestor data to after any additional indexer hooks are run. Typically useful for plugins that use ancestor data to determine cascading data (like restrictions). If the ancestor data is already present, this allows the index run to proceed much faster as no additional requests for ancestor data need to be made during the run.

In our local testing, this cut the index time by roughly half when plugins that used ancestor data were instantiated.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing including dev and local containers (MariaDB 10.11, Solr 9.8) and provided ArchivesSpace core dev containers. All existing tests pass.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
