### PR TITLE
ANW-2251: Add a new class that provides the tree and record pane with a single source of truth for their initial context

### DIFF
--- a/frontend/app/assets/javascripts/InfiniteTreeInitialContext.js
+++ b/frontend/app/assets/javascripts/InfiniteTreeInitialContext.js
@@ -1,0 +1,50 @@
+//= require InfiniteTreeIds
+
+(function (exports) {
+  class InfiniteTreeInitialContext {
+    /**
+     * @constructor
+     * @param {string} rootUri - Backend URI of the root record, e.g. "/repositories/2/resources/123"
+     */
+    constructor(rootUri) {
+      this.rootUri = rootUri;
+      this.locationHash = this.#resolveInitialHash();
+      this.isRoot = this.locationHash === InfiniteTreeIds.treeLinkUrl(rootUri);
+    }
+
+    /**
+     * @returns {Object} context - Initial context for the tree
+     * @returns {boolean} context.isRoot - Whether the initial selection is the root
+     * @returns {string} [context.locationHash] - The document's URI fragment after page load
+     * @returns {string} context.rootUri - Backend URI of the root record
+     */
+    get context() {
+      return this.isRoot
+        ? { isRoot: true, rootUri: this.rootUri }
+        : {
+            isRoot: false,
+            locationHash: this.locationHash,
+            rootUri: this.rootUri,
+          };
+    }
+
+    /**
+     * Ensures a canonical location hash exists when the hash is empty (root).
+     *
+     * @returns {string} - The document's location hash after processing
+     */
+    #resolveInitialHash() {
+      const currentHash = window.location.hash;
+
+      if (currentHash === '') {
+        window.location.hash = InfiniteTreeIds.uriToLocationHash(this.rootUri);
+
+        return window.location.hash;
+      }
+
+      return currentHash;
+    }
+  }
+
+  exports.InfiniteTreeInitialContext = InfiniteTreeInitialContext;
+})(window);

--- a/frontend/app/assets/javascripts/InfiniteTreeRecordPane.js
+++ b/frontend/app/assets/javascripts/InfiniteTreeRecordPane.js
@@ -4,25 +4,27 @@
   class InfiniteTreeRecordPane {
     /**
      * @constructor
-     * @param {string} uriFragment - The document's URI fragment at page load
-     * @param {string} rootRecordUri - The backend URI of the root record
+     * @param {Object} initialContext - The data for the initial "current node" to load
+     * @param {boolean} initialContext.isRoot - Whether the initial selection is the root
+     * @param {string} initialContext.locationHash - The document's URI fragment at page load
+     * @param {string} initialContext.rootUri - The backend URI of the root record
      * @returns {InfiniteTreeRecordPane}
      */
-    constructor(uriFragment, rootRecordUri) {
+    constructor(initialContext) {
       this.container = document.querySelector('#infinite-tree-record-pane');
 
       this.container.addEventListener('infiniteTree:nodeSelect', e => {
         this.loadRecord(e.detail.recordPath);
       });
 
-      const shouldLoadRoot =
-        uriFragment === '' ||
-        uriFragment === InfiniteTreeIds.treeLinkUrl(rootRecordUri);
-
-      if (shouldLoadRoot) {
-        this.loadRecord(InfiniteTreeIds.backendUriToFrontendUri(rootRecordUri));
+      if (initialContext.isRoot) {
+        this.loadRecord(
+          InfiniteTreeIds.backendUriToFrontendUri(initialContext.rootUri)
+        );
       } else {
-        this.loadRecord(InfiniteTreeIds.locationHashToFrontendUri(uriFragment));
+        this.loadRecord(
+          InfiniteTreeIds.locationHashToFrontendUri(initialContext.locationHash)
+        );
       }
     }
 

--- a/frontend/app/views/shared/_infinite_tree.html.erb
+++ b/frontend/app/views/shared/_infinite_tree.html.erb
@@ -3,6 +3,7 @@
    read_only = false if read_only.blank?
 %>
 
+<%= javascript_include_tag "InfiniteTreeInitialContext.js" %>
 <%= javascript_include_tag "InfiniteTree.js" %>
 <%= javascript_include_tag "InfiniteTreeResizer.js" %>
 <%= javascript_include_tag "InfiniteTreeRecordPane.js" %>
@@ -84,13 +85,9 @@
 </template>
 
 <script>
-const resourceUri = "<%= @resource.uri %>";
+const rootUri = "<%= @resource.uri %>";
 
-if (window.location.hash === '') {
-  window.location.hash = InfiniteTreeIds.uriToLocationHash(resourceUri);
-}
-
-const uriFragment = window.location.hash;
+const initialContext = new InfiniteTreeInitialContext(rootUri).context;
 
 // ANW-2322 Temporarily copy and adapt ENUMERATION_TRANSLATIONS from largetree.js
 // for use in a .js file (not .js.erb)
@@ -125,9 +122,8 @@ const EnumerationTranslations2 = {
 };
 
 const infiniteTree = new InfiniteTree(
+  initialContext,
   "<%= Rails.configuration.infinite_tree_batch_size %>",
-  uriFragment,
-  resourceUri,
   {
     sep: "<%= I18n.t("resource.identifier_separator") %>",
     bulk: "<%= I18n.t("date_type_bulk.bulk") %>",
@@ -135,5 +131,5 @@ const infiniteTree = new InfiniteTree(
   }
 );
 
-const infiniteTreeRecordPane = new InfiniteTreeRecordPane(uriFragment, resourceUri);
+const infiniteTreeRecordPane = new InfiniteTreeRecordPane(initialContext);
 </script>


### PR DESCRIPTION
This PR lessens the parameters that the new tree and record pane accept, as well as provide a single source of truth outside of the template layer for handling the document's uri fragment and setting the initial "current record" in each the tree and pane.