### PR TITLE
Optimize handling of deletes against Solr

### DIFF
--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -1146,7 +1146,8 @@ class IndexerCommon
     # batching internally.
     #
     # So, we group them into boolean clauses here to amortize the cost of all of
-    # that.
+    # that.  Note that the size of each query group must be lower than Solr's
+    # <maxBooleanClauses> setting.
 
     id_deletes = delete_request.fetch(:delete).select {|r| r['id']}
     grouped_queries = delete_request

--- a/solr/solrconfig.xml
+++ b/solr/solrconfig.xml
@@ -5,7 +5,6 @@
   <dataDir>${solr.data.dir:}</dataDir>
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}" />
   <updateHandler class="solr.DirectUpdateHandler2">
-    <maxPendingDeletes>1000</maxPendingDeletes>
     <autoCommit>
       <maxDocs>1000</maxDocs>
       <maxTime>60000</maxTime>


### PR DESCRIPTION
Hi there,

We at Hudson Molonglo have been working with Mary Kidd at Yale and @Blake- to troubleshoot some issues around indexing performance.

We ended up discovering a performance issue with deletes.  There's more detail below (and in the comments of the commit), but the gist is that deletes are applied during the commit process, and when they take a long time they lock out everyone else who is trying to write to the Solr index.  When large numbers of deletes are happening (for example, when the PUI indexer is working through a large tree), all other index update activity ends up stalled waiting for the commit to finish.

This commit ensures that deletes are applied somewhat regularly, and also rewrites the delete queries to be around 500x faster.

------------------------------
Solr stores deletes and applies them at commit time.  If you go a long time between commits, this can cause OOM issues and/or long commit times as thousands of deletes are finally applied.

To avoid these issues, apply periodic soft commits against Solr to force it to process deletes, and rewrite our delete queries into wider OR clauses to amortize the cost of doing queries.
