### PR TITLE
ANW-2251 Fix infinite tree record pane request path for prefixed domains

### DIFF
--- a/frontend/app/assets/javascripts/InfiniteTree.js
+++ b/frontend/app/assets/javascripts/InfiniteTree.js
@@ -110,7 +110,11 @@
       node.classList.add('current');
 
       const nodeSelectEvent = new CustomEvent('infiniteTree:nodeSelect', {
-        detail: { recordPath: node.dataset.uri.split('/').slice(-2).join('/') },
+        detail: {
+          requestPath: AS.app_prefix(
+            node.dataset.uri.split('/').slice(-2).join('/')
+          ),
+        },
       });
 
       this.recordPaneEl.dispatchEvent(nodeSelectEvent);

--- a/frontend/app/assets/javascripts/InfiniteTreeRecordPane.js
+++ b/frontend/app/assets/javascripts/InfiniteTreeRecordPane.js
@@ -14,7 +14,7 @@
       this.container = document.querySelector('#infinite-tree-record-pane');
 
       this.container.addEventListener('infiniteTree:nodeSelect', e => {
-        this.loadRecord(e.detail.recordPath);
+        this.loadRecord(e.detail.requestPath);
       });
 
       if (initialContext.isRoot) {
@@ -29,10 +29,10 @@
     }
 
     /**
-     * @param {string} recordPath - The path to the record, e.g. "resources/123"
+     * @param {string} requestPath - The prefixed frontend URI to the record, e.g. "/resources/123"
      */
-    async loadRecord(recordPath) {
-      const url = AS.app_prefix(recordPath) + '?inline=true';
+    async loadRecord(requestPath) {
+      const url = requestPath + '?inline=true';
 
       this.#blockUI();
 


### PR DESCRIPTION
This PR fixes a bug from the recent ANW-2251 work where the record pane did not load the readonly record form on a prefixed domain. The problem was that the form request URL mishandled the prefix so that the prefix was included twice in the GET request.

## Problem

<img width="1492" height="886" alt="ANW-2251-request problem" src="https://github.com/user-attachments/assets/a88482d0-bfc9-4482-bb6d-29cc28ee7bb1" />

## Solution

![ANW-2251-record-pane-request-fix](https://github.com/user-attachments/assets/0f262491-9400-4462-a382-2ce17241ee8d)