### PR TITLE
concurrent-ruby v1.3.5 has removed the dependency on logger

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
     childprocess (5.0.0)
     choice (0.2.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.5)
     connection_pool (2.4.1)
     crass (1.0.6)
     csv (3.3.0)

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
     childprocess (5.0.0)
     choice (0.2.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.5)
     connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.3-java)

--- a/frontend/config/boot.rb
+++ b/frontend/config/boot.rb
@@ -8,3 +8,4 @@ require 'aspace_gems'
 ASpaceGems.setup
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require 'logger'

--- a/indexer/Gemfile.lock
+++ b/indexer/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     bigdecimal (3.1.8-java)
     builder (3.3.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.5)
     connection_pool (2.4.1)
     crack (1.0.0)
       bigdecimal

--- a/public/config/boot.rb
+++ b/public/config/boot.rb
@@ -8,3 +8,4 @@ require 'aspace_gems'
 ASpaceGems.setup
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require 'logger'


### PR DESCRIPTION
https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
