### PR TITLE
ANW-2725 post-4.2.0 E2E test additions - accessions

### DIFF
--- a/e2e-tests/Gemfile.lock
+++ b/e2e-tests/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-24
   arm64-darwin-25
   x86_64-linux
 

--- a/e2e-tests/staff_features/accessions/accession_create.feature
+++ b/e2e-tests/staff_features/accessions/accession_create.feature
@@ -12,3 +12,8 @@ Feature: Accession Create
      When the user clicks on 'Save'
      Then the following error messages are displayed
        | Identifier - Property is required but was missing  |
+  Scenario: Accession cannot be created by user with view-only permissions
+    Given a viewer user is logged in
+     When the user clicks on 'Browse'
+      And the user clicks on 'Accessions'
+     Then the 'Create Accession' button is not present on the page

--- a/e2e-tests/staff_features/accessions/accession_edit.feature
+++ b/e2e-tests/staff_features/accessions/accession_edit.feature
@@ -10,6 +10,11 @@ Feature: Accession Edit
     Given the Accession is opened in the view mode
      When the user clicks on 'Edit'
      Then the Accession is opened in the edit mode
+  Scenario: Accession cannot be edited by user with view-only permissions
+    Given a viewer user is logged in
+     When the user clicks on 'Browse'
+      And the user clicks on 'Accessions'
+     Then the 'Edit' button is not present on the page
   Scenario Outline: Accession is successfully updated
     Given the Accession is opened in edit mode
      When the user changes the '<Field>' field to '<NewValue>'

--- a/e2e-tests/staff_features/accessions/accession_edit_default_values.feature
+++ b/e2e-tests/staff_features/accessions/accession_edit_default_values.feature
@@ -4,16 +4,16 @@ Feature: Accession Edit Default Values
       And the Pre-populate Records option is checked in Repository Preferences
       And the user is on the Accessions page
   Scenario: Open Accession Edit Default values page
-    When the user clicks on 'Edit Default Values'
-    Then the Accession Record Defaults page is displayed
+     When the user clicks on 'Edit Default Values'
+     Then the Accession Record Defaults page is displayed
   Scenario: Edit Default Values
     Given the user is on the Accession Record Default page
-    When the user fills in 'Title' with 'Default Test Title'
+     When the user fills in 'Title' with 'Default Test Title'
       And the user clicks on 'Save'
-    Then the 'Defaults' updated message is displayed
+     Then the 'Defaults' updated message is displayed
       And the new Accession form has the following default values
-      | form_section      | form_field | form_value         |
-      | Basic Information | Title      | Default Test Title |
+        | form_section      | form_field | form_value         |
+        | Basic Information | Title      | Default Test Title |
   Scenario: Archivist user cannot edit default values
     Given an archivist user is logged in
      When the user clicks on 'Browse'

--- a/e2e-tests/staff_features/accessions/accession_edit_default_values.feature
+++ b/e2e-tests/staff_features/accessions/accession_edit_default_values.feature
@@ -1,0 +1,21 @@
+Feature: Accession Edit Default Values
+  Background:
+    Given an administrator user is logged in
+      And the Pre-populate Records option is checked in Repository Preferences
+      And the user is on the Accessions page
+  Scenario: Open Accession Edit Default values page
+    When the user clicks on 'Edit Default Values'
+    Then the Accession Record Defaults page is displayed
+  Scenario: Edit Default Values
+    Given the user is on the Accession Record Default page
+    When the user fills in 'Title' with 'Default Test Title'
+      And the user clicks on 'Save'
+    Then the 'Defaults' updated message is displayed
+      And the new Accession form has the following default values
+      | form_section      | form_field | form_value         |
+      | Basic Information | Title      | Default Test Title |
+  Scenario: Archivist user cannot edit default values
+    Given an archivist user is logged in
+     When the user clicks on 'Browse'
+      And the user clicks on 'Accessions'
+     Then the 'Edit Default Values' button is not present on the page

--- a/e2e-tests/staff_features/accessions/accession_publish.feature
+++ b/e2e-tests/staff_features/accessions/accession_publish.feature
@@ -1,10 +1,12 @@
 Feature: Acccession Publish
+
   Background:
     Given an administrator user is logged in
-    And an Accession has been created
+      And an Accession has been created
+
   Scenario: Publish the Accession record from the Publish checkbox in the Basic Information section
     Given the Accession is opened in edit mode
-    When the user checks 'Publish'
-    And the user clicks on 'Save'
-    Then the 'Accession' updated message is displayed
-    And the 'View Published' button is displayed
+     When the user checks 'Publish'
+      And the user clicks on 'Save'
+     Then the 'Accession' updated message is displayed
+      And the 'View Published' button is displayed

--- a/e2e-tests/staff_features/accessions/accession_publish.feature
+++ b/e2e-tests/staff_features/accessions/accession_publish.feature
@@ -1,0 +1,10 @@
+Feature: Acccession Publish
+  Background:
+    Given an administrator user is logged in
+    And an Accession has been created
+  Scenario: Publish the Accession record from the Publish checkbox in the Basic Information section
+    Given the Accession is opened in edit mode
+    When the user checks 'Publish'
+    And the user clicks on 'Save'
+    Then the 'Accession' updated message is displayed
+    And the 'View Published' button is displayed

--- a/e2e-tests/staff_features/accessions/step_definitions/accession_edit_default_values.rb
+++ b/e2e-tests/staff_features/accessions/step_definitions/accession_edit_default_values.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+Given 'the user is on the Accessions page' do
+  visit "#{STAFF_URL}/accessions"
+end
+
+Then 'the Accession Record Defaults page is displayed' do
+  expect(current_url).to include 'accessions/defaults'
+end
+
+Given 'the user is on the Accession Record Default page' do
+  visit "#{STAFF_URL}/accessions/defaults"
+  wait_for_ajax
+end
+
+Then 'the new Accession form has the following default values' do |form_values_table|
+  visit "#{STAFF_URL}/accessions/new"
+  expect(page).to have_selector('h2', visible: true, text: 'Accession')
+
+  expect_form_values(form_values_table)
+end

--- a/e2e-tests/staff_features/shared/step_definitions.rb
+++ b/e2e-tests/staff_features/shared/step_definitions.rb
@@ -592,3 +592,7 @@ end
 Then 'the {string} link is not visible' do |link_text|
   expect(page).not_to have_link(link_text)
 end
+
+Then 'the {string} button is not present on the page' do |string|
+  expect(page).to_not have_selector('button', text: text)
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a few E2E tests to the Accessions functional area, increasing automation in advance of the next round of regression testing. This is a re-do of this [pull request](https://github.com/archivesspace/archivesspace/pull/4060), to correct formatting.

## Related JIRA Ticket or GitHub Issue
[ANW-2725](https://archivesspace.atlassian.net/browse/ANW-2725)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[ANW-2725]: https://archivesspace.atlassian.net/browse/ANW-2725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ