### PR TITLE
ANW-2476 Set resource fields not to duplicate in AppConfig

### DIFF
--- a/backend/app/lib/job_runners/resource_duplicate_runner.rb
+++ b/backend/app/lib/job_runners/resource_duplicate_runner.rb
@@ -13,7 +13,12 @@ class ResourceDuplicateRunner < JobRunner
 
         @job.write_output(I18n.t("resource_duplicate_job.going_to_duplicate_job", resource_id: resource_id))
 
-        resource_duplicate = ::Lib::Resource::Duplicate.new(resource_id)
+        if AppConfig.has_key?(:resource_fields_not_to_duplicate)
+          skip_fields = AppConfig[:resource_fields_not_to_duplicate]
+        end
+        skip_fields ||= []
+
+        resource_duplicate = ::Lib::Resource::Duplicate.new(resource_id, skip_fields)
         resource_duplicate.duplicate
 
         if resource_duplicate.errors.length == 0

--- a/backend/app/lib/resource/duplicate.rb
+++ b/backend/app/lib/resource/duplicate.rb
@@ -3,9 +3,10 @@ module Lib
     class Duplicate
       attr_reader :resource_id, :errors, :resource
 
-      def initialize(resource_id)
+      def initialize(resource_id, skip_fields = [])
         @errors = []
         @resource_id = resource_id
+        @skip_fields = skip_fields
       end
 
       def duplicate
@@ -50,6 +51,10 @@ module Lib
         resource_source_json_model.id_0 = "[Duplicated] #{resource_source_json_model.id_0}"
         resource_source_json_model.title = "[Duplicated] #{resource_source_json_model.title}"
         resource_source_json_model.ead_id = "[Duplicated] #{resource_source_json_model.ead_id}" if resource_source_json_model.ead_id.present?
+
+        if @skip_fields.any?
+          nullify_fields(resource_source_json_model)
+        end
 
         resource_source_json_model.linked_agents.each do |linked_agent|
           linked_agent['id'] = nil
@@ -140,6 +145,25 @@ module Lib
           end
         end
       end
+
+      def nullify_fields(resource_source_json_model)
+        @skip_fields.each do |field|
+          required_fields = ['dates', 'extents', 'finding_aid_language', 'finding_aid_script',
+                              'id_0', 'lang_materials', 'level', 'publish', 'title']
+          next if required_fields.any?(field)
+
+          if resource_source_json_model.respond_to?(field)
+            if resource_source_json_model["#{field}"].is_a?(Array)
+              resource_source_json_model["#{field}"] = []
+            else
+              resource_source_json_model["#{field}"] = nil
+            end
+          end
+        end
+
+        resource_source_json_model
+      end
+
     end
   end
 end

--- a/backend/spec/model_resource_duplicate_job.rb
+++ b/backend/spec/model_resource_duplicate_job.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+def resource_duplicate_job(resource_uri)
+  build( :json_job,
+         :job => build(:json_resource_duplicate_job,
+                       source: resource_uri)
+       )
+end
+
+describe 'Resource Duplicate job' do
+  let(:user) { create_nobody_user }
+  let(:resource) { Resource.create_from_json(build(:json_resource)) }
+
+  before(:each) do
+    allow(::Lib::Resource::Duplicate).to receive(:new).and_call_original
+  end
+
+  it 'calls duplicate wih the resource id' do
+    json = resource_duplicate_job(resource.uri)
+    job = Job.create_from_json(json, :user => user )
+    jr = JobRunner.for(job)
+    jr.run
+
+    expect(::Lib::Resource::Duplicate).to have_received(:new).with(resource.id, [])
+  end
+
+  context 'when AppConfig[:resource_fields_not_to_duplicate] has content' do
+    before(:each) do
+      allow(AppConfig).to receive(:[]).and_call_original
+      allow(AppConfig).to receive(:[]).with(:resource_fields_not_to_duplicate) { ['finding_aid_status'] }
+    end
+
+    it 'calls duplicate wih the resource id and array from AppConfig' do
+      json = resource_duplicate_job(resource.uri)
+      job = Job.create_from_json(json, :user => user )
+      jr = JobRunner.for(job)
+      jr.run
+
+      expect(::Lib::Resource::Duplicate).to have_received(:new).with(resource.id, ['finding_aid_status'])
+    end
+  end
+end

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -263,6 +263,12 @@ AppConfig[:report_pdf_font_family] = "\"DejaVu Sans\", sans-serif"
 # USE WITH CAUTION - running custom reports that are too complex may cause ASpace to crash
 AppConfig[:enable_custom_reports] = false
 
+# Option to drop select fields from resource record duplication
+# Note: If required resource record fields (e.g. 'level') are added here, they will be ignored
+# Example:
+# AppConfig[:resource_fields_not_to_duplicate] = ['finding_aid_status', 'finding_aid_author']
+AppConfig[:resource_fields_not_to_duplicate] = []
+
 # Path to system Java -- required when creating PDFs on Windows
 AppConfig[:path_to_java] = "java"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
MVP implementation of a way to exclude select resource record fields for duplication when using the post-4.x "Duplicate Resource" functionality.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Adds a new optional array to `config.rb` to allow system administrators to select resource record fields that will not be duplicated.

I did this in the most expedient way I could that would 1. be generally multipurpose-able by other users, but, also, 2. get us what we need here at SI.  That said, happy to receive feedback or requests for future improvements based on the team's review of the feature request and PR.  (For example, this only makes resource duplication configurable, but I could imagine a world where folks would want to extend this to archival objects.  Also, I went with a config setting for ease-of-development, but, again, I could see users wishing to do this as system admins in the UI or even on a repo-by-repo basis as repo admins.  Both of those would obviously require more time/effort.)

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-2476

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New tests added, tested manually.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
Yes - I've documented the setting in AppConfig itself, but if we decide to go this route I'm happy to add documentation elsewhere when the time comes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
