### PR TITLE
Fix frontend Safari table column horizontal scroll bug

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/tables.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/tables.scss
@@ -199,5 +199,5 @@ table.table-spreadsheet {
 }
 
 table .col {
-  width: max-content;
+  width: fit-content;
 }


### PR DESCRIPTION
This PR fixes a layout bug in the Safari browser where, when viewing a table like the resources index view, the table scrolled horizontally outside of the page container. Switching from `width: max-content` to `width: fit-content` works cross browser as expected.

## Safari problem

<img width="1512" height="982" alt="problem" src="https://github.com/user-attachments/assets/acc86348-e224-47d7-a9bd-8aa7a8a6e1f6" />

## Safari solution

<img width="1512" height="982" alt="solution" src="https://github.com/user-attachments/assets/bbe1de80-9567-4943-b078-f4a37262b159" />
