### PR TITLE
ANW-2647 Correcting phantom read/write conflict in bulk/batch imports in MariaDB

### DIFF
--- a/backend/app/lib/job_runners/batch_import_runner.rb
+++ b/backend/app/lib/job_runners/batch_import_runner.rb
@@ -29,15 +29,17 @@ class BatchImportRunner < JobRunner
     import_subjects     = @json.job["import_subjects"] == "1" ? true : false
     import_repository   = @json.job["import_repository"] == "1" ? true : false
 
+	input_file_paths = @job.job_files.map(&:full_file_path)
+
     # Wrap the import in a transaction if the DB supports MVCC
     begin
       DB.open(DB.supports_mvcc?,
               :retry_on_optimistic_locking_fail => true) do
         created_uris = []
         begin
-          @job.job_files.each_with_index do |input_file, i|
+          input_file_paths.each_with_index do |input_file, i|
             ticker.log(("=" * 50) + "\n#{filenames[i]}\n" + ("=" * 50)) if filenames[i]
-            converter = Converter.for(@json.job['import_type'], input_file.full_file_path, {:import_events => import_maint_events, :import_subjects => import_subjects, :import_repository => import_repository})
+            converter = Converter.for(@json.job['import_type'], file_path, {:import_events => import_maint_events, :import_subjects => import_subjects, :import_repository => import_repository})
             begin
               RequestContext.open(:create_enums => true,
                                   :current_username => @job.owner.username,

--- a/backend/app/lib/job_runners/bulk_import_runner.rb
+++ b/backend/app/lib/job_runners/bulk_import_runner.rb
@@ -17,11 +17,17 @@ class BulkImportRunner < JobRunner
     ticker.log("Start new bulk_import for job: #{@job.id}")
     last_error = nil
     # Wrap the import in a transaction if the DB supports MVCC
+
+	# Get the job input file and prep output variables.
+	input_file_path = @job.job_files[0].full_file_path
+	output_file = nil
+	created_uris = []
+
     begin
       DB.open(DB.supports_mvcc?,
               :retry_on_optimistic_locking_fail => true) do
         begin
-          @input_file = @job.job_files[0].full_file_path
+          @input_file = input_file_path
           @current_user = User.find(:username => @job.owner.username)
           @load_type = @json.job["load_type"]
           @validate_only = @json.job["only_validate"] == "true"
@@ -45,12 +51,12 @@ class BulkImportRunner < JobRunner
               ticker.log(("=" * 50) + "\n")
               ticker.log(I18n.t(@validate_only ? "bulk_import.log_validation" : "bulk_import.log_complete", :file => @json.job["filename"]))
               ticker.log("\n" + ("=" * 50) + "\n")
-              file = ASUtils.tempfile("load_spreadsheet_job_")
-              generate_csv(file, report)
-              file.rewind
+              output_file = ASUtils.tempfile("load_spreadsheet_job_")
+              generate_csv(output_file, report)
+              output_file.rewind
               @job.write_output(I18n.t("bulk_import.log_results"))
-              @job.add_file(file)
-              @job.record_created_uris(importer.record_uris) unless @validate_only
+
+              created_uris = importer.record_uris unless @validate_only
             end
           end
         rescue JSONModel::ValidationException, BulkImportException => e
@@ -61,6 +67,17 @@ class BulkImportRunner < JobRunner
       last_error = $!
     end
     self.success!
+	if output_file
+		DB.open do
+			@job.add_file(output_file)
+		end
+	end
+	unless created_uris.nil? || created_uris.empty?
+		DB.open do
+			@job.record_created_uris(created_uris)
+		end
+	end
+
     if last_error
       ticker.log("\n\n")
       ticker.log("!" * 50)


### PR DESCRIPTION
## Description

These changes alter the structure of the SQL queries executed by `bulk_import_runner.rb` and `batch_import_runner.rb` to move the final insertion of the report into the `job_input_file` table outside of the transaction that governs all of the item imports. 

MariaDB was suffering a phantom read/write conflict which caused the bulk imports to fail.

## Related JIRA Ticket or GitHub Issue
[Jira Issue ANW-2647](https://archivesspace.atlassian.net/browse/ANW-2647).

## How Has This Been Tested?

We shut down and applied the changes to our development copy of ArchivesSpace. When they worked, we also applied them to our production copy of ArchivesSpace and had our local archivists try their imports again.  They succeeded.

We have not tested against MySQL, only against MariaDB. I do not anticipate MySQL having any particular issue with this alteration.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project (as far as I know).
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Our attempts to get the test system operational failed with error messages reporting "An error occurred while installing sassc (2.4.0), and Bundler cannot continue."  Testing system is running Red Hat Enterprise Linux release 9.7 with MariaDB 11.8.6 and SE Linux enabled.