### PR TITLE
Hotfix: Change merge modal confirmation button color from default to primary

### DIFF
--- a/frontend/app/views/shared/_merge_dropdown.html.erb
+++ b/frontend/app/views/shared/_merge_dropdown.html.erb
@@ -25,8 +25,7 @@
                                      :class => "btn btn-primary merge-button",
                                      :"data-title" => confirmation_title,
                                      :"data-message" => confirmation_msg,
-                                     :"data-confirm-btn-label" => "#{t("actions.merge")}",
-                                     :"data-confirm-btn-class" => "btn btn-default"
+                                     :"data-confirm-btn-label" => "#{t("actions.merge")}"
                                    })
           %>
           <button type="button" class="btn btn-default btn-cancel"><%= t("actions.cancel") %></button>


### PR DESCRIPTION
Quick Softserv bug fix.

## Problem

<img width="1478" height="821" alt="hotfix default" src="https://github.com/user-attachments/assets/2e91748c-0c20-46b0-b421-60cd9eb5e134" />

## Solution

<img width="1477" height="814" alt="hotfix primary" src="https://github.com/user-attachments/assets/b137fe7f-a588-42c8-a655-606624d864de" />
