### PR TITLE
Make Boolean and Sort Search opts thread-safe

### DIFF
--- a/public/app/models/search.rb
+++ b/public/app/models/search.rb
@@ -1,30 +1,28 @@
 class Search < Struct.new(:q, :op, :field, :limit, :from_year, :to_year, :filter_fields, :filter_values, :filter_q, :filter_from_year, :filter_to_year, :recordtypes, :dates_searched, :sort, :dates_within, :text_within, :search_statement)
 
   @@BooleanOpts = []
-
-  def Search.get_boolean_opts
-    if @@BooleanOpts.empty?
-      %w(AND OR NOT).each do |opt|
-        @@BooleanOpts.push([ I18n.t("advanced_search.operator.#{opt}"), opt])
-      end
-    end
-    @@BooleanOpts
-  end
-
-  # we create all the possible sort options here, then refine them according to what's being sorted
   @@SortOpts = {}
 
-  def Search.get_sort_opts
-    if @@SortOpts.empty?
-      @@SortOpts['relevance'] = [I18n.t('search_sorting.relevance'), ""]
-      # the things we do for I18n!
-      %w(title_sort year_sort identifier).each do |type|
-        %w(asc desc).each do |dir|
-          @@SortOpts["#{type}_#{dir}"] = [I18n.t('search_sorting.sorting', :type => I18n.t("search_sorting.#{type}"), :direction => I18n.t("search_sorting.#{dir}")), "#{type} #{dir}"]
-        end
+  def self.init
+    %w(AND OR NOT).each do |opt|
+      @@BooleanOpts.push([ I18n.t("advanced_search.operator.#{opt}"), opt])
+    end
+    @@SortOpts['relevance'] = [I18n.t('search_sorting.relevance'), ""]
+    # the things we do for I18n!
+    %w(title_sort year_sort identifier).each do |type|
+      %w(asc desc).each do |dir|
+        @@SortOpts["#{type}_#{dir}"] = [I18n.t('search_sorting.sorting', :type => I18n.t("search_sorting.#{type}"), :direction => I18n.t("search_sorting.#{dir}")), "#{type} #{dir}"]
       end
     end
-    @@SortOpts
+  end
+
+  def Search.get_boolean_opts
+    @@BooleanOpts.dup
+  end
+
+
+  def Search.get_sort_opts
+    @@SortOpts.dup
   end
 
 

--- a/public/config/application.rb
+++ b/public/config/application.rb
@@ -100,6 +100,10 @@ module ArchivesSpacePublic
   end
 end
 
+Rails.application.config.after_initialize do
+  Search.init
+end
+
 # Load plugin init.rb files (if present)
 ASUtils.order_plugins(ASUtils.find_local_directories('public')).each do |dir|
   init_file = File.join(dir, "plugin_init.rb")

--- a/public/spec/models/search_spec.rb
+++ b/public/spec/models/search_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe "Search model" do
+
+  it "doesn't allow concurrency to overpopulate Boolean Opts" do
+    threads = []
+    5.times do
+      threads << Thread.new do
+        Search.get_boolean_opts
+      end
+    end
+    threads.map(&:join)
+    boolean_opts = Search.get_boolean_opts
+    boolean_opts.reject! {|opt| opt.nil?}
+    entries = boolean_opts.map {|pair| pair[0] }
+    expect(entries).to eq entries.uniq
+  end
+end


### PR DESCRIPTION
Boolean and Sort opts are stored as class variables of the Search class. Previously these were initialized on demand in the context of a request. In cases where two or more request occurred simultaneously after startup, these variables could be overpopulated with redundant entries.

## Description
I moved the logic for populating `Search::@@BooleanOpts` and `Search::@@SortOpts` from getter methods 
to a dedicated `init` method that is now called in the `after_initialize` block. This prevents the possibility of
these variables being overpopulated by competing requests after app startup. See attached screenshot.

## Related JIRA Ticket or GitHub Issue
None / Unknown

## How Has This Been Tested?
I added a test for `@@BooleanOpts` - I omitted tests for `@@SortOpts` because it is harder to reproduce the 
problem consistently, though it does exit there as well: 

```
      expected: ["relevance", "title_sort_asc", "title_sort_desc", "year_sort_asc", "year_sort_desc", "identifier_asc", "identifier_desc"]
            got: ["relevance", "title_sort_asc", "title_sort_asc", "title_sort_desc", "year_sort_asc", "year_sort_desc", "identifier_asc", "identifier_asc", "identifier_desc"]
```

## Screenshots (if appropriate):
<img width="583" height="367" alt="image" src="https://github.com/user-attachments/assets/9ba072cc-20bb-4a24-9a83-dca2eadf52c6" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
