### PR TITLE
ANW-2459 Do not duplicate ao note persistent_id

### DIFF
--- a/frontend/app/controllers/archival_objects_controller.rb
+++ b/frontend/app/controllers/archival_objects_controller.rb
@@ -18,6 +18,11 @@ class ArchivalObjectsController < ApplicationController
       @archival_object.ref_id = nil
       @archival_object.instances = []
       @archival_object.position = params[:position]
+      @archival_object.notes.each do |note|
+        if note.is_a?(Hash)
+          note.delete('persistent_id')
+        end
+      end
 
       flash[:success] = t("archival_object._frontend.messages.duplicated", archival_object_display_string: clean_mixed_content(@archival_object.display_string))
     else

--- a/frontend/spec/controllers/archival_objects_controller_spec.rb
+++ b/frontend/spec/controllers/archival_objects_controller_spec.rb
@@ -17,6 +17,9 @@ describe ArchivalObjectsController, type: :controller do
     let (:resource) { create(:json_resource) }
     let (:archival_object) { create(:json_archival_object,
                                     :resource => {'ref' => resource.uri}) }
+    let (:archival_object_with_note) { create(:json_archival_object,
+                                               :notes => [ build(:json_note_singlepart) ],
+                                               :resource => {'ref' => resource.uri}) }
     let (:random_archival_object) { create(:json_archival_object) }
     let (:accession) { create(:json_accession) }
     let(:default_values) {
@@ -97,6 +100,18 @@ describe ArchivalObjectsController, type: :controller do
 
       result.find(:css, "#archival_object_title_") do |form_input|
         expect(form_input.value).to eq(archival_object.title)
+      end
+    end
+
+    it "does not duplicate persistent id when duplicating an archival object note" do
+      get :new, params: { resource_id: resource.id,
+                          duplicate_from_archival_object: { uri: archival_object_with_note.uri } }
+
+      expect(response.status).to eq 200
+      result = Capybara.string(response.body)
+
+      result.find(:css, "#archival_object_notes__0__persistent_id_") do |new_persistent_id|
+        expect(new_persistent_id.value).to eq("")
       end
     end
 


### PR DESCRIPTION
Drops any existing note `persistent_id`s when duplicating an archival object.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
As described in JIRA, the newly added "Add Duplicate" functionality will duplicate existing note `persistent_id`s.  This violates the uniqueness requirements of id attributes for various EAD elements.  As a repository that requires valid EAD2002 as part of the pipeline to our public access system, we're finding use of the new duplication feature is piling up invalid EAD because of the issue described.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-2459

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test added and passing.  Manually tested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
