### PR TITLE
ANW-2681 Improve required_fields endpoint documentation and error handling

### DIFF
--- a/backend/app/controllers/required_fields.rb
+++ b/backend/app/controllers/required_fields.rb
@@ -39,11 +39,15 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:manage_repository])
     .returns([200, :created],
              [400, :error]) \
-  do
-    obj = RequiredFields.create_or_update(params[:required_fields], params[:repo_id], params[:record_type])
+    do
+      unless params[:record_type].start_with?("agent_")
+        raise(NotAllowed.new, "You can only customize required fields for agents")
+      end
 
-    updated_response(obj)
-  end
+      obj = RequiredFields.create_or_update(params[:required_fields], params[:repo_id], params[:record_type])
+
+      updated_response(obj)
+    end
 
 
   Endpoint.get('/repositories/:repo_id/required_fields/:record_type')

--- a/backend/app/controllers/required_fields.rb
+++ b/backend/app/controllers/required_fields.rb
@@ -2,7 +2,7 @@ class ArchivesSpaceService < Sinatra::Base
 
 
   Endpoint.post('/repositories/:repo_id/required_fields/:record_type')
-    .description("Require fields for a record type")
+    .description("Add or change repository-level required fields for an agent record type")
     .params(["required_fields", JSONModel(:required_fields), "The fields required", :body => true],
             ["repo_id", :repo_id],
             ["record_type", String])
@@ -17,7 +17,7 @@ class ArchivesSpaceService < Sinatra::Base
 
 
   Endpoint.get('/repositories/:repo_id/required_fields/:record_type')
-    .description("Get required fields for a record type")
+    .description("Get custom, repository-level required fields for an agent record type")
     .params(["repo_id", :repo_id],
             ["record_type", String])
     .permissions([:view_repository])

--- a/backend/app/controllers/required_fields.rb
+++ b/backend/app/controllers/required_fields.rb
@@ -55,15 +55,16 @@ class ArchivesSpaceService < Sinatra::Base
     .params(["repo_id", :repo_id],
             ["record_type", String])
     .permissions([:view_repository])
-    .returns([200, :created],
-             [400, :error]) \
-  do
-    id = "#{params[:repo_id]}_#{params[:record_type]}"
-    json = RequiredFields.to_jsonmodel(id)
+    .returns([200, "[(:required_fields)]"],
+             [400, :error],
+             [404, '{"error" => "RequiredFields not found"}, returned if no custom required '\
+              'fields have been defined for agent record type, or non-agent '\
+              'record type given']) \
+    do
+      id = "#{params[:repo_id]}_#{params[:record_type]}"
+      json = RequiredFields.to_jsonmodel(id)
 
-    json_response(json)
-  end
-
-
+      json_response(json)
+    end
 
 end

--- a/backend/app/controllers/required_fields.rb
+++ b/backend/app/controllers/required_fields.rb
@@ -52,6 +52,12 @@ class ArchivesSpaceService < Sinatra::Base
 
   Endpoint.get('/repositories/:repo_id/required_fields/:record_type')
     .description("Get custom, repository-level required fields for an agent record type")
+    .example("shell") do
+      <<~CONTENTS
+        curl -H "X-ArchivesSpace-Session: $SESSION" \
+          "http://localhost:8089/repositories/2/required_fields/agent_person"
+       CONTENTS
+    end
     .params(["repo_id", :repo_id],
             ["record_type", String])
     .permissions([:view_repository])

--- a/backend/app/controllers/required_fields.rb
+++ b/backend/app/controllers/required_fields.rb
@@ -3,6 +3,36 @@ class ArchivesSpaceService < Sinatra::Base
 
   Endpoint.post('/repositories/:repo_id/required_fields/:record_type')
     .description("Add or change repository-level required fields for an agent record type")
+    .example("shell") do
+      <<~CONTENTS
+        # Add required field to agent_person in repository 2
+        curl -H 'Content-Type: text/json' -H "X-ArchivesSpace-Session: $SESSION" \
+          "http://localhost:8089/repositories/2/required_fields/agent_person" \
+          -d '{
+               "jsonmodel_type": "required_fields",
+               "record_type": "agent_person",
+               "subrecord_requirements": [
+                 {
+                   "property": "metadata_rights_declarations",
+                   "record_type": "metadata_rights_declaration",
+                   "required": true,
+                   "required_fields": [
+                     "descriptive_note"
+                   ]
+                 }
+               ]
+             }'
+
+        # Remove required fields from agent_person in repository 2
+        curl -H 'Content-Type: text/json' -H "X-ArchivesSpace-Session: $SESSION" \
+          "http://localhost:8089/repositories/2/required_fields/agent_person" \
+          -d '{
+               "jsonmodel_type": "required_fields",
+               "record_type": "agent_person",
+               "subrecord_requirements": []
+             }'
+       CONTENTS
+    end
     .params(["required_fields", JSONModel(:required_fields), "The fields required", :body => true],
             ["repo_id", :repo_id],
             ["record_type", String])

--- a/backend/spec/controller_required_fields_spec.rb
+++ b/backend/spec/controller_required_fields_spec.rb
@@ -31,5 +31,25 @@ describe 'Required Fields' do
    expect(required_fields["subrecord_requirements"].first["required_fields"]).to eq(["xlink_title_attribute", "xlink_role_attribute"])
     # at least one subrecord is required
    expect(required_fields["subrecord_requirements"].first["required"]).to be true
- end
+  end
+
+  it "prevents you posting a requirements definition for a repository and non-agent record type" do
+    uri = "/repositories/#{$repo_id}/required_fields/resource"
+    url = URI("#{JSONModel::HTTP.backend_url}#{uri}")
+    required_fields = JSONModel(:required_fields).from_hash(
+      {
+        repo_id: $repo_id,
+        record_type: "resource",
+        subrecord_requirements: [
+          {
+            record_type: "metadata_rights_declaration",
+            property: "metadata_rights_declarations",
+            required: true,
+            required_fields: ["xlink_title_attribute", "xlink_role_attribute"]
+          }
+        ]
+      })
+    response = JSONModel::HTTP.post_json(url, ASUtils.to_json(required_fields))
+    expect(response.status).to eq(400)
+  end
 end

--- a/backend/spec/controller_required_fields_spec.rb
+++ b/backend/spec/controller_required_fields_spec.rb
@@ -4,33 +4,33 @@ require_relative 'spec_slugs_helper'
 describe 'Required Fields' do
 
   it "lets you post and fetch a requirements definition for a repository and record type" do
-   uri = "/repositories/#{$repo_id}/required_fields/agent_person"
-   url = URI("#{JSONModel::HTTP.backend_url}#{uri}")
-   required_fields = JSONModel(:required_fields).from_hash(
-     {
-       repo_id: $repo_id,
-       record_type: "agent_person",
-       subrecord_requirements: [
-         {
-           record_type: "metadata_rights_declaration",
-           property: "metadata_rights_declarations",
-           required: true,
-           required_fields: ["xlink_title_attribute", "xlink_role_attribute"]
-         }
-       ]
-     })
-   response = JSONModel::HTTP.post_json(url, ASUtils.to_json(required_fields))
-   expect(response.status).to eq(200)
-   required_fields = JSONModel(:required_fields).fetch(uri)
+    uri = "/repositories/#{$repo_id}/required_fields/agent_person"
+    url = URI("#{JSONModel::HTTP.backend_url}#{uri}")
+    required_fields = JSONModel(:required_fields).from_hash(
+      {
+        repo_id: $repo_id,
+        record_type: "agent_person",
+        subrecord_requirements: [
+          {
+            record_type: "metadata_rights_declaration",
+            property: "metadata_rights_declarations",
+            required: true,
+            required_fields: ["xlink_title_attribute", "xlink_role_attribute"]
+          }
+        ]
+      })
+    response = JSONModel::HTTP.post_json(url, ASUtils.to_json(required_fields))
+    expect(response.status).to eq(200)
+    required_fields = JSONModel(:required_fields).fetch(uri)
 
     # requirements apply to this type of subrecord
-   expect(required_fields["subrecord_requirements"].first["record_type"]).to eq("metadata_rights_declaration")
+    expect(required_fields["subrecord_requirements"].first["record_type"]).to eq("metadata_rights_declaration")
     # when it is occupying this property on the top-level record
-   expect(required_fields["subrecord_requirements"].first["property"]).to eq("metadata_rights_declarations")
+    expect(required_fields["subrecord_requirements"].first["property"]).to eq("metadata_rights_declarations")
     # the top-level record requires that subrecords of this type have these fields
-   expect(required_fields["subrecord_requirements"].first["required_fields"]).to eq(["xlink_title_attribute", "xlink_role_attribute"])
+    expect(required_fields["subrecord_requirements"].first["required_fields"]).to eq(["xlink_title_attribute", "xlink_role_attribute"])
     # at least one subrecord is required
-   expect(required_fields["subrecord_requirements"].first["required"]).to be true
+    expect(required_fields["subrecord_requirements"].first["required"]).to be true
   end
 
   it "prevents you posting a requirements definition for a repository and non-agent record type" do


### PR DESCRIPTION
## Description

- Clarify required_fields endpoints descriptions
- Add correct shell example for required_fields POST
- Prevent addition of required_fields to non-agent record types
- Document reason for required_fields GET 404 error
- Correct shell example for required_fields GET endpoint

## Related JIRA Ticket or GitHub Issue

https://archivesspace.atlassian.net/browse/ANW-2681

## How Has This Been Tested?

Using development environment set up as per the Tech Docs, synced with master branch: 

- successfully ran backend tests
- generated api docs slate .md file


## Types of changes

This is mostly an API documentation change.

If anyone is using the API to import required_fields for non-agent records for some reason, this does include a breaking change. 

On the other hand, you might consider this a bug fix since it prevents people from creating currently useless ArchivesSpace data, since only agents currently support customized required fields.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [?] My code follows the code style of this project. - I ran `rubocop -a` and it made thousands of changes in hundreds of files, so I reverted that. I did try to follow what I saw in the existing file, in terms of the basic style stuff. Not sure the best way to enforce that I've followed the project code style. Do you all just run rubocop on the files you have changed?
- [ ] My change requires a change to the documentation. - Don't think so
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
