### PR TITLE
Avoid Memory Leaks in Converters

### DIFF
--- a/backend/spec/jsonmodel_import_context_spec.rb
+++ b/backend/spec/jsonmodel_import_context_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'Import JSONModel context' do
+
+  # JSONModel.parse_reference uses a cache to quickly determine an
+  # object's model. But if JSONModel is modified to use a different
+  # uri pattern, the cache will explode if object.id is called for
+  # objects with the variant pattern, such as temporary import uris.
+  it "does not break the JSONModel.parse_reference caching model" do
+    model_lookup_cache = JSONModel.class_variable_get(:@@model_lookup_cache)
+    obj = ASpaceImport::JSONModel(:accession).new
+    expect(model_lookup_cache.value[obj.uri]).to be_nil
+    obj.id
+    expect(model_lookup_cache.value[obj.uri]).to be_nil
+  end
+end

--- a/common/jsonmodel.rb
+++ b/common/jsonmodel.rb
@@ -100,7 +100,7 @@ module JSONModel
   # trying every model every time can be quite significant.  Trying to be a bit
   # cleverer...
   #
-  REFERENCE_KEY_REGEX = /(\/[0-9]+)/
+  REFERENCE_KEY_REGEX = /(\/[0-9]+)|(\/import_[a-f0-9-]+)/
   @@model_lookup_cache = Atomic.new({})
 
   def self.parse_reference(reference, opts = {})


### PR DESCRIPTION
When a JSONModel instance's `id` method is invoked, it calls `parse_reference`, which uses a cache mapping uri patterns to models, e.g. `/respositories/archival_objects => ['archival_object', <Class xxxxx>]`
This is problematic if the object happens to have a non-standard import uri pattern. In these cases an entry was being added to the cache the first time `id` was invoked on any object during an import conversion.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
