### PR TITLE
ANW-2726 add a formatter for feature files, vscode configuration, CI checks

### DIFF
--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -67,6 +67,33 @@ jobs:
         run: |
           bundle exec rubocop
 
+  format-features:
+    name: E2E-format-features
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: e2e-tests
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.0'
+      - name: Cache gems
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Install gems
+        run: |
+          bundle config path vendor/bundle
+          bundle install --quiet --jobs 4 --retry 3
+      - name: Check .feature files are right-aligned
+        run: |
+          bundle exec rake format:check
+
   cucumber-dry-run:
     name: E2E-ensure-all-steps-implemented
     runs-on: ubuntu-latest

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "alexkrechik.cucumberautocomplete",
+    "emeraldwalk.runonsave"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,5 +36,19 @@
   },
   "[scss]": {
     "editor.defaultFormatter": "stylelint.vscode-stylelint"
+  },
+  "[feature]": {
+    "editor.formatOnSave": false,
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true
+  },
+  "emeraldwalk.runonsave": {
+    "commands": [
+      {
+        "match": "e2e-tests/.*\\.feature$",
+        "isAsync": false,
+        "cmd": "cd '${workspaceFolder}/e2e-tests' && FILES='${file}' rake format:features"
+      }
+    ]
   }
 }

--- a/e2e-tests/Gemfile
+++ b/e2e-tests/Gemfile
@@ -7,6 +7,7 @@ gem 'capybara'
 gem 'capybara-screenshot'
 gem 'cucumber'
 gem 'cuke_linter'
+gem 'rake'
 gem 'rspec-expectations'
 gem 'rubocop', require: false
 gem 'selenium-webdriver'

--- a/e2e-tests/Gemfile.lock
+++ b/e2e-tests/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     rack-test (2.2.0)
       rack (>= 1.3)
     rainbow (3.1.1)
+    rake (13.4.2)
     regexp_parser (2.11.3)
     rexml (3.4.4)
     rspec-expectations (3.13.5)
@@ -130,6 +131,7 @@ DEPENDENCIES
   capybara-screenshot
   cucumber
   cuke_linter
+  rake
   rspec-expectations
   rubocop
   selenium-webdriver

--- a/e2e-tests/Rakefile
+++ b/e2e-tests/Rakefile
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rake'
+require_relative 'lib/feature_formatter'
+
+def feature_paths_for(env_files)
+  files = (env_files || '').split(',').map(&:strip).reject(&:empty?)
+  files.empty? ? FeatureFormatter.feature_paths(__dir__) : files
+end
+
+namespace :format do
+  desc 'Reformat .feature files with right-aligned step keywords. Pass FILES=path[,path...] to limit scope.'
+  task :features do
+    changed = feature_paths_for(ENV.fetch('FILES', nil)).filter_map do |path|
+      original = File.read(path)
+      formatted = FeatureFormatter.format(original)
+      next if original == formatted
+
+      File.write(path, formatted)
+      path
+    end
+
+    if changed.empty?
+      puts 'format:features: no changes'
+    else
+      puts "format:features: rewrote #{changed.size} file(s)"
+      changed.each { |p| puts "  #{p}" }
+    end
+  end
+
+  desc 'Check that .feature files are correctly formatted; exit non-zero on diff. Pass FILES=path[,path...] to limit scope.'
+  task :check do
+    misformatted = feature_paths_for(ENV.fetch('FILES', nil)).reject do |path|
+      original = File.read(path)
+      original == FeatureFormatter.format(original)
+    end
+
+    if misformatted.empty?
+      puts 'format:check: ok'
+    else
+      warn 'format:check: the following files are not right-aligned:'
+      misformatted.each { |p| warn "  #{p}" }
+      warn 'Run `bundle exec rake format:features` to fix.'
+      exit 1
+    end
+  end
+end
+
+task default: 'format:features'

--- a/e2e-tests/lib/feature_formatter.rb
+++ b/e2e-tests/lib/feature_formatter.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# Right-aligned Gherkin step keyword indentation:
+#   step text starts at column 11 in every step line.
+#   Given (5)+space → 4 leading spaces
+#   When  (4)+space → 5 leading spaces
+#   Then  (4)+space → 5 leading spaces
+#   And   (3)+space → 6 leading spaces
+#   But   (3)+space → 6 leading spaces
+#   *     (1)+space → 6 leading spaces
+class FeatureFormatter
+  SECTION_INDENT = {
+    'Feature' => 0,
+    'Rule' => 2,
+    'Background' => 2,
+    'Scenario' => 2,
+    'Scenario Outline' => 2,
+    'Scenario Template' => 2
+  }.freeze
+
+  STEP_INDENT = {
+    'Given' => 4,
+    'When' => 5,
+    'Then' => 5,
+    'And' => 6,
+    'But' => 6,
+    '*' => 6
+  }.freeze
+
+  TAG_INDENT = 2
+
+  SECTION_RE = /\A\s*(Feature|Rule|Background|Scenario Outline|Scenario Template|Scenario|Examples)\s*:.*\z/
+  STEP_RE    = /\A\s*(Given|When|Then|And|But|\*)\s+(.*)\z/
+  TABLE_RE   = /\A\s*(\|.*)\z/
+  TAG_RE     = /\A\s*(@.*)\z/
+
+  def self.feature_paths(root)
+    Dir.glob(File.join(root, 'staff_features/**/*.feature'))
+       .reject { |p| File.basename(p).start_with?('.#') }
+  end
+
+  def self.format(source)
+    new.format(source)
+  end
+
+  def initialize
+    @owner_indent = nil
+    @prev_indent = nil
+  end
+
+  def format(source)
+    source.lines.map { |raw| format_line(raw) }.join
+  end
+
+  private
+
+  def format_line(raw)
+    line = raw.chomp
+    newline = raw.end_with?("\n") ? "\n" : ''
+
+    return newline if line.strip.empty?
+    return format_section(Regexp.last_match, line, newline) if SECTION_RE.match(line)
+    return format_step(Regexp.last_match, newline) if STEP_RE.match(line)
+    return format_table(Regexp.last_match, newline) if TABLE_RE.match(line)
+    return format_tag(Regexp.last_match, newline) if TAG_RE.match(line)
+
+    raw
+  end
+
+  def format_section(match, line, newline)
+    kw = match[1]
+    rest = line.sub(/\A\s*#{Regexp.escape(kw)}/, '')
+    indent = kw == 'Examples' ? (@prev_indent || 4) + 2 : SECTION_INDENT[kw]
+    @owner_indent = kw == 'Examples' ? indent : nil
+    @prev_indent = indent
+    "#{' ' * indent}#{kw}#{rest}#{newline}"
+  end
+
+  def format_step(match, newline)
+    kw = match[1]
+    indent = STEP_INDENT[kw]
+    @owner_indent = indent
+    @prev_indent = indent
+    "#{' ' * indent}#{kw} #{match[2]}#{newline}"
+  end
+
+  def format_table(match, newline)
+    indent = (@owner_indent || 4) + 2
+    @prev_indent = indent
+    "#{' ' * indent}#{match[1]}#{newline}"
+  end
+
+  def format_tag(match, newline)
+    @prev_indent = TAG_INDENT
+    "#{' ' * TAG_INDENT}#{match[1]}#{newline}"
+  end
+end

--- a/e2e-tests/staff_features/accessions/accession_calculate_extent.feature
+++ b/e2e-tests/staff_features/accessions/accession_calculate_extent.feature
@@ -1,18 +1,18 @@
 Feature: Calculate Extent of an accession
   Background:
-   Given an administrator user is logged in
-     And an Accession has been created
-     And the Accession is opened in edit mode
+    Given an administrator user is logged in
+      And an Accession has been created
+      And the Accession is opened in edit mode
   Scenario: Extent sub record is added to the Accession
-    When the user clicks on 'More'
-     And the user clicks on 'Calculate Extent'
-     And the user selects 'Whole' from 'Portion' in the modal
-     And the user fills in 'Number' with '123456789' in the modal
-     And the user selects 'Cassettes' from 'Type' in the modal
-     And the user clicks on 'Create Extent' in the modal
-     And the user clicks on 'Save'
-    Then the 'Accession' updated message is displayed
-     And a new Extent is added to the Accession with the following values
-       | Portion      | Whole           |
-       | Number       | 123456789       |
-       | Type         | Cassettes       |
+     When the user clicks on 'More'
+      And the user clicks on 'Calculate Extent'
+      And the user selects 'Whole' from 'Portion' in the modal
+      And the user fills in 'Number' with '123456789' in the modal
+      And the user selects 'Cassettes' from 'Type' in the modal
+      And the user clicks on 'Create Extent' in the modal
+      And the user clicks on 'Save'
+     Then the 'Accession' updated message is displayed
+      And a new Extent is added to the Accession with the following values
+        | Portion      | Whole           |
+        | Number       | 123456789       |
+        | Type         | Cassettes       |

--- a/e2e-tests/staff_features/accessions/accession_edit.feature
+++ b/e2e-tests/staff_features/accessions/accession_edit.feature
@@ -16,10 +16,10 @@ Feature: Accession Edit
       And the user clicks on 'Save'
      Then the 'Accession' updated message is displayed
      Then the field '<Field>' has value '<NewValue>'
-     Examples:
-      | Field    | NewValue                 |
-      | Title    | Updated Test Accession   |
-      | Accession Date     | 2024-10-03               |
+       Examples:
+         | Field    | NewValue                 |
+         | Title    | Updated Test Accession   |
+         | Accession Date     | 2024-10-03               |
   Scenario: Accession is not updated after changes are reverted
     Given the Accession is opened in edit mode
      When the user changes the 'Title' field

--- a/e2e-tests/staff_features/accessions/accession_event_create.feature
+++ b/e2e-tests/staff_features/accessions/accession_event_create.feature
@@ -35,5 +35,5 @@ Feature: Accession Event Create
       And the user fills in 'Begin' with '2020-22-22' in the 'Event Date/Time' form
       And the user links an Agent
       And the user clicks on 'Save'
-    Then only the following error message is displayed
-      | Begin - Not a valid date |
+     Then only the following error message is displayed
+       | Begin - Not a valid date |

--- a/e2e-tests/staff_features/accessions/accession_spawn_digital_object.feature
+++ b/e2e-tests/staff_features/accessions/accession_spawn_digital_object.feature
@@ -11,5 +11,5 @@ Feature: Accession spawn Digital Object
      Then the Create Digital Object modal is displayed
       And the Digital Object title is filled in with the Accession Title
       And the following Digital Object forms have the same values as the Accession
-       | Languages  |
-       | Dates      |
+        | Languages  |
+        | Dates      |

--- a/e2e-tests/staff_features/accessions/accession_staff_link.feature
+++ b/e2e-tests/staff_features/accessions/accession_staff_link.feature
@@ -2,20 +2,20 @@ Feature: Accession Staff Link on Public Interface
 
   Background:
     Given an administrator user is logged in
-    And an Accession has been created
+      And an Accession has been created
 
   Scenario: Staff Only button opens edit view for user with edit permissions
-    When the user visits the Accession on the Public Interface
-    And the user clicks on 'Staff Only' that opens in a new tab
-    Then the 'Save' button is present in the new tab
+     When the user visits the Accession on the Public Interface
+      And the user clicks on 'Staff Only' that opens in a new tab
+     Then the 'Save' button is present in the new tab
 
   Scenario: Staff Only button opens view only for user with view-only permissions
     Given a viewer user is logged in
-    When the user visits the Accession on the Public Interface
-    And the user clicks on 'Staff Only' that opens in a new tab
-    Then the 'Save' button is not present in the new tab
+     When the user visits the Accession on the Public Interface
+      And the user clicks on 'Staff Only' that opens in a new tab
+     Then the 'Save' button is not present in the new tab
 
   Scenario: Staff Only button does not appear for unauthenticated user
     Given the user is logged out
-    When the user visits the Accession on the Public Interface
-    Then the 'Staff Only' link is not visible
+     When the user visits the Accession on the Public Interface
+     Then the 'Staff Only' link is not visible

--- a/e2e-tests/staff_features/accessions/accession_transfer.feature
+++ b/e2e-tests/staff_features/accessions/accession_transfer.feature
@@ -1,13 +1,13 @@
 Feature: Accession Transfer
   Background:
-   Given an administrator user is logged in
-     And a Repository with name 'Transfer Test Repository' has been created
-     And an Accession has been created
-     And the Accession is opened in edit mode
+    Given an administrator user is logged in
+      And a Repository with name 'Transfer Test Repository' has been created
+      And an Accession has been created
+      And the Accession is opened in edit mode
   Scenario: Accession is transferred to another Repository
-    When the user clicks on 'Transfer' in the record toolbar
-     And the user selects 'Transfer Test Repository' from 'Destination Repository'
-     And the user clicks on 'Transfer' in the transfer form
-     And the user clicks on 'Transfer' in the modal
-    Then the following message is displayed
-      | Transfer Successful. Records may take a moment to appear in the target repository while re-indexing takes place. |
+     When the user clicks on 'Transfer' in the record toolbar
+      And the user selects 'Transfer Test Repository' from 'Destination Repository'
+      And the user clicks on 'Transfer' in the transfer form
+      And the user clicks on 'Transfer' in the modal
+     Then the following message is displayed
+       | Transfer Successful. Records may take a moment to appear in the target repository while re-indexing takes place. |

--- a/e2e-tests/staff_features/agents/agent_create.feature
+++ b/e2e-tests/staff_features/agents/agent_create.feature
@@ -1,49 +1,49 @@
 Feature: Agent Create
   Background:
-   Given an administrator user is logged in
-     And the user clicks on 'Create'
-     And the user hovers on 'Agent' in the dropdown menu
+    Given an administrator user is logged in
+      And the user clicks on 'Create'
+      And the user hovers on 'Agent' in the dropdown menu
   Scenario: Agent Person is created
-    When the user clicks on 'Person'
-     And the user fills in 'Primary Part of Name' in the 'Name Forms' form
-     And the user clicks on 'Save'
-    Then the 'Agent' created message is displayed
-     And the 'Primary Part of Name' has a unique value
+     When the user clicks on 'Person'
+      And the user fills in 'Primary Part of Name' in the 'Name Forms' form
+      And the user clicks on 'Save'
+     Then the 'Agent' created message is displayed
+      And the 'Primary Part of Name' has a unique value
   Scenario: Agent Person is not created because required fields are missing
-    When the user clicks on 'Person'
-     And the user clicks on 'Save'
-    Then the following error messages are displayed
-      | Primary Part of Name - Property is required but was missing |
+     When the user clicks on 'Person'
+      And the user clicks on 'Save'
+     Then the following error messages are displayed
+       | Primary Part of Name - Property is required but was missing |
   Scenario: Agent Family is created
-    When the user clicks on 'Family'
-     And the user fills in 'Family Name' in the 'Name Forms' form
-     And the user clicks on 'Save'
-    Then the 'Agent' created message is displayed
-     And the 'Family Name' has a unique value
+     When the user clicks on 'Family'
+      And the user fills in 'Family Name' in the 'Name Forms' form
+      And the user clicks on 'Save'
+     Then the 'Agent' created message is displayed
+      And the 'Family Name' has a unique value
   Scenario: Agent Family is not created because required fields are missing
-    When the user clicks on 'Family'
-     And the user clicks on 'Save'
-    Then the following error messages are displayed
-      | Family Name - Property is required but was missing |
+     When the user clicks on 'Family'
+      And the user clicks on 'Save'
+     Then the following error messages are displayed
+       | Family Name - Property is required but was missing |
   Scenario: Agent Corporate Entity is created
-    When the user clicks on 'Corporate Entity'
-     And the user fills in 'Primary Part of Name' in the 'Name Forms' form
-     And the user clicks on 'Save'
-    Then the 'Agent' created message is displayed
-     And the 'Primary Part of Name' has a unique value
+     When the user clicks on 'Corporate Entity'
+      And the user fills in 'Primary Part of Name' in the 'Name Forms' form
+      And the user clicks on 'Save'
+     Then the 'Agent' created message is displayed
+      And the 'Primary Part of Name' has a unique value
   Scenario: Agent Corporate Entity is not created because required fields are missing
-    When the user clicks on 'Corporate Entity'
-     And the user clicks on 'Save'
-    Then the following error messages are displayed
-      | Primary Part of Name - Property is required but was missing |
+     When the user clicks on 'Corporate Entity'
+      And the user clicks on 'Save'
+     Then the following error messages are displayed
+       | Primary Part of Name - Property is required but was missing |
   Scenario: Agent Software is created
-    When the user clicks on 'Software'
-     And the user fills in 'Software Name' in the 'Name Forms' form
-     And the user clicks on 'Save'
-    Then the 'Agent' created message is displayed
-     And the 'Software Name' has a unique value
+     When the user clicks on 'Software'
+      And the user fills in 'Software Name' in the 'Name Forms' form
+      And the user clicks on 'Save'
+     Then the 'Agent' created message is displayed
+      And the 'Software Name' has a unique value
   Scenario: Agent Software is not created because required fields are missing
-    When the user clicks on 'Software'
-     And the user clicks on 'Save'
-    Then the following error messages are displayed
-      | Software Name - Property is required but was missing |
+     When the user clicks on 'Software'
+      And the user clicks on 'Save'
+     Then the following error messages are displayed
+       | Software Name - Property is required but was missing |

--- a/e2e-tests/staff_features/agents/agent_edit.feature
+++ b/e2e-tests/staff_features/agents/agent_edit.feature
@@ -2,7 +2,7 @@ Feature: Agent Edit
   Background:
     Given an administrator user is logged in
       And an Agent has been created
-   Scenario: Agent is opened in the edit mode from the browse menu
+  Scenario: Agent is opened in the edit mode from the browse menu
     Given the Agent appears in the search results list
      When the user clicks on 'Edit'
      Then the Agent is opened in the edit mode

--- a/e2e-tests/staff_features/agents/agent_merge.feature
+++ b/e2e-tests/staff_features/agents/agent_merge.feature
@@ -1,7 +1,7 @@
 Feature: Agent merge
   Background:
     Given an administrator user is logged in
-     And two Agents A & B have been created
+      And two Agents A & B have been created
   Scenario: Merge two Agents by browsing
     Given the Agent A is opened in edit mode
      When the user clicks on 'Merge'

--- a/e2e-tests/staff_features/assessments/assessment_delete.feature
+++ b/e2e-tests/staff_features/assessments/assessment_delete.feature
@@ -2,7 +2,7 @@ Feature: Assessment Delete
   Background:
     Given an administrator user is logged in
       And an Assessment has been created
-    
+
   Scenario: Assessment is deleted from the search results
      When the user clicks on 'Browse'
       And the user clicks on 'Assessments'
@@ -12,7 +12,7 @@ Feature: Assessment Delete
       And the user clicks on 'Delete Records'
      Then the 'Assessments' deleted message is displayed
       And the Assessment is deleted
-     
+
   Scenario: Assessment is deleted from the view page
     Given the user is on the Assessment view page
      When the user clicks on 'Delete'
@@ -20,7 +20,7 @@ Feature: Assessment Delete
      Then the Assessments page is displayed
       And the 'Assessment' deleted message is displayed
       And the Assessment is deleted
-      
+
   Scenario: Cancel Assessment delete from the view page
     Given the user is on the Assessment view page
      When the user clicks on 'Delete'

--- a/e2e-tests/staff_features/container_profiles/container_profile_edit.feature
+++ b/e2e-tests/staff_features/container_profiles/container_profile_edit.feature
@@ -17,9 +17,9 @@ Feature: Container Profile Edit
       And the user clicks on 'Save'
       And the user clicks on 'Edit'
      Then the field '<Field>' has value '<NewValue>'
-      Examples:
-        | Field | NewValue                       |
-        | Width | 10                             |
+       Examples:
+         | Field | NewValue                       |
+         | Width | 10                             |
   Scenario: Container Profile is not updated after changes are reverted
     Given the Container Profile is opened in edit mode
      When the user changes the 'Name' field

--- a/e2e-tests/staff_features/container_profiles/container_profile_edit_default_values.feature
+++ b/e2e-tests/staff_features/container_profiles/container_profile_edit_default_values.feature
@@ -14,13 +14,13 @@ Feature: Container Profile Edit Default Values
       And the user clicks on 'Save Container Profile'
      Then the 'Defaults' updated message is displayed
       And the new Container Profile form has the following default values
-       | form_section       | form_field        | form_value   |
-       | Basic Information  | Name              | DEFAULT BOX  |
-       | Basic Information  | Extent Dimension  | Width        |
-       | Basic Information  | Depth             | 12           |
-       | Basic Information  | Height            | 15           |
-       | Basic Information  | Width             | 10           |
-       | Basic Information  | Dimension Units   | Inches       |
+        | form_section       | form_field        | form_value   |
+        | Basic Information  | Name              | DEFAULT BOX  |
+        | Basic Information  | Extent Dimension  | Width        |
+        | Basic Information  | Depth             | 12           |
+        | Basic Information  | Height            | 15           |
+        | Basic Information  | Width             | 10           |
+        | Basic Information  | Dimension Units   | Inches       |
 
   Scenario: Change Container Profile Default from Width to Height
     Given a Container Profile Default has been set with Width as Extent Dimension
@@ -30,10 +30,10 @@ Feature: Container Profile Edit Default Values
       And the user clicks on 'Save Container Profile'
      Then the 'Defaults' updated message is displayed
       And the new Container Profile form has the following default values
-       | form_section       | form_field        | form_value   |
-       | Basic Information  | Name              | DEFAULT BOX  |
-       | Basic Information  | Extent Dimension  | Height       |
-       | Basic Information  | Depth             | 12           |
-       | Basic Information  | Height            | 15           |
-       | Basic Information  | Width             | 10           |
-       | Basic Information  | Dimension Units   | Inches       |
+        | form_section       | form_field        | form_value   |
+        | Basic Information  | Name              | DEFAULT BOX  |
+        | Basic Information  | Extent Dimension  | Height       |
+        | Basic Information  | Depth             | 12           |
+        | Basic Information  | Height            | 15           |
+        | Basic Information  | Width             | 10           |
+        | Basic Information  | Dimension Units   | Inches       |

--- a/e2e-tests/staff_features/digital_objects/digital_object_suppress.feature
+++ b/e2e-tests/staff_features/digital_objects/digital_object_suppress.feature
@@ -1,8 +1,8 @@
 Feature: Digital Object Suppress
   Background:
     Given an administrator user is logged in
-     And a Digital Object has been created
-     And the Digital Object is opened in edit mode
+      And a Digital Object has been created
+      And the Digital Object is opened in edit mode
   Scenario: Digital Object is suppressed
     Given the Digital Object is not suppressed
      When the user clicks on 'Suppress'

--- a/e2e-tests/staff_features/events/event_edit.feature
+++ b/e2e-tests/staff_features/events/event_edit.feature
@@ -16,11 +16,11 @@ Feature: Event Edit
       And the user clicks on 'Save'
      Then the 'Event' saved message is displayed
       And the field '<Field>' has value '<NewValue>'
-       Examples:
-        | Field        | NewValue           |
-        | Type         | Component Transfer |
-        | Outcome      | Pass               |
-        | Outcome Note | Test Note          |
+        Examples:
+          | Field        | NewValue           |
+          | Type         | Component Transfer |
+          | Outcome      | Pass               |
+          | Outcome Note | Test Note          |
   Scenario: Event is not updated after changes are reverted
     Given the Event is opened in edit mode
      When the user changes the 'Type' field to 'Accumulation'

--- a/e2e-tests/staff_features/events/event_edit_default_values.feature
+++ b/e2e-tests/staff_features/events/event_edit_default_values.feature
@@ -10,6 +10,6 @@ Feature: Event Edit Default Values
       And the user clicks on 'Save'
      Then the 'Defaults' updated message is displayed
       And the new Event form has the following default values
-       | form_section      | form_field   | form_value |
-       | Basic Information | Type         | Collection |
-       | Basic Information | Outcome Note | Default Event Outcome Note |
+        | form_section      | form_field   | form_value |
+        | Basic Information | Type         | Collection |
+        | Basic Information | Outcome Note | Default Event Outcome Note |

--- a/e2e-tests/staff_features/jobs/jobs.feature
+++ b/e2e-tests/staff_features/jobs/jobs.feature
@@ -2,13 +2,13 @@ Feature: Jobs
   Background:
     Given an administrator user is logged in
   Scenario: Import location job can be created
-     Given the user is on the Import Job page
-      When the user selects 'Location CSV' from 'Import Type'
-       And the user adds 'templates/aspace_location_import_template.csv' as a file
-       And the user clicks on 'Start Job'
-      Then the Import Job page is displayed
-       And the job completes
-       And the user clicks on 'Refresh Page'
-       And the 'New & Modified Records' section is displayed
-       And the New & Modified Records section contains 3 links
-       And the record links do not display 'Record belongs to a different repository'
+    Given the user is on the Import Job page
+     When the user selects 'Location CSV' from 'Import Type'
+      And the user adds 'templates/aspace_location_import_template.csv' as a file
+      And the user clicks on 'Start Job'
+     Then the Import Job page is displayed
+      And the job completes
+      And the user clicks on 'Refresh Page'
+      And the 'New & Modified Records' section is displayed
+      And the New & Modified Records section contains 3 links
+      And the record links do not display 'Record belongs to a different repository'

--- a/e2e-tests/staff_features/locations/location_create.feature
+++ b/e2e-tests/staff_features/locations/location_create.feature
@@ -32,11 +32,11 @@ Feature: Location Create
      Then the following error messages are displayed
        | Building - Property is required but was missing           |
        | Coordinate Range 1 - Property is required but was missing |
-    Scenario: Number of Locations is previewed
-      Given the New Batch Location page is displayed
-       When the user fills in 'Building'
-        And the user fills in Coordinate Range 1 Label with 'Test'
-        And the user fills in Coordinate Range 1 Range Start with '1'
-        And the user fills in Coordinate Range 1 Range End with '3'
-        And the user clicks on 'Preview Locations'
-       Then the Preview Locations modal with the number of Locations is displayed
+  Scenario: Number of Locations is previewed
+    Given the New Batch Location page is displayed
+     When the user fills in 'Building'
+      And the user fills in Coordinate Range 1 Label with 'Test'
+      And the user fills in Coordinate Range 1 Range Start with '1'
+      And the user fills in Coordinate Range 1 Range End with '3'
+      And the user clicks on 'Preview Locations'
+     Then the Preview Locations modal with the number of Locations is displayed

--- a/e2e-tests/staff_features/locations/location_edit.feature
+++ b/e2e-tests/staff_features/locations/location_edit.feature
@@ -16,9 +16,9 @@ Feature: Location Edit
       And the user clicks on 'Save'
      Then the 'Location' saved message is displayed
       And the field '<Field>' has value '<NewValue>'
-      Examples:
-      | Field    | NewValue      |
-      | Building | Test Building |
+        Examples:
+          | Field    | NewValue      |
+          | Building | Test Building |
   Scenario: Location is not updated after changes are reverted
     Given the Location is opened in edit mode
      When the user fills in 'Building' with 'New Building'

--- a/e2e-tests/staff_features/locations/location_edit_default_values.feature
+++ b/e2e-tests/staff_features/locations/location_edit_default_values.feature
@@ -10,6 +10,6 @@ Feature: Location Edit Default Values
       And the user clicks on 'Save Location'
      Then the 'Defaults' updated message is displayed
       And the new Location form has the following default values
-       | form_field | form_value    |
-       | Building   | Test Building |
-       | Barcode    | 12345678      |
+        | form_field | form_value    |
+        | Building   | Test Building |
+        | Barcode    | 12345678      |

--- a/e2e-tests/staff_features/resources/resource_component_edit_default_values.feature
+++ b/e2e-tests/staff_features/resources/resource_component_edit_default_values.feature
@@ -15,6 +15,6 @@ Feature: Resource Component Edit Default Values
       And the user clicks on 'Save'
      Then the 'Defaults' updated message is displayed
       And the new Resource Component form has the following default values
-       | form_section       | form_field                    | form_value                      |
-       | Basic Information  | Title                         | Default Component Test          |
-       | Basic Information  | Level of Description          | File                            |
+        | form_section       | form_field                    | form_value                      |
+        | Basic Information  | Title                         | Default Component Test          |
+        | Basic Information  | Level of Description          | File                            |

--- a/e2e-tests/staff_features/resources/resource_edit.feature
+++ b/e2e-tests/staff_features/resources/resource_edit.feature
@@ -16,9 +16,9 @@ Feature: Resource Edit
       And the user clicks on 'Save'
      Then the 'Resource' updated message is displayed
      Then the field '<Field>' has value '<NewValue>'
-      Examples:
-       | Field | NewValue              |
-       | Title | Updated Test Resource |
+       Examples:
+         | Field | NewValue              |
+         | Title | Updated Test Resource |
   Scenario: Resource is not updated after changes are reverted
     Given the Resource is opened in edit mode
      When the user changes the 'Title' field
@@ -38,8 +38,8 @@ Feature: Resource Edit
       And the user clicks on 'Confirm Removal'
       And the user clicks on 'Save'
      Then the following error messages are displayed
-      | Languages - At least 1 item(s) is required |
-      | Must contain at least one Language         |
+       | Languages - At least 1 item(s) is required |
+       | Must contain at least one Language         |
       And the Resource has one Language with the original values
   Scenario: Delete sub-record of a Resource
     Given the Resource is opened in edit mode

--- a/e2e-tests/staff_features/resources/resource_related_accession.feature
+++ b/e2e-tests/staff_features/resources/resource_related_accession.feature
@@ -5,93 +5,93 @@ Feature: Resource Related Accession Create and Link
 
   Scenario: Create and link a related accession from resource form
     Given the user is on the New Resource page
-    When the user fills in 'Title'
-    And the user fills in 'Identifier'
-    And the user selects 'Collection' from 'Level of Description'
-    And the user fills in 'Language' with 'English' and selects 'English' in the 'Languages' form
-    And the user selects 'Single' from 'Type' in the 'Dates' form
-    And the user fills in 'Begin' with '2026-01-01' in the 'Dates' form
-    And the user fills in 'Number' with '1' in the 'Extents' form
-    And the user selects 'Linear Feet' from 'Type' in the 'Extents' form
-    And the user fills in 'Language of Description' with 'English' and selects 'English' in the 'Finding Aid Data' form
-    And the user fills in 'Script of Description' with 'Latin' and selects 'Latin' in the 'Finding Aid Data' form
-    And the user clicks on 'Add Related Accession'
-    And the user clicks on the first dropdown in the 'Related Accessions' form
-    And the user clicks on 'Create' in the dropdown menu in the 'Related Accessions' form
-    And the user fills in 'Identifier' in the modal
-    And the user fills in 'Title' with 'Test Related Accession' in the modal
-    And the user fills in 'Accession Date' with '2026-01-05' in the modal
-    And the user clicks on 'Create and Link' in the modal
-    Then the accession 'Test Related Accession' appears in the related accessions linker
-    When the user clicks on 'Save Resource'
-    Then the 'Resource' created message is displayed
-    And the accession 'Test Related Accession' is linked to the resource
+     When the user fills in 'Title'
+      And the user fills in 'Identifier'
+      And the user selects 'Collection' from 'Level of Description'
+      And the user fills in 'Language' with 'English' and selects 'English' in the 'Languages' form
+      And the user selects 'Single' from 'Type' in the 'Dates' form
+      And the user fills in 'Begin' with '2026-01-01' in the 'Dates' form
+      And the user fills in 'Number' with '1' in the 'Extents' form
+      And the user selects 'Linear Feet' from 'Type' in the 'Extents' form
+      And the user fills in 'Language of Description' with 'English' and selects 'English' in the 'Finding Aid Data' form
+      And the user fills in 'Script of Description' with 'Latin' and selects 'Latin' in the 'Finding Aid Data' form
+      And the user clicks on 'Add Related Accession'
+      And the user clicks on the first dropdown in the 'Related Accessions' form
+      And the user clicks on 'Create' in the dropdown menu in the 'Related Accessions' form
+      And the user fills in 'Identifier' in the modal
+      And the user fills in 'Title' with 'Test Related Accession' in the modal
+      And the user fills in 'Accession Date' with '2026-01-05' in the modal
+      And the user clicks on 'Create and Link' in the modal
+     Then the accession 'Test Related Accession' appears in the related accessions linker
+     When the user clicks on 'Save Resource'
+     Then the 'Resource' created message is displayed
+      And the accession 'Test Related Accession' is linked to the resource
 
   Scenario: Validation errors prevent inline accession creation
     Given the user is on the New Resource page
-    When the user fills in 'Title'
-    And the user fills in 'Identifier'
-    And the user selects 'Collection' from 'Level of Description'
-    And the user fills in 'Language' with 'English' and selects 'English' in the 'Languages' form
-    And the user selects 'Single' from 'Type' in the 'Dates' form
-    And the user fills in 'Begin' with '2026-01-01' in the 'Dates' form
-    And the user fills in 'Number' with '1' in the 'Extents' form
-    And the user selects 'Linear Feet' from 'Type' in the 'Extents' form
-    And the user fills in 'Language of Description' with 'English' and selects 'English' in the 'Finding Aid Data' form
-    And the user fills in 'Script of Description' with 'Latin' and selects 'Latin' in the 'Finding Aid Data' form
-    And the user clicks on 'Add Related Accession'
-    And the user clicks on the first dropdown in the 'Related Accessions' form
-    And the user clicks on 'Create' in the dropdown menu in the 'Related Accessions' form
-    And the user fills in 'Title' with 'Incomplete Accession'
-    And the user clicks on 'Create and Link'
-    Then the following error messages are displayed
-      | Identifier - Property is required but was missing |
-    And the user fills in 'Identifier' in the modal
-    And the user fills in 'Date' with '2026-01-05' in the modal
-    And the user clicks on 'Create and Link' in the modal
-    Then the accession 'Incomplete Accession' appears in the related accessions linker
+     When the user fills in 'Title'
+      And the user fills in 'Identifier'
+      And the user selects 'Collection' from 'Level of Description'
+      And the user fills in 'Language' with 'English' and selects 'English' in the 'Languages' form
+      And the user selects 'Single' from 'Type' in the 'Dates' form
+      And the user fills in 'Begin' with '2026-01-01' in the 'Dates' form
+      And the user fills in 'Number' with '1' in the 'Extents' form
+      And the user selects 'Linear Feet' from 'Type' in the 'Extents' form
+      And the user fills in 'Language of Description' with 'English' and selects 'English' in the 'Finding Aid Data' form
+      And the user fills in 'Script of Description' with 'Latin' and selects 'Latin' in the 'Finding Aid Data' form
+      And the user clicks on 'Add Related Accession'
+      And the user clicks on the first dropdown in the 'Related Accessions' form
+      And the user clicks on 'Create' in the dropdown menu in the 'Related Accessions' form
+      And the user fills in 'Title' with 'Incomplete Accession'
+      And the user clicks on 'Create and Link'
+     Then the following error messages are displayed
+       | Identifier - Property is required but was missing |
+      And the user fills in 'Identifier' in the modal
+      And the user fills in 'Date' with '2026-01-05' in the modal
+      And the user clicks on 'Create and Link' in the modal
+     Then the accession 'Incomplete Accession' appears in the related accessions linker
 
   Scenario: Create multiple related accessions for a single resource
     Given the user is on the New Resource page
-    When the user fills in 'Title'
-    And the user fills in 'Identifier'
-    And the user selects 'Collection' from 'Level of Description'
-    And the user fills in 'Language' with 'English' and selects 'English' in the 'Languages' form
-    And the user selects 'Single' from 'Type' in the 'Dates' form
-    And the user fills in 'Begin' with '2026-01-01' in the 'Dates' form
-    And the user fills in 'Number' with '1' in the 'Extents' form
-    And the user selects 'Linear Feet' from 'Type' in the 'Extents' form
-    And the user fills in 'Language of Description' with 'English' and selects 'English' in the 'Finding Aid Data' form
-    And the user fills in 'Script of Description' with 'Latin' and selects 'Latin' in the 'Finding Aid Data' form
-    And the user clicks on 'Add Related Accession'
-    And the user clicks on the first dropdown in the 'Related Accessions' form
-    And the user clicks on 'Create' in the dropdown menu in the 'Related Accessions' form
-    And the user fills in 'Identifier' in the modal
-    And the user fills in 'Title' with 'First Accession' in the modal
-    And the user fills in 'Accession Date' with '2026-01-05' in the modal
-    And the user clicks on 'Create and Link' in the modal
-    And the user clicks on 'Add Related Accession'
-    And the user clicks on the last dropdown in the 'Related Accessions' form
-    And the user clicks on 'Create' in the dropdown menu in the 'Related Accessions' form
-    And the user fills in 'Identifier' in the modal
-    And the user fills in 'Title' with 'Second Accession' in the modal
-    And the user fills in 'Accession Date' with '2026-01-05' in the modal
-    And the user clicks on 'Create and Link' in the modal
-    And the user clicks on 'Save Resource'
-    Then the 'Resource' created message is displayed
-    And the accession 'First Accession' is linked to the resource
-    And the accession 'Second Accession' is linked to the resource
+     When the user fills in 'Title'
+      And the user fills in 'Identifier'
+      And the user selects 'Collection' from 'Level of Description'
+      And the user fills in 'Language' with 'English' and selects 'English' in the 'Languages' form
+      And the user selects 'Single' from 'Type' in the 'Dates' form
+      And the user fills in 'Begin' with '2026-01-01' in the 'Dates' form
+      And the user fills in 'Number' with '1' in the 'Extents' form
+      And the user selects 'Linear Feet' from 'Type' in the 'Extents' form
+      And the user fills in 'Language of Description' with 'English' and selects 'English' in the 'Finding Aid Data' form
+      And the user fills in 'Script of Description' with 'Latin' and selects 'Latin' in the 'Finding Aid Data' form
+      And the user clicks on 'Add Related Accession'
+      And the user clicks on the first dropdown in the 'Related Accessions' form
+      And the user clicks on 'Create' in the dropdown menu in the 'Related Accessions' form
+      And the user fills in 'Identifier' in the modal
+      And the user fills in 'Title' with 'First Accession' in the modal
+      And the user fills in 'Accession Date' with '2026-01-05' in the modal
+      And the user clicks on 'Create and Link' in the modal
+      And the user clicks on 'Add Related Accession'
+      And the user clicks on the last dropdown in the 'Related Accessions' form
+      And the user clicks on 'Create' in the dropdown menu in the 'Related Accessions' form
+      And the user fills in 'Identifier' in the modal
+      And the user fills in 'Title' with 'Second Accession' in the modal
+      And the user fills in 'Accession Date' with '2026-01-05' in the modal
+      And the user clicks on 'Create and Link' in the modal
+      And the user clicks on 'Save Resource'
+     Then the 'Resource' created message is displayed
+      And the accession 'First Accession' is linked to the resource
+      And the accession 'Second Accession' is linked to the resource
 
   Scenario: Create and link related accession to existing resource
     Given a Resource has been created
-    And the Resource is opened in edit mode
-    And the user clicks on 'Add Related Accession'
-    And the user clicks on the first dropdown in the 'Related Accessions' form
-    And the user clicks on 'Create' in the dropdown menu in the 'Related Accessions' form
-    And the user fills in 'Identifier' in the modal
-    And the user fills in 'Title' with 'New Related Accession' in the modal
-    And the user fills in 'Accession Date' with '2026-01-05' in the modal
-    And the user clicks on 'Create and Link' in the modal
-    And the user clicks on 'Save Resource'
-    Then the 'Resource' updated message is displayed
-    And the accession 'New Related Accession' is linked to the resource
+      And the Resource is opened in edit mode
+      And the user clicks on 'Add Related Accession'
+      And the user clicks on the first dropdown in the 'Related Accessions' form
+      And the user clicks on 'Create' in the dropdown menu in the 'Related Accessions' form
+      And the user fills in 'Identifier' in the modal
+      And the user fills in 'Title' with 'New Related Accession' in the modal
+      And the user fills in 'Accession Date' with '2026-01-05' in the modal
+      And the user clicks on 'Create and Link' in the modal
+      And the user clicks on 'Save Resource'
+     Then the 'Resource' updated message is displayed
+      And the accession 'New Related Accession' is linked to the resource

--- a/e2e-tests/staff_features/resources/resource_transfer.feature
+++ b/e2e-tests/staff_features/resources/resource_transfer.feature
@@ -10,4 +10,4 @@ Feature: Resource Transfer
       And the user clicks on 'Transfer' in the transfer form
       And the user clicks on 'Transfer' in the modal
      Then the following message is displayed
-      | Transfer Successful. Records may take a moment to appear in the target repository while re-indexing takes place. |
+       | Transfer Successful. Records may take a moment to appear in the target repository while re-indexing takes place. |

--- a/e2e-tests/staff_features/subjects/subject_add_external_document.feature
+++ b/e2e-tests/staff_features/subjects/subject_add_external_document.feature
@@ -11,13 +11,13 @@ Feature: Subject External Documemt
       And the user clicks on 'Save Subject'
      Then the 'Subject' saved message is displayed
       And a new External Document is added to the Subject with the following values
-       | Title    | Test title    |
-       | Location | Test location |
+        | Title    | Test title    |
+        | Location | Test location |
   Scenario: External Document is not added because required fields are missing
      When the user clicks on 'External Documents'
       And the user clicks on 'Add External Document'
       And the user clicks on 'Save Subject'
      Then the following error messages are displayed
-        | Title - Property is required but was missing    |
-        | Location - Property is required but was missing |
+       | Title - Property is required but was missing    |
+       | Location - Property is required but was missing |
 

--- a/e2e-tests/staff_features/subjects/subject_edit.feature
+++ b/e2e-tests/staff_features/subjects/subject_edit.feature
@@ -16,9 +16,9 @@ Feature: Subject Edit
       And the user clicks on 'Save'
      Then the 'Subject' saved message is displayed
      Then the field '<Field>' has value '<NewValue>'
-      Examples:
-       | Field        | NewValue        |
-       | Scope Note   | Test Scope Note |
+       Examples:
+         | Field        | NewValue        |
+         | Scope Note   | Test Scope Note |
   Scenario: Subject is not updated
     Given the Subject is opened in edit mode
      When the user clears 'Source' in the 'Basic Information' form

--- a/e2e-tests/staff_features/subjects/subject_edit_default_values.feature
+++ b/e2e-tests/staff_features/subjects/subject_edit_default_values.feature
@@ -10,6 +10,6 @@ Feature: Subject Edit Default Values
       And the user clicks on 'Save'
      Then the 'Defaults' updated message is displayed
       And the new Subject form has the following default values
-       | form_section      | form_field   | form_value |
-       | Basic Information | Authority ID | Test ID    |
-       | Basic Information | Scope Note   | Text       |
+        | form_section      | form_field   | form_value |
+        | Basic Information | Authority ID | Test ID    |
+        | Basic Information | Scope Note   | Text       |

--- a/e2e-tests/staff_features/top_containers/top_container_view.feature
+++ b/e2e-tests/staff_features/top_containers/top_container_view.feature
@@ -1,7 +1,7 @@
 Feature: Top Container View
   Background:
     Given an administrator user is logged in
-    And a Resource with a Top Container has been created
+      And a Resource with a Top Container has been created
   Scenario: View Top Container from the search results
     Given the user is on the Top Containers page
      When the user fills in 'Keyword' with the Resource title


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a Gherkin formatter for the e2e-tests suite that normalizes step keyword indentation and wires it into local dev and CI.

  - e2e-tests/lib/feature_formatter.rb - FeatureFormatter class implementing the right-aligned style: step text starts at column 11 in every step line (Given 4sp, When/Then 5sp, And/But/* 6sp). Tables inherit owner-step indent + 2; Examples: is placed at the preceding line's indent + 2.
  - e2e-tests/Rakefile - rake format:features and rake format:check (verify, exit 1 on diff). Both accept FILES=path[,path...] to limit scope.
  - .github/workflows/codescan.yml - new format-features job runs bundle exec rake format:check on every PR.
  - .vscode/settings.json + extensions.json - recommends emeraldwalk.runonsave and runs rake format:features on save for any e2e-tests/**/*.feature.

  Applied format:features across the suite to bring the 30 non-conforming files in line. Diffs are whitespace-only.


<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related JIRA Ticket or GitHub Issue
[ANW-2726]
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How to run it

```
  cd e2e-tests
  bundle install
  bundle exec rake format:check     # verify
  bundle exec rake format:features  # auto-fix
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[ANW-2726]: https://archivesspace.atlassian.net/browse/ANW-2726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ