### PR TITLE
ANW_2494 Remove jquery.kiketable.colsizable.css

### DIFF
--- a/frontend/app/views/shared/_rde.html.erb
+++ b/frontend/app/views/shared/_rde.html.erb
@@ -1,6 +1,5 @@
 <%= render_aspace_partial :partial => "#{@children.child_type.to_s.pluralize}/rde_templates" %>
 
-<%= stylesheet_link_tag "jquery.kiketable.colsizable.css" %>
 <%= stylesheet_link_tag "archivesspace/rde" %>
 <div class="rde-wrapper">
   <div class="modal-body">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
https://github.com/archivesspace/archivesspace/commit/9d6ad0e520e1cce25be3909d6f335969c791ba69 deleted `frontend/vendor/assets/stylesheets/jquery.kiketable.colsizable.css`, but it is still referenced in `frontend/app/views/shared/_rde.html.erb`.  As a result, a `FATAL` error is logged whenever a user loads the RDE.  There's no functionality/performance impact to this bug - an identical/relocated/renamed css now exists at `frontend/app/assets/stylesheets/jquery.kiketable.colsizable-1.1.css` and is imported via `frontend/app/assets/stylesheets/archivesspace/rde.scss` in the line below this change in `frontend/app/views/shared/_rde.html.erb` - but it does clutter up our logs with false fatals.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-2494

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Confirmed RDE works locally as expected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
