### PR TITLE
ANW-2497: Replace readonly largetree with InfiniteTree for Digital Objects and Classifications

### DIFF
--- a/frontend/app/views/classifications/_infinite_tree_templates.html.erb
+++ b/frontend/app/views/classifications/_infinite_tree_templates.html.erb
@@ -1,0 +1,24 @@
+<template id="infinite-tree-root-node-template">
+  <li class="root node" role="treeitem" id data-uri>
+    <div class="node-row">
+      <div class="node-body" title>
+        <div class="node-column" data-column="title">
+          <a class="record-title" href></a>
+        </div>
+      </div>
+    </div>
+  </li>
+</template>
+
+<template id="infinite-tree-node-template">
+  <li class="node" role="treeitem" id data-uri>
+    <div class="node-row">
+      <div class="node-body" title>
+        <div class="node-indentation"></div>
+        <div class="node-column" data-column="title">
+          <a class="record-title" href></a>
+        </div>
+      </div>
+    </div>
+  </li>
+</template>

--- a/frontend/app/views/classifications/show.html.erb
+++ b/frontend/app/views/classifications/show.html.erb
@@ -1,3 +1,3 @@
 <%= setup_context :object => @classification %>
 
-<%= render_aspace_partial :partial => "shared/largetree", :locals => {:root_record => @classification, :read_only => true} %>
+<%= render_aspace_partial :partial => "shared/infinite_tree", :locals => {:root_record => @classification, :read_only => true} %>

--- a/frontend/app/views/digital_objects/_infinite_tree_templates.html.erb
+++ b/frontend/app/views/digital_objects/_infinite_tree_templates.html.erb
@@ -1,0 +1,28 @@
+<template id="infinite-tree-root-node-template">
+  <li class="root node" role="treeitem" id data-uri>
+    <div class="node-row">
+      <div class="node-body" title>
+        <div class="node-column" data-column="title">
+          <a class="record-title" href></a>
+        </div>
+        <div class="node-column" data-column="type"></div>
+        <div class="node-column" data-column="container"></div>
+      </div>
+    </div>
+  </li>
+</template>
+
+<template id="infinite-tree-node-template">
+  <li class="node" role="treeitem" id data-uri>
+    <div class="node-row">
+      <div class="node-body" title>
+        <div class="node-indentation"></div>
+        <div class="node-column" data-column="title">
+          <a class="record-title" href></a>
+        </div>
+        <div class="node-column" data-column="type"></div>
+        <div class="node-column" data-column="container"></div>
+      </div>
+    </div>
+  </li>
+</template>

--- a/frontend/app/views/digital_objects/show.html.erb
+++ b/frontend/app/views/digital_objects/show.html.erb
@@ -1,4 +1,4 @@
 <%= setup_context :object => @digital_object %>
 
 <%= render_aspace_partial :partial => "transfer/transfer_failures", :locals => { :transfer_errors => @transfer_errors } %>
-<%= render_aspace_partial :partial => "shared/largetree", :locals => {:root_record => @digital_object, :read_only => true} %>
+<%= render_aspace_partial :partial => "shared/infinite_tree", :locals => {:root_record => @digital_object, :read_only => true} %>

--- a/frontend/app/views/resources/_infinite_tree_templates.html.erb
+++ b/frontend/app/views/resources/_infinite_tree_templates.html.erb
@@ -1,0 +1,36 @@
+<template id="infinite-tree-root-node-template">
+  <li class="root node" role="treeitem" id data-uri>
+    <div class="node-row">
+      <div class="node-body" title>
+        <div class="node-column" data-column="title">
+          <a class="record-title" href></a>
+        </div>
+        <div class="node-column" data-column="level"></div>
+        <div class="node-column" data-column="type"></div>
+        <div class="node-column" data-column="container"></div>
+        <% if defined?(show_identifiers) && show_identifiers %>
+          <div class="node-column" data-column="identifier"></div>
+        <% end %>
+      </div>
+    </div>
+  </li>
+</template>
+
+<template id="infinite-tree-node-template">
+  <li class="node" role="treeitem" id data-uri>
+    <div class="node-row">
+      <div class="node-body" title>
+        <div class="node-indentation"></div>
+        <div class="node-column" data-column="title">
+          <a class="record-title" href></a>
+        </div>
+        <div class="node-column" data-column="level"></div>
+        <div class="node-column" data-column="type"></div>
+        <div class="node-column" data-column="container"></div>
+        <% if defined?(show_identifiers) && show_identifiers %>
+          <div class="node-column" data-column="identifier"></div>
+        <% end %>
+      </div>
+    </div>
+  </li>
+</template>

--- a/frontend/app/views/shared/_infinite_tree.html.erb
+++ b/frontend/app/views/shared/_infinite_tree.html.erb
@@ -1,5 +1,6 @@
 <%
-   show_identifiers = AppConfig[:display_identifiers_in_largetree_container]
+   root_type = root_record.jsonmodel_type
+   show_identifiers = root_type == 'resource' && AppConfig[:display_identifiers_in_largetree_container]
    read_only = false if read_only.blank?
 %>
 
@@ -11,7 +12,7 @@
 
 <div
   id="infinite-tree-container"
-  data-resource-uri="<%= @resource.uri %>"
+  data-root-uri="<%= root_record.uri %>"
   class="mb-2"
 >
 </div>
@@ -22,23 +23,6 @@
   <ol class="infinite-tree<%= ' has-identifier-column' if show_identifiers %>" role="tree"></ol>
 </template>
 
-<template id="infinite-tree-root-node-template">
-  <li class="root node" role="treeitem" id data-uri>
-    <div class="node-row">
-      <div class="node-body" title>
-        <div class="node-column" data-column="title">
-          <a class="record-title" href></a>
-        </div>
-        <div class="node-column" data-column="level"></div>
-        <div class="node-column" data-column="type"></div>
-        <div class="node-column" data-column="container"></div>
-        <% if show_identifiers %>
-          <div class="node-column" data-column="identifier"></div>
-        <% end %>
-      </div>
-    </div>
-  </li>
-</template>
 
 <template id="infinite-tree-node-list-template">
   <ol
@@ -50,24 +34,6 @@
   ></ol>
 </template>
 
-<template id="infinite-tree-node-template">
-  <li class="node" role="treeitem" id data-uri>
-    <div class="node-row">
-      <div class="node-body" title>
-        <div class="node-indentation"></div>
-        <div class="node-column" data-column="title">
-          <a class="record-title" href></a>
-        </div>
-        <div class="node-column" data-column="level"></div>
-        <div class="node-column" data-column="type"></div>
-        <div class="node-column" data-column="container"></div>
-        <% if show_identifiers %>
-          <div class="node-column" data-column="identifier"></div>
-        <% end %>
-      </div>
-    </div>
-  </li>
-</template>
 
 <template id="infinite-tree-expand-button-template">
   <button class="node-expand" type="button">
@@ -84,8 +50,14 @@
   <span class="badge badge-warning"><%= I18n.t("states.suppressed") %></span>
 </template>
 
+<% if root_type == 'resource' %>
+  <%= render_aspace_partial partial: 'resources/infinite_tree_templates', locals: { show_identifiers: show_identifiers } %>
+<% else %>
+  <%= render_aspace_partial partial: "#{root_type}s/infinite_tree_templates" %>
+<% end %>
+
 <script>
-const rootUri = "<%= @resource.uri %>";
+const rootUri = "<%= root_record.uri %>";
 
 const initialContext = new InfiniteTreeInitialContext(rootUri).context;
 
@@ -125,7 +97,7 @@ const infiniteTree = new InfiniteTree(
   initialContext,
   "<%= Rails.configuration.infinite_tree_batch_size %>",
   {
-    sep: "<%= I18n.t("resource.identifier_separator") %>",
+    sep: "<%= I18n.t("#{root_type}.identifier_separator") %>",
     bulk: "<%= I18n.t("date_type_bulk.bulk") %>",
     enumerations: EnumerationTranslations2
   }


### PR DESCRIPTION
- [x] Implement readonly InfiniteTree for DOs and Classifications
- [ ] Fix broken tests
- [ ] Add new tests

[ANW-2497](https://archivesspace.atlassian.net/browse/ANW-2497)

[ANW-2497]: https://archivesspace.atlassian.net/browse/ANW-2497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ