### PR TITLE
ANW-2776 Fix the new enumeration modal heading layout and label attribute

### DIFF
--- a/frontend/app/views/enumerations/_new.html.erb
+++ b/frontend/app/views/enumerations/_new.html.erb
@@ -3,8 +3,8 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal">×</button>
           <h3><%= t("enumeration._frontend.action.create_value") %></h3>
+          <button type="button" class="close" data-dismiss="modal">×</button>
         </div>
         <div class="modal-body">
           <%= render_aspace_partial :partial => "shared/form_messages", :locals => {:form => form} %>
@@ -17,7 +17,7 @@
               </div>
             </div>
             <div class="form-group required">
-              <label class="control-label" for="enum_selector"><%= t("enumeration.value") %></label>
+              <label class="control-label" for="enumeration_value_"><%= t("enumeration.value") %></label>
               <div class="controls">
                 <%= form.textfield :value %>
               </div>


### PR DESCRIPTION
[ANW-2776](https://archivesspace.atlassian.net/browse/ANW-2776)

This PR fixes two small bugs in the new enumerations modal.

<img width="1208" height="739" alt="ANW-2776-solution" src="https://github.com/user-attachments/assets/de9c11da-2ee4-4503-863d-4276a52121c4" />


[ANW-2776]: https://archivesspace.atlassian.net/browse/ANW-2776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ