### PR TITLE
standardize all docker compose to image: mysql:8

### DIFF
--- a/docker-compose-dev-full.yml
+++ b/docker-compose-dev-full.yml
@@ -1,7 +1,7 @@
 # docker-compose -f docker-compose-release.yml build
 # docker-compose -f docker-compose-release.yml up
 
-version: '3.8'
+version: "3.8"
 
 x-app: &app
 
@@ -30,7 +30,7 @@ services:
       - 4567:4567
 
   db:
-    image: mysql:8.0-oracle
+    image: mysql:8
     command: --character-set-server=UTF8MB4 --innodb_buffer_pool_size=2G --innodb_buffer_pool_instances=2 --log_bin_trust_function_creators=1
     ports:
       - "3308:3306"
@@ -43,19 +43,19 @@ services:
     command: solr-create -p 8983 -c archivesspace -d archivesspace
     ports:
       - "8985:8983"
-#  web:
-#    build:
-#      args:
-#        default: default.conf.release
-#      context: ./proxy
-#    image: archivesspace/proxy-release:1.21
-#    ports:
-#      - "8080:80"
-#    depends_on:
-#      - app
+  #  web:
+  #    build:
+  #      args:
+  #        default: default.conf.release
+  #      context: ./proxy
+  #    image: archivesspace/proxy-release:1.21
+  #    ports:
+  #      - "8080:80"
+  #    depends_on:
+  #      - app
 
   db-test:
-    image: mysql:8.0-oracle
+    image: mysql:8
     command: --character-set-server=UTF8MB4 --innodb_buffer_pool_size=2G --innodb_buffer_pool_instances=2 --log_bin_trust_function_creators=1
     ports:
       - "3307:3306"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -5,7 +5,7 @@ version: '3.8'
 services:
   db1:
     container_name: as_dev_db
-    image: mysql:8.0
+    image: mysql:8
     command: --character-set-server=UTF8MB4 --innodb_buffer_pool_size=2G --innodb_buffer_pool_instances=2 --log_bin_trust_function_creators=1
     ports:
       - "3306:3306"
@@ -16,7 +16,7 @@ services:
       - ./build/mysql_db_fixtures:/docker-entrypoint-initdb.d
   db2:
     container_name: as_test_db
-    image: mysql:8.0
+    image: mysql:8
     command: --character-set-server=UTF8MB4 --innodb_buffer_pool_size=2G --innodb_buffer_pool_instances=2 --log_bin_trust_function_creators=1
     ports:
       - "3307:3306"

--- a/docker-compose-dist.yml
+++ b/docker-compose-dist.yml
@@ -26,7 +26,7 @@ services:
       - .env.docker.release
   db:
     container_name: as_dist_db
-    image: mysql:8.0
+    image: mysql:8
     command: --character-set-server=UTF8MB4 --innodb_buffer_pool_size=2G --innodb_buffer_pool_instances=2 --log_bin_trust_function_creators=1
     ports:
       - "3309:3306"

--- a/docker-compose-release.yml
+++ b/docker-compose-release.yml
@@ -16,7 +16,7 @@ services:
       - .env.docker.release
   db:
     container_name: as_release_db
-    image: mysql:8.0
+    image: mysql:8
     command: --character-set-server=UTF8MB4 --innodb_buffer_pool_size=2G --innodb_buffer_pool_instances=2 --log_bin_trust_function_creators=1
     ports:
       - "3308:3306"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - 4567:4567
 
   db:
-    image: mysql:8.0-oracle
+    image: mysql:8
     command: --character-set-server=UTF8MB4 --innodb_buffer_pool_size=2G --innodb_buffer_pool_instances=2 --log_bin_trust_function_creators=1
     ports:
       - "3308:3306"
@@ -56,7 +56,7 @@ services:
 #      - app
 
   db-test:
-    image: mysql:8.0-oracle
+    image: mysql:8
     command: --character-set-server=UTF8MB4 --innodb_buffer_pool_size=2G --innodb_buffer_pool_instances=2 --log_bin_trust_function_creators=1
     ports:
       - "3307:3306"


### PR DESCRIPTION
These different docker-compose files had slightly different mysql docker images. This sets them all to "image: mysql:8" which will pull the latest 8 version which is currently 8.4.7

```
image: mysql:8
MySQL Server 8.4.7

image: mysql:8.0
Server version: 8.0.44 

image: mysql:mysql:8.0-oracle
MySQL Server 8.0.44 
```

8.0.44 is latest in 8.0
8.4.7 is latest in 8.4

8.0 every version EOLs next year so ArchivesSpace should probably be running 8.4 now.