### PR TITLE
ANW-2536: Fix the default column sorting on page load for the repositories index view

### DIFF
--- a/frontend/app/controllers/repositories_controller.rb
+++ b/frontend/app/controllers/repositories_controller.rb
@@ -11,8 +11,9 @@ class RepositoriesController < ApplicationController
 
 
   def index
-    @search_data = Search.global(params_for_backend_search.merge({"facet[]" => []}),
-                                 "repositories")
+    criteria = params_for_backend_search.merge({ "facet[]" => [] })
+    criteria["sort"] ||= Search.default_sort_for_type("repositories")
+    @search_data = Search.global(criteria, "repositories")
   end
 
   def reorder

--- a/frontend/spec/features/accessions_spec.rb
+++ b/frontend/spec/features/accessions_spec.rb
@@ -639,7 +639,7 @@ describe 'Accessions', js: true do
             }
           }
         end
-  
+
         before do
           set_repo repo
           record_1
@@ -647,7 +647,7 @@ describe 'Accessions', js: true do
           run_index_round
           login_admin
           select_repository(repo)
-  
+
           # Show 7 of 10 sortable columns
           set_browse_column_preferences('accession', {
             4 => 'Acquisition Type',
@@ -655,10 +655,10 @@ describe 'Accessions', js: true do
             6 => 'Restrictions Apply',
             7 => 'Access Restrictions',
           })
-  
+
           visit '/accessions'
         end
-  
+
         it_behaves_like 'sortable results table'
       end
 
@@ -678,7 +678,7 @@ describe 'Accessions', js: true do
           # TODO: Fix application to sort URIs numerically by ID (separate ticket)
           uri_asc = [record_1, record_2].sort_by { |r| r.uri }.map(&:title)
           uri_desc = uri_asc.reverse
-  
+
           {
             # 'publish' => {
             #   asc: [record_2.title, record_1.title],
@@ -698,7 +698,7 @@ describe 'Accessions', js: true do
             }
           }
         end
-  
+
         before do
           set_repo repo
           record_1
@@ -706,17 +706,17 @@ describe 'Accessions', js: true do
           run_index_round
           login_admin
           select_repository(repo)
-  
+
           # Show the remaining three of ten sortable columns
           set_browse_column_preferences('accession', {
             # 2 => 'Published',
             3 => 'Use Restrictions',
             4 => 'URI'
           })
-  
+
           visit '/accessions'
         end
-  
+
         it_behaves_like 'sortable results table'
       end
     end

--- a/frontend/spec/features/resources_spec.rb
+++ b/frontend/spec/features/resources_spec.rb
@@ -1366,7 +1366,7 @@ describe 'Resources', js: true do
           # TODO: Fix application to sort URIs numerically by ID (separate ticket)
           uri_asc = [record_1, record_2].sort_by { |r| r.uri }.map(&:title)
           uri_desc = uri_asc.reverse
-  
+
           {
             'title_sort' => {
               asc: [record_1.title, record_2.title],
@@ -1382,7 +1382,7 @@ describe 'Resources', js: true do
             }
           }
         end
-  
+
         before do
           set_repo repo
           record_1
@@ -1390,16 +1390,16 @@ describe 'Resources', js: true do
           run_index_round
           login_admin
           select_repository(repo)
-  
+
           # Show all sortable columns
           set_browse_column_preferences('resource', {
             2 => 'Restrictions',
             3 => 'URI'
           })
-  
+
           visit '/resources'
         end
-  
+
         it_behaves_like 'sortable results table'
       end
     end

--- a/frontend/spec/shared/column_sorting_examples.rb
+++ b/frontend/spec/shared/column_sorting_examples.rb
@@ -15,7 +15,7 @@
 # - primary_column_class [String] CSS class for the primary sortable column (default: 'title')
 # - sorting_in_url [Boolean] Whether to verify that sort parameters are reflected in the URL
 # - default_sort_key [String] The sort key that the page uses by default on initial load.
-#   When the first column matches this key, the test expects desc→asc→desc instead of 
+#   When the first column matches this key, the test expects desc→asc→desc instead of
 #   asc→desc→asc, because the page is already sorted by this column in ascending order on page load.
 
 RSpec.shared_examples 'sortable results table' do


### PR DESCRIPTION
This PR fixes a bug where the Repositories index view search results table doesn't set the default sort on page load.

Before this PR, the search results table for the repositories index view wasn't sorting by the default column ("Title") on page load. It was instead sorting by "score desc". This happened because `Search.global` did not apply a default sort when none was provided.

## Solution

![ANW-2536-solution](https://github.com/user-attachments/assets/5fabc0d4-bbe4-4194-ac99-9baca6d338a2)
