### PR TITLE
ANW-2365: Fix the hardcoded `include-unpublished` search parameter in the url that generates a pdf for a resource in the frontend

### DIFF
--- a/frontend/app/views/resources/_toolbar.html.erb
+++ b/frontend/app/views/resources/_toolbar.html.erb
@@ -68,7 +68,7 @@
         <% if job_types['print_to_pdf_job']['create_permissions'].reject{|perm| user_can?(perm)}.empty? %>
 
           <li class="dropdown-item p-0 dropdown-submenu">
-            <%= link_to t("actions.print_to_pdf"), {:controller => :exports,  :action => :print_to_pdf, :id => @resource.id, :include_unpublished => false }, :id => 'print-to-pdf-link', :target => "_blank", :class => "py-1 px-4 d-block text-decoration-none" %>
+            <%= link_to t("actions.print_to_pdf"), {:controller => :exports,  :action => :print_to_pdf, :id => @resource.id, :include_unpublished => pref_include_unpublished }, :id => 'print-to-pdf-link', :target => "_blank", :class => "py-1 px-4 d-block text-decoration-none" %>
             <div class="dropdown-menu">
               <fieldset>
                 <label class="checkbox" for="include-unpublished-pdf">


### PR DESCRIPTION
This PR fixes a Softserv-related bug that hardcoded the value for the `include-unpublished` search param in the URL that generates the PDF for a Resource in the frontend app via the record toolbar's "Export" dropdown menu. The search param value was harcoded to "false", which meant that, on page load, unpublished children would not be included in the PDF, regardless of the user's repository preferences settings. (The correct behavior was forced by JS once the user started to check/uncheck the "include unpublished" checkbox in the toolbar's dropdown menu after page load.)

The URL should change accordingly on page load based on the user's repository preferences ("Include Unpublished Records in Exports?"), as well as by toggling the "include unpublished" checkbox that appears when the "Generate PDF" button in the record toolbar's "Export" dropdown menu is hovered.

[ANW-2365](https://archivesspace.atlassian.net/browse/ANW-2365)

## Screenshots from the page load state

### Problem

<img width="1476" height="822" alt="ANW-2365 problem" src="https://github.com/user-attachments/assets/6445285c-a7ed-447f-b7c4-c1312f2ef8c7" />

### Solution

<img width="1496" height="826" alt="ANW-2365 solution" src="https://github.com/user-attachments/assets/99f226ab-5457-4b16-a7a4-7cecff1de249" />

[ANW-2365]: https://archivesspace.atlassian.net/browse/ANW-2365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ