### PR TITLE
ANW-2529 Fix sorting for search results tables for Container Profiles, Location Profiles, and Repositories

### DIFF
--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -485,6 +485,7 @@ class IndexerCommon
       if doc['primary_type'] == 'repository'
         doc['repository'] = doc["id"]
         doc['title'] = record['record']['repo_code']
+        doc['title_sort'] = clean_for_sort(record['record']['display_string'])
         doc['repo_sort'] = record['record']['display_string']
         doc['slug'] = record['record']['slug']
         doc['is_slug_auto'] = record['record']['is_slug_auto']
@@ -867,6 +868,7 @@ class IndexerCommon
     add_document_prepare_hook {|doc, record|
       if doc['primary_type'] == 'container_profile'
         doc['title'] = record['record']['display_string']
+        doc['title_sort'] = clean_for_sort(record['record']['display_string'])
         doc['display_string'] = record['record']['display_string']
         doc['note'] = record['record']['note']
 
@@ -891,6 +893,7 @@ class IndexerCommon
     add_document_prepare_hook {|doc, record|
       if doc['primary_type'] == 'location_profile'
         doc['title'] = record['record']['display_string']
+        doc['title_sort'] = clean_for_sort(record['record']['display_string'])
         doc['display_string'] = record['record']['display_string']
 
         ['width', 'height', 'depth'].each do |property|


### PR DESCRIPTION
This PR stems from [ANW-2529](https://archivesspace.atlassian.net/browse/ANW-2529), and is meant to feed the PR for [ANW-2171](https://archivesspace.atlassian.net/browse/ANW-2171). This PR fixes the broken sort functionality on the Title field for Container Profiles, Location Profiles, and Repositories, by adding the missing `title_sort` index field for each record type.

This issue was discovered while working on the tests for ANW-2171. As such, the specs for this PR will be made available via ANW-2171 (see #3761).

## Screenshots

### Problem

![broken container profiles browse table sorting](https://github.com/user-attachments/assets/12fec933-5b61-4442-ad92-0638d43efc57)

![broken location profiles linker browse modal table sorting](https://github.com/user-attachments/assets/5d3b2601-02da-410c-8f56-87977add393e)

![broken repositories browse table sorting](https://github.com/user-attachments/assets/b470a3e4-4dfd-459f-b50f-17f1a1cb3e7d)

### Solution

![ANW-2529-container-profiles](https://github.com/user-attachments/assets/942fa575-cd70-4586-afaa-24973ec30239)

![ANW-2529-location-profiles](https://github.com/user-attachments/assets/8bfa3409-7616-43a0-95b8-991119ac96f8)

![ANW-2529-repos](https://github.com/user-attachments/assets/341b1edd-d58e-4db4-a6af-98881cb23662)



[ANW-2529]: https://archivesspace.atlassian.net/browse/ANW-2529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-2171]: https://archivesspace.atlassian.net/browse/ANW-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ