### PR TITLE
ANW-2217: pdf export preserve top container tile containing semicolon

### DIFF
--- a/public/app/views/pdf/_archival_object.html.erb
+++ b/public/app/views/pdf/_archival_object.html.erb
@@ -54,38 +54,20 @@ end
             <% if instance['sub_container'] %>
                 <div class="container-information">
                     <%
-                      if instance['sub_container'] &&
-                         instance['sub_container']['top_container'] &&
-                         instance['sub_container']['top_container']['_resolved'] &&
-                         instance['sub_container']['top_container']['_resolved']['display_string']
+                      box_string = lambda {
+                        return '' unless instance.dig('sub_container', 'top_container', '_resolved', 'display_string')
 
-                        # Extract just the container type and indicator from the display string
-                        # The display string format is: "Type Indicator: series_info [barcode_info]"
-                        # We want to extract "Type Indicator" part only
                         tc_resolved = instance['sub_container']['top_container']['_resolved']
-                        if tc_resolved['type'] && tc_resolved['indicator']
-                          box_string = "#{tc_resolved['type'].capitalize} #{tc_resolved['indicator']}"
-                        else
-                          # Fallback to parsing display_string
-                          tc_display_string = tc_resolved['display_string'].split(':')[0]
-                          if tc_display_string =~ /:/
-                            box_string = tc_display_string.split(':')[0]
-                          else
-                            box_string = tc_display_string
-													end
-                        end
+                        return "#{tc_resolved['type'].capitalize} #{tc_resolved['indicator']}" if tc_resolved['type'] && tc_resolved['indicator']
 
-                      else
-                        box_string = ""
-                      end
+                        tc_resolved['display_string'].split(':')[0]
+                      }.call
 
-                      if instance['sub_container'] &&
-                         instance['sub_container']['type_2'] &&
-                         instance['sub_container']['indicator_2']
-                        folder_string = instance['sub_container']['type_2'] + " " + instance['sub_container']['indicator_2']
-                      else
-                        folder_string = ""
-                      end
+                      folder_string = lambda {
+                        return '' unless instance['sub_container']['type_2'] && instance['sub_container']['indicator_2']
+
+                        "#{instance['sub_container']['type_2']} #{instance['sub_container']['indicator_2']}"
+                      }.call
                     %>
 
                     <% unless box_string.empty? && folder_string.empty? %>

--- a/public/app/views/pdf/_archival_object.html.erb
+++ b/public/app/views/pdf/_archival_object.html.erb
@@ -59,13 +59,20 @@ end
                          instance['sub_container']['top_container']['_resolved'] &&
                          instance['sub_container']['top_container']['_resolved']['display_string']
 
-                        tc_display_string = instance['sub_container']['top_container']['_resolved']['display_string'].split(':')[0]
-
-
-                        if tc_display_string =~ /:/
-                          box_string = tc_display_string.split(':')[0]
+                        # Extract just the container type and indicator from the display string
+                        # The display string format is: "Type Indicator: series_info [barcode_info]"
+                        # We want to extract "Type Indicator" part only
+                        tc_resolved = instance['sub_container']['top_container']['_resolved']
+                        if tc_resolved['type'] && tc_resolved['indicator']
+                          box_string = "#{tc_resolved['type'].capitalize} #{tc_resolved['indicator']}"
                         else
-                          box_string = tc_display_string
+                          # Fallback to parsing display_string
+                          tc_display_string = tc_resolved['display_string'].split(':')[0]
+                          if tc_display_string =~ /:/
+                            box_string = tc_display_string.split(':')[0]
+                          else
+                            box_string = tc_display_string
+													end
                         end
 
                       else

--- a/public/spec/models/finding_aid_pdf_spec.rb
+++ b/public/spec/models/finding_aid_pdf_spec.rb
@@ -89,12 +89,10 @@ describe "FindingAidPDF" do
 
     resource = create(:resource, title: "Resource Title #{now}", publish: true)
 
-    # Create a top container with an indicator containing a semicolon
     top_container = create(:json_top_container,
       indicator: "Series 1: accession 2",
       type: "box")
 
-    # Create an archival object with this container
     archival_object = create(:archival_object,
       title: "Archival Object with Semicolon Container #{now}",
       resource: { 'ref' => resource.uri },
@@ -115,7 +113,6 @@ describe "FindingAidPDF" do
     source_file = pdf.source_file
     html = File.read(source_file)
 
-    # The container indicator should appear in full, not truncated at the semicolon
     expect(html).to include "box series 1: accession 2"
   end
 end

--- a/public/spec/models/finding_aid_pdf_spec.rb
+++ b/public/spec/models/finding_aid_pdf_spec.rb
@@ -88,12 +88,12 @@ describe "FindingAidPDF" do
     set_repo repository
 
     resource = create(:resource, title: "Resource Title #{now}", publish: true)
-    
-    # Create a top container with an indicator containing a semicolon  
-    top_container = create(:json_top_container, 
+
+    # Create a top container with an indicator containing a semicolon
+    top_container = create(:json_top_container,
       indicator: "Series 1: accession 2",
       type: "box")
-    
+
     # Create an archival object with this container
     archival_object = create(:archival_object,
       title: "Archival Object with Semicolon Container #{now}",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The code assumed that Indicator doesn't contain semicolon and thus it was just splitting a `:`. This diff makes sure that pdf  export will preserve top container tiles containing semicolon

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-2217
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![CleanShot 2025-09-30 at 19 33 42@2x](https://github.com/user-attachments/assets/4e02f4a8-a230-4244-ac00-b74342acf07b)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
