### PR TITLE
Add Yale's extended CSV export

### DIFF
--- a/backend/app/model/extended_csv_export_stream.rb
+++ b/backend/app/model/extended_csv_export_stream.rb
@@ -1,0 +1,232 @@
+require 'csv'
+require 'tempfile'
+
+class ExtendedCSVExportStream
+
+  EXCLUDED_PROPERTIES = Set.new([
+    '_resolved',
+    'lock_version',
+    'created_by',
+    'last_modified_by',
+    'user_mtime',
+    'system_mtime',
+    'create_time',
+    '_inherited',
+    'tree'
+  ])
+
+  HANDLE_NESTED_RECORDS = [
+    'dates',
+    'extents',
+    'instances',
+    'sub_container',
+    'digital_object',
+    'subjects',
+    'linked_agents',
+    'names'
+  ]
+
+  # Hints for how CSV columns should be ordered.
+  PARTIAL_FIELD_ORDERING = [
+    'jsonmodel_type',
+    'uri',
+    'title',
+    'display_string',
+    'finding_aid_title',
+    'finding_aid_',
+    'id_0', 'id_1', 'id_2', 'id_3',
+    'component_id',
+    'ref_id',
+    'level',
+    'position',
+
+    /extents::\d+::number/,
+    /extents::\d+::portion/,
+    /extents::\d+::type/,
+
+    /dates::\d+::date_type/,
+    /dates::\d+::label/,
+    /dates::\d+::begin/,
+    /dates::\d+::end/,
+    /dates::\d+::expression/,
+  ]
+
+  CUSTOM_EXTRACTORS = {
+    'subject::ref' => :extract_subject,
+    'agent_person::ref' => :extract_agent,
+    'agent_family::ref' => :extract_agent,
+    'agent_corporate_entity::ref' => :extract_agent,
+    'agent_software::ref' => :extract_agent,
+  }
+
+  def initialize
+    @headers = Set.new
+    @mapped_stream = Tempfile.new
+  end
+
+  def <<(json)
+    mapped = map_record(json)
+
+    unless mapped.empty?
+      mapped.keys.each do |header|
+        @headers << header
+      end
+
+      @mapped_stream.write(mapped.to_json)
+      @mapped_stream.write("\n")
+    end
+  end
+
+  def headers
+    self.sort_headers(@headers.to_a)
+  end
+
+  def to_csv(&block)
+    begin
+      ordered_headers = headers
+
+      block.call(CSV.generate_line(ordered_headers))
+
+      @mapped_stream.rewind
+
+      @mapped_stream.each do |line|
+        r = JSON.parse(line)
+        block.call(CSV.generate_line(ordered_headers.map {|h| r.fetch(h, nil)}))
+      end
+    ensure
+      close
+    end
+  end
+
+  def close
+    return if @closed
+
+    @closed = true
+    @mapped_stream.close unless @mapped_stream.closed?
+    @mapped_stream.unlink
+  end
+
+  protected
+
+  def sort_headers(headers)
+    # First pass: order headers alphabetically, which groups columns into their subrecords
+    headers.sort!
+
+    # Sort according to our PARTIAL_FIELD_ORDERING above, keeping subrecords
+    # together but ordering within them as needed.
+    headers.sort_by! {|h|
+      fields = h.split('::')
+
+      path = fields[0...-1].map {|f| (f =~ /\A[0-9]+\z/) ? sprintf('%05d', f) : f}.join('::')
+      field = fields[-1]
+
+      score = PARTIAL_FIELD_ORDERING.index(h) ||
+              PARTIAL_FIELD_ORDERING.index {|elt| elt.is_a?(Regexp) && h =~ elt} ||
+              999
+
+      "#{path}::#{sprintf('%05d', score)}::#{field}"
+    }
+
+    headers
+  end
+
+  def extract_properties(r)
+    result = extract_properties_with_custom_extractor(r)
+
+    result || extract_scalar_properties(r)
+  end
+
+  def extract_properties_with_custom_extractor(r)
+    extractor_description = nil
+
+    if r.is_a?(Hash)
+      extractor_description = r['jsonmodel_type']
+
+      extractor_description ||= if r['_resolved'] && r['_resolved']['jsonmodel_type']
+                                  "%s::ref" % [r['_resolved']['jsonmodel_type']]
+                                end
+    end
+
+    if extractor = extract_properties_for_type(extractor_description)
+      self.send(extractor, r)
+    else
+      nil
+    end
+  end
+
+  def extract_properties_for_type(jsonmodel_type)
+    CUSTOM_EXTRACTORS.fetch(jsonmodel_type, nil)
+  end
+
+  def extract_subject(r)
+    if r.include?('_resolved')
+      r = r.fetch('_resolved')
+    end
+
+    extract_scalar_properties(r).select {|k, _| ['source', 'title', 'uri'].include?(k)}
+  end
+
+  def extract_agent(r)
+    if r.include?('_resolved')
+      r = r.fetch('_resolved')
+    end
+
+    extract_scalar_properties(r)
+  end
+
+  def exclude_property?(prop)
+    @extra_excluded_properties ||= Set.new(AppConfig[:extended_csv_export_extra_excluded_properties])
+
+    EXCLUDED_PROPERTIES.include?(prop) || @extra_excluded_properties.include?(prop)
+  end
+
+  def nested_records
+    @nested_records ||= (HANDLE_NESTED_RECORDS + AppConfig[:extended_csv_export_extra_nested_records])
+  end
+
+  def extract_scalar_properties(r)
+    result = r.select {|k, v| !exclude_property?(k) && (v.is_a?(String) || v.is_a?(Integer) || v.is_a?(Float))}
+
+    # Treat refs specially here, flattening them out.
+    r.each do |k, v|
+      if !exclude_property?(k) && v.is_a?(Hash) && v['ref']
+        (extract_properties_with_custom_extractor(v) || v).each do |ref_key, ref_val|
+          next if exclude_property?(ref_key)
+          result["#{k}::#{ref_key}"] = ref_val
+        end
+      end
+    end
+
+    result
+  end
+
+  def max_nested
+    @max_nested ||= AppConfig[:extended_csv_export_max_nested_records]
+  end
+
+  def map_record(r)
+    return r unless r.is_a?(Hash)
+
+    mapped = extract_properties(r)
+
+    self.nested_records.each do |property|
+      ASUtils.wrap(r.fetch(property, [])).each_with_index do |nested, idx|
+        next unless nested.is_a?(Hash)
+        next if idx > max_nested
+
+        mapped_nested = map_record(nested)
+
+        mapped_nested.each do |k, v|
+          if idx == max_nested
+            v = "MAX_NESTED_RECORDS_REACHED"
+          end
+
+          mapped["#{property}::#{idx}::#{k}"] = v
+        end
+      end
+    end
+
+    mapped
+  end
+
+end

--- a/backend/app/model/search.rb
+++ b/backend/app/model/search.rb
@@ -169,6 +169,42 @@ class Search
   end
 
   def self.search_csv( params, repo_id )
+    if AppConfig[:extended_csv_export_enabled]
+      extended_csv_export(params, repo_id)
+    else
+      search_csv_solr(params, repo_id)
+    end
+  end
+
+  def self.extended_csv_export(params, repo_id)
+    csv_clz = Kernel.const_get(AppConfig[:extended_csv_export_class].intern)
+
+    Enumerator.new do |y|
+      csv = csv_clz.new
+      begin
+        page = 1
+        loop do
+          hits = search(params.merge(:fields => ['json'], :dt => 'json',
+                                     :page => page, :page_size => 200),
+                        repo_id)
+          break if hits.fetch('results', []).empty?
+
+          hits.fetch('results').each do |result|
+            csv << ASUtils.json_parse(result.fetch('json'))
+          end
+          page += 1
+        end
+
+        csv.to_csv do |chunk|
+          y << chunk
+        end
+      ensure
+        csv.close
+      end
+    end
+  end
+
+  def self.search_csv_solr( params, repo_id )
     # first let's get a json response with the number of pages
     p = params.dup
     p[:dt] = "json"

--- a/backend/spec/model_extended_csv_export_stream_spec.rb
+++ b/backend/spec/model_extended_csv_export_stream_spec.rb
@@ -1,0 +1,399 @@
+require 'spec_helper'
+require 'csv'
+
+describe ExtendedCSVExportStream do
+
+  before(:each) do
+    allow(AppConfig).to receive(:[]).and_call_original
+    allow(AppConfig).to receive(:[]).with(:extended_csv_export_extra_excluded_properties).and_return([])
+    allow(AppConfig).to receive(:[]).with(:extended_csv_export_extra_nested_records).and_return([])
+    allow(AppConfig).to receive(:[]).with(:extended_csv_export_max_nested_records).and_return(10)
+  end
+
+  def collect_csv(csv_export_stream)
+    lines = []
+    csv_export_stream.to_csv {|line| lines << line}
+    lines
+  end
+
+  def parse_csv_output(csv_export_stream)
+    lines = collect_csv(csv_export_stream)
+
+    parsed = lines.map {|l| CSV.parse_line(l)}
+
+    headers = parsed.first
+    rows = parsed[1..].map {|row| headers.zip(row).to_h}
+
+    [headers, rows]
+  end
+
+  describe 'excluded property filtering' do
+    ExtendedCSVExportStream::EXCLUDED_PROPERTIES.each do |prop|
+      it "excludes the '#{prop}' property" do
+        stream = ExtendedCSVExportStream.new
+        stream << {prop => 'some_value', 'title' => 'keep'}
+        headers, _rows = parse_csv_output(stream)
+        expect(headers).not_to include(prop)
+        expect(headers).to include('title')
+      end
+    end
+
+    context 'with extra excluded properties via AppConfig' do
+      before(:each) do
+        allow(AppConfig).to receive(:[]).with(:extended_csv_export_extra_excluded_properties).and_return(['custom_field'])
+      end
+
+      it 'excludes properties listed in AppConfig[:extended_csv_export_extra_excluded_properties]' do
+        stream = ExtendedCSVExportStream.new
+        stream << {'custom_field' => 'gone', 'title' => 'keep'}
+        headers, _rows = parse_csv_output(stream)
+        expect(headers).not_to include('custom_field')
+        expect(headers).to include('title')
+      end
+    end
+  end
+
+  describe 'reference flattening' do
+    it 'flattens a hash with a "ref" key into parent::ref column' do
+      stream = ExtendedCSVExportStream.new
+      stream << {'repository' => {'ref' => '/repositories/2'}}
+      headers, rows = parse_csv_output(stream)
+      expect(headers).to include('repository::ref')
+      expect(rows.first['repository::ref']).to eq('/repositories/2')
+    end
+
+    it 'flattens additional keys in the ref hash' do
+      stream = ExtendedCSVExportStream.new
+      stream << {'classification' => {'ref' => '/classifications/1', 'display_string' => 'Class A'}}
+      headers, rows = parse_csv_output(stream)
+      expect(headers).to include('classification::ref', 'classification::display_string')
+      expect(rows.first['classification::display_string']).to eq('Class A')
+    end
+
+    it 'filters excluded properties within ref hashes' do
+      stream = ExtendedCSVExportStream.new
+      stream << {'classification' => {'ref' => '/classifications/1', 'lock_version' => 3}}
+      headers, _rows = parse_csv_output(stream)
+      expect(headers).to include('classification::ref')
+      expect(headers).not_to include('classification::lock_version')
+    end
+  end
+
+  describe 'nested record flattening' do
+    context 'dates' do
+      it 'flattens a single date into dates::0::field columns' do
+        stream = ExtendedCSVExportStream.new
+        stream << {
+          'title' => 'Test',
+          'dates' => [{'begin' => '2020-01-01', 'end' => '2020-12-31', 'date_type' => 'inclusive', 'label' => 'creation'}]
+        }
+        headers, rows = parse_csv_output(stream)
+        expect(headers).to include('dates::0::begin', 'dates::0::end', 'dates::0::date_type', 'dates::0::label')
+        expect(rows.first['dates::0::begin']).to eq('2020-01-01')
+      end
+
+      it 'flattens multiple dates with incrementing indices' do
+        stream = ExtendedCSVExportStream.new
+        stream << {
+          'title' => 'Test',
+          'dates' => [
+            {'begin' => '2020-01-01', 'date_type' => 'inclusive'},
+            {'begin' => '2021-06-15', 'date_type' => 'single'}
+          ]
+        }
+        headers, rows = parse_csv_output(stream)
+        expect(headers).to include('dates::0::begin', 'dates::1::begin')
+        expect(rows.first['dates::0::begin']).to eq('2020-01-01')
+        expect(rows.first['dates::1::begin']).to eq('2021-06-15')
+      end
+    end
+
+    context 'extents' do
+      it 'flattens extent subrecords into extents::0::field columns' do
+        stream = ExtendedCSVExportStream.new
+        stream << {
+          'title' => 'Test',
+          'extents' => [{'number' => '5', 'portion' => 'whole', 'extent_type' => 'linear_feet'}]
+        }
+        headers, rows = parse_csv_output(stream)
+        expect(headers).to include('extents::0::number', 'extents::0::portion', 'extents::0::extent_type')
+        expect(rows.first['extents::0::number']).to eq('5')
+      end
+    end
+
+    context 'instances' do
+      it 'flattens instance subrecords' do
+        stream = ExtendedCSVExportStream.new
+        stream << {
+          'title' => 'Test',
+          'instances' => [{'instance_type' => 'mixed_materials', 'jsonmodel_type' => 'instance'}]
+        }
+        headers, rows = parse_csv_output(stream)
+        expect(headers).to include('instances::0::instance_type')
+        expect(rows.first['instances::0::instance_type']).to eq('mixed_materials')
+      end
+    end
+
+    context 'with extra nested records via AppConfig' do
+      before(:each) do
+        allow(AppConfig).to receive(:[]).with(:extended_csv_export_extra_nested_records).and_return(['notes'])
+      end
+
+      it 'processes additional nested record types from AppConfig' do
+        stream = ExtendedCSVExportStream.new
+        stream << {
+          'title' => 'Test',
+          'notes' => [{'type' => 'abstract', 'content' => 'A note'}]
+        }
+        headers, _rows = parse_csv_output(stream)
+        expect(headers).to include('notes::0::type', 'notes::0::content')
+      end
+    end
+  end
+
+  describe 'custom extractors' do
+    describe 'extract_subject' do
+      it 'extracts only source, title, and uri from a resolved subject' do
+        stream = ExtendedCSVExportStream.new
+        stream << {
+          'title' => 'Test',
+          'subjects' => [{
+                           'ref' => '/subjects/1',
+                           '_resolved' => {
+                             'jsonmodel_type' => 'subject',
+                             'title' => 'History',
+                             'source' => 'lcsh',
+                             'uri' => '/subjects/1',
+                             'terms' => [{'term' => 'History'}],
+                             'vocabulary' => '/vocabularies/1',
+                             'authority_id' => 'sh12345'
+                           }
+                         }]
+        }
+        headers, rows = parse_csv_output(stream)
+
+        subject_headers = headers.select {|h| h.start_with?('subjects::0::')}
+        expect(subject_headers).to contain_exactly('subjects::0::source', 'subjects::0::title', 'subjects::0::uri')
+        expect(rows.first['subjects::0::title']).to eq('History')
+        expect(rows.first['subjects::0::source']).to eq('lcsh')
+      end
+
+      it 'does not include terms, vocabulary, or other non-selected fields' do
+        stream = ExtendedCSVExportStream.new
+        stream << {
+          'title' => 'Test',
+          'subjects' => [{
+                           'ref' => '/subjects/1',
+                           '_resolved' => {
+                             'jsonmodel_type' => 'subject',
+                             'title' => 'History',
+                             'source' => 'lcsh',
+                             'uri' => '/subjects/1',
+                             'terms' => [{'term' => 'History'}],
+                             'vocabulary' => '/vocabularies/1'
+                           }
+                         }]
+        }
+        headers, _rows = parse_csv_output(stream)
+        expect(headers).not_to include('subjects::0::vocabulary')
+        expect(headers).not_to include('subjects::0::authority_id')
+      end
+    end
+
+    describe 'extract_agent' do
+      %w[agent_person agent_family agent_corporate_entity agent_software].each do |agent_type|
+        it "extracts all scalar properties from a resolved #{agent_type}" do
+          stream = ExtendedCSVExportStream.new
+          stream << {
+            'title' => 'Test',
+            'linked_agents' => [{
+                                  'ref' => "/agents/#{agent_type}/1",
+                                  '_resolved' => {
+                                    'jsonmodel_type' => agent_type,
+                                    'title' => 'Agent Name',
+                                    'uri' => "/agents/#{agent_type}/1",
+                                    'display_name' => {'sort_name' => 'Name, Agent'}
+                                  }
+                                }]
+          }
+          headers, rows = parse_csv_output(stream)
+
+          expect(headers).to include("linked_agents::0::title")
+          expect(rows.first["linked_agents::0::title"]).to eq('Agent Name')
+        end
+      end
+    end
+  end
+
+  describe 'max nested records limit' do
+    before(:each) do
+      allow(AppConfig).to receive(:[]).with(:extended_csv_export_max_nested_records).and_return(2)
+    end
+
+    it 'processes nested records below the limit normally' do
+      stream = ExtendedCSVExportStream.new
+      stream << {
+        'title' => 'Test',
+        'dates' => [
+          {'begin' => '2020-01-01'},
+          {'begin' => '2021-01-01'}
+        ]
+      }
+      _headers, rows = parse_csv_output(stream)
+      expect(rows.first['dates::0::begin']).to eq('2020-01-01')
+      expect(rows.first['dates::1::begin']).to eq('2021-01-01')
+    end
+
+    it 'replaces values with MAX_NESTED_RECORDS_REACHED at the limit index' do
+      stream = ExtendedCSVExportStream.new
+      stream << {
+        'title' => 'Test',
+        'dates' => [
+          {'begin' => '2020-01-01'},
+          {'begin' => '2021-01-01'},
+          {'begin' => '2022-01-01'}  # index 2 == max_nested
+        ]
+      }
+      _headers, rows = parse_csv_output(stream)
+      expect(rows.first['dates::2::begin']).to eq('MAX_NESTED_RECORDS_REACHED')
+    end
+
+    it 'skips nested records beyond the limit' do
+      stream = ExtendedCSVExportStream.new
+      stream << {
+        'title' => 'Test',
+        'dates' => [
+          {'begin' => '2020-01-01'},
+          {'begin' => '2021-01-01'},
+          {'begin' => '2022-01-01'},
+          {'begin' => '2023-01-01'}  # index 3 > max_nested, skipped
+        ]
+      }
+      headers, _rows = parse_csv_output(stream)
+      expect(headers).not_to include('dates::3::begin')
+    end
+  end
+
+  describe 'header sorting' do
+    it 'prioritizes jsonmodel_type, uri, title, display_string at the top' do
+      stream = ExtendedCSVExportStream.new
+      stream << {'zzz_field' => 'val', 'title' => 'val', 'uri' => 'val', 'jsonmodel_type' => 'resource', 'display_string' => 'val'}
+      headers, _rows = parse_csv_output(stream)
+      priority_fields = headers.first(4)
+      expect(priority_fields).to eq(%w[jsonmodel_type uri title display_string])
+    end
+
+    it 'places finding_aid_ prefixed fields early' do
+      stream = ExtendedCSVExportStream.new
+      stream << {'zzz_field' => 'val', 'finding_aid_title' => 'val', 'finding_aid_status' => 'val', 'title' => 'val'}
+      headers, _rows = parse_csv_output(stream)
+      fa_title_idx = headers.index('finding_aid_title')
+      fa_status_idx = headers.index('finding_aid_status')
+      zzz_idx = headers.index('zzz_field')
+      expect(fa_title_idx).to be < zzz_idx
+      expect(fa_status_idx).to be < zzz_idx
+    end
+
+    it 'places id_0 through id_3 before general fields' do
+      stream = ExtendedCSVExportStream.new
+      stream << {'zzz_field' => 'val', 'id_0' => '1', 'id_1' => '2'}
+      headers, _rows = parse_csv_output(stream)
+      expect(headers.index('id_0')).to be < headers.index('zzz_field')
+      expect(headers.index('id_1')).to be < headers.index('zzz_field')
+    end
+
+    it 'groups nested record columns together by prefix' do
+      stream = ExtendedCSVExportStream.new
+      stream << {
+        'title' => 'Test',
+        'dates' => [{'begin' => '2020', 'end' => '2021'}],
+        'extents' => [{'number' => '5', 'portion' => 'whole'}]
+      }
+      headers, _rows = parse_csv_output(stream)
+
+      dates_indices = headers.each_index.select {|i| headers[i].start_with?('dates::')}
+      extents_indices = headers.each_index.select {|i| headers[i].start_with?('extents::')}
+
+      # All dates columns are together
+      expect(dates_indices).to eq((dates_indices.min..dates_indices.max).to_a)
+
+      # All extents columns are together
+      expect(extents_indices).to eq((extents_indices.min..extents_indices.max).to_a)
+    end
+
+    it 'orders date subfields correctly: date_type, label, begin, end, expression' do
+      stream = ExtendedCSVExportStream.new
+      stream << {
+        'title' => 'Test',
+        'dates' => [{'expression' => 'circa 2020', 'end' => '2020-12-31', 'begin' => '2020-01-01', 'label' => 'creation', 'date_type' => 'inclusive'}]
+      }
+      headers, _rows = parse_csv_output(stream)
+      date_headers = headers.select {|h| h.start_with?('dates::0::')}
+
+      expected_order = %w[dates::0::date_type dates::0::label dates::0::begin dates::0::end dates::0::expression]
+      expect(date_headers).to eq(expected_order)
+    end
+
+    it 'orders extent subfields correctly: number, portion, type' do
+      stream = ExtendedCSVExportStream.new
+      stream << {
+        'title' => 'Test',
+        'extents' => [{'extent_type' => 'linear_feet', 'portion' => 'whole', 'number' => '5'}]
+      }
+      headers, _rows = parse_csv_output(stream)
+      extent_headers = headers.select {|h| h.start_with?('extents::0::')}
+
+      expected_order = %w[extents::0::number extents::0::portion extents::0::extent_type]
+      expect(extent_headers).to eq(expected_order)
+    end
+
+    it 'sorts nested indices numerically (::2:: before ::10::)' do
+      stream = ExtendedCSVExportStream.new
+      record = {'title' => 'Test', 'dates' => []}
+      11.times {|i| record['dates'] << {'begin' => "20#{sprintf('%02d', i)}-01-01"}}
+
+      stream << record
+      headers, _rows = parse_csv_output(stream)
+      date_begin_headers = headers.select {|h| h =~ /\Adates::\d+::begin\z/}
+      indices = date_begin_headers.map {|h| Integer(h.split('::')[1])}
+      expect(indices).to eq(indices.sort)
+    end
+  end
+
+  describe 'multiple records with different schemas' do
+    it 'produces headers that are the union of all record fields' do
+      stream = ExtendedCSVExportStream.new
+      stream << {'title' => 'First', 'level' => 'collection'}
+      stream << {'title' => 'Second', 'uri' => '/resources/1'}
+      headers, _rows = parse_csv_output(stream)
+      expect(headers).to include('title', 'level', 'uri')
+    end
+
+    it 'fills missing fields with nil (empty CSV cells)' do
+      stream = ExtendedCSVExportStream.new
+      stream << {'title' => 'First', 'level' => 'collection'}
+      stream << {'title' => 'Second', 'uri' => '/resources/1'}
+      _headers, rows = parse_csv_output(stream)
+      expect(rows[0]['uri']).to be_nil
+      expect(rows[1]['level']).to be_nil
+    end
+  end
+
+  describe 'edge cases' do
+    it 'handles an empty hash without writing a data row' do
+      stream = ExtendedCSVExportStream.new
+      stream << {}
+      lines = collect_csv(stream)
+      # Only the header row should be present
+      expect(lines.length).to eq(1)
+    end
+
+    it 'handles a record where all properties are excluded' do
+      stream = ExtendedCSVExportStream.new
+      stream << {'lock_version' => 1, '_resolved' => {}, 'system_mtime' => '2020-01-01'}
+      lines = collect_csv(stream)
+      # Only the header row should be present
+      expect(lines.length).to eq(1)
+    end
+  end
+end

--- a/backend/spec/model_search_spec.rb
+++ b/backend/spec/model_search_spec.rb
@@ -117,4 +117,39 @@ describe Search do
       Search.search(params, repo.id)
     end
   end
+
+  context "Search result CSV export" do
+
+    let(:mock_search_results) {
+      {
+        "results" => [
+          {
+            "json" => build(:json_resource).to_json
+          }
+        ]
+      }
+    }
+
+    let(:mock_empty_results) {
+      {
+        "results" => []
+      }
+    }
+
+    it "uses the extended CSV export when enabled" do
+      allow(AppConfig).to receive(:[]).and_call_original
+      allow(AppConfig).to receive(:[]).with(:extended_csv_export_enabled).and_return(true)
+
+      allow(Search).to receive(:search).with(hash_including(:page => 1), repo.id).and_return(mock_search_results)
+      allow(Search).to receive(:search).with(hash_including(:page => 2), repo.id).and_return(mock_empty_results)
+
+      csv = ""
+      Search.search_csv({:page => 1, :page_size => 10}, repo.id).each do |chunk|
+        csv << chunk
+      end
+
+      expect(csv).to include("dates::0::")
+    end
+
+  end
 end

--- a/common/config/config-defaults.rb
+++ b/common/config/config-defaults.rb
@@ -867,3 +867,54 @@ AppConfig[:bulk_archival_object_updater_max_rows] = 1000
 # Default search scope setting
 # Options: 'all_record_types', 'collections_only'
 AppConfig[:search_default_scope] = 'all_record_types'
+
+# Extended CSV export changes the format used when exporting search
+# results. Each record in the search results appears as a row in the resulting
+# CSV, with additional columns added to capture the nested records (up to a
+# configurable maximum).
+#
+# For example, an export of a Resource record might include columns such as:
+#
+#   title
+#   finding_aid_title
+#   level
+#   ead_id
+#   dates::0::date_type
+#   dates::0::label
+#   dates::0::begin
+#   dates::0::end
+#   dates::0::expression
+#   dates::1::date_type
+#   dates::1::label
+#   dates::1::begin
+#   dates::1::end
+#   dates::1::expression
+#   extents::0::number
+#   extents::0::portion
+#   extents::0::extent_type
+#   ... many others!
+#
+# Extended CSV export is enabled with the following option
+AppConfig[:extended_csv_export_enabled] = false
+
+# By default, up to 10 instances of each nested record (dates, extents,
+# subjects, etc.) are included for each record. Increasing this number will
+# allow for more instances of nested records and produce CSVs exports with more columns.
+AppConfig[:extended_csv_export_max_nested_records] = 10
+
+# Extended CSV export automatically exports the major nested record types, but
+# you can add extras by including the appropriate property name from the
+# exported record's JSONModel schema.
+#
+# Example syntax: AppConfig[:extended_csv_export_extra_nested_records] = ['dates', 'extents']
+AppConfig[:extended_csv_export_extra_nested_records] = []
+
+# To suppress certain properties from being included in CSV exports, you can
+# specify them here.
+#
+# Example syntax: AppConfig[:extended_csv_export_extra_excluded_properties] = ['lock_version']
+AppConfig[:extended_csv_export_extra_excluded_properties] = []
+
+# Expert: If you want to customize the extended CSV export from a plugin, you
+# can replace the standard implementation with your own version here.
+AppConfig[:extended_csv_export_class] = 'ExtendedCSVExportStream'


### PR DESCRIPTION
This adds a new CSV export format for record listings.  When enabled via AppConfig, it replaces the standard ArchivesSpace "Download CSV" function on record listings and search results.

It differs from the standard ArchivesSpace CSV export in that it broadens the scope of what is exported:

  * All top-level properties of each record are exported (excluding system-level properties)

  * Nested records like extents and dates are also extracted for each record and added as columns.

  * Certain relationships to other records (such as agents and subjects) are also extracted and included as columns.

The result is a lot more data in a lot more columns.  For example, exporting a set of Resource and Archival Object records might yield a set of CSV columns like:

    jsonmodel_type
    uri
    title
    display_string
    finding_aid_title
    id_0
    ref_id
    level
    position
    ead_id
    finding_aid_author
    finding_aid_edition_statement
    finding_aid_language
    finding_aid_language_note
    finding_aid_script
    finding_aid_status
    dates::0::date_type
    dates::0::label
    dates::0::begin
    dates::0::end
    dates::0::expression
    dates::0::jsonmodel_type
    extents::0::number
    extents::0::portion
    extents::0::container_summary
    extents::0::extent_type
    extents::0::jsonmodel_type
    instances::0::instance_type
    instances::0::jsonmodel_type
    instances::0::sub_container::0::indicator_2
    instances::0::sub_container::0::jsonmodel_type
    instances::0::sub_container::0::type_2
    instances::0::sub_container::0::top_container::ref
    linked_agents::0::agent_type
    linked_agents::0::jsonmodel_type
    linked_agents::0::title
    linked_agents::0::uri
    ...
    linked_agents::10::agent_type
    linked_agents::10::jsonmodel_type
    linked_agents::10::title
    linked_agents::10::uri
    parent::ref
    repository::ref
    resource::ref
    subjects::0::source
    subjects::0::title
    subjects::0::uri
    ...
    subjects::9::source
    subjects::9::title
    subjects::9::uri

## Testing it

Extended CSV export is opt-in via `AppConfig`.  You can enable it with:

```
AppConfig[:extended_csv_export_enabled] = true
```

After that, the "Download CSV" toolbar buttons will produce reports in the extended CSV format.

This feature was contributed by Yale University and developed by Hudson Molonglo.