### PR TITLE
ANW-2347: Fix translation keys related to top_container_mgmt

### DIFF
--- a/frontend/app/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_results.html.erb
@@ -99,9 +99,9 @@
             </td>
           <% elsif field == 'exported_to_ils' %>
             <% if container_json['exported_to_ils'].blank? %>
-              <td><%= t('top_container_mgmt.not_exported') %></td>
+              <td><%= t('search.top_container_mgmt.not_exported_to_ils') %></td>
             <% else %>
-              <td><%= t('top_container_mgmt.exported_to_ils') %></td>
+              <td><%= t('search.top_container_mgmt.exported_to_ils') %></td>
             <% end %>
           <% elsif field == 'restricted' %>
             <% if container_json['restricted'] %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Solves [ANW-2347](https://archivesspace.atlassian.net/browse/ANW-2347) by using the correct translation key `search.top_container_mgmt` instead of `top_container_management` or  `top_container_mgmt`. This follows the [en.yml](https://github.com/archivesspace/archivesspace/blob/6dad3df2b1fa452df8d5397a0f41250ffc144a12/frontend/config/locales/en.yml#L456-L469) structure.

![CleanShot 2025-09-12 at 19 37 11@2x](https://github.com/user-attachments/assets/c776c892-0c6f-4db0-9f58-a09601bafa21)

## Screenshots (if appropriate):
I couldn't replicate the test scenario locally so I just altered the [_results.html.erb](https://github.com/archivesspace/archivesspace/blob/f5350adbbffbea1f53c7a48d21cbb3ec6417f6dc/frontend/app/views/top_containers/bulk_operations/_results.html.erb#L1-L133) to test the changes.

|Before | After|
|-------|------|
|![CleanShot 2025-09-12 at 19 29 34@2x](https://github.com/user-attachments/assets/ce3eec0f-6fb0-4d08-92da-7b1b77ae6cc7)|![CleanShot 2025-09-12 at 19 29 54@2x](https://github.com/user-attachments/assets/5220c8a8-bbc3-4133-84d6-a2cc75a83a29)|


[ANW-2347]: https://archivesspace.atlassian.net/browse/ANW-2347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ