### PR TITLE
ANW-2687: Fix URLs in both apps with invalid double-slashes when running the Docker production setup

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -382,9 +382,9 @@
       <env key="APPCONFIG_DB_URL" value="jdbc:mysql://db:3306/archivesspace?useUnicode=true&amp;characterEncoding=UTF-8&amp;user=as&amp;password=as123&amp;useSSL=false&amp;allowPublicKeyRetrieval=true" />
       <env key="APPCONFIG_SOLR_URL" value="http://solr:8983/solr/archivesspace" />
       <env key="APPCONFIG_FORCE_SSL" value="false" />
-      <env key="APPCONFIG_FRONTEND_PROXY_URL" value="http://localhost/staff/" />
+      <env key="APPCONFIG_FRONTEND_PROXY_URL" value="http://localhost/staff" />
       <env key="APPCONFIG_OAI_PROXY_URL" value="http://localhost/oai" />
-      <env key="APPCONFIG_PUBLIC_PROXY_URL" value="http://localhost/" />
+      <env key="APPCONFIG_PUBLIC_PROXY_URL" value="http://localhost" />
 
       <arg line="-Iapp/lib scripts/export_config.rb docker_prod/archivesspace/config/config.rb true" />
     </java>

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -220,6 +220,7 @@ AppConfig[:allow_non_utf8_mysql_database] = false
 # If you are serving user-facing applications via proxy
 # (i.e., another domain or port, or via https, or for a prefix) it is
 # recommended that you record those URLs in your configuration
+# NOTE: ensure no trailing slashes on these URLs
 AppConfig[:frontend_proxy_url] = proc { AppConfig[:frontend_url] }
 AppConfig[:public_proxy_url] = proc { AppConfig[:public_url] }
 AppConfig[:oai_proxy_url] = 'http://your-public-oai-url.example.com'


### PR DESCRIPTION
[ANW-2687](https://archivesspace.atlassian.net/browse/ANW-2687)

This PR fixes an issue where some public and frontend URLs contained double-slashes when running in the Docker production environment. This bug resulted in:

**PUI bugs**

- a resource's "Collection Organization" view not loading any data
- the "Staff Only" button not showing up when a user was also logged into the SUI
- the “Cite Item Description” provided an invalid URL back to the item being cited
- invalid URLs were provided to search engines via JSON-LD `application/ld+json` script blocks

**SUI bugs**

- Location batch update sidebar (see related screenshot section for steps to reproduce)
- OAI config edit page
- Active bulk import job redirect (solution not shown here)

## Note about testing this with a different docker image

The first commit in this PR changed view files and thus could be transformed into plugins and tested against the v4.2.0 release Docker configuration package. However the second and third commits changed controller and model files and thus could not be transformed into plugins and tested against the v4.2.0 Docker config package.

[NOTE that the commits in this PR changed, see the original commits at #4022]

So [a separate PR was opened with the changes from this PR on a branch cut from the the `release-v4.2.x` branch](https://github.com/archivesspace/archivesspace/pull/4022) to verify that the new release works as expected with regard to these issues. This was done by 1) deleting the related docker containers, images, and volumes, then 2) editing the `.env` file in the docker application with the following change (and 3) re-running `docker compose up --detach` after):

```diff
- ARCHIVESSPACE_DOCKER_TAG=4.2.0
+ ARCHIVESSPACE_DOCKER_TAG=ANW-2687
```

The same change was applied to the v4.1.1 docker config package to confirm these fixes in that release as well.

## Screenshots of the PUI solution

### Collection Organization fix

This screenshot shows the Collection Organization page with data loaded as expected.

<img width="1488" height="884" alt="solution showing Collection Org data loaded and Staff Only button" src="https://github.com/user-attachments/assets/aceaf49f-b716-4157-b13e-23c715534c98" />

### Staff only, citation, and SEO fixes

This screenshot shows the "Staff Only" link for a logged in user, correct citation data, and SEO metadata in the DOM (not visible in the page).

<img width="754" height="447" alt="solution showing correct citation and SEO metadata" src="https://github.com/user-attachments/assets/6c5eb4af-62f0-49e4-a25f-32cee5be62b9" />

## Screenshots of the SUI solution

### Location batch update sidebar

This screenshot shows the expected URLs on hover of the links in the "Locations to update" sidebar:

1. Go to http://localhost/staff/
2. Navigate to Browse → Locations
3. Select multiple locations using the checkboxes
4. Click Edit Batch
5. In the sidebar on the left, look at the "Locations to Update" links

<img width="1512" height="899" alt="solution sui batch location sidebar" src="https://github.com/user-attachments/assets/035a151c-1bb6-4aff-9c22-35edecebd38e" />

### OAI config edit page

This screenshot shows the expected URLs on hover of the "Per Repo OAI Settings" links:

<img width="1512" height="898" alt="solution sui aoi settings" src="https://github.com/user-attachments/assets/65b8e2a1-715f-4cd8-9a4b-b632d679f684" />

[ANW-2687]: https://archivesspace.atlassian.net/browse/ANW-2687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ