### PR TITLE
fix: Remove unnecessary record creation in frontend events spec

### DIFF
--- a/frontend/spec/factories.rb
+++ b/frontend/spec/factories.rb
@@ -318,13 +318,6 @@ module Factories
         height { '20' }
         depth { '20' }
       end
-
-      factory :event, class: JSONModel(:event) do
-        event_type { generate(:event_type) }
-        date { build(:date) }
-        linked_agents { [{'ref' => create(:agent_person).uri, 'role' => generate(:agent_role)}] }
-        linked_records { [{'ref' => create(:accession).uri, 'role' => generate(:record_role)}] }
-      end
     end
   end
 end

--- a/frontend/spec/features/events_spec.rb
+++ b/frontend/spec/features/events_spec.rb
@@ -285,14 +285,12 @@ describe 'Events', js: true do
   end
 
   describe 'Linked Agents is_primary behavior' do
-    let(:record_type) { 'event' }
-    let(:record) { create(:event) }
-    let(:edit_path) { "/events/#{record.id}/edit" }
-
     before :each do
       login_admin
-      select_repository @repository
     end
+
+    let(:record_type) { 'event' }
+    let(:edit_path) { "/events/new" }
 
     it_behaves_like 'not supporting is_primary on top-level linked agents'
   end

--- a/frontend/spec/shared/linked_agents_is_primary_examples.rb
+++ b/frontend/spec/shared/linked_agents_is_primary_examples.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 # Shared helpers and examples for verifying is_primary behavior on linked agents.
-# These examples do not create records. The spec file must define:
-# - let(:record_type) { 'accession' | 'resource' | 'digital_object' | 'archival_object' | 'digital_object_component' | 'event' }
-# - let(:record) { create(:...) } with any linked_agents/rights_statements as needed
-# - let(:edit_path) { "/#{record_type}/#{record.id}/edit" or the appropriate child path }
 
+# Requires:
+# - let(:record_type) - 'accession', etc.
 RSpec.shared_context 'linked agents is_primary helpers' do
   let(:top_level_linked_agents_section) { "section##{record_type}_linked_agents_" }
   let(:top_level_linked_agents_first_li) { "#{top_level_linked_agents_section} .subrecord-form-list > li[data-index='0']" }
@@ -16,6 +14,9 @@ RSpec.shared_context 'linked agents is_primary helpers' do
   let(:save_button_selector) { 'button[type="submit"]' }
 end
 
+# Requires:
+# - let(:record_type) - 'accession', etc.
+# - let(:edit_path) - the edit path for the record
 RSpec.shared_examples 'supporting is_primary on top-level linked agents' do
   include_context 'linked agents is_primary helpers'
 
@@ -67,6 +68,9 @@ RSpec.shared_examples 'supporting is_primary on top-level linked agents' do
   end
 end
 
+# Requires:
+# - let(:record_type) - 'accession', etc.
+# - let(:edit_path) - the edit path for the record
 RSpec.shared_examples 'not supporting is_primary on top-level linked agents' do
   include_context 'linked agents is_primary helpers'
 
@@ -80,6 +84,9 @@ RSpec.shared_examples 'not supporting is_primary on top-level linked agents' do
   end
 end
 
+# Requires:
+# - let(:record_type) - 'accession', etc.
+# - let(:edit_path) - the edit path for the record
 RSpec.shared_examples 'not supporting is_primary on rights statement linked agents' do
   include_context 'linked agents is_primary helpers'
 


### PR DESCRIPTION
This PR replaces the creation of an event record in a spec with the new event form to avoid the unnecessary overhead.

It also undoes the `:event` factory created alongside the event record creation from the recent [ANW-1874](https://github.com/archivesspace/archivesspace/pull/3730) since it is no longer used (and probably shouldn't have been created in the first place since `create(:json_event)` exists).

[ANW-1874]: https://archivesspace.atlassian.net/browse/ANW-1874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ