### PR TITLE
Add workflow to dispatch an event for the Tech Docs repo to consume

### DIFF
--- a/.github/workflows/tech-docs-release-dispatch.yml
+++ b/.github/workflows/tech-docs-release-dispatch.yml
@@ -1,0 +1,30 @@
+# Notifies archivesspace/tech-docs when a new release is published to auto-update
+# its mention of the latest release.
+
+name: Tech-docs release dispatch
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch-tech-docs:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.TECH_DOCS_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'archivesspace',
+              repo: 'tech-docs',
+              event_type: 'new-archivesspace-release',
+              client_payload: {
+                tag_name: context.payload.release.tag_name,
+                html_url: context.payload.release.html_url,
+              },
+            })

--- a/.github/workflows/tech-docs-release-dispatch.yml
+++ b/.github/workflows/tech-docs-release-dispatch.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.TECH_DOCS_DISPATCH_TOKEN }}
+          github-token: ${{ secrets.ASPACE_CI_BOT_TOKEN }}
           script: |
             await github.rest.repos.createDispatchEvent({
               owner: 'archivesspace',


### PR DESCRIPTION
This workflow runs when a new release is published. It sends the new release tag and url to the Tech Docs repo, which then submits a PR to update the latest release version listed in the docs. This workflow uses the [aspace-ci-bot](https://github.com/aspace-ci-bot).

See https://github.com/archivesspace/tech-docs/pull/305
- the Tech Docs Action run in response to a mock `new-archivesspace-release` event, see https://github.com/archivesspace/tech-docs/actions/runs/23760785479