### PR TITLE
Replaced ; with & for cURL examples

### DIFF
--- a/backend/app/controllers/exports.rb
+++ b/backend/app/controllers/exports.rb
@@ -234,7 +234,7 @@ class ArchivesSpaceService < Sinatra::Base
         curl -s -F password="admin" "http://localhost:8089/users/admin/login"
         set SESSION="session_id"
         curl -H "X-ArchivesSpace-Session: $SESSION" \\
-        "http://localhost:8089/repositories/2/resources/marc21/577.xml?include_unpublished_marc=true;include_unpublished_notes=false" //
+        "http://localhost:8089/repositories/2/resources/marc21/577.xml?include_unpublished_marc=true&include_unpublished_notes=false" //
         --output marc21.xml
       SHELL
     end

--- a/backend/app/controllers/id_lookup_controller.rb
+++ b/backend/app/controllers/id_lookup_controller.rb
@@ -50,7 +50,7 @@ class ArchivesSpaceService < Sinatra::Base
         # Finding resources with ARKs
         
         curl -H "X-ArchivesSpace-Session: $SESSION" //
-        "http://localhost:8089/repositories/:repo_id:/find_by_id/resources?ark[]=ark%3A%2F####%2F######;resolve[]=resources"
+        "http://localhost:8089/repositories/:repo_id:/find_by_id/resources?ark[]=ark%3A%2F####%2F######&resolve[]=resources"
         # Replace "http://localhost:8089" with your ASpace API URL, :repo_id: with the repository ID, 
         # ark%3A%2F####%2F###### with the ARK you are searching for - NOTE, make sure to encode any characters like 
         # : into %3A and / into %2F - and only add resolve[]=resources if you want the JSON for the returned record - 
@@ -132,21 +132,21 @@ class ArchivesSpaceService < Sinatra::Base
         # If using Git Bash, replace set with export
   
         curl -H "X-ArchivesSpace-Session: $SESSION" //
-        "http://localhost:8089/repositories/:repo_id:/find_by_id/archival_objects?component_id[]=hello_im_a_component_id;resolve[]=archival_objects"
+        "http://localhost:8089/repositories/:repo_id:/find_by_id/archival_objects?component_id[]=hello_im_a_component_id&resolve[]=archival_objects"
         # Replace "http://localhost:8089" with your ASpace API URL, :repo_id: with the repository ID, 
         # "hello_im_a_component_id" with the component ID you are searching for, and only add 
         # "resolve[]=archival_objects" if you want the JSON for the returned record - otherwise, it will return the 
         # record URI only
   
         curl -H "X-ArchivesSpace-Session: $SESSION" //
-        "http://localhost:8089/repositories/:repo_id:/find_by_id/archival_objects?ref_id[]=hello_im_a_ref_id;resolve[]=archival_objects"
+        "http://localhost:8089/repositories/:repo_id:/find_by_id/archival_objects?ref_id[]=hello_im_a_ref_id&resolve[]=archival_objects"
         # Replace "http://localhost:8089" with your ASpace API URL, :repo_id: with the repository ID, 
         # "hello_im_a_ref_id" with the ref ID you are searching for, and only add 
         # "resolve[]=archival_objects" if you want the JSON for the returned record - otherwise, it will return the 
         # record URI only
 
         curl -H "X-ArchivesSpace-Session: $SESSION" //
-        "http://localhost:8089/repositories/:repo_id:/find_by_id/archival_objects?ark[]=ark%3A%2F####%2F######;resolve[]=archival_objects"
+        "http://localhost:8089/repositories/:repo_id:/find_by_id/archival_objects?ark[]=ark%3A%2F####%2F######&resolve[]=archival_objects"
         # Replace "http://localhost:8089" with your ASpace API URL, :repo_id: with the repository ID, 
         # "ark%3A%2F####%2F######" with the ark you are searching for - NOTE, make sure to encode any characters like 
         # : into %3A and / into %2F - and only add "resolve[]=archival_objects" if you want the JSON for the returned 
@@ -221,7 +221,7 @@ class ArchivesSpaceService < Sinatra::Base
         # If using Git Bash, replace set with export
   
         curl -H "X-ArchivesSpace-Session: $SESSION" //
-        "http://localhost:8089/repositories/:repo_id:/find_by_id/digital_object_components?component_id[]=im_a_do_component_id;resolve[]=digital_object_components"
+        "http://localhost:8089/repositories/:repo_id:/find_by_id/digital_object_components?component_id[]=im_a_do_component_id&resolve[]=digital_object_components"
         # Replace "http://localhost:8089" with your ASpace API URL, :repo_id: with the repository ID, 
         # "im_a_do_component_id" with the component ID you are searching for, and only add 
         # "resolve[]=digital_object_components" if you want the JSON for the returned record - otherwise, it will return
@@ -270,7 +270,7 @@ class ArchivesSpaceService < Sinatra::Base
         # If using Git Bash, replace set with export
   
         curl -H "X-ArchivesSpace-Session: $SESSION" //
-        "http://localhost:8089/repositories/:repo_id:/find_by_id/digital_objects?digital_object_id[]=hello_im_a_digobj_id;resolve[]=digital_objects"
+        "http://localhost:8089/repositories/:repo_id:/find_by_id/digital_objects?digital_object_id[]=hello_im_a_digobj_id&resolve[]=digital_objects"
         # Replace "http://localhost:8089" with your ASpace API URL, :repo_id: with the repository ID, 
         # "hello_im_a_digobj_id" with the digital object ID you are searching for, and only add 
         # "resolve[]=digital_objects" if you want the JSON for the returned record - otherwise, it will return the 
@@ -319,14 +319,14 @@ class ArchivesSpaceService < Sinatra::Base
         # If using Git Bash, replace set with export
     
         curl -H "X-ArchivesSpace-Session: $SESSION" //
-        "http://localhost:8089/repositories/:repo_id:/find_by_id/top_containers?indicator[]=123;resolve[]=top_containers"
+        "http://localhost:8089/repositories/:repo_id:/find_by_id/top_containers?indicator[]=123&resolve[]=top_containers"
         # Replace "http://localhost:8089" with your ASpace API URL, :repo_id: with the repository ID, 
         # "123" with the indicator you are searching for, and only add 
         # "resolve[]=top_containers" if you want the JSON for the returned record - otherwise, it will return the 
         # record URI only
     
         curl -H "X-ArchivesSpace-Session: $SESSION" //
-        "http://localhost:8089/repositories/:repo_id:/find_by_id/top_containers?barcode[]=123456789;resolve[]=top_containers"
+        "http://localhost:8089/repositories/:repo_id:/find_by_id/top_containers?barcode[]=123456789&resolve[]=top_containers"
         # Replace "http://localhost:8089" with your ASpace API URL, :repo_id: with the repository ID, 
         # "123456789" with the barcode you are searching for, and only add 
         # "resolve[]=top_containers" if you want the JSON for the returned record - otherwise, it will return the 


### PR DESCRIPTION
Fixes issue introduced in 4.0 where semicolons no longer work for cURL examples. Ampersands are backwards compatible.

## Description
Fixes issue introduced in 4.0 where semicolons no longer work for cURL examples. Ampersands are backwards compatible.

## Related JIRA Ticket or GitHub Issue
#4034
[TD-65](https://archivesspace.atlassian.net/browse/TD-65)

## How Has This Been Tested?
Tested endpoints with new syntax.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[TD-65]: https://archivesspace.atlassian.net/browse/TD-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ