### PR TITLE
ANW-1870: Remove non-breaking space character from public infinite_records template

### DIFF
--- a/public/app/views/resources/_infinite_records.html.erb
+++ b/public/app/views/resources/_infinite_records.html.erb
@@ -11,7 +11,7 @@
         class="waypoint"
         data-waypoint-number="<%= i %>"
         data-uris="<%= refs.map {|r| r['ref']}.join(';') %>"
-      >&nbsp;</div>
+      ></div>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
This is a very minor change that just removes a non-breaking space character from the public infinite_records template. 