### PR TITLE
ANW-1993: Fix Assessments records linker 'View' popover

### DIFF
--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -336,6 +336,7 @@ $(function () {
         }
         $('.token-input-list', $linkerWrapper).sortable({
           items: 'li.token-input-token',
+          cancel: '.has-popover', // Prevent dragging when clicking on popover elements
         });
         $('.token-input-list', $linkerWrapper)
           .off('sortupdate')

--- a/frontend/app/assets/stylesheets/archivesspace/token-input.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/token-input.scss
@@ -101,14 +101,14 @@ li.token-input-token {
   margin: 0 4px 4px 0;
   padding: 2px 4px;
 
-  &.has-popover {
-    cursor: pointer;
-  }
-
   &:hover {
     @include vertical(#a4e3ff, #77d5ff);
     @include transition('linear .2s');
   }
+}
+
+ul.token-input-list .has-popover {
+  cursor: default;
 }
 
 .token-popover.popover {
@@ -137,10 +137,6 @@ li.token-input-token .token-input-delete-token {
 
 li.token-input-selected-token {
   font-weight: bold;
-}
-
-li.token-input-selected-token span {
-  color: #bbb;
 }
 
 div.token-input-dropdown {

--- a/frontend/spec/features/assessments_spec.rb
+++ b/frontend/spec/features/assessments_spec.rb
@@ -377,4 +377,27 @@ describe 'Assessments', js: true do
       expect(cells[1]).to have_text(assessment.id)
     end
   end
+
+  describe 'Records linker' do
+    let(:resource) {
+      create(
+        :resource,
+        title: "Test resource #{Time.now.to_i}"
+      )
+    }
+    let(:assessment) {
+      create(:json_assessment, {
+        'records' => [{'ref' => resource.uri}]
+      })
+    }
+
+    before(:each) do
+      visit "assessments/#{assessment.id}/edit"
+    end
+
+    let(:linker_token_selector) { '.linker-wrapper:has(#token-input-assessment_records_) .token-input-token' }
+    let(:linked_record) { resource }
+
+    it_behaves_like 'having a popover to view the linked record'
+  end
 end

--- a/frontend/spec/shared/linker_examples.rb
+++ b/frontend/spec/shared/linker_examples.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# These variables should be defined in the calling spec:
+# - let(:linked_record) - the linked record object
+# - let(:linker_token_selector) - the selector for the linked record token in the linker
+RSpec.shared_examples 'having a popover to view the linked record' do
+  it 'opens the readonly view of the linked record in a new browser tab' do
+    readonly_linked_record_path = "#{linked_record['jsonmodel_type']}s/#{linked_record['id']}"
+
+    aggregate_failures 'starting out not on the linked record page' do
+      expect(current_path).not_to match(readonly_linked_record_path)
+    end
+
+    aggregate_failures 'popover is shown by clicking the linked record token' do
+      expect(page).to have_css(linker_token_selector, text: linked_record['title'])
+      expect(page).not_to have_css('body > .popover:last-child', visible: :all)
+      find(linker_token_selector).click
+      expect(page).to have_css('body > .popover:last-child', text: 'View', visible: true)
+    end
+
+    aggregate_failures 'clicking the popover link opens the linked record in a new browser tab' do
+      within 'body > .popover:last-child' do
+        click_on 'View'
+      end
+
+      expect(page.windows.size).to eq 2
+      switch_to_window(page.windows[1])
+
+      expect(page).to have_css('.record-pane h2', text: linked_record['title'])
+      expect(current_path).to match(readonly_linked_record_path)
+    end
+
+    aggregate_failures 'resetting the browser' do
+      page.current_window.close
+      switch_to_window(page.windows[0])
+      expect(page.windows.size).to eq 1
+      expect(current_path).not_to match(readonly_linked_record_path)
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes a bug where, on the staff Assessments edit form, the selected record in the records linker in the "Basic Information" subform did not show the "View" popover when the selected record was clicked, as is expected on all linkers.

This PR also makes the mouse pointer consistent across linkers for interacting with the selected record, and the color of full linked record display string more consistent, including any icons when present, when the record title has been clicked to show the "View" popover.

[ANW-1993](https://archivesspace.atlassian.net/browse/ANW-1993)

## Screenshots

### Problem

![ANW-1993-problem](https://github.com/user-attachments/assets/8632140f-f310-42b8-b72f-72ce9d0ea818)

### Solution

![ANW-1993-solution](https://github.com/user-attachments/assets/1637dfc6-3c48-4c78-b1e6-d193679a91e7)


[ANW-1993]: https://archivesspace.atlassian.net/browse/ANW-1993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ