### PR TITLE
ANW-785 manage top containers from a resource/accession

### DIFF
--- a/e2e-tests/helpers/helpers.rb
+++ b/e2e-tests/helpers/helpers.rb
@@ -139,6 +139,22 @@ def ensure_test_repository_exists
   end
 
   select_test_repository
+rescue Capybara::ElementNotFound
+  visit STAFF_URL
+  click_on 'System'
+  click_on 'Manage Repositories'
+  click_on 'Create Repository'
+
+  fill_in 'repository_repository__repo_code_', with: 'repository_test'
+  fill_in 'repository_repository__name_', with: 'Repository Test'
+  find('#repository_repository__publish_').check
+  click_on 'Save'
+
+  expect(page).to have_css('.alert.alert-success.with-hide-alert', text: 'Repository Created')
+  expect(page).to have_css('.alert.alert-info.with-hide-alert', text: 'Repository is Currently Selected')
+
+  visit STAFF_URL
+  select_test_repository
 end
 
 def select_test_repository

--- a/e2e-tests/helpers/helpers.rb
+++ b/e2e-tests/helpers/helpers.rb
@@ -139,6 +139,18 @@ def ensure_test_repository_exists
   end
 
   ensure_test_repository_selected
+end
+
+def ensure_test_repository_selected
+  click_on 'Select Repository'
+  within '.dropdown-menu' do
+    find('select').select 'repository_test'
+    click_on 'Select Repository'
+  end
+  expect(find('.alert.alert-success').text).to eq 'The Repository repository_test is now active'
+
+  click_on 'repository_test'
+  @repository_id = current_url.split('/').pop
 rescue Capybara::ElementNotFound
   visit STAFF_URL
   click_on 'System'
@@ -154,17 +166,6 @@ rescue Capybara::ElementNotFound
   expect(page).to have_css('.alert.alert-info.with-hide-alert', text: 'Repository is Currently Selected')
 
   visit STAFF_URL
-  ensure_test_repository_selected
-end
-
-def ensure_test_repository_selected
-  click_on 'Select Repository'
-  within '.dropdown-menu' do
-    find('select').select 'repository_test'
-    click_on 'Select Repository'
-  end
-  expect(find('.alert.alert-success').text).to eq 'The Repository repository_test is now active'
-
   click_on 'repository_test'
   @repository_id = current_url.split('/').pop
 end

--- a/e2e-tests/helpers/helpers.rb
+++ b/e2e-tests/helpers/helpers.rb
@@ -138,7 +138,7 @@ def ensure_test_repository_exists
     visit STAFF_URL
   end
 
-  select_test_repository
+  ensure_test_repository_selected
 rescue Capybara::ElementNotFound
   visit STAFF_URL
   click_on 'System'
@@ -154,10 +154,10 @@ rescue Capybara::ElementNotFound
   expect(page).to have_css('.alert.alert-info.with-hide-alert', text: 'Repository is Currently Selected')
 
   visit STAFF_URL
-  select_test_repository
+  ensure_test_repository_selected
 end
 
-def select_test_repository
+def ensure_test_repository_selected
   click_on 'Select Repository'
   within '.dropdown-menu' do
     find('select').select 'repository_test'

--- a/e2e-tests/staff_features/accessions/step_definitions/accession_shared.rb
+++ b/e2e-tests/staff_features/accessions/step_definitions/accession_shared.rb
@@ -125,6 +125,8 @@ Given 'an Accession with a Top Container has been created' do
   fill_in 'top_container_indicator_', with: @uuid
   click_on 'Create and Link'
 
+  sleep 3
+
   click_on 'Save'
   expect(page).to have_text "Accession Accession Title #{@uuid} created"
 end

--- a/e2e-tests/staff_features/accessions/step_definitions/accession_shared.rb
+++ b/e2e-tests/staff_features/accessions/step_definitions/accession_shared.rb
@@ -150,6 +150,8 @@ Given 'the Accession is opened in edit mode' do
   end
 
   click_on 'Edit'
+
+  expect(page).to have_selector('h2', visible: true, text: 'Accession')
 end
 
 Then 'a new Extent is added to the Accession with the following values' do |form_values_table|

--- a/e2e-tests/staff_features/accessions/step_definitions/accession_shared.rb
+++ b/e2e-tests/staff_features/accessions/step_definitions/accession_shared.rb
@@ -124,8 +124,7 @@ Given 'an Accession with a Top Container has been created' do
 
   fill_in 'top_container_indicator_', with: @uuid
   click_on 'Create and Link'
-
-  sleep 3
+  expect(page).to have_css('.top_container', wait: 10)
 
   click_on 'Save'
   expect(page).to have_text "Accession Accession Title #{@uuid} created"

--- a/e2e-tests/staff_features/accessions/step_definitions/accession_shared.rb
+++ b/e2e-tests/staff_features/accessions/step_definitions/accession_shared.rb
@@ -124,7 +124,7 @@ Given 'an Accession with a Top Container has been created' do
 
   fill_in 'top_container_indicator_', with: @uuid
   click_on 'Create and Link'
-  expect(page).to have_css('.top_container', wait: 10)
+  expect(page).to have_css('.top_container')
 
   click_on 'Save'
   expect(page).to have_text "Accession Accession Title #{@uuid} created"

--- a/e2e-tests/staff_features/resources/step_definitions/resource_delete.rb
+++ b/e2e-tests/staff_features/resources/step_definitions/resource_delete.rb
@@ -48,6 +48,3 @@ Then 'the Resources page is displayed' do
   expect(find('h2').text).to have_text 'Resources'
 end
 
-Then 'the user is still on the Resource view page' do
-  expect(current_url).to include "resources/#{@resource_id}"
-end

--- a/e2e-tests/staff_features/resources/step_definitions/resource_shared.rb
+++ b/e2e-tests/staff_features/resources/step_definitions/resource_shared.rb
@@ -71,7 +71,7 @@ Given 'the Resource is opened in the view mode' do
   visit "#{STAFF_URL}/resources/#{@resource_id}"
 end
 
-Given 'the Resource is opened in edit mode' do
+Given 'the Resource is being edited' do
   visit "#{STAFF_URL}/resources/#{@resource_id}/edit"
   expect(page).to have_selector('h2', visible: true, text: 'Resource')
   wait_for_ajax # still needed for dropdown menus to become active

--- a/e2e-tests/staff_features/resources/step_definitions/resource_shared.rb
+++ b/e2e-tests/staff_features/resources/step_definitions/resource_shared.rb
@@ -22,6 +22,8 @@ Given 'a Resource with a Top Container has been created' do
   fill_in 'top_container_indicator_', with: @uuid
   click_on 'Create and Link'
 
+  sleep 3
+
   languages = all('#resource_lang_materials_ .subrecord-form-list li')
   click_on 'Add Language' if languages.length == 0
 

--- a/e2e-tests/staff_features/resources/step_definitions/resource_shared.rb
+++ b/e2e-tests/staff_features/resources/step_definitions/resource_shared.rb
@@ -3,8 +3,6 @@
 Given 'a Resource with a Top Container has been created' do
   visit "#{STAFF_URL}/resources/new"
 
-  visit "#{STAFF_URL}/resources/new"
-
   fill_in 'resource_title_', with: "Resource #{@uuid}"
   fill_in 'resource_id_0_', with: "Resource #{@uuid}"
   find('#resource_publish_').check
@@ -22,12 +20,9 @@ Given 'a Resource with a Top Container has been created' do
   fill_in 'top_container_indicator_', with: @uuid
   click_on 'Create and Link'
 
-  sleep 3
+  click_on 'Add Language'
 
-  languages = all('#resource_lang_materials_ .subrecord-form-list li')
-  click_on 'Add Language' if languages.length == 0
-
-  within '#resource_lang_materials_ li.sort-enabled.initialised' do
+  within('#resource_lang_materials_ li.sort-enabled.initialised', match: :first) do
     element = find('#resource_lang_materials__0__language_and_script__language_')
     element.send_keys(ORIGINAL_LANGUAGE)
     element.send_keys(:tab)

--- a/e2e-tests/staff_features/resources/step_definitions/resource_shared.rb
+++ b/e2e-tests/staff_features/resources/step_definitions/resource_shared.rb
@@ -19,7 +19,7 @@ Given 'a Resource with a Top Container has been created' do
 
   fill_in 'top_container_indicator_', with: @uuid
   click_on 'Create and Link'
-  expect(page).to have_css('.top_container', wait: 10)
+  expect(page).to have_css('.top_container')
 
   click_on 'Add Language'
 
@@ -126,4 +126,8 @@ end
 
 Then 'the Resource view page is displayed' do
   expect(find('h2').text).to eq "Resource #{@uuid} Resource"
+end
+
+Then 'the user is still on the Resource view page' do
+  expect(current_url).to include "resources/#{@resource_id}"
 end

--- a/e2e-tests/staff_features/resources/step_definitions/resource_shared.rb
+++ b/e2e-tests/staff_features/resources/step_definitions/resource_shared.rb
@@ -19,6 +19,7 @@ Given 'a Resource with a Top Container has been created' do
 
   fill_in 'top_container_indicator_', with: @uuid
   click_on 'Create and Link'
+  expect(page).to have_css('.top_container', wait: 10)
 
   click_on 'Add Language'
 
@@ -66,7 +67,7 @@ Given 'the Resource is opened in the view mode' do
   visit "#{STAFF_URL}/resources/#{@resource_id}"
 end
 
-Given 'the Resource is being edited' do
+Given 'the Resource is opened in edit mode' do
   visit "#{STAFF_URL}/resources/#{@resource_id}/edit"
   expect(page).to have_selector('h2', visible: true, text: 'Resource')
   wait_for_ajax # still needed for dropdown menus to become active

--- a/e2e-tests/staff_features/top_containers/step_definitions/top_container_manage_for_record.rb
+++ b/e2e-tests/staff_features/top_containers/step_definitions/top_container_manage_for_record.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+def open_top_containers_panel_with_retry
+  retries = 0
+  loop do
+    within '#other-dropdown' do
+      find('.dropdown-toggle').click
+    end
+    find('.access-top-containers-btn').click
+    wait_for_ajax
+
+    break if page.has_css?('#accessTopContainersModal #bulk_operation_results tbody tr', wait: 5)
+
+    page.execute_script("$('#accessTopContainersModal').modal('hide')")
+    wait_for_ajax
+    sleep 1
+
+    retries += 1
+    raise 'Top containers did not appear in the management panel after multiple attempts' if retries >= 4
+
+    sleep 2
+  end
+end
+
+Given 'the top container management panel is open for a resource' do
+  visit "#{STAFF_URL}/resources/#{@resource_id}/edit"
+  expect(page).to have_selector('h2', visible: true, text: 'Resource')
+  wait_for_ajax
+  open_top_containers_panel_with_retry
+end
+
+When 'the archivist opens the top container management panel for the resource' do
+  open_top_containers_panel_with_retry
+end
+
+Then 'all top containers linked to that resource are displayed' do
+  within '#accessTopContainersModal' do
+    expect(page).to have_css('#bulk_operation_results tbody tr', text: @uuid)
+  end
+end
+
+When "the archivist views a top container's details" do
+  within '#accessTopContainersModal' do
+    find('.inline-tc-view-btn', match: :first).click
+  end
+  wait_for_ajax
+end
+
+Then 'the top container information is displayed in full' do
+  within '#accessTopContainerSubModal' do
+    expect(page).to have_text @uuid
+  end
+end
+
+When 'the archivist updates the barcode of a top container' do
+  @new_barcode = SecureRandom.uuid
+  within '#accessTopContainersModal' do
+    find('.inline-tc-edit-btn', match: :first).click
+  end
+  wait_for_ajax
+  within '#accessTopContainerSubModal' do
+    fill_in 'Barcode', with: @new_barcode
+    click_on 'Save Top Container'
+  end
+  wait_for_ajax
+end
+
+Then 'the archivist remains within the resource context' do
+  expect(current_url).to include "/resources/#{@resource_id}"
+end
+
+Then 'the updated barcode is reflected in the top container management view' do
+  within '#accessTopContainersModal' do
+    expect(page).to have_css('#bulk_operation_results tbody td.top-container-barcode', text: @new_barcode)
+  end
+end
+
+When 'the archivist applies a bulk barcode update to the selected top containers' do
+  @new_barcode = SecureRandom.uuid
+  within '#accessTopContainersModal #bulk_operation_results tbody' do
+    find('input[type="checkbox"]', match: :first).click
+  end
+  within '#accessTopContainersModal' do
+    find('button', text: 'Bulk Operations', match: :first).click
+  end
+  find('#showBulkActionRapidBarcodeEntry').click
+  wait_for_ajax
+  within '#bulkActionBarcodeRapidEntryModal' do
+    find('input[type="text"]').fill_in with: @new_barcode
+    click_on 'Update 1 records'
+  end
+  wait_for_ajax
+end
+
+Then 'the bulk barcode update is confirmed' do
+  within '#bulkActionBarcodeRapidEntryModal' do
+    expect(page).to have_css('.alert-success')
+  end
+end
+
+Then 'the affected top containers reflect the updated barcode' do
+  visit "#{STAFF_URL}/top_containers/#{@top_container_id}/edit"
+  expect(page).to have_field('Barcode', with: @new_barcode)
+end
+
+When 'the archivist opens the top container management panel for the accession' do
+  expect(page).to have_selector('h2', visible: true, text: 'Accession')
+  wait_for_ajax
+  open_top_containers_panel_with_retry
+end
+
+Then 'all top containers linked to that accession are displayed' do
+  within '#accessTopContainersModal' do
+    expect(page).to have_css('#bulk_operation_results tbody tr', text: @uuid)
+  end
+end

--- a/e2e-tests/staff_features/top_containers/step_definitions/top_container_manage_for_record.rb
+++ b/e2e-tests/staff_features/top_containers/step_definitions/top_container_manage_for_record.rb
@@ -1,31 +1,5 @@
 # frozen_string_literal: true
 
-def open_top_containers_panel_with_retry
-  retries = 0
-  loop do
-    within '#other-dropdown' do
-      find('.dropdown-toggle').click
-    end
-    find('.access-top-containers-btn').click
-    wait_for_ajax
-
-    break if page.has_css?('#accessTopContainersModal #bulk_operation_results tbody tr', wait: 5)
-
-    page.execute_script("$('#accessTopContainersModal').modal('hide')")
-    wait_for_ajax
-    sleep 1
-
-    retries += 1
-    raise 'Top containers did not appear in the management panel after multiple attempts' if retries >= 4
-
-    sleep 2
-  end
-end
-
-When 'the archivist manages top containers for the resource' do
-  open_top_containers_panel_with_retry
-end
-
 Then 'all top containers linked to that resource are displayed' do
   within '#accessTopContainersModal' do
     expect(page).to have_css('#bulk_operation_results tbody tr', text: @uuid)
@@ -96,10 +70,26 @@ Then 'the affected top containers reflect the updated barcode' do
   expect(page).to have_field('Barcode', with: @new_barcode)
 end
 
-When 'the archivist opens the top container management panel for the accession' do
-  expect(page).to have_selector('h2', visible: true, text: 'Accession')
-  wait_for_ajax
-  open_top_containers_panel_with_retry
+When 'the user opens the top container management panel' do
+  retries = 0
+  loop do
+    within '#other-dropdown' do
+      find('.dropdown-toggle').click
+    end
+    find('.access-top-containers-btn').click
+    wait_for_ajax
+
+    break if page.has_css?('#accessTopContainersModal #bulk_operation_results tbody tr', wait: 5)
+
+    page.execute_script("$('#accessTopContainersModal').modal('hide')")
+    wait_for_ajax
+    sleep 1
+
+    retries += 1
+    raise 'Top containers did not appear in the management panel after multiple attempts' if retries >= 4
+
+    sleep 2
+  end
 end
 
 Then 'all top containers linked to that accession are displayed' do

--- a/e2e-tests/staff_features/top_containers/step_definitions/top_container_manage_for_record.rb
+++ b/e2e-tests/staff_features/top_containers/step_definitions/top_container_manage_for_record.rb
@@ -22,14 +22,7 @@ def open_top_containers_panel_with_retry
   end
 end
 
-Given 'the top container management panel is open for a resource' do
-  visit "#{STAFF_URL}/resources/#{@resource_id}/edit"
-  expect(page).to have_selector('h2', visible: true, text: 'Resource')
-  wait_for_ajax
-  open_top_containers_panel_with_retry
-end
-
-When 'the archivist opens the top container management panel for the resource' do
+When 'the archivist manages top containers for the resource' do
   open_top_containers_panel_with_retry
 end
 

--- a/e2e-tests/staff_features/top_containers/step_definitions/top_container_manage_for_record.rb
+++ b/e2e-tests/staff_features/top_containers/step_definitions/top_container_manage_for_record.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-Then 'all top containers linked to that resource are displayed' do
+Then 'the top container appears linked in the modal' do
   within '#accessTopContainersModal' do
     expect(page).to have_css('#bulk_operation_results tbody tr', text: @uuid)
   end
 end
 
-When "the archivist views a top container's details" do
+When "the user views a top container's details" do
   within '#accessTopContainersModal' do
     find('.inline-tc-view-btn', match: :first).click
   end
@@ -19,7 +19,7 @@ Then 'the top container information is displayed in full' do
   end
 end
 
-When 'the archivist updates the barcode of a top container' do
+When 'the user updates the barcode of a top container' do
   @new_barcode = SecureRandom.uuid
   within '#accessTopContainersModal' do
     find('.inline-tc-edit-btn', match: :first).click
@@ -32,7 +32,7 @@ When 'the archivist updates the barcode of a top container' do
   wait_for_ajax
 end
 
-Then 'the archivist remains within the resource context' do
+Then 'the user remains within the resource context' do
   expect(current_url).to include "/resources/#{@resource_id}"
 end
 
@@ -42,7 +42,7 @@ Then 'the updated barcode is reflected in the top container management view' do
   end
 end
 
-When 'the archivist applies a bulk barcode update to the selected top containers' do
+When 'the user applies a bulk barcode update to the selected top containers' do
   @new_barcode = SecureRandom.uuid
   within '#accessTopContainersModal #bulk_operation_results tbody' do
     find('input[type="checkbox"]', match: :first).click
@@ -57,9 +57,6 @@ When 'the archivist applies a bulk barcode update to the selected top containers
     click_on 'Update 1 records'
   end
   wait_for_ajax
-end
-
-Then 'the bulk barcode update is confirmed' do
   within '#bulkActionBarcodeRapidEntryModal' do
     expect(page).to have_css('.alert-success')
   end
@@ -73,27 +70,25 @@ end
 When 'the user opens the top container management panel' do
   retries = 0
   loop do
+    expect(page).to have_selector('h2', visible: true, wait: 15)
+    expect(page).to have_css('.access-top-containers-btn[data-tc-initialized]', visible: :all, wait: 10)
+    wait_for_ajax
+
+    if find('.access-top-containers-btn', visible: :all).disabled?
+      retries += 1
+      raise 'Top containers button never became enabled after multiple attempts' if retries >= 10
+      sleep 3
+      page.evaluate_script('window.location.reload()')
+      sleep 0.5
+      next
+    end
+
     within '#other-dropdown' do
       find('.dropdown-toggle').click
     end
+    sleep 0.3
     find('.access-top-containers-btn').click
     wait_for_ajax
-
-    break if page.has_css?('#accessTopContainersModal #bulk_operation_results tbody tr', wait: 5)
-
-    page.execute_script("$('#accessTopContainersModal').modal('hide')")
-    wait_for_ajax
-    sleep 1
-
-    retries += 1
-    raise 'Top containers did not appear in the management panel after multiple attempts' if retries >= 4
-
-    sleep 2
-  end
-end
-
-Then 'all top containers linked to that accession are displayed' do
-  within '#accessTopContainersModal' do
-    expect(page).to have_css('#bulk_operation_results tbody tr', text: @uuid)
+    break
   end
 end

--- a/e2e-tests/staff_features/top_containers/step_definitions/top_container_manage_for_record.rb
+++ b/e2e-tests/staff_features/top_containers/step_definitions/top_container_manage_for_record.rb
@@ -13,12 +13,6 @@ When "the user views a top container's details" do
   wait_for_ajax
 end
 
-Then 'the top container information is displayed in full' do
-  within '#accessTopContainerSubModal' do
-    expect(page).to have_text @uuid
-  end
-end
-
 When 'the user updates the barcode of a top container' do
   @new_barcode = SecureRandom.uuid
   within '#accessTopContainersModal' do
@@ -30,10 +24,6 @@ When 'the user updates the barcode of a top container' do
     click_on 'Save Top Container'
   end
   wait_for_ajax
-end
-
-Then 'the user remains within the resource context' do
-  expect(current_url).to include "/resources/#{@resource_id}"
 end
 
 Then 'the updated barcode is reflected in the top container management view' do

--- a/e2e-tests/staff_features/top_containers/top_container_manage_for_record.feature
+++ b/e2e-tests/staff_features/top_containers/top_container_manage_for_record.feature
@@ -1,0 +1,36 @@
+Feature: Manage Top Containers from a Resource or Accession Record
+  As an archivist
+  I want to view and update top containers associated with a record
+  So that I can manage container information without losing my place in the record
+
+  Background:
+    Given an administrator user is logged in
+      And a Resource with a Top Container has been created
+
+  Scenario: Top containers linked to a resource are accessible from the resource record
+    Given the Resource is opened in edit mode
+     When the archivist opens the top container management panel for the resource
+     Then all top containers linked to that resource are displayed
+
+  Scenario: An archivist can inspect the details of a top container
+    Given the top container management panel is open for a resource
+     When the archivist views a top container's details
+     Then the top container information is displayed in full
+
+  Scenario: An archivist can correct top container information from within the resource record
+    Given the top container management panel is open for a resource
+     When the archivist updates the barcode of a top container
+     Then the archivist remains within the resource context
+      And the updated barcode is reflected in the top container management view
+
+  Scenario: An archivist can apply a bulk update to top containers for a resource
+    Given the top container management panel is open for a resource
+     When the archivist applies a bulk barcode update to the selected top containers
+     Then the bulk barcode update is confirmed
+      And the affected top containers reflect the updated barcode
+
+  Scenario: Top containers linked to an accession are accessible from the accession record
+    Given an Accession with a Top Container has been created
+      And the Accession is opened in edit mode
+     When the archivist opens the top container management panel for the accession
+     Then all top containers linked to that accession are displayed

--- a/e2e-tests/staff_features/top_containers/top_container_manage_for_record.feature
+++ b/e2e-tests/staff_features/top_containers/top_container_manage_for_record.feature
@@ -5,32 +5,35 @@ Feature: Manage Top Containers from a Resource or Accession Record
 
   Background:
     Given an administrator user is logged in
-      And a Resource with a Top Container has been created
+    And a Resource with a Top Container has been created
 
-  Scenario: Top containers linked to a resource are accessible from the resource record
-    Given the Resource is opened in edit mode
-     When the archivist opens the top container management panel for the resource
-     Then all top containers linked to that resource are displayed
+  Scenario: An archivist can manage top containers linked to a resource
+    Given the Resource is being edited
+    When the archivist manages top containers for the resource
+    Then all top containers linked to that resource are displayed
 
-  Scenario: An archivist can inspect the details of a top container
-    Given the top container management panel is open for a resource
-     When the archivist views a top container's details
-     Then the top container information is displayed in full
+  Scenario: An archivist can view the details of a top container
+    Given the Resource is being edited
+    And the archivist manages top containers for the resource
+    When the archivist views a top container's details
+    Then the top container information is displayed in full
 
   Scenario: An archivist can correct top container information from within the resource record
-    Given the top container management panel is open for a resource
-     When the archivist updates the barcode of a top container
-     Then the archivist remains within the resource context
-      And the updated barcode is reflected in the top container management view
+    Given the Resource is being edited
+    And the archivist manages top containers for the resource
+    When the archivist updates the barcode of a top container
+    Then the archivist remains within the resource context
+    And the updated barcode is reflected in the top container management view
 
   Scenario: An archivist can apply a bulk update to top containers for a resource
-    Given the top container management panel is open for a resource
-     When the archivist applies a bulk barcode update to the selected top containers
-     Then the bulk barcode update is confirmed
-      And the affected top containers reflect the updated barcode
+    Given the Resource is being edited
+    And the archivist manages top containers for the resource
+    When the archivist applies a bulk barcode update to the selected top containers
+    Then the bulk barcode update is confirmed
+    And the affected top containers reflect the updated barcode
 
-  Scenario: Top containers linked to an accession are accessible from the accession record
+  Scenario: An archivist can manage top containers linked to an accession
     Given an Accession with a Top Container has been created
-      And the Accession is opened in edit mode
-     When the archivist opens the top container management panel for the accession
-     Then all top containers linked to that accession are displayed
+    And the Accession is opened in edit mode
+    When the archivist opens the top container management panel for the accession
+    Then all top containers linked to that accession are displayed

--- a/e2e-tests/staff_features/top_containers/top_container_manage_for_record.feature
+++ b/e2e-tests/staff_features/top_containers/top_container_manage_for_record.feature
@@ -9,31 +9,31 @@ Feature: Manage Top Containers from a Resource or Accession Record
 
   Scenario: An archivist can manage top containers linked to a resource
     Given the Resource is being edited
-    When the archivist manages top containers for the resource
+    When the user opens the top container management panel
     Then all top containers linked to that resource are displayed
 
   Scenario: An archivist can view the details of a top container
     Given the Resource is being edited
-    And the archivist manages top containers for the resource
-    When the archivist views a top container's details
+    When the user opens the top container management panel
+    And the archivist views a top container's details
     Then the top container information is displayed in full
 
   Scenario: An archivist can correct top container information from within the resource record
     Given the Resource is being edited
-    And the archivist manages top containers for the resource
-    When the archivist updates the barcode of a top container
+    When the user opens the top container management panel
+    And the archivist updates the barcode of a top container
     Then the archivist remains within the resource context
     And the updated barcode is reflected in the top container management view
 
   Scenario: An archivist can apply a bulk update to top containers for a resource
     Given the Resource is being edited
-    And the archivist manages top containers for the resource
-    When the archivist applies a bulk barcode update to the selected top containers
+    When the user opens the top container management panel
+    And the archivist applies a bulk barcode update to the selected top containers
     Then the bulk barcode update is confirmed
     And the affected top containers reflect the updated barcode
 
   Scenario: An archivist can manage top containers linked to an accession
     Given an Accession with a Top Container has been created
     And the Accession is opened in edit mode
-    When the archivist opens the top container management panel for the accession
+    When the user opens the top container management panel
     Then all top containers linked to that accession are displayed

--- a/e2e-tests/staff_features/top_containers/top_container_manage_for_record.feature
+++ b/e2e-tests/staff_features/top_containers/top_container_manage_for_record.feature
@@ -1,5 +1,5 @@
 Feature: Manage Top Containers from a Resource or Accession Record
-  As an archivist
+  As an administrator
   I want to view and update top containers associated with a record
   So that I can manage container information without losing my place in the record
 
@@ -7,33 +7,32 @@ Feature: Manage Top Containers from a Resource or Accession Record
     Given an administrator user is logged in
     And a Resource with a Top Container has been created
 
-  Scenario: An archivist can manage top containers linked to a resource
-    Given the Resource is being edited
+  Scenario: An administrator can manage top containers linked to a resource
+    Given the Resource is opened in edit mode
     When the user opens the top container management panel
-    Then all top containers linked to that resource are displayed
+    Then the top container appears linked in the modal
 
-  Scenario: An archivist can view the details of a top container
-    Given the Resource is being edited
+  Scenario: An administrator can view the details of a top container
+    Given the Resource is opened in edit mode
     When the user opens the top container management panel
-    And the archivist views a top container's details
+    And the user views a top container's details
     Then the top container information is displayed in full
 
-  Scenario: An archivist can correct top container information from within the resource record
-    Given the Resource is being edited
+  Scenario: An administrator can correct top container information from within the resource record
+    Given the Resource is opened in edit mode
     When the user opens the top container management panel
-    And the archivist updates the barcode of a top container
-    Then the archivist remains within the resource context
+    And the user updates the barcode of a top container
+    Then the user remains within the resource context
     And the updated barcode is reflected in the top container management view
 
-  Scenario: An archivist can apply a bulk update to top containers for a resource
-    Given the Resource is being edited
+  Scenario: An administrator can apply a bulk update to top containers for a resource
+    Given the Resource is opened in edit mode
     When the user opens the top container management panel
-    And the archivist applies a bulk barcode update to the selected top containers
-    Then the bulk barcode update is confirmed
+    And the user applies a bulk barcode update to the selected top containers
     And the affected top containers reflect the updated barcode
 
-  Scenario: An archivist can manage top containers linked to an accession
+  Scenario: An administrator can manage top containers linked to an accession
     Given an Accession with a Top Container has been created
     And the Accession is opened in edit mode
     When the user opens the top container management panel
-    Then all top containers linked to that accession are displayed
+    Then the top container appears linked in the modal

--- a/e2e-tests/staff_features/top_containers/top_container_manage_for_record.feature
+++ b/e2e-tests/staff_features/top_containers/top_container_manage_for_record.feature
@@ -16,13 +16,13 @@ Feature: Manage Top Containers from a Resource or Accession Record
     Given the Resource is opened in edit mode
     When the user opens the top container management panel
     And the user views a top container's details
-    Then the top container information is displayed in full
+    Then the top container appears linked in the modal
 
   Scenario: An administrator can correct top container information from within the resource record
     Given the Resource is opened in edit mode
     When the user opens the top container management panel
     And the user updates the barcode of a top container
-    Then the user remains within the resource context
+    Then the user is still on the Resource view page
     And the updated barcode is reflected in the top container management view
 
   Scenario: An administrator can apply a bulk update to top containers for a resource

--- a/frontend/app/assets/javascripts/access_top_containers.js
+++ b/frontend/app/assets/javascripts/access_top_containers.js
@@ -1,0 +1,194 @@
+// Stacked-modal backdrop fix. This seems to be the best solution I could find for the problem.
+// Bootstrap assigns all modals z-index:1050 and all backdrops z-index:1040,
+// so a second backdrop never dims the modal beneath it.
+// I added these twohandlers to escalate each new modal and its backdrop above the existing stack.
+$(document).on('show.bs.modal', '.modal', function () {
+  var openCount = $('.modal.show').length;
+  if (openCount > 0) {
+    var backdropZ = 1040 + openCount * 20;
+    $(this).css('z-index', backdropZ + 10);
+    setTimeout(function () {
+      $('.modal-backdrop').last().css('z-index', backdropZ);
+    }, 0);
+  }
+});
+
+$(document).on('hidden.bs.modal', '.modal', function () {
+  if ($('.modal.show').length > 0) {
+    $('body').addClass('modal-open');
+  }
+});
+
+$(document).on('click', '.access-top-containers-btn', function () {
+  var $btn = $(this);
+  var recordUri = $btn.data('record-uri');
+  var recordType = $btn.data('record-type');
+  var recordTitle = $btn.data('record-title');
+
+  var $modal = AS.openCustomModal(
+    'accessTopContainersModal',
+    recordTitle,
+    '<div class="modal-body"><div class="p-4"><p>Loading...</p></div></div>',
+    'full'
+  );
+
+  $modal.data('record-uri', recordUri);
+  $modal.data('record-type', recordType);
+  $modal.data('record-title', recordTitle);
+
+  loadAccessTopContainersModal($modal, recordUri, recordType, recordTitle);
+});
+
+function loadAccessTopContainersModal(
+  $modal,
+  recordUri,
+  recordType,
+  recordTitle,
+  saved
+) {
+  $.ajax({
+    url: AS.app_prefix('top_containers/access_top_containers'),
+    data: {
+      record_uri: recordUri,
+      record_type: recordType,
+      record_title: recordTitle,
+      saved: saved || false,
+    },
+    type: 'GET',
+    success: function (html) {
+      $modal.find('.modal-body').html(html);
+      $('.linker:not(.initialised)', $modal).linker();
+      AS.initBulkContainerOperations(
+        null,
+        $modal.find('#bulk_operation_results'),
+        $modal.find('.record-toolbar.bulk-operation-toolbar')
+      );
+    },
+    error: function (jqXHR) {
+      $modal
+        .find('.modal-body')
+        .html(
+          '<div class="alert alert-danger m-3">' + jqXHR.responseText + '</div>'
+        );
+    },
+  });
+}
+
+function openTopContainerSubModal(tcId, mode) {
+  var title = mode === 'edit' ? 'Edit Top Container' : 'Top Container';
+  var $subModal = AS.openCustomModal(
+    'accessTopContainerSubModal',
+    title,
+    '<div class="modal-body"><div class="p-4"><p>Loading...</p></div></div>',
+    'large'
+  );
+
+  var url = AS.app_prefix(
+    'top_containers/' + tcId + (mode === 'edit' ? '/edit' : '')
+  );
+
+  $.ajax({
+    url: url,
+    data: { inline: true },
+    type: 'GET',
+    success: function (html) {
+      $subModal.find('.modal-body').html(html);
+      if (mode === 'edit') {
+        $('.linker:not(.initialised)', $subModal).linker();
+        $(document).trigger('loadedrecordform.aspace', [
+          $subModal.find('.modal-body'),
+        ]);
+      }
+    },
+    error: function (jqXHR) {
+      $subModal
+        .find('.modal-body')
+        .html(
+          '<div class="alert alert-danger m-3">' + jqXHR.responseText + '</div>'
+        );
+    },
+  });
+
+  return $subModal;
+}
+
+function topContainerIdFromUri(uri) {
+  if (!uri) {
+    return null;
+  }
+  var parts = uri.split('/');
+  return parts[parts.length - 1];
+}
+
+$(document).on('click', '.inline-tc-view-btn', function (event) {
+  event.preventDefault();
+  var id = topContainerIdFromUri($(this).data('tc-uri'));
+  if (!id) {
+    return;
+  }
+  openTopContainerSubModal(id, 'view');
+});
+
+$(document).on('click', '.inline-tc-edit-btn', function (event) {
+  event.preventDefault();
+  var id = topContainerIdFromUri($(this).data('tc-uri'));
+  if (!id) {
+    return;
+  }
+  openTopContainerSubModal(id, 'edit');
+});
+
+$(document).on(
+  'submit',
+  '#accessTopContainerSubModal form.aspace-record-form',
+  function (event) {
+    event.preventDefault();
+
+    var $form = $(this);
+    var $subModal = $form.closest('#accessTopContainerSubModal');
+    var $outerModal = $('#accessTopContainersModal');
+
+    $.ajax({
+      url: $form.attr('action'),
+      data: $form.serialize() + '&inline=true',
+      type: 'POST',
+      success: function (response, _ignoredStatus, jqXHR) {
+        var contentType = jqXHR.getResponseHeader('Content-Type') || '';
+
+        if (contentType.indexOf('application/json') !== -1) {
+          $subModal.modal('hide');
+
+          var recordUri = $outerModal.data('record-uri');
+          var recordType = $outerModal.data('record-type');
+          var recordTitle = $outerModal.data('record-title');
+
+          $outerModal
+            .find('.modal-body')
+            .html('<div class="p-4"><p>Loading...</p></div>');
+          loadAccessTopContainersModal(
+            $outerModal,
+            recordUri,
+            recordType,
+            recordTitle,
+            true
+          );
+        } else {
+          $subModal.find('.modal-body').html(response);
+          $('.linker:not(.initialised)', $subModal).linker();
+          $(document).trigger('loadedrecordform.aspace', [
+            $subModal.find('.modal-body'),
+          ]);
+        }
+      },
+      error: function (jqXHR) {
+        $subModal
+          .find('.modal-body')
+          .html(
+            '<div class="alert alert-danger m-3">' +
+              jqXHR.responseText +
+              '</div>'
+          );
+      },
+    });
+  }
+);

--- a/frontend/app/assets/javascripts/access_top_containers.js
+++ b/frontend/app/assets/javascripts/access_top_containers.js
@@ -1,7 +1,7 @@
 // Stacked-modal backdrop fix. This seems to be the best solution I could find for the problem.
 // Bootstrap assigns all modals z-index:1050 and all backdrops z-index:1040,
 // so a second backdrop never dims the modal beneath it.
-// I added these twohandlers to escalate each new modal and its backdrop above the existing stack.
+// Added these two handlers to escalate each new modal and its backdrop above the existing stack.
 $(document).on('show.bs.modal', '.modal', function () {
   const openCount = $('.modal.show').length;
   if (openCount > 0) {
@@ -75,9 +75,10 @@ function loadAccessTopContainersModal(
 }
 
 function openTopContainerSubModal(tcId, mode) {
-  const title = mode === 'edit'
-    ? AS.access_top_containers_locales.edit_top_container
-    : AS.access_top_containers_locales.view_top_container;
+  const title =
+    mode === 'edit'
+      ? AS.access_top_containers_locales.edit_top_container
+      : AS.access_top_containers_locales.view_top_container;
   const $subModal = AS.openCustomModal(
     'accessTopContainerSubModal',
     title,
@@ -206,12 +207,11 @@ $(document).on('loadedrecordform.aspace', function () {
       data: {
         record_uri: $btn.data('record-uri'),
         record_type: $btn.data('record-type'),
-        count_only: true
+        count_only: true,
       },
       type: 'GET',
       dataType: 'json',
       success: function (data) {
-        console.log('[TC] count_only response:', JSON.stringify(data), 'count:', data && data.count, 'type:', typeof (data && data.count));
         $btn.find('.tc-btn-spinner').addClass('d-none');
         $btn.find('.tc-btn-label').removeClass('d-none');
 
@@ -224,14 +224,16 @@ $(document).on('loadedrecordform.aspace', function () {
             .attr('data-placement', 'auto')
             .attr('title', AS.access_top_containers_locales.no_top_containers)
             .addClass('has-tooltip');
-          $wrapper.tooltip({ container: 'body', placement: 'auto' }).addClass('initialised');
+          $wrapper
+            .tooltip({ container: 'body', placement: 'auto' })
+            .addClass('initialised');
         }
       },
       error: function () {
         $btn.find('.tc-btn-spinner').addClass('d-none');
         $btn.find('.tc-btn-label').removeClass('d-none');
         $btn.prop('disabled', false);
-      }
+      },
     });
   });
 });

--- a/frontend/app/assets/javascripts/access_top_containers.js
+++ b/frontend/app/assets/javascripts/access_top_containers.js
@@ -3,9 +3,9 @@
 // so a second backdrop never dims the modal beneath it.
 // I added these twohandlers to escalate each new modal and its backdrop above the existing stack.
 $(document).on('show.bs.modal', '.modal', function () {
-  var openCount = $('.modal.show').length;
+  const openCount = $('.modal.show').length;
   if (openCount > 0) {
-    var backdropZ = 1040 + openCount * 20;
+    const backdropZ = 1040 + openCount * 20;
     $(this).css('z-index', backdropZ + 10);
     setTimeout(function () {
       $('.modal-backdrop').last().css('z-index', backdropZ);
@@ -20,15 +20,15 @@ $(document).on('hidden.bs.modal', '.modal', function () {
 });
 
 $(document).on('click', '.access-top-containers-btn', function () {
-  var $btn = $(this);
-  var recordUri = $btn.data('record-uri');
-  var recordType = $btn.data('record-type');
-  var recordTitle = $btn.data('record-title');
+  const $btn = $(this);
+  const recordUri = $btn.data('record-uri');
+  const recordType = $btn.data('record-type');
+  const recordTitle = $btn.data('record-title');
 
-  var $modal = AS.openCustomModal(
+  const $modal = AS.openCustomModal(
     'accessTopContainersModal',
-    recordTitle,
-    '<div class="modal-body"><div class="p-4"><p>Loading...</p></div></div>',
+    $btn.data('modal-title'),
+    `<div class="modal-body"><div class="p-4"><p>${AS.locales.loading}</p></div></div>`,
     'full'
   );
 
@@ -44,7 +44,7 @@ function loadAccessTopContainersModal(
   recordUri,
   recordType,
   recordTitle,
-  saved
+  saved = false
 ) {
   $.ajax({
     url: AS.app_prefix('top_containers/access_top_containers'),
@@ -52,7 +52,7 @@ function loadAccessTopContainersModal(
       record_uri: recordUri,
       record_type: recordType,
       record_title: recordTitle,
-      saved: saved || false,
+      saved: saved,
     },
     type: 'GET',
     success: function (html) {
@@ -75,15 +75,17 @@ function loadAccessTopContainersModal(
 }
 
 function openTopContainerSubModal(tcId, mode) {
-  var title = mode === 'edit' ? 'Edit Top Container' : 'Top Container';
-  var $subModal = AS.openCustomModal(
+  const title = mode === 'edit'
+    ? AS.access_top_containers_locales.edit_top_container
+    : AS.access_top_containers_locales.view_top_container;
+  const $subModal = AS.openCustomModal(
     'accessTopContainerSubModal',
     title,
-    '<div class="modal-body"><div class="p-4"><p>Loading...</p></div></div>',
+    `<div class="modal-body"><div class="p-4"><p>${AS.locales.loading}</p></div></div>`,
     'large'
   );
 
-  var url = AS.app_prefix(
+  const url = AS.app_prefix(
     'top_containers/' + tcId + (mode === 'edit' ? '/edit' : '')
   );
 
@@ -116,13 +118,13 @@ function topContainerIdFromUri(uri) {
   if (!uri) {
     return null;
   }
-  var parts = uri.split('/');
+  const parts = uri.split('/');
   return parts[parts.length - 1];
 }
 
 $(document).on('click', '.inline-tc-view-btn', function (event) {
   event.preventDefault();
-  var id = topContainerIdFromUri($(this).data('tc-uri'));
+  const id = topContainerIdFromUri($(this).data('tc-uri'));
   if (!id) {
     return;
   }
@@ -131,7 +133,7 @@ $(document).on('click', '.inline-tc-view-btn', function (event) {
 
 $(document).on('click', '.inline-tc-edit-btn', function (event) {
   event.preventDefault();
-  var id = topContainerIdFromUri($(this).data('tc-uri'));
+  const id = topContainerIdFromUri($(this).data('tc-uri'));
   if (!id) {
     return;
   }
@@ -144,27 +146,27 @@ $(document).on(
   function (event) {
     event.preventDefault();
 
-    var $form = $(this);
-    var $subModal = $form.closest('#accessTopContainerSubModal');
-    var $outerModal = $('#accessTopContainersModal');
+    const $form = $(this);
+    const $subModal = $form.closest('#accessTopContainerSubModal');
+    const $outerModal = $('#accessTopContainersModal');
 
     $.ajax({
       url: $form.attr('action'),
       data: $form.serialize() + '&inline=true',
       type: 'POST',
       success: function (response, _ignoredStatus, jqXHR) {
-        var contentType = jqXHR.getResponseHeader('Content-Type') || '';
+        const contentType = jqXHR.getResponseHeader('Content-Type') || '';
 
         if (contentType.indexOf('application/json') !== -1) {
           $subModal.modal('hide');
 
-          var recordUri = $outerModal.data('record-uri');
-          var recordType = $outerModal.data('record-type');
-          var recordTitle = $outerModal.data('record-title');
+          const recordUri = $outerModal.data('record-uri');
+          const recordType = $outerModal.data('record-type');
+          const recordTitle = $outerModal.data('record-title');
 
           $outerModal
             .find('.modal-body')
-            .html('<div class="p-4"><p>Loading...</p></div>');
+            .html(`<div class="p-4"><p>${AS.locales.loading}</p></div>`);
           loadAccessTopContainersModal(
             $outerModal,
             recordUri,
@@ -192,3 +194,44 @@ $(document).on(
     });
   }
 );
+
+$(document).on('loadedrecordform.aspace', function () {
+  $('.access-top-containers-btn:not([data-tc-initialized])').each(function () {
+    const $btn = $(this);
+    $btn.attr('data-tc-initialized', 'true');
+    const $wrapper = $btn.closest('.access-top-containers-wrapper');
+
+    $.ajax({
+      url: AS.app_prefix('top_containers/access_top_containers'),
+      data: {
+        record_uri: $btn.data('record-uri'),
+        record_type: $btn.data('record-type'),
+        count_only: true
+      },
+      type: 'GET',
+      dataType: 'json',
+      success: function (data) {
+        console.log('[TC] count_only response:', JSON.stringify(data), 'count:', data && data.count, 'type:', typeof (data && data.count));
+        $btn.find('.tc-btn-spinner').addClass('d-none');
+        $btn.find('.tc-btn-label').removeClass('d-none');
+
+        if (data.count > 0) {
+          $btn.prop('disabled', false);
+        } else {
+          $btn.prop('disabled', true).css('pointer-events', 'none');
+          $wrapper
+            .attr('data-toggle', 'tooltip')
+            .attr('data-placement', 'auto')
+            .attr('title', AS.access_top_containers_locales.no_top_containers)
+            .addClass('has-tooltip');
+          $wrapper.tooltip({ container: 'body', placement: 'auto' }).addClass('initialised');
+        }
+      },
+      error: function () {
+        $btn.find('.tc-btn-spinner').addClass('d-none');
+        $btn.find('.tc-btn-label').removeClass('d-none');
+        $btn.prop('disabled', false);
+      }
+    });
+  });
+});

--- a/frontend/app/assets/javascripts/accessions.js
+++ b/frontend/app/assets/javascripts/accessions.js
@@ -1,0 +1,2 @@
+//= require top_containers.bulk
+//= require access_top_containers

--- a/frontend/app/assets/javascripts/application.js
+++ b/frontend/app/assets/javascripts/application.js
@@ -25,3 +25,5 @@
 //= require bootstrap_overrides
 //= require bootstrap3-typeahead
 //= require jquery.matchHeight
+//= require top_containers.bulk
+//= require access_top_containers

--- a/frontend/app/assets/javascripts/application.js
+++ b/frontend/app/assets/javascripts/application.js
@@ -25,5 +25,3 @@
 //= require bootstrap_overrides
 //= require bootstrap3-typeahead
 //= require jquery.matchHeight
-//= require top_containers.bulk
-//= require access_top_containers

--- a/frontend/app/assets/javascripts/resources.js
+++ b/frontend/app/assets/javascripts/resources.js
@@ -1,0 +1,2 @@
+//= require top_containers.bulk
+//= require access_top_containers

--- a/frontend/app/assets/javascripts/top_containers.bulk.js
+++ b/frontend/app/assets/javascripts/top_containers.bulk.js
@@ -9,27 +9,28 @@ function BulkContainerSearch($search_form, $results_container, $toolbar) {
   this.$results_container = $results_container;
   this.$toolbar = $toolbar;
 
-  this.setup_form();
-  this.setup_results_list();
-  // If there is any stored search parameters and we're still looking at the same repository, reload them
-  // when navigating or refreshing. Else wipe the stored search params.
-  if (
-    $('.repo-container > div > a').attr('href') ===
-    sessionStorage.getItem('currentRepository')
-  ) {
-    var data = sessionStorage.getItem('top_container_search_data');
-    if (data != null && data != undefined) {
-      var parsed_data = JSON.parse(data);
-      $.each(parsed_data, function (key, value) {
-        $('#' + key).val(value);
-      });
-      this.perform_search(parsed_data);
-      this.update_export_button(parsed_data);
+  if ($search_form && $search_form.length) {
+    this.setup_form();
+    if (
+      $('.repo-container > div > a').attr('href') ===
+      sessionStorage.getItem('currentRepository')
+    ) {
+      var data = sessionStorage.getItem('top_container_search_data');
+      if (data != null && data != undefined) {
+        var parsed_data = JSON.parse(data);
+        $.each(parsed_data, function (key, value) {
+          $('#' + key).val(value);
+        });
+        this.perform_search(parsed_data);
+        this.update_export_button(parsed_data);
+      }
+    } else {
+      sessionStorage.setItem('top_container_search_data', null);
+      sessionStorage.setItem('currentRepository', null);
     }
-  } else {
-    sessionStorage.setItem('top_container_search_data', null);
-    sessionStorage.setItem('currentRepository', null);
   }
+
+  this.setup_results_list();
 }
 
 BulkContainerSearch.prototype.setup_form = function () {
@@ -931,12 +932,8 @@ function BulkActionDelete(bulkContainerSearch) {
  * Initialise all special features on this page
  *
  */
-$(function () {
-  var bulkContainerSearch = new BulkContainerSearch(
-    $('#bulk_operation_form'),
-    $('#bulk_operation_results'),
-    $('.record-toolbar.bulk-operation-toolbar')
-  );
+AS.initBulkContainerOperations = function ($form, $results, $toolbar) {
+  var bulkContainerSearch = new BulkContainerSearch($form, $results, $toolbar);
 
   new BulkActionBarcodeRapidEntry(bulkContainerSearch);
   new BulkActionIndicatorRapidEntry(bulkContainerSearch);
@@ -946,4 +943,12 @@ $(function () {
   new BulkActionMultipleLocationUpdate(bulkContainerSearch);
   new BulkActionMerge(bulkContainerSearch);
   new BulkActionDelete(bulkContainerSearch);
+};
+
+$(function () {
+  AS.initBulkContainerOperations(
+    $('#bulk_operation_form'),
+    $('#bulk_operation_results'),
+    $('.record-toolbar.bulk-operation-toolbar')
+  );
 });

--- a/frontend/app/assets/javascripts/top_containers.js
+++ b/frontend/app/assets/javascripts/top_containers.js
@@ -1,0 +1,1 @@
+//= require top_containers.bulk

--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -4,7 +4,7 @@ require 'advanced_query_builder'
 
 class TopContainersController < ApplicationController
 
-  set_access_control  'view_repository' => [:bulk_operations_browse, :bulk_operation_search, :index, :show, :typeahead],
+  set_access_control  'view_repository' => [:bulk_operations_browse, :bulk_operation_search, :index, :show, :typeahead, :access_top_containers],
                       'update_container_record' => [:new, :create, :edit, :update],
                       'manage_container_record' => [:delete, :batch_delete, :batch_merge, :bulk_operations, :bulk_operation_update, :update_barcodes, :update_indicators, :update_locations]
 
@@ -106,11 +106,13 @@ class TopContainersController < ApplicationController
 
   def show
     @top_container = JSONModel(:top_container).find(params[:id], find_opts)
+    render_aspace_partial :partial => 'top_containers/show_inline' if inline?
   end
 
 
   def edit
     @top_container = JSONModel(:top_container).find(params[:id], find_opts)
+    render_aspace_partial :partial => 'top_containers/edit_inline' if inline?
   end
 
 
@@ -119,11 +121,17 @@ class TopContainersController < ApplicationController
                 :model => JSONModel(:top_container),
                 :obj => JSONModel(:top_container).find(params[:id], find_opts),
                 :on_invalid => ->() {
-                  return render action: 'edit'
+                  return render_aspace_partial :partial => 'top_containers/edit_inline' if inline?
+                  render action: 'edit'
                 },
                 :on_valid => ->(id) {
-                  flash[:success] = t('top_container._frontend.messages.updated')
-                  redirect_to :controller => :top_containers, :action => :show, :id => id
+                  if inline?
+                    @top_container.refetch
+                    render :json => @top_container.to_hash
+                  else
+                    flash[:success] = t('top_container._frontend.messages.updated')
+                    redirect_to :controller => :top_containers, :action => :show, :id => id
+                  end
                 })
   end
 
@@ -240,6 +248,47 @@ class TopContainersController < ApplicationController
 
     get_browse_col_prefs
     render_aspace_partial :partial => 'top_containers/bulk_operations/browse', :locals => {:results => results}
+  end
+
+
+  def access_top_containers
+    @top_container_previous_search = {}
+
+    if params['record_uri']
+      record_type = params['record_type']
+
+      if ['resource', 'accession'].include?(record_type)
+        if record_type == 'resource'
+          params['collection_resource'] = { 'ref' => params['record_uri'] }
+        elsif record_type == 'accession'
+          params['collection_accession'] = { 'ref' => params['record_uri'] }
+        end
+
+        @top_container_previous_search[record_type] = {
+          'uri'            => params['record_uri'],
+          'id'             => params['record_uri'],
+          'title'          => params['record_title'],
+          'jsonmodel_type' => record_type
+        }
+
+        begin
+          results = perform_search
+        rescue MissingFilterException
+          results = nil
+        end
+      end
+    end
+
+    get_browse_col_prefs
+    csv_fields = @pref_cols.reject { |f| NON_CSV_FIELDS.include?(f) }
+    record_type = params['record_type']
+    export_url = if %w[resource accession].include?(record_type)
+                   url_for(controller: :top_containers, action: :index, format: :csv,
+                           :"collection_#{record_type}" => { ref: params['record_uri'] }, 'fields[]' => csv_fields)
+                 end
+    flash_message = params[:saved] == 'true' ? t('top_container._frontend.messages.updated') : nil
+    render_aspace_partial :partial => 'top_containers/bulk_operations/manage_for_record',
+                          :locals  => { :results => results, :flash_message => flash_message, :export_url => export_url }
   end
 
 

--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -276,6 +276,10 @@ class TopContainersController < ApplicationController
         rescue MissingFilterException
           results = nil
         end
+
+        if params['count_only'] == 'true'
+          return render json: { count: results ? results['response']['numFound'].to_i : 0 }
+        end
       end
     end
 

--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -253,6 +253,7 @@ class TopContainersController < ApplicationController
 
   def access_top_containers
     @top_container_previous_search = {}
+    results = nil
 
     if params['record_uri']
       record_type = params['record_type']

--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -62,6 +62,15 @@
             <% if user_can?('update_assessment_record') %>
               <li><%= link_to t('assessment._frontend.action.create_for_record'), {:controller => :assessments, :action => :new, :record_uri => @accession.uri}, :class => "dropdown-item" %></li>
             <% end %>
+            <li>
+              <button type="button"
+                      class="btn rounded-0 dropdown-item access-top-containers-btn"
+                      data-record-uri="<%= @accession.uri %>"
+                      data-record-type="accession"
+                      data-record-title="<%= h(strip_tags(clean_mixed_content(@accession.title))) %>">
+                <%= (user_can?('update_container_record') || user_can?('manage_container_record')) ? t("navbar.manage_top_containers") : t("navbar.view_top_containers") %>
+              </button>
+            </li>
           </ul>
         </div>
         <% if user_can?('suppress_archival_record') || user_can?('delete_archival_record') %>

--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -63,13 +63,15 @@
               <li><%= link_to t('assessment._frontend.action.create_for_record'), {:controller => :assessments, :action => :new, :record_uri => @accession.uri}, :class => "dropdown-item" %></li>
             <% end %>
             <li>
-              <button type="button"
-                      class="btn rounded-0 dropdown-item access-top-containers-btn"
-                      data-record-uri="<%= @accession.uri %>"
-                      data-record-type="accession"
-                      data-record-title="<%= h(strip_tags(clean_mixed_content(@accession.title))) %>">
-                <%= (user_can?('update_container_record') || user_can?('manage_container_record')) ? t("navbar.manage_top_containers") : t("navbar.view_top_containers") %>
-              </button>
+              <%= render_aspace_partial :partial => "shared/access_top_containers_button",
+                                        :locals => {
+                                          :record_uri      => @accession.uri,
+                                          :record_type     => 'accession',
+                                          :record_title    => h(strip_tags(clean_mixed_content(@accession.title))),
+                                          :button_classes  => "btn rounded-0 dropdown-item",
+                                          :wrapper_classes => "d-block w-100",
+                                          :loading_state   => false
+                                        } %>
             </li>
           </ul>
         </div>

--- a/frontend/app/views/shared/_access_top_containers_button.html.erb
+++ b/frontend/app/views/shared/_access_top_containers_button.html.erb
@@ -1,0 +1,16 @@
+<span class="access-top-containers-wrapper <%= wrapper_classes %>">
+  <button type="button"
+          class="<%= button_classes %> access-top-containers-btn"
+          data-record-uri="<%= record_uri %>"
+          data-record-type="<%= record_type %>"
+          data-record-title="<%= record_title %>"
+          data-modal-title="<%= t('navbar.top_containers_for', record_title: record_title) %>"
+          <%= "disabled='disabled'" if local_assigns[:loading_state] %>>
+    <% if local_assigns[:loading_state] %>
+      <span class="tc-btn-spinner spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+    <% end %>
+    <span class="tc-btn-label<%= " d-none" if local_assigns[:loading_state] %>">
+      <%= (user_can?('update_container_record') || user_can?('manage_container_record')) ? t("navbar.manage_top_containers") : t("navbar.view_top_containers") %>
+    </span>
+  </button>
+</span>

--- a/frontend/app/views/shared/_resource_toolbar.html.erb
+++ b/frontend/app/views/shared/_resource_toolbar.html.erb
@@ -143,6 +143,17 @@
             <% if user_can?('administer_system') && AppConfig[:arks_enabled] && record['ark_name'] %>
               <li><%= render_aspace_partial :partial => "shared/ark_editor", :locals => {:record => record} %></li>
             <% end %>
+            <% if record_type == 'resource' %>
+              <li>
+                <button type="button"
+                        class="btn rounded-0 dropdown-item access-top-containers-btn"
+                        data-record-uri="<%= record.uri %>"
+                        data-record-type="resource"
+                        data-record-title="<%= h(strip_tags(clean_mixed_content(record.title))) %>">
+                  <%= (user_can?('update_container_record') || user_can?('manage_container_record')) ? t("navbar.manage_top_containers") : t("navbar.view_top_containers") %>
+                </button>
+              </li>
+            <% end %>
           </ul>
         </div>
       <% end %>

--- a/frontend/app/views/shared/_resource_toolbar.html.erb
+++ b/frontend/app/views/shared/_resource_toolbar.html.erb
@@ -145,13 +145,15 @@
             <% end %>
             <% if record_type == 'resource' %>
               <li>
-                <button type="button"
-                        class="btn rounded-0 dropdown-item access-top-containers-btn"
-                        data-record-uri="<%= record.uri %>"
-                        data-record-type="resource"
-                        data-record-title="<%= h(strip_tags(clean_mixed_content(record.title))) %>">
-                  <%= (user_can?('update_container_record') || user_can?('manage_container_record')) ? t("navbar.manage_top_containers") : t("navbar.view_top_containers") %>
-                </button>
+                <%= render_aspace_partial :partial => "shared/access_top_containers_button",
+                                          :locals => {
+                                            :record_uri      => record.uri,
+                                            :record_type     => 'resource',
+                                            :record_title    => h(strip_tags(clean_mixed_content(record.title))),
+                                            :button_classes  => "btn rounded-0 dropdown-item",
+                                            :wrapper_classes => "d-block w-100",
+                                            :loading_state   => false
+                                          } %>
               </li>
             <% end %>
           </ul>

--- a/frontend/app/views/shared/_templates.html.erb
+++ b/frontend/app/views/shared/_templates.html.erb
@@ -228,6 +228,20 @@
   }
 </script>
 
+<script>
+  AS.locales = {
+    loading: "<%= j(t("actions.loading")) %>"
+  }
+</script>
+
+<script>
+  AS.access_top_containers_locales = {
+    edit_top_container: "<%= j(t("navbar.edit_top_container")) %>",
+    view_top_container: "<%= j(t("navbar.view_top_container")) %>",
+    no_top_containers: "<%= j(t("navbar.no_top_containers")) %>"
+  }
+</script>
+
 
 
 <div id="subform_remove_confirmation_template"><!--

--- a/frontend/app/views/shared/_view_only_toolbar.html.erb
+++ b/frontend/app/views/shared/_view_only_toolbar.html.erb
@@ -5,5 +5,16 @@
         <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => record} %>
       <% end %>
     </div>
+    <% if ['resource', 'accession'].include?(record['jsonmodel_type']) %>
+      <div class="btn-group">
+        <button type="button"
+                class="btn btn-sm btn-default access-top-containers-btn"
+                data-record-uri="<%= record.uri %>"
+                data-record-type="<%= record['jsonmodel_type'] %>"
+                data-record-title="<%= h(strip_tags(clean_mixed_content(record.title))) %>">
+          <%= (user_can?('update_container_record') || user_can?('manage_container_record')) ? t("navbar.manage_top_containers") : t("navbar.view_top_containers") %>
+        </button>
+      </div>
+    <% end %>
   </div>
 </section>

--- a/frontend/app/views/shared/_view_only_toolbar.html.erb
+++ b/frontend/app/views/shared/_view_only_toolbar.html.erb
@@ -4,17 +4,17 @@
       <% if AppConfig[:enable_public] %>
         <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => record} %>
       <% end %>
+      <% if ['resource', 'accession'].include?(record['jsonmodel_type']) %>
+        <%= render_aspace_partial :partial => "shared/access_top_containers_button",
+                                  :locals => {
+                                    :record_uri      => record.uri,
+                                    :record_type     => record['jsonmodel_type'],
+                                    :record_title    => h(strip_tags(clean_mixed_content(record.title))),
+                                    :button_classes  => "btn btn-sm btn-default",
+                                    :wrapper_classes => "btn-group",
+                                    :loading_state   => true
+                                  } %>
+      <% end %>
     </div>
-    <% if ['resource', 'accession'].include?(record['jsonmodel_type']) %>
-      <div class="btn-group">
-        <button type="button"
-                class="btn btn-sm btn-default access-top-containers-btn"
-                data-record-uri="<%= record.uri %>"
-                data-record-type="<%= record['jsonmodel_type'] %>"
-                data-record-title="<%= h(strip_tags(clean_mixed_content(record.title))) %>">
-          <%= (user_can?('update_container_record') || user_can?('manage_container_record')) ? t("navbar.manage_top_containers") : t("navbar.view_top_containers") %>
-        </button>
-      </div>
-    <% end %>
   </div>
 </section>

--- a/frontend/app/views/top_containers/_edit_inline.html.erb
+++ b/frontend/app/views/top_containers/_edit_inline.html.erb
@@ -1,0 +1,10 @@
+<%= form_for @top_container, :as => "top_container", :url => {:action => :update, :id => @top_container.id}, :html => {:class => 'form-horizontal aspace-record-form', :id => "edit_top_container_inline"} do |f| %>
+  <%= form_context :top_container, @top_container do |form| %>
+    <%= render_aspace_partial :partial => "form", :locals => {:form => form} %>
+
+    <div class="form-actions pl-0">
+      <button type="submit" class="btn btn-primary"><%= t("top_container._frontend.action.save") %></button>
+      <button type="button" class="btn btn-default" data-dismiss="modal"><%= t("actions.cancel") %></button>
+    </div>
+  <% end %>
+<% end %>

--- a/frontend/app/views/top_containers/_edit_inline.html.erb
+++ b/frontend/app/views/top_containers/_edit_inline.html.erb
@@ -2,7 +2,7 @@
   <%= form_context :top_container, @top_container do |form| %>
     <%= render_aspace_partial :partial => "form", :locals => {:form => form} %>
 
-    <div class="form-actions pl-0">
+    <div class="form-actions pl-0 d-flex justify-content-between">
       <button type="submit" class="btn btn-primary"><%= t("top_container._frontend.action.save") %></button>
       <button type="button" class="btn btn-default" data-dismiss="modal"><%= t("actions.cancel") %></button>
     </div>

--- a/frontend/app/views/top_containers/_show_inline.html.erb
+++ b/frontend/app/views/top_containers/_show_inline.html.erb
@@ -1,0 +1,99 @@
+<div class="record-pane">
+  <section id="basic_information">
+    <%= readonly_context :top_container, @top_container do |readonly| %>
+      <h2><%= @top_container.display_string %> <span class="label label-info badge"><%= t("top_container._singular") %></span></h2>
+
+      <%= render_aspace_partial :partial => "shared/flash_messages" %>
+
+      <% define_template "top_container", jsonmodel_definition(:top_container) do |form| %>
+
+        <%= render_plugin_partials("top_of_basic_information_top_container",
+                                   :form => form,
+                                   :record => @top_container) %>
+
+        <% if @top_container.container_profile %>
+          <div class="form-group token-list">
+            <label class="control-label col-sm-2"><%= t("container_profile._singular") %></label>
+            <div class="controls col-sm-8">
+              <%= render_token :object => @top_container["container_profile"]["_resolved"],
+                              :label => @top_container["container_profile"]["_resolved"]["name"],
+                              :type => "container_profile",
+                              :uri => @top_container["container_profile"]["ref"] %>
+            </div>
+          </div>
+        <% end %>
+
+        <%= readonly.label_and_textarea "type" %>
+        <%= readonly.label_and_textarea "indicator" %>
+        <%= readonly.label_and_textarea "barcode" %>
+        <%= readonly.label_and_textarea "internal_note" %>
+        <%= readonly.label_and_textarea "ils_holding_id" %>
+        <%= readonly.label_and_textarea "ils_item_id" %>
+        <%= readonly.label_and_textarea "exported_to_ils", :default => t("top_container.not_exported") %>
+
+        <%= render_plugin_partials("basic_information_top_container",
+                                   :form => readonly,
+                                   :record => @top_container) %>
+
+        <% if @top_container["container_locations"].length > 0 %>
+          <hr>
+          <section id="container_locations">
+            <%= render_aspace_partial :partial => "container_locations/show", :locals => { :container_locations => @top_container["container_locations"]} %>
+          </section>
+        <% end %>
+
+        <section id="rights_restrictions">
+          <h3 class="subrecord-form-heading"><%= t("top_container._frontend.section.active_restrictions") %></h3>
+          <% if @top_container["active_restrictions"].length > 0 %>
+            <table class="table table-bordered table-striped">
+              <thead>
+                <tr>
+                  <th><%= t("rights_restriction.linked_records") %></th>
+                  <th><%= t("rights_restriction.restriction_note_type") %></th>
+                  <th><%= t("rights_restriction.begin") %></th>
+                  <th><%= t("rights_restriction.end") %></th>
+                  <th><%= t("rights_restriction.local_access_restriction_type") %></th>
+                </tr>
+              </thead>
+              <tbody>
+                <% @top_container["active_restrictions"].each do |restriction| %>
+                  <tr>
+                    <td>
+                      <div class="token-list">
+                        <%= render_token :object => restriction["linked_records"]["_resolved"],
+                                        :label => restriction["linked_records"]["_resolved"]["title"],
+                                        :type => restriction["linked_records"]["_resolved"]["jsonmodel_type"],
+                                        :uri => restriction["linked_records"]["ref"] %>
+                      </div>
+                    </td>
+                    <td><%= t("enumerations.note_multipart_type.#{restriction["restriction_note_type"]}") %></td>
+                    <td><%= restriction["begin"] %></td>
+                    <td><%= restriction["end"] %></td>
+                    <td>
+                      <ul>
+                        <% Array.wrap(restriction["local_access_restriction_type"]).
+                            map{|type| t("enumerations.restriction_type.#{type}")}.
+                            sort.each do |type| %>
+                          <li><%= type %></li>
+                        <% end %>
+                      </ul>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          <% else %>
+            <div class="alert alert-info"><%= t("top_container._frontend.messages.no_active_restrictions") %></div>
+          <% end %>
+        </section>
+
+        <%= show_plugins_for(@top_container, readonly) %>
+
+        <hr>
+        <%= display_audit_info(@top_container) %>
+      <% end %>
+
+      <% readonly.emit_template("top_container") %>
+    <% end %>
+  </section>
+</div>

--- a/frontend/app/views/top_containers/bulk_operations/_manage_for_record.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_manage_for_record.html.erb
@@ -1,0 +1,23 @@
+<div id="topContainersManageForRecord">
+  <% if flash_message %>
+    <div class="alert alert-success alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert">&times;</button>
+      <%= flash_message %>
+    </div>
+  <% end %>
+  <% if results.nil? %>
+    <p><%= t("search.no_results") %></p>
+  <% else %>
+    <% csv_fields = @pref_cols.reject { |f| %w[restricted].include?(f) } %>
+    <%= render_aspace_partial :partial => "top_containers/bulk_operations/toolbar",
+          :locals => { :fields => csv_fields, :export_url => export_url } %>
+    <div id="bulk_operation_results" class="record-pane">
+      <%= render_aspace_partial :partial => "top_containers/bulk_operations/results",
+            :locals => { :results => results, :inline_actions => true, :multiselect => user_can?('manage_container_record') } %>
+    </div>
+    <%= render_aspace_partial :partial => "top_containers/bulk_operations/toolbar",
+          :locals => { :fields => csv_fields, :export_url => export_url } %>
+  <% end %>
+
+  <%= render_aspace_partial :partial => "top_containers/bulk_operations/bulk_action_templates" %>
+</div>

--- a/frontend/app/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_results.html.erb
@@ -3,6 +3,7 @@
 <%
   multiselect = true if multiselect.nil?
   show_edit_actions = true if show_edit_actions.nil?
+  inline_actions = false if !defined?(inline_actions)
   top_containers = results['response']['docs']
   num_found = results['response']["numFound"].to_i
   rows = results['responseHeader']['params']['rows'].to_i
@@ -52,7 +53,7 @@
           </td>
           <% @pref_cols.each do |field| %>
             <% next if field == 'no_value' %>
-            <% if field == 'resource_accession'%>
+            <% if field == 'resource_accession' %>
               <td class="top-container-collection">
                 <% if container_json['collection'].present? %>
                   <%
@@ -133,16 +134,22 @@
                 <td><%= t('search.top_container_mgmt.not_restricted') %></td>
               <% end %>
             <% else %>
-                <td class="top-container-<%=field%>"> <%= container_json[field] %> </td>
+                <td class="top-container-<%=field%>"><%= container_json[field] %></td>
             <% end %>
           <% end %>
 
           <% if show_edit_actions %>
           <td>
             <div class="btn-group">
-              <%= link_to I18n.t("actions.view"), {:controller => :resolver, :action => :resolve_readonly, :uri => container_json["uri"]}, :class => "btn btn-sm btn-default" %>
+              <%= link_to I18n.t("actions.view"),
+                    {:controller => :resolver, :action => :resolve_readonly, :uri => container_json["uri"]},
+                    :class => "btn btn-sm btn-default #{'inline-tc-view-btn' if inline_actions}",
+                    :"data-tc-uri" => (inline_actions ? container_json["uri"] : nil) %>
               <% if can_edit %>
-                <%= link_to I18n.t("actions.edit"), {:controller => :resolver, :action => :resolve_edit, :uri => container_json["uri"]}, :class => "btn btn-sm btn-primary" %>
+                <%= link_to I18n.t("actions.edit"),
+                      {:controller => :resolver, :action => :resolve_edit, :uri => container_json["uri"]},
+                      :class => "btn btn-sm btn-primary #{'inline-tc-edit-btn' if inline_actions}",
+                      :"data-tc-uri" => (inline_actions ? container_json["uri"] : nil) %>
               <% end %>
             </div>
           </td>

--- a/frontend/app/views/top_containers/bulk_operations/_toolbar.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_toolbar.html.erb
@@ -1,7 +1,7 @@
 <div class="record-toolbar bulk-operation-toolbar d-flex justify-content-end">
   <div class="btn-group">
-    <%= link_to I18n.t("actions.export_csv"), request.parameters.merge({ :format => :csv, :fields =>
-        fields }), class: "searchExport btn btn-sm btn-primary" %>
+    <% csv_export_url = defined?(export_url) && export_url ? export_url : request.parameters.merge({ :format => :csv, :fields => fields }) %>
+    <%= link_to I18n.t("actions.export_csv"), csv_export_url, class: "searchExport btn btn-sm btn-primary" %>
     <% if user_can?('manage_container_record') %>
       <div class="btn-group dropdown" role="group">
         <button
@@ -11,14 +11,14 @@
           aria-expanded="false"
         ><%= t("top_container._frontend.bulk_operations.title") %></button>
         <div class="dropdown-menu dropdown-menu-right">
-          <button type="button" class="btn rounded-0 dropdown-item" id="bulkActionUpdateIlsHolding"><%= I18n.t("top_container._frontend.bulk_operations.update_ils_holding_ids")%></button>
-          <button type="button" class="btn rounded-0 dropdown-item" id="bulkActionUpdateContainerProfile"><%= I18n.t("top_container._frontend.bulk_operations.update_container_profiles")%></button>
-          <button type="button" class="btn rounded-0 dropdown-item" id="bulkActionUpdateLocation"><%= I18n.t("top_container._frontend.bulk_operations.update_locations_singular")%></button>
-          <button type="button" class="btn rounded-0 dropdown-item" id="bulkActionUpdateMultipleLocation"><%= I18n.t("top_container._frontend.bulk_operations.update_locations_multiple")%></button>
-          <button type="button" class="btn rounded-0 dropdown-item" id="showBulkActionRapidBarcodeEntry"><%= I18n.t("top_container._frontend.bulk_operations.rapid_barcode_entry")%></button>
-          <button type="button" class="btn rounded-0 dropdown-item" id="showBulkActionRapidIndicatorEntry"><%= I18n.t("top_container._frontend.bulk_operations.rapid_indicator_entry")%></button>
-          <button type="button" class="btn rounded-0 dropdown-item" id="bulkActionMerge"><%= I18n.t("top_container._frontend.bulk_operations.batch_merge")%></button>
-          <button type="button" class="btn rounded-0 dropdown-item" id="bulkActionDelete"><span class="text-error"><%= I18n.t("top_container._frontend.bulk_operations.batch_delete")%></button>
+          <button type="button" class="btn rounded-0 dropdown-item" id="bulkActionUpdateIlsHolding"><%= I18n.t("top_container._frontend.bulk_operations.update_ils_holding_ids") %></button>
+          <button type="button" class="btn rounded-0 dropdown-item" id="bulkActionUpdateContainerProfile"><%= I18n.t("top_container._frontend.bulk_operations.update_container_profiles") %></button>
+          <button type="button" class="btn rounded-0 dropdown-item" id="bulkActionUpdateLocation"><%= I18n.t("top_container._frontend.bulk_operations.update_locations_singular") %></button>
+          <button type="button" class="btn rounded-0 dropdown-item" id="bulkActionUpdateMultipleLocation"><%= I18n.t("top_container._frontend.bulk_operations.update_locations_multiple") %></button>
+          <button type="button" class="btn rounded-0 dropdown-item" id="showBulkActionRapidBarcodeEntry"><%= I18n.t("top_container._frontend.bulk_operations.rapid_barcode_entry") %></button>
+          <button type="button" class="btn rounded-0 dropdown-item" id="showBulkActionRapidIndicatorEntry"><%= I18n.t("top_container._frontend.bulk_operations.rapid_indicator_entry") %></button>
+          <button type="button" class="btn rounded-0 dropdown-item" id="bulkActionMerge"><%= I18n.t("top_container._frontend.bulk_operations.batch_merge") %></button>
+          <button type="button" class="btn rounded-0 dropdown-item" id="bulkActionDelete"><span class="text-error"><%= I18n.t("top_container._frontend.bulk_operations.batch_delete") %></button>
         </div>
       </div>
     <% end %>

--- a/frontend/app/views/top_containers/index.html.erb
+++ b/frontend/app/views/top_containers/index.html.erb
@@ -21,6 +21,4 @@
   </div>
 --></div>
 
-<%= javascript_include_tag("top_containers.bulk") %>
-
 <%= render_aspace_partial :partial => "top_containers/bulk_operations/bulk_action_templates" %>

--- a/frontend/config/locales/de.yml
+++ b/frontend/config/locales/de.yml
@@ -319,6 +319,7 @@ de:
     search_button_title: Alle Aufzeichnungen durchsuchen
     manage_groups: Gruppen verwalten
     manage_top_containers: Haupt-Behältnisse verwalten
+    view_top_containers: Haupt-Behältnisse anzeigen
     import_ead: EAD-Datei
     register_prefix: Benötigen Sie einen Zugang?
   job:

--- a/frontend/config/locales/de.yml
+++ b/frontend/config/locales/de.yml
@@ -320,6 +320,10 @@ de:
     manage_groups: Gruppen verwalten
     manage_top_containers: Haupt-Behältnisse verwalten
     view_top_containers: Haupt-Behältnisse anzeigen
+    top_containers_for: "Haupt-Behältnisse für %{record_title}"
+    no_top_containers: Keine verknüpften Haupt-Behältnisse
+    edit_top_container: Haupt-Behältnis bearbeiten
+    view_top_container: Haupt-Behältnis
     import_ead: EAD-Datei
     register_prefix: Benötigen Sie einen Zugang?
   job:

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -609,6 +609,7 @@ en:
     manage_container_profiles: Manage Container Profiles
     manage_location_profiles: Manage Location Profiles
     manage_top_containers: Manage Top Containers
+    view_top_containers: View Top Containers
     manage_enumerations: Manage Controlled Value Lists
     global_preferences: Global Preferences
     global_settings: Global Settings

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -610,6 +610,10 @@ en:
     manage_location_profiles: Manage Location Profiles
     manage_top_containers: Manage Top Containers
     view_top_containers: View Top Containers
+    top_containers_for: "Top Containers for %{record_title}"
+    no_top_containers: No linked top containers
+    edit_top_container: Edit Top Container
+    view_top_container: Top Container
     manage_enumerations: Manage Controlled Value Lists
     global_preferences: Global Preferences
     global_settings: Global Settings

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -608,6 +608,7 @@ es:
     manage_container_profiles: Gestionar Container Profiles
     manage_location_profiles: Gestionar Location Profiles
     manage_top_containers: Gestionar Top Containers
+    view_top_containers: Ver Top Containers
     manage_enumerations: Administrar listas de valores controlados
     global_preferences: Preferencias globales
     user_repo_preferences: Valores predeterminados de preferencia de usuario

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -609,6 +609,10 @@ es:
     manage_location_profiles: Gestionar Location Profiles
     manage_top_containers: Gestionar Top Containers
     view_top_containers: Ver Top Containers
+    top_containers_for: "Top Containers de %{record_title}"
+    no_top_containers: No hay Top Containers vinculados
+    edit_top_container: Editar Top Container
+    view_top_container: Top Container
     manage_enumerations: Administrar listas de valores controlados
     global_preferences: Preferencias globales
     user_repo_preferences: Valores predeterminados de preferencia de usuario

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -670,6 +670,7 @@ fr:
     manage_container_profiles: Gérer profils de conditionnements
     manage_location_profiles: Gérer profils de localisations
     manage_top_containers: Gérer Top conditionnements
+    view_top_containers: Voir les Top conditionnements
     manage_enumerations: Gérer listes de valeurs contrôlées
     global_preferences: Préférences globales
     user_repo_preferences: Préférences par défaut de service d'archives

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -671,6 +671,10 @@ fr:
     manage_location_profiles: Gérer profils de localisations
     manage_top_containers: Gérer Top conditionnements
     view_top_containers: Voir les Top conditionnements
+    top_containers_for: "Top conditionnements pour %{record_title}"
+    no_top_containers: Aucun top conditionnement lié
+    edit_top_container: Modifier le top conditionnement
+    view_top_container: Top conditionnement
     manage_enumerations: Gérer listes de valeurs contrôlées
     global_preferences: Préférences globales
     user_repo_preferences: Préférences par défaut de service d'archives

--- a/frontend/config/locales/it.yml
+++ b/frontend/config/locales/it.yml
@@ -423,6 +423,12 @@ it:
   navbar:
     import_marcxml_subjects_and_agents: MARCXML (solo soggetti e agents)
     toggle_navigation: Attiva/disattiva navigazione
+    manage_top_containers: Gestisci Top Container
+    view_top_containers: Visualizza Top Container
+    top_containers_for: "Top Container per %{record_title}"
+    no_top_containers: Nessun top container collegato
+    edit_top_container: Modifica Top Container
+    view_top_container: Top Container
   footer:
     keyboard_shortcuts: Scorciatoie da tastiera
     archivesspace_home_html: Visita <a 

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -572,6 +572,7 @@ ja:
     manage_container_profiles: コンテナプロファイルの管理
     manage_location_profiles: ロケーションプロファイルを管理する
     manage_top_containers: トップコンテナを管理する
+    view_top_containers: トップコンテナを表示する
     manage_enumerations: 管理された値リストの管理
     global_preferences: グローバル設定
     user_repo_preferences: ユーザー設定

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -573,6 +573,10 @@ ja:
     manage_location_profiles: ロケーションプロファイルを管理する
     manage_top_containers: トップコンテナを管理する
     view_top_containers: トップコンテナを表示する
+    top_containers_for: "%{record_title}のトップコンテナ"
+    no_top_containers: リンクされたトップコンテナがありません
+    edit_top_container: トップコンテナを編集する
+    view_top_container: トップコンテナ
     manage_enumerations: 管理された値リストの管理
     global_preferences: グローバル設定
     user_repo_preferences: ユーザー設定

--- a/frontend/config/locales/pl.yml
+++ b/frontend/config/locales/pl.yml
@@ -300,6 +300,7 @@ pl:
     manage_container_profiles: Zarządzaj profilami kontenerów
     manage_location_profiles: Zarządzaj profilami lokalizacji
     manage_top_containers: Zarządzaj najlepszymi kontenerami
+    view_top_containers: Przeglądaj najlepsze kontenery
     manage_enumerations: Zarządzaj listami wartości kontrolowanych
     global_preferences: Preferencje globalne
     global_settings: Ustawienia globalne

--- a/frontend/config/locales/pl.yml
+++ b/frontend/config/locales/pl.yml
@@ -301,6 +301,10 @@ pl:
     manage_location_profiles: Zarządzaj profilami lokalizacji
     manage_top_containers: Zarządzaj najlepszymi kontenerami
     view_top_containers: Przeglądaj najlepsze kontenery
+    top_containers_for: "Najlepsze kontenery dla %{record_title}"
+    no_top_containers: Brak powiązanych najlepszych kontenerów
+    edit_top_container: Edytuj najlepszy kontener
+    view_top_container: Najlepszy kontener
     manage_enumerations: Zarządzaj listami wartości kontrolowanych
     global_preferences: Preferencje globalne
     global_settings: Ustawienia globalne

--- a/frontend/config/locales/uk.yml
+++ b/frontend/config/locales/uk.yml
@@ -276,6 +276,7 @@ uk:
     manage_container_profiles: Керування профілями контейнерів
     manage_location_profiles: Керування профілями місцезнаходження
     manage_top_containers: Керування головними контейнерами
+    view_top_containers: Перегляд головних контейнерів
     manage_enumerations: Керування списками контрольованих значень
     global_preferences: Глобальні налаштування
     global_settings: Глобальні налаштування

--- a/frontend/config/locales/uk.yml
+++ b/frontend/config/locales/uk.yml
@@ -277,6 +277,10 @@ uk:
     manage_location_profiles: Керування профілями місцезнаходження
     manage_top_containers: Керування головними контейнерами
     view_top_containers: Перегляд головних контейнерів
+    top_containers_for: "Головні контейнери для %{record_title}"
+    no_top_containers: Немає пов'язаних головних контейнерів
+    edit_top_container: Редагувати головний контейнер
+    view_top_container: Головний контейнер
     manage_enumerations: Керування списками контрольованих значень
     global_preferences: Глобальні налаштування
     global_settings: Глобальні налаштування

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -270,6 +270,7 @@ ArchivesSpace::Application.routes.draw do
     match('container_profiles/:id' => 'container_profiles#update', :via => [:post])
     match('container_profiles/:id/delete' => 'container_profiles#delete', :via => [:post])
 
+    match('top_containers/access_top_containers' => 'top_containers#access_top_containers', :via => [:get, :post])
     resources :top_containers
     match('top_containers/search/typeahead' => 'top_containers#typeahead', :via => [:get])
     match('top_containers/bulk_operations/search' => 'top_containers#bulk_operations', :via => [:get])

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -270,7 +270,7 @@ ArchivesSpace::Application.routes.draw do
     match('container_profiles/:id' => 'container_profiles#update', :via => [:post])
     match('container_profiles/:id/delete' => 'container_profiles#delete', :via => [:post])
 
-    match('top_containers/access_top_containers' => 'top_containers#access_top_containers', :via => [:get, :post])
+    match('top_containers/access_top_containers' => 'top_containers#access_top_containers', :via => [:get])
     resources :top_containers
     match('top_containers/search/typeahead' => 'top_containers#typeahead', :via => [:get])
     match('top_containers/bulk_operations/search' => 'top_containers#bulk_operations', :via => [:get])

--- a/frontend/spec/controllers/top_containers_controller_spec.rb
+++ b/frontend/spec/controllers/top_containers_controller_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_helper'
+
+describe TopContainersController, type: :controller do
+  render_views
+
+  before(:all) do
+    set_repo($repo)
+    @top_container = create(:top_container, indicator: 'Test Box 1')
+    @resource = create(:resource)
+  end
+
+  before(:each) do
+    set_repo($repo)
+    session = User.login('admin', 'admin')
+    User.establish_session(controller, session, 'admin')
+    controller.session[:repo_id] = JSONModel.repository
+  end
+
+  describe 'access_top_containers' do
+    it 'renders the manage_for_record partial' do
+      get :access_top_containers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to have_css('#topContainersManageForRecord')
+    end
+
+    it 'shows a success flash message when saved=true' do
+      get :access_top_containers, params: { saved: 'true' }
+
+      result = Capybara.string(response.body)
+      expect(result).to have_css('.alert.alert-success')
+    end
+
+    it 'does not show a flash message when saved is not set' do
+      get :access_top_containers
+
+      result = Capybara.string(response.body)
+      expect(result).not_to have_css('.alert.alert-success')
+    end
+
+    it 'does not show a flash message when saved=false' do
+      get :access_top_containers, params: { saved: 'false' }
+
+      result = Capybara.string(response.body)
+      expect(result).not_to have_css('.alert.alert-success')
+    end
+
+    it 'accepts a resource record_uri without error' do
+      get :access_top_containers, params: {
+        record_uri: @resource.uri,
+        record_type: 'resource',
+        record_title: @resource.title
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to have_css('#topContainersManageForRecord')
+    end
+  end
+
+  describe 'inline show' do
+    it 'renders the show_inline partial when inline=true' do
+      get :show, params: { id: @top_container.id, inline: true }
+
+      result = Capybara.string(response.body)
+      aggregate_failures do
+        expect(result).to have_content('Test Box 1')
+        expect(result).not_to have_css('nav.navbar')
+      end
+    end
+
+    it 'renders the full show page when inline is not set' do
+      get :show, params: { id: @top_container.id }
+
+      expect(response.body).to have_css('nav.navbar')
+    end
+  end
+
+  describe 'inline edit' do
+    it 'renders the edit_inline partial when inline=true' do
+      get :edit, params: { id: @top_container.id, inline: true }
+
+      result = Capybara.string(response.body)
+      aggregate_failures do
+        expect(result).to have_css('form.aspace-record-form#edit_top_container_inline')
+        expect(result).not_to have_css('nav.navbar')
+      end
+    end
+
+    it 'renders the full edit page when inline is not set' do
+      get :edit, params: { id: @top_container.id }
+
+      expect(response.body).to have_css('nav.navbar')
+    end
+  end
+
+  describe 'inline update' do
+    it 'returns JSON when inline=true and data is valid' do
+      new_indicator = "Updated Box #{Time.now.to_i}"
+      current = JSONModel(:top_container).find(@top_container.id)
+
+      post :update, params: {
+        id: @top_container.id,
+        inline: true,
+        top_container: { indicator: new_indicator, lock_version: current.lock_version }
+      }
+
+      aggregate_failures do
+        expect(response.content_type).to match(%r{application/json})
+        json = JSON.parse(response.body)
+        expect(json['indicator']).to eq(new_indicator)
+        expect(json['uri']).to match(%r{/repositories/\d+/top_containers/\d+})
+      end
+    end
+
+    it 're-renders the edit_inline partial with errors when inline=true and indicator is blank' do
+      current = JSONModel(:top_container).find(@top_container.id)
+
+      post :update, params: {
+        id: @top_container.id,
+        inline: true,
+        top_container: { indicator: '', lock_version: current.lock_version }
+      }
+
+      result = Capybara.string(response.body)
+      aggregate_failures do
+        expect(result).to have_css('form.aspace-record-form#edit_top_container_inline')
+        expect(result).to have_css('.alert.alert-danger')
+      end
+    end
+
+    it 'redirects to show page when inline is not set and data is valid' do
+      current = JSONModel(:top_container).find(@top_container.id)
+
+      post :update, params: {
+        id: @top_container.id,
+        top_container: { indicator: "Redirect Box #{Time.now.to_i}", lock_version: current.lock_version }
+      }
+
+      expect(response).to redirect_to(action: :show, id: @top_container.id)
+    end
+  end
+end

--- a/frontend/spec/features/accessions_spec.rb
+++ b/frontend/spec/features/accessions_spec.rb
@@ -912,6 +912,38 @@ describe 'Accessions', js: true do
     end
   end
 
+  describe 'Manage Top Containers modal' do
+    before(:all) do
+      @tc_repo = create(:repo, repo_code: "accession_tc_test_#{Time.now.to_i}")
+      set_repo(@tc_repo)
+      @accession_container = create(:top_container, indicator: "Accession Box #{Time.now.to_i}")
+      @tc_accession = create(:accession,
+        title: "TC Accession #{Time.now.to_i}",
+        instances: [build(:json_instance,
+          sub_container: build(:json_sub_container,
+            top_container: { ref: @accession_container.uri }))]
+      )
+      run_all_indexers
+    end
+
+    before(:each) do
+      login_admin
+      select_repository(@tc_repo)
+    end
+
+    it 'opens from the accession edit toolbar and shows linked containers' do
+      visit "/accessions/#{@tc_accession.id}/edit"
+
+      find('#other-dropdown button').click
+      click_button 'Manage Top Containers'
+
+      within '#accessTopContainersModal' do
+        wait_for_ajax
+        expect(page).to have_css('#bulk_operation_results tbody tr')
+        expect(page).to have_content(@accession_container.indicator)
+      end
+    end
+  end
 end
 
 describe 'Accessions (view-only permissions)', js: true do
@@ -952,5 +984,16 @@ describe 'Accessions (view-only permissions)', js: true do
     view_published_link = find_link('View Published')
     expect(view_published_link[:href]).to include('/accessions/')
     expect(view_published_link[:target]).to eq('_blank')
+  end
+
+  it 'can open the View Top Containers modal from the accession show page' do
+    visit "/accessions/#{@published_accession.id}"
+
+    click_button 'View Top Containers'
+
+    within '#accessTopContainersModal' do
+      wait_for_ajax
+      expect(page).to have_css('#topContainersManageForRecord')
+    end
   end
 end

--- a/frontend/spec/features/accessions_spec.rb
+++ b/frontend/spec/features/accessions_spec.rb
@@ -950,9 +950,15 @@ describe 'Accessions (view-only permissions)', js: true do
   before(:all) do
     @view_only_repo = create(:repo, repo_code: "view_only_test_#{Time.now.to_i}", publish: true)
     set_repo(@view_only_repo)
-    @published_accession = create(:json_accession, publish: true)
+    @view_only_tc = create(:top_container, indicator: "View Only Box #{Time.now.to_i}")
+    @published_accession = create(:json_accession,
+      publish: true,
+      instances: [build(:json_instance,
+        sub_container: build(:json_sub_container,
+          top_container: { ref: @view_only_tc.uri }))]
+    )
     @view_only_user = create_user(@view_only_repo => ['repository-viewers'])
-    run_index_round
+    run_periodic_index
   end
 
   before(:each) do

--- a/frontend/spec/features/resources_spec.rb
+++ b/frontend/spec/features/resources_spec.rb
@@ -1771,6 +1771,70 @@ describe 'Resources', js: true do
     end
   end
 
+  describe 'Manage Top Containers modal' do
+    before(:all) do
+      set_repo @repository
+      @managed_resource = create(:resource, title: "Managed Resource #{Time.now.to_i}")
+      @managed_container = create(:top_container, indicator: "Managed Box #{Time.now.to_i}")
+      create(:archival_object,
+        title: "Managed Resource Object #{Time.now.to_i}",
+        resource: { ref: @managed_resource.uri },
+        instances: [build(:json_instance,
+          :sub_container => build(:json_sub_container,
+            :top_container => { ref: @managed_container.uri }))]
+      )
+      run_all_indexers
+    end
+
+    it 'opens from the resource edit toolbar and shows linked containers' do
+      visit "/resources/#{@managed_resource.id}/edit"
+
+      find('#other-dropdown button').click
+      click_button 'Manage Top Containers'
+
+      within '#accessTopContainersModal' do
+        wait_for_ajax
+        expect(page).to have_css('#bulk_operation_results tbody tr')
+        expect(page).to have_content(@managed_container.indicator)
+      end
+    end
+
+    it 'allows inline editing of a container and shows a success message' do
+      new_indicator = "Updated Box #{Time.now.to_i}"
+
+      visit "/resources/#{@managed_resource.id}/edit"
+
+      find('#other-dropdown button').click
+      click_button 'Manage Top Containers'
+
+      within '#accessTopContainersModal' do
+        wait_for_ajax
+        within '#bulk_operation_results tbody tr', text: @managed_container.indicator do
+          find('.inline-tc-edit-btn').click
+        end
+      end
+
+      within '#accessTopContainerSubModal' do
+        fill_in 'top_container[indicator]', with: new_indicator
+        find("button[type='submit']").click
+      end
+
+      within '#accessTopContainersModal' do
+        wait_for_ajax
+        expect(page).to have_css('.alert.alert-success')
+
+        within '#bulk_operation_results tbody tr' do
+          find('.inline-tc-view-btn').click
+        end
+      end
+
+      within '#accessTopContainerSubModal' do
+        wait_for_ajax
+        expect(page).to have_content(new_indicator)
+      end
+    end
+  end
+
   describe 'view-only permissions' do
     before(:all) do
       @view_only_repo = create(:repo, repo_code: "view_only_resources_#{Time.now.to_i}", publish: true)
@@ -1812,6 +1876,30 @@ describe 'Resources', js: true do
       expect(view_published_link[:href]).to include('/repositories/')
       expect(view_published_link[:href]).to include('/resources/')
       expect(view_published_link[:target]).to eq('_blank')
+    end
+
+    it 'can open the View Top Containers modal from the resource show page' do
+      visit "/resources/#{@published_resource.id}"
+      wait_for_ajax
+
+      click_button 'View Top Containers'
+
+      within '#accessTopContainersModal' do
+        wait_for_ajax
+        expect(page).to have_css('#topContainersManageForRecord')
+      end
+    end
+
+    it 'does not show Edit buttons in the View Top Containers modal' do
+      visit "/resources/#{@published_resource.id}"
+      wait_for_ajax
+
+      click_button 'View Top Containers'
+
+      within '#accessTopContainersModal' do
+        wait_for_ajax
+        expect(page).not_to have_css('.inline-tc-edit-btn')
+      end
     end
   end
 end

--- a/frontend/spec/features/resources_spec.rb
+++ b/frontend/spec/features/resources_spec.rb
@@ -1839,9 +1839,17 @@ describe 'Resources', js: true do
     before(:all) do
       @view_only_repo = create(:repo, repo_code: "view_only_resources_#{Time.now.to_i}", publish: true)
       set_repo(@view_only_repo)
-      @published_resource = create(:resource, title: "Published Resource #{Time.now.to_i}", publish: true)
+      @view_only_tc = create(:top_container, indicator: "View Only Box #{Time.now.to_i}")
+      @published_resource = create(:resource,
+        title: "Published Resource #{Time.now.to_i}",
+        publish: true,
+        instances: [build(:json_instance,
+          sub_container: build(:json_sub_container,
+            top_container: { ref: @view_only_tc.uri }))]
+      )
       @view_only_user = create_user(@view_only_repo => ['repository-viewers'])
-      run_index_round
+
+      run_periodic_index
     end
 
     before(:each) do
@@ -1880,7 +1888,7 @@ describe 'Resources', js: true do
 
     it 'can open the View Top Containers modal from the resource show page' do
       visit "/resources/#{@published_resource.id}"
-      wait_for_ajax
+      expect(page).to have_css('.access-top-containers-btn:not([disabled])')
 
       click_button 'View Top Containers'
 
@@ -1892,7 +1900,7 @@ describe 'Resources', js: true do
 
     it 'does not show Edit buttons in the View Top Containers modal' do
       visit "/resources/#{@published_resource.id}"
-      wait_for_ajax
+      expect(page).to have_css('.access-top-containers-btn:not([disabled])')
 
       click_button 'View Top Containers'
 


### PR DESCRIPTION
## Description
Adds a "Manage Top Containers" button to the Resource and Accession toolbars (both edit and view-only). Clicking it opens a modal showing all top containers linked to that record.                                                                                                                               
                                                                                                                                                                                             
From that modal, staff can view or edit any individual top container inline via a stacked sub-modal. Edits save in place and refresh the container list without closing either modal.

## Related JIRA Ticket or GitHub Issue
[ANW-785]

## How Has This Been Tested?
- exploratory test
- added necessary automated specs and e2e feature spec 

## Screenshots (if appropriate):
<img width="864" height="558" alt="TopContainerInline" src="https://github.com/user-attachments/assets/9bb67726-4b0b-47b2-8ccd-c40e5b971c10" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[ANW-785]: https://archivesspace.atlassian.net/browse/ANW-785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ