### PR TITLE
ANW-2692 set the prefered locale from AppConfig if preferences miss it

### DIFF
--- a/backend/app/model/preference.rb
+++ b/backend/app/model/preference.rb
@@ -92,7 +92,6 @@ class Preference < Sequel::Model(:preference)
     filter = {:repo_id => repo_id, :user_uniq => [user_id.to_s, 'GLOBAL_USER']}
     json_prefs = {'defaults' => {}}
     prefs = {}
-    defaults = {}
 
     if repo_id != Repository.global_repo_id
       self.filter(filter).each do |pref|
@@ -135,7 +134,9 @@ class Preference < Sequel::Model(:preference)
     jsons = super
 
     jsons.zip(objs).each do |json, obj|
-      json['defaults'] = JSONModel(:defaults).from_json(obj.defaults)
+      parsed = ASUtils.json_parse(obj.defaults)
+      parsed['locale'] ||= AppConfig[:locale].to_s
+      json['defaults'] = JSONModel(:defaults).from_hash(parsed)
     end
 
     jsons

--- a/frontend/app/controllers/preferences_controller.rb
+++ b/frontend/app/controllers/preferences_controller.rb
@@ -17,7 +17,7 @@ class PreferencesController < ApplicationController
       pref = JSONModel(:preference).from_hash(@current_prefs[user_scope])
     else
       pref = JSONModel(:preference).new({
-                                        :defaults => {},
+                                        :defaults => { 'locale' => AppConfig[:locale].to_s },
                                         :user_id => params['repo'] ? nil : JSONModel(:user).id_for(session[:user_uri])
                                       })
       pref.save(opts)


### PR DESCRIPTION
## Description
Adding the Dutch language option (that is sorted first in the languages dropdown on the UI) revealed that preferences for the global_user (and possibly all users?) did not include a setting for language and it was only coincidental that english was chosen by default, just because it was the first one in the dropdown list.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
[ANW-2692]
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[ANW-2692]: https://archivesspace.atlassian.net/browse/ANW-2692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ