### PR TITLE
ANW-2762 trying to link a resource to a classification with many linked records

### DIFF
--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -8,6 +8,26 @@ $(function () {
     resource_edit_path_regex
   );
 
+  // ANW-2762: A token only needs a record's identity/display fields
+  var resolvedForToken = function (json) {
+    if (!json) {
+      return json;
+    }
+
+    var trimmed = $.extend({}, json);
+    delete trimmed.linked_records;
+
+    if (typeof trimmed.json === 'string') {
+      var inner = JSON.parse(trimmed.json);
+      if (inner) {
+        delete inner.linked_records;
+        trimmed.json = JSON.stringify(inner);
+      }
+    }
+
+    return trimmed;
+  };
+
   $.fn.linker = function () {
     $(this).each(function () {
       var $this = $(this);
@@ -515,7 +535,9 @@ $(function () {
               .children('div')
               .children('.icon-token')
               .addClass(config.span_class);
-            $('input[name*=resolved]', tokenEl).val(JSON.stringify(item.json));
+            $('input[name*=resolved]', tokenEl).val(
+              JSON.stringify(resolvedForToken(item.json))
+            );
             return tokenEl;
           },
           resultsFormatter: function (item) {

--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -8,26 +8,6 @@ $(function () {
     resource_edit_path_regex
   );
 
-  // ANW-2762: A token only needs a record's identity/display fields
-  var resolvedForToken = function (json) {
-    if (!json) {
-      return json;
-    }
-
-    var trimmed = $.extend({}, json);
-    delete trimmed.linked_records;
-
-    if (typeof trimmed.json === 'string') {
-      var inner = JSON.parse(trimmed.json);
-      if (inner) {
-        delete inner.linked_records;
-        trimmed.json = JSON.stringify(inner);
-      }
-    }
-
-    return trimmed;
-  };
-
   $.fn.linker = function () {
     $(this).each(function () {
       var $this = $(this);
@@ -536,7 +516,7 @@ $(function () {
               .children('.icon-token')
               .addClass(config.span_class);
             $('input[name*=resolved]', tokenEl).val(
-              JSON.stringify(resolvedForToken(item.json))
+              JSON.stringify(omitLinkedRecords(item.json))
             );
             return tokenEl;
           },
@@ -696,6 +676,26 @@ $(function () {
         ? `<code class="emph render-nonproport">${content}</code>`
         : `<span class="emph render-${render}">${content}</span>`;
     }
+  }
+
+  // ANW-2762: A token only needs a record's identity/display fields
+  function omitLinkedRecords(json) {
+    if (!json) {
+      return json;
+    }
+
+    const trimmed = { ...json };
+    delete trimmed.linked_records;
+
+    if (typeof trimmed.json === 'string') {
+      const inner = JSON.parse(trimmed.json);
+      if (inner) {
+        delete inner.linked_records;
+        trimmed.json = JSON.stringify(inner);
+      }
+    }
+
+    return trimmed;
   }
 });
 

--- a/frontend/spec/features/classifications_spec.rb
+++ b/frontend/spec/features/classifications_spec.rb
@@ -152,6 +152,43 @@ describe 'Classifications', js: true do
     expect(element).to have_text(classification.title)
   end
 
+  it "does not embed a classification's linked records in the link token" do
+    now = Time.now.to_i
+
+    linked_resource = create(:resource, title: "Linked resource #{now}")
+    classification = create(
+      :json_classification,
+      :title => "Classification Title #{now}",
+      :identifier => "Classification Identifier #{now}",
+      :linked_records => [{ ref: linked_resource.uri }]
+    )
+
+    run_all_indexers
+
+    click_on 'Create'
+    click_on 'Accession'
+
+    fill_in 'Title', with: "Accession Title #{now}"
+    fill_in 'Identifier', with: "Accession Identifier #{now}"
+
+    click_on 'Add Classification'
+
+    element = find('#token-input-accession_classifications__0__ref_')
+    element.fill_in with: classification.title
+    find('li.token-input-dropdown-item2', match: :first).click
+
+    resolved = find("input[name*='[_resolved]']", visible: :all).value
+    expect(resolved).not_to be_empty
+    expect(resolved).not_to include('linked_records')
+    expect(resolved).not_to include(linked_resource.uri)
+
+    find('button', text: 'Save Accession', match: :first).click
+    expect(page).to have_text "Accession Accession Title #{now} created"
+
+    element = find('#accession_classifications_')
+    expect(element).to have_text(classification.title)
+  end
+
   it 'has the linked records on the classifications view page' do
     resource = create(:resource)
     classification = create(:classification, linked_records: [{ ref: resource.uri }])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-2762]
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->

## Summary

Linking a Classification with hundreds of linked records to a Resource or Accession from the staff UI failed to save with Rack::QueryParser::QueryLimitError (total query size exceeds limit (4194304)). Linking the other direction (starting from the Classification)  worked fine.

The indexer resolves every record linked to a Classification into that Classification's stored Solr json. When you pick a Classification in the linker, the widget stashes the whole search-result blob - including that resolved linked_records list - into the token's  hidden _resolved field. For a Classification with 400-500+ links, that single field make the form submission request to exceed Rack's 4MB query-size limit.

This Pull Request is dropping the linked_records list in the linker tokens _resolved field which is not used anywhere.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [x] Have you added tests to cover these changes? If not why:


[ANW-2762]: https://archivesspace.atlassian.net/browse/ANW-2762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ