### PR TITLE
ANW-2654: Bump CI dependencies

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - name: Cache JRuby
       id: cache-jruby
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: ${{ runner.os }}-java${{ inputs.java-version || 11 }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         path: |
@@ -48,7 +48,7 @@ runs:
 
     - name: Cache gems directory
       id: cache-gems
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: ${{ runner.os }}-java${{ inputs.java-version || 11 }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         path: |
@@ -56,7 +56,7 @@ runs:
 
     - name: Cache mysql connector
       id: cache-mysql-connector
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: ${{ inputs.mysql-connector-url }}
         path: |

--- a/.github/workflows/all_specs_dispatch.yml
+++ b/.github/workflows/all_specs_dispatch.yml
@@ -54,7 +54,7 @@ jobs:
       public: ${{ steps.filter.outputs.public }}
       common: ${{ steps.filter.outputs.common }}
     steps:
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@v4
       id: filter
       with:
         filters: |

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -48,9 +48,9 @@ jobs:
           - 8984:8983
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         java-version: ${{ inputs.java-version || 17 }} # https://archivesspace.atlassian.net/browse/ANW-2022
         distribution: temurin

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -57,7 +57,7 @@ jobs:
       image_tag: ${{ steps.meta_archivesspace.outputs.version }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ inputs.java-version || 17 }}
           distribution: temurin
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: npm ci
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: npm ci
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/common-frontend.yml
+++ b/.github/workflows/common-frontend.yml
@@ -94,7 +94,7 @@ jobs:
         SELENIUM_CHROME: ${{ inputs.browser == 'chrome' }}
         ARCHIVESSPACE_VERSION: ${{ github.ref }}
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       if: failure()
       with:
         name: failed_spec_saved_pages(${{ inputs.name }})_Java_${{ inputs.java-version || 17 }}

--- a/.github/workflows/common-frontend.yml
+++ b/.github/workflows/common-frontend.yml
@@ -52,8 +52,8 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - run: geckodriver --version
     - run: firefox --version
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
       with:
         java-version: ${{ inputs.java-version || 17 }}
         distribution: temurin

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -30,9 +30,9 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         java-version: ${{ inputs.java-version || 17 }} # https://archivesspace.atlassian.net/browse/ANW-2022
         distribution: temurin

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-results-shard-${{ matrix.shard }}
           path: |
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload screenshots on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-failure-screenshots-shard-${{ matrix.shard }}
           path: /tmp/screenshots/

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -30,8 +30,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
       with:
         java-version: ${{ inputs.java-version || 17 }}
         distribution: temurin

--- a/.github/workflows/locales.yml
+++ b/.github/workflows/locales.yml
@@ -33,7 +33,7 @@ jobs:
     name: fix_locales
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -65,7 +65,7 @@ jobs:
             echo "should_proceed=true" >> $GITHUB_OUTPUT
             echo "Will create commit with message: $EXPECTED_MESSAGE"
           fi
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: steps.check-last-commit.outputs.should_proceed == 'true'
         with:
           java-version: ${{ inputs.java-version || 17  }} # https://github.com/actions/runner/issues/2372

--- a/.github/workflows/public.yml
+++ b/.github/workflows/public.yml
@@ -101,7 +101,7 @@ jobs:
 
     - name: Upload the ci logs
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failed_spec_saved_pages(public)_Java_${{ inputs.java-version || 17 }}
         path: ci_logs/*

--- a/.github/workflows/public.yml
+++ b/.github/workflows/public.yml
@@ -67,8 +67,8 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - run: geckodriver --version
     - run: firefox --version
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
       with:
         java-version: ${{ inputs.java-version || 17  }} # https://github.com/actions/runner/issues/2372
         distribution: temurin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           fetch-depth: 0
@@ -23,7 +23,7 @@ jobs:
       - run: git fetch --tags
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17' # https://archivesspace.atlassian.net/browse/ANW-2022

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17' # https://archivesspace.atlassian.net/browse/ANW-2022


### PR DESCRIPTION
[ANW-2654](https://archivesspace.atlassian.net/browse/ANW-2654)

This PR fixes most of the Node.js 20 deprecation warning messages in our current CI runs.

Of the 5 outdated dependencies listed in the ticket. At the time of writing, there wasn't an update available for [`browser-actions/setup-geckodriver@latest`](https://github.com/browser-actions/setup-geckodriver).

## Screenshots of the solution

### Showing no more warnings

[via the Rubocop job](https://github.com/archivesspace/archivesspace/actions/runs/23211201235/job/67460174165):

<img width="1228" height="628" alt="Screenshot 2026-03-17 at 4 19 21 PM" src="https://github.com/user-attachments/assets/59d460b3-5e86-4db1-83a3-d790bfe70e54" />

### Showing only the expected `browser-actions/setup-geckodriver@latest` warning

[Via a frontend job](https://github.com/archivesspace/archivesspace/actions/runs/23211201235/job/67460682728):

<img width="1416" height="789" alt="Screenshot 2026-03-17 at 4 20 01 PM" src="https://github.com/user-attachments/assets/c9f225d0-fa3f-409a-9def-f9416d44290d" />


[ANW-2654]: https://archivesspace.atlassian.net/browse/ANW-2654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ