### PR TITLE
ANW-2546_add_apple_touch_icon

### DIFF
--- a/frontend/app/views/site/_favicon.html.erb
+++ b/frontend/app/views/site/_favicon.html.erb
@@ -1,2 +1,3 @@
 <link rel="icon" type="image/png" href="<%= asset_path('favicon-AS.png', skip_pipeline: true) %>">
 <link rel="icon" type="image/svg+xml" href="<%= asset_path('favicon-AS.svg', skip_pipeline: true) %>">
+<link rel="apple-touch-icon" type="image/png" href="<%= asset_path('favicon-AS.png', skip_pipeline: true) %>">

--- a/frontend/spec/features/favicons_spec.rb
+++ b/frontend/spec/features/favicons_spec.rb
@@ -4,11 +4,13 @@ require 'rails_helper.rb'
 describe 'Favicons', js: true do
   let(:png) { 'link[rel="icon"][type="image/png"][href="/favicon-AS.png"]' }
   let(:svg) { 'link[rel="icon"][type="image/svg+xml"][href="/favicon-AS.svg"]' }
+  let(:apple) { 'link[rel="apple-touch-icon"][type="image/png"][href="/favicon-AS.png"]' }
 
   it 'are present by default as png and svg' do
     visit '/'
     expect(page).to have_css(png, visible: false)
     expect(page).to have_css(svg, visible: false)
+    expect(page).to have_css(apple, visible: false)
     visit '/favicon-AS.png'
     visit '/favicon-AS.svg'
   end
@@ -19,5 +21,6 @@ describe 'Favicons', js: true do
     visit '/'
     expect(page).to_not have_css(png, visible: false)
     expect(page).to_not have_css(svg, visible: false)
+    expect(page).to_not have_css(apple, visible: false)
   end
 end

--- a/public/app/views/shared/_favicon.html.erb
+++ b/public/app/views/shared/_favicon.html.erb
@@ -1,2 +1,3 @@
 <link rel="icon" type="image/png" href="<%= asset_path('favicon-AS.png', skip_pipeline: true) %>">
 <link rel="icon" type="image/svg+xml" href="<%= asset_path('favicon-AS.svg', skip_pipeline: true) %>">
+<link rel="apple-touch-icon" type="image/png" href="<%= asset_path('favicon-AS.png', skip_pipeline: true) %>">

--- a/public/spec/features/favicons_spec.rb
+++ b/public/spec/features/favicons_spec.rb
@@ -4,11 +4,13 @@ require 'rails_helper.rb'
 describe 'Favicons', js: true do
   let(:png) { 'link[rel="icon"][type="image/png"][href="/favicon-AS.png"]' }
   let(:svg) { 'link[rel="icon"][type="image/svg+xml"][href="/favicon-AS.svg"]' }
+  let(:apple) { 'link[rel="apple-touch-icon"][type="image/png"][href="/favicon-AS.png"]' }
 
   it 'are present by default as png and svg' do
     visit '/'
     expect(page).to have_css(png, visible: false)
     expect(page).to have_css(svg, visible: false)
+    expect(page).to have_css(apple, visible: false)
     visit '/favicon-AS.png'
     visit '/favicon-AS.svg'
   end
@@ -19,5 +21,6 @@ describe 'Favicons', js: true do
     visit '/'
     expect(page).to_not have_css(png, visible: false)
     expect(page).to_not have_css(svg, visible: false)
+    expect(page).to_not have_css(apple, visible: false)
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds a valid `apple-touch-icon` to resolve recurring FATAL log lines as described in JIRA.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://archivesspace.atlassian.net/browse/ANW-2546

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
_Maybe?_ This just uses this existing ASpace favicon, and instructions on how to customize that (and cease using the defaults shipped with ArchivesSpace) are at: https://docs.archivesspace.org/customization/plugins/#customizing-the-favicon As currently delivered, this won't really change any of that.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
