### PR TITLE
Run Rubocop on e2e-tests in codescan workflow

### DIFF
--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -39,6 +39,34 @@ jobs:
         run: |
           ./build/run rubocop
 
+  rubocop-e2e:
+    name: Rubocop-e2e
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: e2e-tests
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.0'
+      - name: Cache gems
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Install gems
+        run: |
+          gem install parallel_tests
+          bundle config path vendor/bundle
+          bundle install --quiet --jobs 4 --retry 3
+      - name: Run rubocop
+        run: |
+          bundle exec rubocop
+
   eslint:
     name: ESLint_Java_v${{ inputs.java-version || 17 }}
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -73,9 +73,6 @@ jobs:
           gem install parallel_tests
           bundle config path vendor/bundle
           bundle install --quiet --jobs 4 --retry 3
-      - name: Run rubocop
-        run: |
-          bundle exec rubocop
       - name: Cucumber strict dry run to check for not implemented steps
         run: |
           bundle exec cucumber --dry-run --strict


### PR DESCRIPTION
## Description
This PR addresses the issue of Rubocop code style checks for the e2e suite running after docker has been built, which means we get a Rubocop failure for the code in the e2e-tests directory too late. 

The rubocop call was running once on each shard of the e2e suite, which also created an additional waste.

To avoid the waste of energy and time, this runs the Rubocop check once as early as possible.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
