### PR TITLE
ANW-1620 fix clear and display reviewers

### DIFF
--- a/backend/spec/model_custom_report_template_spec.rb
+++ b/backend/spec/model_custom_report_template_spec.rb
@@ -183,4 +183,102 @@ describe 'Custom Report Template model' do
     expect(reviewer_filter).not_to be_empty
   end
 
+  it 'includes reviewer names as a column in assessment report results when reviewer field is included' do
+    repo = create(:repo, repo_code: "test_reviewer_col_#{Time.now.to_i}")
+    RequestContext.put(:repo_id, repo.id)
+    JSONModel.set_repository(repo.id)
+
+    reviewer = create(:json_agent_person)
+    create(:json_assessment, 'reviewer' => [{'ref' => reviewer.uri}])
+
+    template_data = {
+      "custom_record_type" => "assessment",
+      "fields" => {
+        "reviewer" => { "include" => "1" }
+      }
+    }
+
+    template = JSONModel(:custom_report_template).from_hash({
+      "name" => "Reviewer Column Test #{Time.now.to_i}",
+      "limit" => 10,
+      "data" => template_data.to_json
+    })
+
+    template_id = CustomReportTemplate.create_from_json(template).id
+
+    mock_job = double('Job')
+    allow(mock_job).to receive(:write_output)
+
+    report = CustomReport.new({'template' => template_id.to_s, :repo_id => repo.id}, mock_job, $testdb)
+
+    row = report.query.first
+    expect(row).not_to be_nil
+    expect(row[:reviewer]).to be_a(String)
+  end
+
+  it 'concatenates multiple reviewer names in assessment report results' do
+    repo = create(:repo, repo_code: "test_multi_reviewer_#{Time.now.to_i}")
+    RequestContext.put(:repo_id, repo.id)
+    JSONModel.set_repository(repo.id)
+
+    reviewer1 = create(:json_agent_person)
+    reviewer2 = create(:json_agent_person)
+    create(:json_assessment, 'reviewer' => [{'ref' => reviewer1.uri}, {'ref' => reviewer2.uri}])
+
+    template_data = {
+      "custom_record_type" => "assessment",
+      "fields" => {
+        "reviewer" => { "include" => "1" }
+      }
+    }
+
+    template = JSONModel(:custom_report_template).from_hash({
+      "name" => "Multi-Reviewer Column Test #{Time.now.to_i}",
+      "limit" => 10,
+      "data" => template_data.to_json
+    })
+
+    template_id = CustomReportTemplate.create_from_json(template).id
+
+    mock_job = double('Job')
+    allow(mock_job).to receive(:write_output)
+
+    report = CustomReport.new({'template' => template_id.to_s, :repo_id => repo.id}, mock_job, $testdb)
+
+    row = report.query.first
+    expect(row[:reviewer]).to include(reviewer1.names[0]['sort_name'])
+    expect(row[:reviewer]).to include(reviewer2.names[0]['sort_name'])
+  end
+
+  it 'returns nil reviewer column in assessment report results when assessment has no reviewer' do
+    repo = create(:repo, repo_code: "test_no_reviewer_#{Time.now.to_i}")
+    RequestContext.put(:repo_id, repo.id)
+    JSONModel.set_repository(repo.id)
+
+    create(:json_assessment, 'reviewer' => [])
+
+    template_data = {
+      "custom_record_type" => "assessment",
+      "fields" => {
+        "reviewer" => { "include" => "1" }
+      }
+    }
+
+    template = JSONModel(:custom_report_template).from_hash({
+      "name" => "No Reviewer Column Test #{Time.now.to_i}",
+      "limit" => 10,
+      "data" => template_data.to_json
+    })
+
+    template_id = CustomReportTemplate.create_from_json(template).id
+
+    mock_job = double('Job')
+    allow(mock_job).to receive(:write_output)
+
+    report = CustomReport.new({'template' => template_id.to_s, :repo_id => repo.id}, mock_job, $testdb)
+
+    row = report.query.first
+    expect(row[:reviewer]).to be_nil
+  end
+
 end

--- a/backend/spec/model_custom_report_template_spec.rb
+++ b/backend/spec/model_custom_report_template_spec.rb
@@ -212,8 +212,7 @@ describe 'Custom Report Template model' do
     report = CustomReport.new({'template' => template_id.to_s, :repo_id => repo.id}, mock_job, $testdb)
 
     row = report.query.first
-    expect(row).not_to be_nil
-    expect(row[:reviewer]).to be_a(String)
+    expect(row[:reviewer]).to include(reviewer.names[0]['sort_name'])
   end
 
   it 'concatenates multiple reviewer names in assessment report results' do

--- a/frontend/app/views/custom_report_templates/_form.html.erb
+++ b/frontend/app/views/custom_report_templates/_form.html.erb
@@ -121,7 +121,7 @@
 										%>
 										<div class="mt-2 d-flex flex-column align-items-start gap-2">
 											<%= text_area_tag "custom_report_template[data][#{record_type}][fields][#{field_name}][values]", array_for_textarea(field_data["values"]), :value => field_data['values'], :readonly => true, :class => 'border border-gray--secondary rounded', :style => "height:100px" %>
-											<input type="button" class="btn btn-default" value="Clear" class="d-block user-field-clear-button">
+											<input type="button" class="btn btn-default d-block user-field-clear-button" value="Clear">
 										</div>
 									</div>
 								</div>

--- a/frontend/spec/controllers/jobs_controller_spec.rb
+++ b/frontend/spec/controllers/jobs_controller_spec.rb
@@ -15,7 +15,7 @@ describe JobsController, type: :controller do
 
       allow(JSONModel::HTTP).to receive(:get_json).and_call_original
       allow(JSONModel::HTTP).to receive(:get_json).with(/output_files/).and_return([1, 2, 3])
-      allow(JSONModel::HTTP).to receive(:get_json).with("/job_types").and_return({'print_to_pdf_job' => {'cancel_permissions' => [], 'create_permissions' => []}, 'report_job' => {'cancel_permissions' => [], 'create_permissions' => []}})
+      allow(JSONModel::HTTP).to receive(:get_json).with("/job_types").and_return({report_job: {cancel_permissions: [], create_permissions: []}})
       allow(JSONModel::HTTP).to receive(:get_json).with("/notifications").and_call_original
 
       allow(JSONModel(:job)).to receive(:find).with("1", "resolve[]" => "repository").and_return(mod_job)

--- a/frontend/spec/controllers/jobs_controller_spec.rb
+++ b/frontend/spec/controllers/jobs_controller_spec.rb
@@ -15,7 +15,7 @@ describe JobsController, type: :controller do
 
       allow(JSONModel::HTTP).to receive(:get_json).and_call_original
       allow(JSONModel::HTTP).to receive(:get_json).with(/output_files/).and_return([1, 2, 3])
-      allow(JSONModel::HTTP).to receive(:get_json).with("/job_types").and_return({report_job: {cancel_permissions: [], create_permissions: []}})
+      allow(JSONModel::HTTP).to receive(:get_json).with("/job_types").and_return({'print_to_pdf_job' => {'cancel_permissions' => [], 'create_permissions' => []}, 'report_job' => {'cancel_permissions' => [], 'create_permissions' => []}})
       allow(JSONModel::HTTP).to receive(:get_json).with("/notifications").and_call_original
 
       allow(JSONModel(:job)).to receive(:find).with("1", "resolve[]" => "repository").and_return(mod_job)

--- a/reports/custom/custom_report.rb
+++ b/reports/custom/custom_report.rb
@@ -196,12 +196,14 @@ class CustomReport < AbstractReport
 
   def select_fields
     columns = {}
+    raw_expressions = []
     @fields.each do |field|
-      next if field[:name] == 'reviewer'
       if field[:data_type] == 'Enum'
         columns["#{field[:name]}_id"] = field[:alias] || field[:name]
       elsif field[:name] == 'title'
         columns['title'] = field[:alias] || 'record_title'
+      elsif field[:name] == 'reviewer'
+        raw_expressions << reviewer_column_select
       else
         columns[field[:name]] = field[:alias] || field[:name]
       end
@@ -215,7 +217,16 @@ class CustomReport < AbstractReport
         job.write_output(msg)
       end
     end
+    select_fields += raw_expressions.join
     select_fields
+  end
+
+  def reviewer_column_select
+    ", (SELECT GROUP_CONCAT(np.sort_name SEPARATOR ', ')" \
+    " FROM assessment_reviewer_rlshp rlshp" \
+    " JOIN name_person np ON np.agent_person_id = rlshp.agent_person_id" \
+    " AND np.is_display_name = 1" \
+    " WHERE rlshp.assessment_id = assessment.id) AS reviewer"
   end
 
   def fix_row(row)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-1620]

## Summary
QA review brought up suggestion to improve the usability of the original change. This it to include it as a field within the report itself as opposed to just a filter on the report so a non-filtered report can be created displaying all assessments with an assigned reviewer. 

While examining this, I also noted a 2-year old bug that prevented you from using the "Clear" button to remove filters that were set. Quick fix also applied.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [x] Have you added tests to cover these changes? If not why:


[ANW-1620]: https://archivesspace.atlassian.net/browse/ANW-1620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ