### PR TITLE
ANW-1874: Constrain the use of `is_primary` for top-level linked agents to Accessions and abstract Archival Objects only

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -918,7 +918,6 @@
       <param name="coverage_report_dir" value="frontend" />
       <param name="aspace.integration" value="true" />
       <param name="dir" value="../frontend" />
-      <param name="pattern" value="spec/*/*_spec.rb" />
       <!-- feature tests copied from old selenium tests may be order-dependent -->
       <param name="order" value="defined" />
       <param name="tag" value="${tag}" />

--- a/frontend/app/assets/javascripts/representativemembers.js
+++ b/frontend/app/assets/javascripts/representativemembers.js
@@ -38,7 +38,7 @@ $(function () {
           ':input[name$="[' + rep_field_name + ']"]',
           $subform
         );
-        if ($hiddenRepStateField.length === 0) return; // No hidden field, nothing to do here
+        if ($hiddenRepStateField.length === 0) return; // ANW-1874 No hidden field, nothing to do here
 
         const isRepresentative = $hiddenRepStateField.val() === '1';
         const $labelBtn = $subform.find('.is-representative-label');

--- a/frontend/app/assets/javascripts/representativemembers.js
+++ b/frontend/app/assets/javascripts/representativemembers.js
@@ -33,8 +33,14 @@ $(function () {
 
         const $subform = $(subform);
         const $section = $subform.closest('section.subrecord-form');
-        const isRepresentative =
-          $(':input[name$="[' + rep_field_name + ']"]', $subform).val() === '1';
+
+        const $hiddenRepStateField = $(
+          ':input[name$="[' + rep_field_name + ']"]',
+          $subform
+        );
+        if ($hiddenRepStateField.length === 0) return; // No hidden field, nothing to do here
+
+        const isRepresentative = $hiddenRepStateField.val() === '1';
         const $labelBtn = $subform.find('.is-representative-label');
         const $repBtn = $subform.find('.is-representative-toggle');
         const eventName =

--- a/frontend/app/views/linked_agents/_template.html.erb
+++ b/frontend/app/views/linked_agents/_template.html.erb
@@ -12,10 +12,12 @@
   <% define_template "#{defn[:type]}_linked_agent", jsonmodel_definition(defn[:type], "linked_agents") do |form| %>
 
     <div class="subrecord-form-fields agent_links">
+      <% if [:accession, :resource, :archival_object, :digital_object, :digital_object_component].include?(defn[:type]) %>
       <h3 class="subrecord-form-heading">
        <%= form.button_with_tooltip(I18n.t("linked_agent._frontend.action.make_primary_tooltip"), I18n.t("linked_agent.is_primary"), [], ["badge badge-pill badge-primary fs-14px is-representative-label"], false) %>
        <%= form.button_with_tooltip(I18n.t("linked_agent._frontend.action.make_primary_tooltip"), I18n.t("linked_agent._frontend.action.make_primary"), [], ["is-representative-toggle"]) %>
       </h3>
+      <% end %>
       <% if defn[:role] %>
         <%= form.label_and_select("role", form.possible_options_for("role", true), :field_opts => {:class => "linked_agent_role"}) %>
       <% end %>
@@ -33,7 +35,9 @@
         <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "terms", :heading_text => t("subject._frontend.section.terms")} %>
       </div>
 
+      <% if [:accession, :resource, :archival_object, :digital_object, :digital_object_component].include?(defn[:type]) %>
       <%= form.hidden_input "is_primary", form["is_primary"] ? 1 : 0 %>
+      <% end %>
     </div>
   <% end %>
 

--- a/frontend/app/views/linked_agents/_template.html.erb
+++ b/frontend/app/views/linked_agents/_template.html.erb
@@ -10,9 +10,9 @@
    ].each do |defn| %>
 
   <% define_template "#{defn[:type]}_linked_agent", jsonmodel_definition(defn[:type], "linked_agents") do |form| %>
-
+    <% type_supports_is_primary = [:accession, :resource, :archival_object, :digital_object, :digital_object_component].include?(defn[:type]) %>
     <div class="subrecord-form-fields agent_links">
-      <% if [:accession, :resource, :archival_object, :digital_object, :digital_object_component].include?(defn[:type]) %>
+      <% if type_supports_is_primary %>
       <h3 class="subrecord-form-heading">
        <%= form.button_with_tooltip(I18n.t("linked_agent._frontend.action.make_primary_tooltip"), I18n.t("linked_agent.is_primary"), [], ["badge badge-pill badge-primary fs-14px is-representative-label"], false) %>
        <%= form.button_with_tooltip(I18n.t("linked_agent._frontend.action.make_primary_tooltip"), I18n.t("linked_agent._frontend.action.make_primary"), [], ["is-representative-toggle"]) %>
@@ -35,7 +35,7 @@
         <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "terms", :heading_text => t("subject._frontend.section.terms")} %>
       </div>
 
-      <% if [:accession, :resource, :archival_object, :digital_object, :digital_object_component].include?(defn[:type]) %>
+      <% if type_supports_is_primary %>
       <%= form.hidden_input "is_primary", form["is_primary"] ? 1 : 0 %>
       <% end %>
     </div>

--- a/frontend/spec/factories.rb
+++ b/frontend/spec/factories.rb
@@ -318,6 +318,13 @@ module Factories
         height { '20' }
         depth { '20' }
       end
+
+      factory :event, class: JSONModel(:event) do
+        event_type { generate(:event_type) }
+        date { build(:date) }
+        linked_agents { [{'ref' => create(:agent_person).uri, 'role' => generate(:agent_role)}] }
+        linked_records { [{'ref' => create(:accession).uri, 'role' => generate(:record_role)}] }
+      end
     end
   end
 end

--- a/frontend/spec/features/accessions_spec.rb
+++ b/frontend/spec/features/accessions_spec.rb
@@ -552,40 +552,6 @@ describe 'Accessions', js: true do
     end
   end
 
-  it 'can mark a linked_agent as primary' do
-    now = Time.now.to_i
-    click_on('Create')
-    click_on('Accession')
-    fill_in('Title', with: accession_title)
-    fill_in("Identifier", with: "test_#{Time.now}")
-    click_on('Save')
-
-    agent = create(
-      :agent_person,
-      names: [build(:name_person,
-      name_order: 'inverted',
-      primary_name: "Subject Agent #{now}",
-      rest_of_name: "Subject Agent #{now}",
-      sort_name: "Subject Agent #{now}")]
-    )
-
-    run_index_round
-
-    click_on('Add Agent Link')
-    select 'Creator', from: 'Role'
-
-    # Find agent by AJAX and select the first
-    element = find('#token-input-accession_linked_agents__0__ref_')
-    element.fill_in with: agent.names.first['primary_name']
-    dropdown_items = all('li.token-input-dropdown-item2')
-    dropdown_items.first.click
-
-    click_on('Make Primary')
-
-    click_on('Save')
-    expect(page).to have_text "Accession #{accession_title} updated"
-  end
-
   describe 'toolbar' do
     it 'has a "more" dropdown menu that is aligned to the right side of its control button' do
       accession = create(:json_accession)
@@ -622,7 +588,7 @@ describe 'Accessions', js: true do
     end
     let(:edit_path) { "/accessions/#{record.id}/edit" }
 
-    it_behaves_like 'supports is_primary on top-level linked agents'
-    it_behaves_like 'disallows is_primary on rights statement linked agents'
+    it_behaves_like 'supporting is_primary on top-level linked agents'
+    it_behaves_like 'not supporting is_primary on rights statement linked agents'
   end
 end

--- a/frontend/spec/features/accessions_spec.rb
+++ b/frontend/spec/features/accessions_spec.rb
@@ -597,4 +597,32 @@ describe 'Accessions', js: true do
       )
     end
   end
+
+describe 'Linked Agents is_primary behavior' do
+  let(:record_type) { 'accession' }
+  let(:agent) { create(:agent_person) }
+  let(:record) do
+    create(:accession,
+      title: "Accession Title #{Time.now.to_i}",
+      linked_agents: [
+        { ref: agent.uri, role: 'creator' }
+      ],
+      rights_statements: [
+        build(:json_rights_statement,
+          rights_type: 'copyright',
+          status: 'copyrighted',
+          jurisdiction: 'AU',
+          start_date: Time.now.strftime('%Y-%m-%d'),
+          linked_agents: [
+            { ref: agent.uri, role: 'rights_holder' }
+          ]
+        )
+      ]
+    )
+  end
+  let(:edit_path) { "/accessions/#{record.id}/edit" }
+
+  it_behaves_like 'supports is_primary on top-level linked agents'
+  it_behaves_like 'disallows is_primary on rights statement linked agents'
+end
 end

--- a/frontend/spec/features/accessions_spec.rb
+++ b/frontend/spec/features/accessions_spec.rb
@@ -598,31 +598,31 @@ describe 'Accessions', js: true do
     end
   end
 
-describe 'Linked Agents is_primary behavior' do
-  let(:record_type) { 'accession' }
-  let(:agent) { create(:agent_person) }
-  let(:record) do
-    create(:accession,
-      title: "Accession Title #{Time.now.to_i}",
-      linked_agents: [
-        { ref: agent.uri, role: 'creator' }
-      ],
-      rights_statements: [
-        build(:json_rights_statement,
-          rights_type: 'copyright',
-          status: 'copyrighted',
-          jurisdiction: 'AU',
-          start_date: Time.now.strftime('%Y-%m-%d'),
-          linked_agents: [
-            { ref: agent.uri, role: 'rights_holder' }
-          ]
-        )
-      ]
-    )
-  end
-  let(:edit_path) { "/accessions/#{record.id}/edit" }
+  describe 'Linked Agents is_primary behavior' do
+    let(:record_type) { 'accession' }
+    let(:agent) { create(:agent_person) }
+    let(:record) do
+      create(:accession,
+        title: "Accession Title #{Time.now.to_i}",
+        linked_agents: [
+          { ref: agent.uri, role: 'creator' }
+        ],
+        rights_statements: [
+          build(:json_rights_statement,
+            rights_type: 'copyright',
+            status: 'copyrighted',
+            jurisdiction: 'AU',
+            start_date: Time.now.strftime('%Y-%m-%d'),
+            linked_agents: [
+              { ref: agent.uri, role: 'rights_holder' }
+            ]
+          )
+        ]
+      )
+    end
+    let(:edit_path) { "/accessions/#{record.id}/edit" }
 
-  it_behaves_like 'supports is_primary on top-level linked agents'
-  it_behaves_like 'disallows is_primary on rights statement linked agents'
-end
+    it_behaves_like 'supports is_primary on top-level linked agents'
+    it_behaves_like 'disallows is_primary on rights statement linked agents'
+  end
 end

--- a/frontend/spec/features/archival_objects_spec.rb
+++ b/frontend/spec/features/archival_objects_spec.rb
@@ -449,4 +449,41 @@ describe 'Archival objects', js: true do
     element = find('#resource_publish_')
     expect(element.checked?).to eq(false)
   end
+
+  describe 'Linked Agents is_primary behavior' do
+    let(:record_type) { 'archival_object' }
+    let(:agent) { create(:agent_person) }
+    let(:parent_resource) do
+      create(
+        :resource,
+        title: "Resource Title #{Time.now.to_i}"
+      )
+    end
+    let(:record) do
+      create(
+        :archival_object,
+        resource: { ref: parent_resource.uri },
+        title: "Archival Object Title #{Time.now.to_i}",
+        linked_agents: [
+          { ref: agent.uri, role: 'creator' }
+        ],
+        rights_statements: [
+          build(
+            :json_rights_statement,
+            rights_type: 'copyright',
+            status: 'copyrighted',
+            jurisdiction: 'AU',
+            start_date: Time.now.strftime('%Y-%m-%d'),
+            linked_agents: [
+              { ref: agent.uri, role: 'rights_holder' }
+            ]
+          )
+        ]
+      )
+    end
+    let(:edit_path) { "/resources/#{parent_resource.id}/edit#tree::archival_object_#{record.id}" }
+
+    it_behaves_like 'supporting is_primary on top-level linked agents'
+    it_behaves_like 'not supporting is_primary on rights statement linked agents'
+  end
 end

--- a/frontend/spec/features/digital_objects_spec.rb
+++ b/frontend/spec/features/digital_objects_spec.rb
@@ -365,32 +365,71 @@ describe 'Digital Objects', js: true do
   end
 
   describe 'Linked Agents is_primary behavior' do
-    let(:record_type) { 'digital_object' }
     let(:agent) { create(:agent_person) }
-    let(:record) do
-      create(
-        :digital_object,
-        title: "Digital Object Title #{Time.now.to_i}",
-        linked_agents: [
-          { ref: agent.uri, role: 'creator' }
-        ],
-        rights_statements: [
-          build(
-            :json_rights_statement,
-            rights_type: 'copyright',
-            status: 'copyrighted',
-            jurisdiction: 'AU',
-            start_date: Time.now.strftime('%Y-%m-%d'),
-            linked_agents: [
-              { ref: agent.uri, role: 'rights_holder' }
-            ]
-          )
-        ]
-      )
-    end
-    let(:edit_path) { "/digital_objects/#{record.id}/edit" }
 
-    it_behaves_like 'supports is_primary on top-level linked agents'
-    it_behaves_like 'disallows is_primary on rights statement linked agents'
+    context 'for a parent Digital Object' do
+      let(:record_type) { 'digital_object' }
+      let(:record) do
+        create(
+          :digital_object,
+          title: "Digital Object Title #{Time.now.to_i}",
+          linked_agents: [
+            { ref: agent.uri, role: 'creator' }
+          ],
+          rights_statements: [
+            build(
+              :json_rights_statement,
+              rights_type: 'copyright',
+              status: 'copyrighted',
+              jurisdiction: 'AU',
+              start_date: Time.now.strftime('%Y-%m-%d'),
+              linked_agents: [
+                { ref: agent.uri, role: 'rights_holder' }
+              ]
+            )
+          ]
+        )
+      end
+      let(:edit_path) { "/digital_objects/#{record.id}/edit" }
+
+      it_behaves_like 'supporting is_primary on top-level linked agents'
+      it_behaves_like 'not supporting is_primary on rights statement linked agents'
+    end
+
+    context 'for child Digital Object Components' do
+      let(:record_type) { 'digital_object_component' }
+      let(:parent_digital_object) do
+        create(
+          :digital_object,
+          title: "Digital Object Title #{Time.now.to_i}"
+        )
+      end
+      let(:record) do
+        create(
+          :digital_object_component,
+          digital_object: { ref: parent_digital_object.uri },
+          title: "Digital Object Component Title #{Time.now.to_i}",
+          linked_agents: [
+            { ref: agent.uri, role: 'creator' }
+          ],
+          rights_statements: [
+            build(
+              :json_rights_statement,
+              rights_type: 'copyright',
+              status: 'copyrighted',
+              jurisdiction: 'AU',
+              start_date: Time.now.strftime('%Y-%m-%d'),
+              linked_agents: [
+                { ref: agent.uri, role: 'rights_holder' }
+              ]
+            )
+          ]
+        )
+      end
+      let(:edit_path) { "/digital_objects/#{parent_digital_object.id}/edit#tree::digital_object_component_#{record.id}" }
+
+      it_behaves_like 'supporting is_primary on top-level linked agents'
+      it_behaves_like 'not supporting is_primary on rights statement linked agents'
+    end
   end
 end

--- a/frontend/spec/features/digital_objects_spec.rb
+++ b/frontend/spec/features/digital_objects_spec.rb
@@ -363,4 +363,34 @@ describe 'Digital Objects', js: true do
     element = find('#digital_object_component_file_versions__file_version_1')
     expect(element).to have_text "File Format Caption 2 #{now}"
   end
+
+  describe 'Linked Agents is_primary behavior' do
+    let(:record_type) { 'digital_object' }
+    let(:agent) { create(:agent_person) }
+    let(:record) do
+      create(
+        :digital_object,
+        title: "Digital Object Title #{Time.now.to_i}",
+        linked_agents: [
+          { ref: agent.uri, role: 'creator' }
+        ],
+        rights_statements: [
+          build(
+            :json_rights_statement,
+            rights_type: 'copyright',
+            status: 'copyrighted',
+            jurisdiction: 'AU',
+            start_date: Time.now.strftime('%Y-%m-%d'),
+            linked_agents: [
+              { ref: agent.uri, role: 'rights_holder' }
+            ]
+          )
+        ]
+      )
+    end
+    let(:edit_path) { "/digital_objects/#{record.id}/edit" }
+
+    it_behaves_like 'supports is_primary on top-level linked agents'
+    it_behaves_like 'disallows is_primary on rights statement linked agents'
+  end
 end

--- a/frontend/spec/features/events_spec.rb
+++ b/frontend/spec/features/events_spec.rb
@@ -283,4 +283,14 @@ describe 'Events', js: true do
     csv = File.read(csv_files[0])
     expect(csv).to include("Agent Name #{@now}")
   end
+
+  describe 'Agent Links subform' do
+    it 'does not allow an agent to be marked primary' do
+      login_admin
+      visit '/events/new'
+      expect(page).to have_css('#event_linked_agents_ #event_linked_agents__0_', visible: true)
+      expect(page).not_to have_content 'Make Primary'
+      expect(page).not_to have_css('#event_linked_agents__0__is_primary_')
+    end
+  end
 end

--- a/frontend/spec/features/events_spec.rb
+++ b/frontend/spec/features/events_spec.rb
@@ -284,13 +284,16 @@ describe 'Events', js: true do
     expect(csv).to include("Agent Name #{@now}")
   end
 
-  describe 'Agent Links subform' do
-    it 'does not allow an agent to be marked primary' do
+  describe 'Linked Agents is_primary behavior' do
+    let(:record_type) { 'event' }
+    let(:record) { create(:event) }
+    let(:edit_path) { "/events/#{record.id}/edit" }
+
+    before :each do
       login_admin
-      visit '/events/new'
-      expect(page).to have_css('#event_linked_agents_ #event_linked_agents__0_', visible: true)
-      expect(page).not_to have_content 'Make Primary'
-      expect(page).not_to have_css('#event_linked_agents__0__is_primary_')
+      select_repository @repository
     end
+
+    it_behaves_like 'not supporting is_primary on top-level linked agents'
   end
 end

--- a/frontend/spec/features/resources_spec.rb
+++ b/frontend/spec/features/resources_spec.rb
@@ -253,6 +253,7 @@ describe 'Resources', js: true do
         find(".sidebar-entry-resource_linked_agents_ a").click
         within "#resource_linked_agents_" do
           click_button "Add Agent Link"
+          expect(page).to have_content 'Make Primary' # ANW-1874
           agent_subrecords = find_all("li.linked_agent_initialised")
           within agent_subrecords.last do
             field = find("input[role='searchbox']")
@@ -838,6 +839,7 @@ describe 'Resources', js: true do
 
     within '#resource_rights_statements_' do
       click_on 'Add Agent Link'
+      expect(page).not_to have_content 'Make Primary' # ANW-1874
     end
 
     element = find('#token-input-resource_rights_statements__0__linked_agents__0__ref_')

--- a/frontend/spec/features/resources_spec.rb
+++ b/frontend/spec/features/resources_spec.rb
@@ -253,7 +253,7 @@ describe 'Resources', js: true do
         find(".sidebar-entry-resource_linked_agents_ a").click
         within "#resource_linked_agents_" do
           click_button "Add Agent Link"
-          expect(page).to have_content 'Make Primary' # ANW-1874
+          expect(page).to have_content 'Make Primary'
           agent_subrecords = find_all("li.linked_agent_initialised")
           within agent_subrecords.last do
             field = find("input[role='searchbox']")
@@ -839,7 +839,7 @@ describe 'Resources', js: true do
 
     within '#resource_rights_statements_' do
       click_on 'Add Agent Link'
-      expect(page).not_to have_content 'Make Primary' # ANW-1874
+      expect(page).not_to have_content 'Make Primary'
     end
 
     element = find('#token-input-resource_rights_statements__0__linked_agents__0__ref_')

--- a/frontend/spec/features/resources_spec.rb
+++ b/frontend/spec/features/resources_spec.rb
@@ -1264,8 +1264,8 @@ describe 'Resources', js: true do
     end
     let(:edit_path) { "/resources/#{record.id}/edit" }
 
-    it_behaves_like 'supports is_primary on top-level linked agents'
-    it_behaves_like 'disallows is_primary on rights statement linked agents'
+    it_behaves_like 'supporting is_primary on top-level linked agents'
+    it_behaves_like 'not supporting is_primary on rights statement linked agents'
   end
 
   describe 'export to pdf' do

--- a/frontend/spec/features/resources_spec.rb
+++ b/frontend/spec/features/resources_spec.rb
@@ -1238,6 +1238,36 @@ describe 'Resources', js: true do
     expect(element).to have_text "Digital Object Title #{now}"
   end
 
+  describe 'Linked Agents is_primary behavior' do
+    let(:record_type) { 'resource' }
+    let(:agent) { create(:agent_person) }
+    let(:record) do
+      create(
+        :resource,
+        title: "Resource Title #{Time.now.to_i}",
+        linked_agents: [
+          { ref: agent.uri, role: 'creator' }
+        ],
+        rights_statements: [
+          build(
+            :json_rights_statement,
+            rights_type: 'copyright',
+            status: 'copyrighted',
+            jurisdiction: 'AU',
+            start_date: Time.now.strftime('%Y-%m-%d'),
+            linked_agents: [
+              { ref: agent.uri, role: 'rights_holder' }
+            ]
+          )
+        ]
+      )
+    end
+    let(:edit_path) { "/resources/#{record.id}/edit" }
+
+    it_behaves_like 'supports is_primary on top-level linked agents'
+    it_behaves_like 'disallows is_primary on rights statement linked agents'
+  end
+
   describe 'export to pdf' do
     shared_examples 'has the correct export-to-pdf configuration' do
       it 'the print to pdf link href has the correct value for the include_unpublished parameter' do

--- a/frontend/spec/rails_helper.rb
+++ b/frontend/spec/rails_helper.rb
@@ -9,6 +9,9 @@ require 'selenium-webdriver'
 require 'aspace_helper'
 require File.expand_path("../../../common/spec/support/file_runtime_formatter.rb", __FILE__)
 
+# Load shared examples
+Dir[File.expand_path('../shared/**/*.rb', __FILE__)].sort.each { |f| require f }
+
 CHROME_OPTS = ENV.fetch('CHROME_OPTS', "--headless=new --no-sandbox --enable-logging --log-level=0 --v=1 --remote-debugging-port=9222 --incognito --disable-extensions --auto-open-devtools-for-tabs --window-size=1920,1080 --disable-dev-shm-usage").split(' ')
 FIREFOX_OPTS = ENV.fetch('FIREFOX_OPTS', '-headless --width=1920 --height=1080').split(' ')
 

--- a/frontend/spec/shared/linked_agents_is_primary_examples.rb
+++ b/frontend/spec/shared/linked_agents_is_primary_examples.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 # Shared helpers and examples for verifying is_primary behavior on linked agents.
-# NOTE: These examples DO NOT create records. The spec file must define:
+# These examples do not create records. The spec file must define:
 # - let(:record_type) { 'accession' | 'resource' | 'digital_object' | 'archival_object' | 'digital_object_component' | 'event' }
 # - let(:record) { create(:...) } with any linked_agents/rights_statements as needed
-# - let(:edit_path) { "/.../#{record.id}/edit" or the appropriate tree anchor }
+# - let(:edit_path) { "/#{record_type}/#{record.id}/edit" or the appropriate child path }
 
 RSpec.shared_context 'linked agents is_primary helpers' do
   let(:top_level_linked_agents_section) { "section##{record_type}_linked_agents_" }

--- a/frontend/spec/shared/linked_agents_is_primary_examples.rb
+++ b/frontend/spec/shared/linked_agents_is_primary_examples.rb
@@ -25,12 +25,12 @@ RSpec.shared_examples 'supporting is_primary on top-level linked agents' do
     within top_level_linked_agents_first_li do
       expect(page).to have_css(make_primary_btn_selector, text: 'Make Primary', visible: true)
       expect(page).to have_css(primary_btn_selector, text: 'Primary', visible: false)
-      expect(find(is_primary_hidden_selector, visible: false).value).to eq('0')
+      expect(page).to have_css("#{is_primary_hidden_selector}[value='0']", visible: false)
 
       find(make_primary_btn_selector).click
       expect(page).to have_css(primary_btn_selector, text: 'Primary', visible: true)
       expect(page).to have_css(make_primary_btn_selector, text: 'Make Primary', visible: false)
-      expect(find(is_primary_hidden_selector, visible: false).value).to eq('1')
+      expect(page).to have_css("#{is_primary_hidden_selector}[value='1']", visible: false)
     end
 
     find('button', text: 'Save', match: :first).click
@@ -38,7 +38,7 @@ RSpec.shared_examples 'supporting is_primary on top-level linked agents' do
     within top_level_linked_agents_first_li do
       expect(page).to have_css(primary_btn_selector, text: 'Primary', visible: true)
       expect(page).to have_css(make_primary_btn_selector, text: 'Make Primary', visible: false)
-      expect(find(is_primary_hidden_selector, visible: false).value).to eq('1')
+      expect(page).to have_css("#{is_primary_hidden_selector}[value='1']", visible: false)
     end
   end
 
@@ -62,7 +62,7 @@ RSpec.shared_examples 'supporting is_primary on top-level linked agents' do
     within top_level_linked_agents_first_li do
       expect(page).to have_css(make_primary_btn_selector, text: 'Make Primary', visible: true)
       expect(page).to have_css(primary_btn_selector, text: 'Primary', visible: false)
-      expect(find(is_primary_hidden_selector, visible: false).value).to eq('0')
+      expect(page).to have_css("#{is_primary_hidden_selector}[value='0']", visible: false)
     end
   end
 end

--- a/frontend/spec/shared/linked_agents_is_primary_examples.rb
+++ b/frontend/spec/shared/linked_agents_is_primary_examples.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# Shared helpers and examples for verifying is_primary behavior on linked agents.
+# NOTE: These examples DO NOT create records. The spec file must define:
+# - let(:record_type) { 'accession' | 'resource' | 'digital_object' | 'archival_object' | 'digital_object_component' | 'event' }
+# - let(:record) { create(:...) } with any linked_agents/rights_statements as needed
+# - let(:edit_path) { "/.../#{record.id}/edit" or the appropriate tree anchor }
+
+RSpec.shared_context 'linked agents is_primary helpers' do
+  def top_level_linked_agents_section(record_type)
+    "section##{record_type}_linked_agents_"
+  end
+
+  def top_level_linked_agents_first_li(record_type)
+    "#{top_level_linked_agents_section(record_type)} .subrecord-form-list > li[data-index='0']"
+  end
+
+  def rights_statement_linked_agents_section(record_type, index = 0)
+    "##{record_type}_rights_statements__#{index}__linked_agents_"
+  end
+
+  def is_primary_hidden_selector
+    "input[type='hidden'][name$='[is_primary]']"
+  end
+
+  def make_primary_btn_selector
+    'button.is-representative-toggle'
+  end
+
+  def primary_btn_selector
+    'button.is-representative-label'
+  end
+end
+
+RSpec.shared_examples 'supports is_primary on top-level linked agents' do
+  include_context 'linked agents is_primary helpers'
+
+  it 'marks primary and persists the state' do
+    visit edit_path
+
+    within top_level_linked_agents_first_li(record_type) do
+      expect(page).to have_css(make_primary_btn_selector, text: 'Make Primary')
+      expect(find(is_primary_hidden_selector, visible: false).value).to eq('0')
+
+      find(make_primary_btn_selector, match: :first).click
+      expect(find(is_primary_hidden_selector, visible: false).value).to eq('1')
+    end
+
+    find('button', text: 'Save', match: :first).click
+    expect(page).to have_css('.alert.alert-success.with-hide-alert')
+    within top_level_linked_agents_first_li(record_type) do
+      expect(page).to have_button('Primary')
+      expect(find(is_primary_hidden_selector, visible: false).value).to eq('1')
+    end
+  end
+end
+
+RSpec.shared_examples 'disallows is_primary on rights statement linked agents' do
+  include_context 'linked agents is_primary helpers'
+
+  it 'does not show primary UI in rights statement linked agents' do
+    visit edit_path
+    within rights_statement_linked_agents_section(record_type) do
+      expect(page).to have_no_css(make_primary_btn_selector, visible: :all)
+      expect(page).to have_no_css(primary_btn_selector, visible: :all)
+      expect(page).to have_no_css(is_primary_hidden_selector, visible: :all)
+    end
+  end
+end
+
+RSpec.shared_examples 'disallows is_primary on top-level linked agents' do
+  include_context 'linked agents is_primary helpers'
+
+  it 'does not show primary UI for top-level linked agents' do
+    visit edit_path
+    # If a pre-created linked agent exists, the selector will match. Otherwise, this will no-op.
+    if page.has_css?(top_level_linked_agents_first_li(record_type))
+      within top_level_linked_agents_first_li(record_type) do
+        expect(page).to have_no_css(make_primary_btn_selector, visible: :all)
+        expect(page).to have_no_css(primary_btn_selector, visible: :all)
+        expect(page).to have_no_css(is_primary_hidden_selector, visible: :all)
+      end
+    else
+      # Fallback: ensure the section itself has no primary UI
+      within top_level_linked_agents_section(record_type) do
+        expect(page).to have_no_css(make_primary_btn_selector, visible: :all)
+        expect(page).to have_no_css(primary_btn_selector, visible: :all)
+        expect(page).to have_no_css(is_primary_hidden_selector, visible: :all)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[ANW-1874](https://archivesspace.atlassian.net/browse/ANW-1874) was originally reported based on seeing multiple linked agents under the Rights Statement subform on an Accession record being marked as primary after a save attempts was made on an invalid Accession form.

Work on this PR uncovered an additional bug that marking a Rights Statement linked agent as "primary" did not "stick", meaning, the record wasn't actually saved with `is_primary` set to true for the given Rights Statement linked agent.

The PRs related to [ANW-504](https://archivesspace.atlassian.net/browse/ANW-504) introduced the feature of allowing a linked agent to be marked as primary. But this was only intended for Accessions, Resources and AOs, Digital Objects and DOCs. However, the same agent linker was used for all use cases where there is an agent linker that corresponds to the `linked_agents` array property on the record's schema (some agent linkers populate a different field than the `linked_agents` array). This `linked_agents` array applies also to Events, and Rights Statements.

So the solution here is to constrain the use of `is_primary`-related logic and markup to only the appropriate Agent subform for Accessions and the "abstract" Archival Objects.

## On the question of is a data migration needed for this PR

Program team devs confirmed that no db migrations are needed for this PR.

## Background info from the ticket that relates to this PR

### Use of is_primary in agent linkers whose schema DOES support is_primary

1. [Abstract Archival Objects](https://github.com/archivesspace/archivesspace/blob/master/common/schemas/abstract_archival_object.rb#L87)
2. [Accessions](https://github.com/archivesspace/archivesspace/blob/master/common/schemas/accession.rb#L189)

### Use of is_primary in agent linkers whose schema DOES NOT support is_primary

1. [Rights Statements agent linker (nested in the Rights Statement subform)](https://github.com/archivesspace/archivesspace/blob/master/common/schemas/rights_statement.rb)
2. [Event Agent Links (top-level subform)](https://github.com/archivesspace/archivesspace/blob/master/common/schemas/event.rb)

### Other uses of linked agents

Note that the Classification Basic Information and the Agent Related Agents subforms use the agent linker too, and have no is_primary in their schemas, but they aren’t used via the linked_agents property like the others are, so the problem doesn’t exist with these two uses.

See past work on adding “primary” agents to Accessions and Archival Objects, https://archivesspace.atlassian.net/browse/ANW-504.

The agent linker is widely used, including in contexts where is_primary is not relevant.

This creates problems where:

Marking a linked agent as “primary” doesn’t work - you mark it primary, save the form, after saving scroll to the Rights Statement subform, or the Event Agent Links, and notice that the linked agent is no longer marked as primary.

Creating 3 linked agents, marking none as primary, then try to save the form while some other field is invalid, then after the validation error page reload flow, scroll to the Rights Statement subform or the Event Agent Links subform, and notice that all 3 agents are marked as primary!

## Solution screenshots

### Events problem

<img width="3024" height="4590" alt="ANW-1874-event-agent-links-problem(1)" src="https://github.com/user-attachments/assets/d2e3c9a4-1883-4e70-92c9-9d82dcddfdfb" />

### Solution for Events agent linker not showing the "Make Primary" button

<img width="3024" height="3630" alt="ANW-1874-solution-events" src="https://github.com/user-attachments/assets/da11e7d3-b31e-4d0e-adf9-138b943fc403" />

### Solution for Rights Statements agent linkers not showing the "Make Primary" buttons

<img width="3024" height="14052" alt="ANW-1874-solution-rights-statements" src="https://github.com/user-attachments/assets/77beb548-1451-4020-83c0-a97aaf07e0d9" />


[ANW-1874]: https://archivesspace.atlassian.net/browse/ANW-1874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-504]: https://archivesspace.atlassian.net/browse/ANW-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ