### PR TITLE
ANW-652 fix performance of classification show action on SUI

### DIFF
--- a/frontend/app/controllers/classifications_controller.rb
+++ b/frontend/app/controllers/classifications_controller.rb
@@ -30,7 +30,10 @@ class ClassificationsController < ApplicationController
     flash.keep
 
     if params[:inline]
-      @classification = JSONModel(:classification).find(params[:id], find_opts)
+      @classification = JSONModel(:classification).find(
+        params[:id],
+        find_opts.tap { |opts| opts["resolve[]"] -= ["linked_records"] }
+      )
       return render_aspace_partial :partial => "classifications/show_inline"
     end
 

--- a/frontend/spec/controllers/classifications_controller_spec.rb
+++ b/frontend/spec/controllers/classifications_controller_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_helper'
+
+describe ClassificationsController, type: :controller do
+  render_views
+
+  before(:each) do
+    set_repo($repo)
+    session = User.login('admin', 'admin')
+    User.establish_session(controller, session, 'admin')
+    controller.session[:repo_id] = JSONModel.repository
+  end
+
+  let(:classification) do
+    resource = create(:json_resource)
+    create(:json_classification, linked_records: [{ 'ref' => resource.uri }])
+  end
+
+  def capture_resolve_opts
+    opts = nil
+    allow(JSONModel(:classification)).to receive(:find).and_wrap_original do |original, *args|
+      opts ||= args[1]
+      original.call(*args)
+    end
+    yield
+    opts
+  end
+
+  describe 'resolving linked records' do
+    # ANW-652: A classification can have thousands of linked records. The show page
+    # lists them through a separate paginated search (see _show_inline.html.erb), so
+    # resolving them when finding the record is wasted work that slows the page down.
+    it 'does not resolve linked_records for the inline show page' do
+      id = classification.id
+
+      opts = capture_resolve_opts do
+        get :show, params: { id: id, inline: true }
+      end
+
+      expect(response).to be_successful
+      expect(opts['resolve[]']).not_to be_empty
+      expect(opts['resolve[]']).not_to include('linked_records')
+    end
+
+    it 'still resolves linked_records for the inline edit form' do
+      id = classification.id
+
+      opts = capture_resolve_opts do
+        get :edit, params: { id: id, inline: true }
+      end
+
+      expect(response).to be_successful
+      expect(opts['resolve[]']).to include('linked_records')
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-652]
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->

## Summary
A classification can have thousands of linked accessions/resources. The staff classification view (inline show) resolved every linked record into the record JSON, which made the page very slow to display - even though the view never uses that resolved data (it lists linked records through a separate paginated search).

This drops linked_records from the resolve list on the show action only.
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [ ] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:


[ANW-652]: https://archivesspace.atlassian.net/browse/ANW-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ