### PR TITLE
Anw 2775 touch root and reindex once per batch

### DIFF
--- a/backend/app/controllers/component_add_children.rb
+++ b/backend/app/controllers/component_add_children.rb
@@ -302,10 +302,23 @@ class ArchivesSpaceService < Sinatra::Base
         ordered = params[:children].each_with_index
       end
 
-      last_child = nil
+      # Moving each child has expensive side effects: bumping the root
+      # record's mtime (TouchRecords) and reindexing every top container in the
+      # tree (ReindexTopContainers). These only apply on the root record, so
+      # reordering hundreds of rows repeats the same whole-tree work over and
+      # over and times the request out (ANW-2775). Defer them during the batch
+      # and apply them once per root record after every child has moved.
+      moved_by_root = {}
+
       ordered.each do |uri, i|
-        last_child = child_class.get_or_die(child_class.my_jsonmodel.id_for(uri))
-        last_child.set_parent_and_position(parent_id, position + i)
+        child = child_class.get_or_die(child_class.my_jsonmodel.id_for(uri))
+        child.set_parent_and_position(parent_id, position + i, skip_side_effects: true)
+        moved_by_root[child.root_record_id] = child # track the last child moved for each root record, so we can apply side effects once per root after the loop
+      end
+
+      moved_by_root.each_value do |child|
+        child_class.touch(child) if child_class.respond_to?(:touch)
+        child.reindex_top_containers if child.respond_to?(:reindex_top_containers)
       end
     end
 

--- a/backend/app/model/mixins/reindex_top_containers.rb
+++ b/backend/app/model/mixins/reindex_top_containers.rb
@@ -68,10 +68,13 @@ module ReindexTopContainers
     ).update(:top_container__system_mtime => Time.now)
   end
 
-  # not defined in accession or resource
-  def set_parent_and_position(*)
+  # When a batch of nodes is being repositioned (e.g. an accept_children
+  # reorder), reindexing is deferred and applied once for the whole batch
+  # rather than once per row. See ANW-2775.
+  def set_parent_and_position(*, skip_side_effects: false)
     super
-    reindex_top_containers
+
+    reindex_top_containers unless skip_side_effects
   end
 
   def set_root(*)

--- a/backend/app/model/mixins/touch_records.rb
+++ b/backend/app/model/mixins/touch_records.rb
@@ -14,9 +14,13 @@ module TouchRecords
     base.extend(ClassMethods)
   end
 
-  def set_parent_and_position(*)
+  # When a batch of nodes is being repositioned (e.g. an accept_children
+  # reorder), the touch is deferred and applied once for the whole batch
+  # rather than once per row. See ANW-2775.
+  def set_parent_and_position(*, skip_side_effects: false)
     super
-    self.class.touch(self)
+
+    self.class.touch(self) unless skip_side_effects
   end
 
   def set_root(*)

--- a/backend/app/model/mixins/tree_nodes.rb
+++ b/backend/app/model/mixins/tree_nodes.rb
@@ -195,7 +195,8 @@ module TreeNodes
   end
 
 
-  def set_parent_and_position(parent_id, position)
+  # skip_side_effects is consumed by the TouchRecords and ReindexTopContainers overrides
+  def set_parent_and_position(parent_id, position, skip_side_effects: false)
     self.class.retry_db_update do
       attempt_set_parent_and_position(parent_id, position)
     end

--- a/backend/spec/model_managed_container_spec.rb
+++ b/backend/spec/model_managed_container_spec.rb
@@ -344,6 +344,20 @@ describe 'Managed Container model' do
     end
 
 
+    it "reindexes top containers when a tree is rearranged via accept_children" do
+      (resource, grandparent, parent, child) = create_tree(top_container_json)
+
+      original_mtime = top_container.refresh.system_mtime
+      ArchivesSpaceService.wait(:long)
+
+      response = JSONModel::HTTP.post_form("#{grandparent.uri}/accept_children",
+                                           "children[]" => [child.uri],
+                                           "position" => 0)
+      expect(response).to be_ok
+      expect(top_container.refresh.system_mtime).to be > original_mtime
+    end
+
+
     it "refreshes top containers when an archival object is deleted" do
       (resource, grandparent, parent, child) = create_tree(top_container_json)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-2775] 
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->

## Summary
Reordering more than 190 rows in the InfiniteTree timed out (504) because the accept_children controller moved each row individually, and every move re-ran two whole-tree side effects: bumping the resource's system_mtime (TouchRecords) and reindexing every top container in the  resource (ReindexTopContainers). Since both depend only on the root record, moving N rows repeated identical whole-tree work N times.

 This Pull Request skips these two side effects while moving each child, then applies touch + reindex_top_containers once per root record for the whole batch. Positioning logic still runs per row, so move ordering is unchanged.

Turns the per-batch cost from O(N * tree size) to O(tree size).
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [ ] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:


[ANW-2775]: https://archivesspace.atlassian.net/browse/ANW-2775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ