### PR TITLE
ANW-2101: Translation missing for new values in event_event_type

### DIFF
--- a/common/locales/enums/it.yml
+++ b/common/locales/enums/it.yml
@@ -824,27 +824,43 @@ it:
       issued: Emesso
       modified: Modificato
     event_event_type:
-      deaccession: Deaccessione
+      accession: Accesso
+      accumulation: Accumulo
+      acknowledgement: Riconoscimento
+      acknowledgement_received: Riconoscimento ricevuto
+      acknowledgement_sent: Riconoscimento inviato
       agreement_received: Accordo ricevuto
       agreement_sent: Accordo inviato
-      appraisal: Valutazione
       agreement_signed: Accordo firmato
+      appraisal: Valutazione
+      assessment: Valutazione
+      capture: Cattura
+      cataloged: Catalogato
       collection: Collezione
+      component_transfer: Trasferimento componenti
       compression: Compressione
       contribution: Contributo
       copyright_transfer: Trasferimento del copyright
       custody_transfer: Trasferimento della custodia
-      deletion: Eliminazione
+      deaccession: Deaccessione
       decompression: Decompressione
       decryption: Decriptazione
+      deletion: Eliminazione
+      digital_signature_validation: Convalida della firma digitale
+      fixity_check: Controllo integrità
+      ingestion: Ingestione
+      message_digest_calculation: Calcolo digest messaggio
+      migration: Migrazione
       normalization: Normalizzazione
       processed: Processato
-      migration: Migrazione
-      replication: Riproduzione
+      processing_completed: Elaborazione completata
+      processing_in_progress: Elaborazione in corso
+      processing_new: Nuova elaborazione
+      processing_started: Elaborazione iniziata
       publication: Pubblicazione
-      request: ''
-      cataloged: Catalogato
-      digital_signature_validation: Convalida della firma digitale
+      replication: Riproduzione
+      request: Richiesta
+      rights_transferred: Diritti trasferiti
       validation: Convalida
       virus_check: Ispezione per i virus
     level_of_detail:

--- a/common/locales/enums/uk.yml
+++ b/common/locales/enums/uk.yml
@@ -1,7 +1,49 @@
 uk:
   enumeration_names:
     accession_sibling_relator: Реляційний консультант з питань приєднання до братів і сестер
-    agent_relationship_hierarchical_relator: Ієрархічний релятор зв'язків між агентами
+    agent_relationship_hier    agent_relationship_parentchild_relator:
+      is_child_of: Дитина пов'язаних осіб
+      is_parent_of: Батьківський елемент пов'язаного елемента
+    event_event_type:
+      accession: Поповнення
+      accumulation: Накопичення
+      acknowledgement: Підтвердження
+      acknowledgement_received: Підтвердження отримано
+      acknowledgement_sent: Підтвердження надіслано
+      agreement_received: Угода отримана
+      agreement_sent: Угода надіслана
+      agreement_signed: Угода підписана
+      appraisal: Оцінка
+      assessment: Оцінювання
+      capture: Захоплення
+      cataloged: Каталогізовано
+      collection: Колекція
+      component_transfer: Передача компонента
+      compression: Стиснення
+      contribution: Внесок
+      copyright_transfer: Передача авторських прав
+      custody_transfer: Передача опіки
+      deaccession: Вилучення
+      decompression: Розпакування
+      decryption: Розшифровка
+      deletion: Видалення
+      digital_signature_validation: Перевірка цифрового підпису
+      fixity_check: Перевірка цілісності
+      ingestion: Поглинання
+      message_digest_calculation: Обчислення дайджесту повідомлення
+      migration: Міграція
+      normalization: Нормалізація
+      processed: Оброблено
+      processing_completed: Обробка завершена
+      processing_in_progress: Обробка в процесі
+      processing_new: Нова обробка
+      processing_started: Обробка розпочата
+      publication: Публікація
+      replication: Реплікація
+      request: Запит
+      rights_transferred: Права передані
+      validation: Валідація
+      virus_check: Перевірка на вірусиhical_relator: Ієрархічний релятор зв'язків між агентами
     agent_relationship_associative_relator: Агент з взаємовідносин з ріелтором
     linked_agent_archival_record_relators: Пов’язані агенти архівних записів
     date_standardized_type: Дата Стандартизований тип

--- a/frontend/app/views/events/edit.html.erb
+++ b/frontend/app/views/events/edit.html.erb
@@ -1,5 +1,5 @@
 <%
-  record_title = "#{t("enumerations.event_event_type.#{@event.event_type}")} (#{@event.id})"
+  record_title = "#{I18n.t("enumerations.event_event_type.#{@event.event_type}", :default => @event.event_type)} (#{@event.id})"
 %>
 
 <%= setup_context :object => @event, :title => record_title %>

--- a/frontend/app/views/events/show.html.erb
+++ b/frontend/app/views/events/show.html.erb
@@ -1,5 +1,5 @@
 <%
-  record_title = "#{t("enumerations.event_event_type.#{@event.event_type}")} (#{@event.id})"
+  record_title = "#{I18n.t("enumerations.event_event_type.#{@event.event_type}", :default => @event.event_type)} (#{@event.id})"
 %>
 
 <%= setup_context :object => @event, :title => record_title %>

--- a/frontend/app/views/jobs/_job_records.html.erb
+++ b/frontend/app/views/jobs/_job_records.html.erb
@@ -4,7 +4,7 @@
       <%
          record_title = result["record"]["_resolved"]["title"]
          if "event" == result["record"]["_resolved"]["jsonmodel_type"]
-           record_title = "#{t("event._singular")}: #{t("enumerations.event_event_type.#{result["record"]["_resolved"]["event_type"]}")}"
+           record_title = "#{t("event._singular")}: #{I18n.t("enumerations.event_event_type.#{result["record"]["_resolved"]["event_type"]}", :default => result["record"]["_resolved"]["event_type"])}"
          elsif "collection_management" == result["record"]["_resolved"]["jsonmodel_type"]
            record_title = "#{t("collection_management._singular")}"
          end

--- a/frontend/app/views/linked_agents/_show.html.erb
+++ b/frontend/app/views/linked_agents/_show.html.erb
@@ -47,7 +47,7 @@
                     <dt><%= t("linked_agent.terms") %></dt>
 
                     <% ASUtils.wrap(link['terms']).each do |term| %>
-                      <dd class="label label-info badge" title="<%= t("enumerations.subject_term_type.#{term["term_type"]}") %>">
+                      <dd class="label label-info badge" title="<%= I18n.t("enumerations.subject_term_type.#{term["term_type"]}", :default => term["term_type"]) %>">
                         <%= term['term'] %>
                       </dd>
                     <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
- Adds a default value for new enum of `event_event_type`
- Adds missing translations for common event types

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-2101

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
|Before | After|
|-------|------|
|![CleanShot 2025-09-30 at 14 42 47@2x](https://github.com/user-attachments/assets/4b96ebf8-645f-452e-9e4a-39a16f9c9af3)||

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
