### PR TITLE
ANW-2732 MLC subrecord badges

### DIFF
--- a/.github/actions/setup-e2e/action.yml
+++ b/.github/actions/setup-e2e/action.yml
@@ -1,0 +1,51 @@
+name: Set up E2E environment
+description: Ruby, gems, geckodriver, and a running ArchivesSpace stack
+
+inputs:
+  image_tag:
+    description: Docker image tag for ArchivesSpace
+    required: true
+  multilingual_content:
+    description: Value for APPCONFIG_MULTILINGUAL_CONTENT
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2.0'
+        working-directory: e2e-tests
+    - uses: actions/cache@v4
+      with:
+        path: e2e-tests/vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('e2e-tests/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+    - name: Install gems
+      shell: bash
+      working-directory: e2e-tests
+      run: |
+        bundle config path vendor/bundle
+        bundle install --quiet --jobs 4 --retry 3
+    - uses: browser-actions/setup-geckodriver@latest
+      with:
+        token: ${{ github.token }}
+    - name: Get geckodriver and firefox versions
+      shell: bash
+      run: |
+        geckodriver --version
+        firefox --version
+    - name: Set up Docker
+      shell: bash
+      working-directory: e2e-tests
+      env:
+        IMAGE_TAG: ${{ inputs.image_tag }}
+        APPCONFIG_MULTILINGUAL_CONTENT: ${{ inputs.multilingual_content }}
+      run: docker compose -f docker-compose.yml up --quiet-pull --detach
+    - name: Wait until the web server is ready
+      shell: bash
+      run: |
+        echo "Waiting for ArchivesSpace to start..."
+        timeout 120 bash -c 'until curl -sf http://localhost:8080 > /dev/null; do sleep 2; done' || echo "Timeout waiting for ArchivesSpace"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -56,39 +56,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ./.github/actions/setup-e2e
         with:
-          ruby-version: '3.2.0'
-          working-directory: e2e-tests
-      - name: Cache gems
-        uses: actions/cache@v3
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-      - name: Install gems
-        run: |
-          gem install parallel_tests
-          bundle config path vendor/bundle
-          bundle install --quiet --jobs 4 --retry 3
-      - uses: browser-actions/setup-geckodriver@latest
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get geckodriver and firefox versions
-        run: |
-          geckodriver --version
-          firefox --version
-      - name: Set up Docker
-        env:
-          IMAGE_TAG: ${{ inputs.image_tag }}
-        run: |
-          docker compose -f docker-compose.yml up --quiet-pull --detach
-      - name: Wait until the web server is ready
-        run: |
-          echo "Waiting for ArchivesSpace to start..."
-          timeout 120 bash -c 'until curl -sf http://localhost:8080 > /dev/null; do sleep 2; done' || echo "Timeout waiting for ArchivesSpace"
+          image_tag: ${{ inputs.image_tag }}
+
       - name: Get feature files for this shard
         id: shard-files
         working-directory: e2e-tests
@@ -116,7 +87,7 @@ jobs:
       - name: Run Cucumber tests (Shard ${{ matrix.shard }}/${{ strategy.job-total }})
         working-directory: e2e-tests
         run: |
-          mkdir reports
+          mkdir -p reports
           bundle exec cucumber \
             --publish-quiet \
             --format pretty \
@@ -152,42 +123,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ./.github/actions/setup-e2e
         with:
-          ruby-version: '3.2.0'
-          working-directory: e2e-tests
-      - name: Cache gems
-        uses: actions/cache@v3
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --quiet --jobs 4 --retry 3
-      - uses: browser-actions/setup-geckodriver@latest
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get geckodriver and firefox versions
-        run: |
-          geckodriver --version
-          firefox --version
-      - name: Set up Docker (MLC enabled)
-        env:
-          IMAGE_TAG: ${{ inputs.image_tag }}
-          APPCONFIG_MULTILINGUAL_CONTENT: "true"
-        run: |
-          docker compose -f docker-compose.yml up --quiet-pull --detach
-      - name: Wait until the web server is ready
-        run: |
-          echo "Waiting for ArchivesSpace to start..."
-          timeout 120 bash -c 'until curl -sf http://localhost:8080 > /dev/null; do sleep 2; done' || echo "Timeout waiting for ArchivesSpace"
+          image_tag: ${{ inputs.image_tag }}
+          multilingual_content: "true"
+
       - name: Run MLC Cucumber tests
         run: |
-          mkdir reports
+          mkdir -p reports
           bundle exec cucumber -p mlc \
             --publish-quiet \
             --format pretty \

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -122,7 +122,7 @@ jobs:
             --format pretty \
             --format json --out reports/cucumber_shard_${{ matrix.shard }}.json \
             --format html --out reports/cucumber_shard_${{ matrix.shard }}.html \
-            --tags "not @wip" \
+            --tags "not @wip and not @mlc_enabled" \
             ${{ steps.shard-files.outputs.files }}
 
       - name: Upload test results
@@ -141,10 +141,76 @@ jobs:
           name: e2e-failure-screenshots-shard-${{ matrix.shard }}
           path: /tmp/screenshots/
 
+  e2e-tests-mlc:
+    name: E2E Tests (MLC enabled)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./e2e-tests
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.0'
+          working-directory: e2e-tests
+      - name: Cache gems
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Install gems
+        run: |
+          bundle config path vendor/bundle
+          bundle install --quiet --jobs 4 --retry 3
+      - uses: browser-actions/setup-geckodriver@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get geckodriver and firefox versions
+        run: |
+          geckodriver --version
+          firefox --version
+      - name: Set up Docker (MLC enabled)
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          APPCONFIG_MULTILINGUAL_CONTENT: "true"
+        run: |
+          docker compose -f docker-compose.yml up --quiet-pull --detach
+      - name: Wait until the web server is ready
+        run: |
+          echo "Waiting for ArchivesSpace to start..."
+          timeout 120 bash -c 'until curl -sf http://localhost:8080 > /dev/null; do sleep 2; done' || echo "Timeout waiting for ArchivesSpace"
+      - name: Run MLC Cucumber tests
+        run: |
+          mkdir reports
+          bundle exec cucumber -p mlc \
+            --publish-quiet \
+            --format pretty \
+            --format json --out reports/cucumber_mlc.json \
+            --format html --out reports/cucumber_mlc.html
+      - name: Upload MLC test results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: e2e-mlc-results
+          path: e2e-tests/reports/
+          retention-days: 7
+      - name: Upload screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: e2e-mlc-failure-screenshots
+          path: /tmp/screenshots/
+
   # Summary job to check overall status
   test-summary:
     name: Test Summary
-    needs: e2e-tests
+    needs: [e2e-tests, e2e-tests-mlc]
     runs-on: ubuntu-latest
     if: always()
 
@@ -156,7 +222,7 @@ jobs:
           echo "All shards completed. Check individual shard results above." >> $GITHUB_STEP_SUMMARY
 
           # This job will fail if any shard failed
-          if [ "${{ needs.e2e-tests.result }}" != "success" ]; then
+          if [ "${{ needs.e2e-tests.result }}" != "success" ] || [ "${{ needs.e2e-tests-mlc.result }}" != "success" ]; then
             echo "❌ Some tests failed" >> $GITHUB_STEP_SUMMARY
             exit 1
           else

--- a/e2e-tests/cucumber.yml
+++ b/e2e-tests/cucumber.yml
@@ -6,4 +6,14 @@ default: |
   --require env.rb
   --require helpers
   --require staff_features
-  --tags "not @skip"
+  --tags "not @skip and not @mlc_enabled"
+
+mlc: |
+  staff_features
+  --publish-quiet
+  --format pretty
+  --color
+  --require env.rb
+  --require helpers
+  --require staff_features
+  --tags "@mlc_enabled"

--- a/e2e-tests/docker-compose.yml
+++ b/e2e-tests/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       APPCONFIG_FRONTEND_PROXY_URL: "http://localhost:8080"
       APPCONFIG_PUBLIC_PROXY_URL: "http://localhost:8081"
       APPCONFIG_SOLR_URL: "http://e2e-solr:8983/solr/archivesspace"
+      APPCONFIG_MULTILINGUAL_CONTENT: ${APPCONFIG_MULTILINGUAL_CONTENT:-false}
       ASPACE_DB_MIGRATE: true
       ASPACE_JAVA_XMX: "-Xmx2048m"
       JAVA_OPTS: "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xss1024k -Djavax.accessibility.assistive_technologies=''"

--- a/e2e-tests/helpers/helpers.rb
+++ b/e2e-tests/helpers/helpers.rb
@@ -258,6 +258,23 @@ def create_resource(uuid)
   find('#resource_publish_').check
   select 'Class', from: 'resource_level_'
 
+  # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
+  if page.has_css?('#resource_lang_descriptions_')
+    within '#resource_lang_descriptions_' do
+      within 'li.sort-enabled.initialised' do
+        fill_in 'Language', with: 'English'
+        wait_for_ajax
+        find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
+        expect(page).to have_css('#resource_lang_descriptions_ .dropdown-item.active[data-value="English"]', visible: false)
+
+        fill_in 'Script', with: 'Latin'
+        wait_for_ajax
+        find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
+        expect(page).to have_css('#resource_lang_descriptions_ .dropdown-item.active[data-value="Latin"]', visible: false)
+      end
+    end
+  end
+
   languages = all('#resource_lang_materials_ .subrecord-form-list li')
   click_on 'Add Language of Materials' if languages.length == 0
   element = find('#resource_lang_materials__0__language_and_script__language_')

--- a/e2e-tests/helpers/helpers.rb
+++ b/e2e-tests/helpers/helpers.rb
@@ -206,6 +206,10 @@ def ensure_test_accession_exists
   visit "#{STAFF_URL}/accessions/new"
   fill_in 'accession_id_0_', with: 'test_accession'
   fill_in 'accession_title_', with: 'test_accession'
+
+  # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
+  create_lang_descriptions('accession') if page.has_css?('#accession_lang_descriptions_')
+
   click_on 'Save'
 end
 
@@ -259,21 +263,7 @@ def create_resource(uuid)
   select 'Class', from: 'resource_level_'
 
   # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
-  if page.has_css?('#resource_lang_descriptions_')
-    within '#resource_lang_descriptions_' do
-      within 'li.sort-enabled.initialised' do
-        fill_in 'Language', with: 'English'
-        wait_for_ajax
-        find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
-        expect(page).to have_css('#resource_lang_descriptions_ .dropdown-item.active[data-value="English"]', visible: false)
-
-        fill_in 'Script', with: 'Latin'
-        wait_for_ajax
-        find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
-        expect(page).to have_css('#resource_lang_descriptions_ .dropdown-item.active[data-value="Latin"]', visible: false)
-      end
-    end
-  end
+  create_lang_descriptions('resource') if page.has_css?('#resource_lang_descriptions_')
 
   languages = all('#resource_lang_materials_ .subrecord-form-list li')
   click_on 'Add Language of Materials' if languages.length == 0
@@ -369,6 +359,22 @@ def expect_record_to_not_be_in_search_results(search_term)
 
   expect(search_result_rows.length).to eq 0
   expect(page).to have_css('.alert.alert-info.with-hide-alert', text: 'No records found')
+end
+
+def create_lang_descriptions(record_type)
+  within "##{record_type}_lang_descriptions_" do
+    within 'li.sort-enabled.initialised' do
+      fill_in 'Language', with: 'English'
+      wait_for_ajax
+      find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
+      expect(page).to have_css("##{record_type}_lang_descriptions_ .dropdown-item.active[data-value='English']", visible: false)
+
+      fill_in 'Script', with: 'Latin'
+      wait_for_ajax
+      find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
+      expect(page).to have_css("##{record_type}_lang_descriptions_ .dropdown-item.active[data-value='Latin']", visible: false)
+    end
+  end
 end
 
 def click_on_string(string)

--- a/e2e-tests/helpers/helpers.rb
+++ b/e2e-tests/helpers/helpers.rb
@@ -208,7 +208,7 @@ def ensure_test_accession_exists
   fill_in 'accession_title_', with: 'test_accession'
 
   # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
-  create_lang_descriptions('accession') if page.has_css?('#accession_lang_descriptions_')
+  add_lang_description('accession', language: 'English', script: 'Latin') if page.has_css?('#accession_lang_descriptions_')
 
   click_on 'Save'
 end
@@ -263,7 +263,7 @@ def create_resource(uuid)
   select 'Class', from: 'resource_level_'
 
   # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
-  create_lang_descriptions('resource') if page.has_css?('#resource_lang_descriptions_')
+  add_lang_description('resource', language: 'English', script: 'Latin') if page.has_css?('#resource_lang_descriptions_')
 
   languages = all('#resource_lang_materials_ .subrecord-form-list li')
   click_on 'Add Language of Materials' if languages.length == 0
@@ -361,18 +361,21 @@ def expect_record_to_not_be_in_search_results(search_term)
   expect(page).to have_css('.alert.alert-info.with-hide-alert', text: 'No records found')
 end
 
-def create_lang_descriptions(record_type)
+def add_lang_description(record_type, language:, script:)
   within "##{record_type}_lang_descriptions_" do
-    within 'li.sort-enabled.initialised' do
-      fill_in 'Language', with: 'English'
-      wait_for_ajax
-      find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
-      expect(page).to have_css("##{record_type}_lang_descriptions_ .dropdown-item.active[data-value='English']", visible: false)
+    existing = all('li.sort-enabled.initialised')
+    click_on 'Add Language of Description' if existing.empty? || !existing.last.find_field('Language').value.empty?
 
-      fill_in 'Script', with: 'Latin'
+    within all('li.sort-enabled.initialised').last do
+      fill_in 'Language', with: language
       wait_for_ajax
-      find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
-      expect(page).to have_css("##{record_type}_lang_descriptions_ .dropdown-item.active[data-value='Latin']", visible: false)
+      find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: language, match: :first).click
+      expect(page).to have_css("##{record_type}_lang_descriptions_ .dropdown-item.active[data-value='#{language}']", visible: false)
+
+      fill_in 'Script', with: script
+      wait_for_ajax
+      find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: script, match: :first).click
+      expect(page).to have_css("##{record_type}_lang_descriptions_ .dropdown-item.active[data-value='#{script}']", visible: false)
     end
   end
 end

--- a/e2e-tests/staff_features/accessions/accession_mlc_content.feature
+++ b/e2e-tests/staff_features/accessions/accession_mlc_content.feature
@@ -1,7 +1,9 @@
 Feature: MLC content display
+
   Background:
     Given an administrator user is logged in
       And an Accession has been created
+
   Scenario: Current Language selector from edit mode resource toolbar
     Given the Accession is opened in edit mode
      When the user clicks on "Current Language"
@@ -9,12 +11,14 @@ Feature: MLC content display
       And the user sees the "Spanish" option in the "Current Language" dropdown
       And the user sees the "French" option in the "Current Language" dropdown
       And the user sees the "German" option in the "Current Language" dropdown
+
   Scenario Outline: MLC default language preview appears on mlc content fields
     Given the Accession is opened in edit mode
      Then the user sees the MLC default language preview before the "<record_type>" "<field>" label
       And the user sees the default language preview summary text "SPA"
       And the default language preview should be present but hidden
       And the user sees a globe icon on the "<record_type>" "<field>" label
+
         Examples:
           | record_type | field                    |
           | accession   | title                    |
@@ -26,6 +30,7 @@ Feature: MLC content display
           | accession   | general_note             |
           | accession   | access_restrictions_note |
           | accession   | use_restrictions_note    |
+
   Scenario: Current Language selector from view mode resource toolbar
     Given the Accession is opened in the view mode
      When the user clicks on "Current Language"
@@ -33,10 +38,12 @@ Feature: MLC content display
       And the user sees the "Spanish" option in the "Current Language" dropdown
       And the user sees the "French" option in the "Current Language" dropdown
       And the user sees the "German" option in the "Current Language" dropdown
+
   Scenario Outline: MLC badge does not appear in read mode
     Given the Accession is opened in the view mode
      Then the user should not see the MLC default language preview before the "<record_type>" "<field>" label
       And the user should not see a globe icon on the "<record_type>" "<field>" label
+
         Examples:
           | record_type | field                    |
           | accession   | title                    |
@@ -48,3 +55,12 @@ Feature: MLC content display
           | accession   | general_note             |
           | accession   | access_restrictions_note |
           | accession   | use_restrictions_note    |
+
+  @mlc_enabled
+  Scenario: Current language badge appears on all subrecords when mlc enabled
+    Given the Accession is opened in edit mode
+     Then the user should see language badges on all subrecords
+
+  Scenario: Current language badge does not appear when mlc disabled
+    Given the Accession is opened in edit mode
+     Then the user should not see a language badge

--- a/e2e-tests/staff_features/accessions/accession_mlc_content.feature
+++ b/e2e-tests/staff_features/accessions/accession_mlc_content.feature
@@ -58,7 +58,8 @@ Feature: MLC content display
 
   @mlc_enabled
   Scenario: Current language badge appears on all subrecords when mlc enabled
-    Given the Accession is opened in edit mode
+    Given a second language of description has been added to the Accession
+      And the Accession is opened in edit mode
      Then the user should see language badges on all subrecords
 
   Scenario: Current language badge does not appear when mlc disabled

--- a/e2e-tests/staff_features/accessions/step_definitions/accession_shared.rb
+++ b/e2e-tests/staff_features/accessions/step_definitions/accession_shared.rb
@@ -32,6 +32,23 @@ Given 'an Accession has been created' do
   find('#accession_use_restrictions_').check
   fill_in 'accession_use_restrictions_note_', with: "Use Restrictions Note #{@uuid}"
 
+  # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
+  if page.has_css?('#accession_lang_descriptions_')
+    within '#accession_lang_descriptions_' do
+      within 'li.sort-enabled.initialised' do
+        fill_in 'Language', with: 'English'
+        wait_for_ajax
+        find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
+        expect(page).to have_css('#accession_lang_descriptions_ .dropdown-item.active[data-value="English"]', visible: false)
+
+        fill_in 'Script', with: 'Latin'
+        wait_for_ajax
+        find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
+        expect(page).to have_css('#accession_lang_descriptions_ .dropdown-item.active[data-value="Latin"]', visible: false)
+      end
+    end
+  end
+
   within '#accession_lang_materials_' do
     click_on 'Add Language of Materials'
 

--- a/e2e-tests/staff_features/accessions/step_definitions/accession_shared.rb
+++ b/e2e-tests/staff_features/accessions/step_definitions/accession_shared.rb
@@ -33,21 +33,7 @@ Given 'an Accession has been created' do
   fill_in 'accession_use_restrictions_note_', with: "Use Restrictions Note #{@uuid}"
 
   # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
-  if page.has_css?('#accession_lang_descriptions_')
-    within '#accession_lang_descriptions_' do
-      within 'li.sort-enabled.initialised' do
-        fill_in 'Language', with: 'English'
-        wait_for_ajax
-        find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
-        expect(page).to have_css('#accession_lang_descriptions_ .dropdown-item.active[data-value="English"]', visible: false)
-
-        fill_in 'Script', with: 'Latin'
-        wait_for_ajax
-        find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
-        expect(page).to have_css('#accession_lang_descriptions_ .dropdown-item.active[data-value="Latin"]', visible: false)
-      end
-    end
-  end
+  create_lang_descriptions('accession') if page.has_css?('#accession_lang_descriptions_')
 
   within '#accession_lang_materials_' do
     click_on 'Add Language of Materials'

--- a/e2e-tests/staff_features/accessions/step_definitions/accession_shared.rb
+++ b/e2e-tests/staff_features/accessions/step_definitions/accession_shared.rb
@@ -33,7 +33,7 @@ Given 'an Accession has been created' do
   fill_in 'accession_use_restrictions_note_', with: "Use Restrictions Note #{@uuid}"
 
   # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
-  create_lang_descriptions('accession') if page.has_css?('#accession_lang_descriptions_')
+  add_lang_description('accession', language: 'English', script: 'Latin') if page.has_css?('#accession_lang_descriptions_')
 
   within '#accession_lang_materials_' do
     click_on 'Add Language of Materials'
@@ -131,6 +131,13 @@ Given 'an Accession with a Top Container has been created' do
 
   click_on 'Save'
   expect(page).to have_text "Accession Accession Title #{@uuid} created"
+end
+
+Given 'a second language of description has been added to the Accession' do
+  visit "#{STAFF_URL}/accessions/#{@accession_id}/edit"
+  add_lang_description('accession', language: 'German', script: 'Latin')
+  click_on 'Save'
+  expect(page).to have_css('.alert.alert-success', text: /Accession.*updated/i)
 end
 
 Given 'the Accession is opened in edit mode' do

--- a/e2e-tests/staff_features/digital_objects/digital_object_component_mlc_content.feature
+++ b/e2e-tests/staff_features/digital_objects/digital_object_component_mlc_content.feature
@@ -1,7 +1,9 @@
 Feature: MLC content display
+
   Background:
     Given an administrator user is logged in
       And a Digital Object with a Digital Object Component has been created
+
   Scenario Outline: MLC badge appears on fields marked with mlc_content_badge across form contexts
     Given the Digital Object is opened in edit mode
      When the user selects the Digital Object Component
@@ -9,16 +11,30 @@ Feature: MLC content display
       And the user sees the default language preview summary text "SPA"
       And the default language preview should be present but hidden
       And the user sees a globe icon on the "<record_type>" "<field>" label
+
         Examples:
           | record_type              | field |
           | digital_object_component | title |
           | digital_object_component | label |
+
   Scenario Outline: MLC badge does not appear in read mode
     Given the Digital Object is opened in the view mode
      When the user selects the Digital Object Component
      Then the user should not see the MLC default language preview before the "<record_type>" "<field>" label
       And the user should not see a globe icon on the "<record_type>" "<field>" label
+
         Examples:
           | record_type              | field |
           | digital_object_component | title |
           | digital_object_component | label |
+
+  @mlc_enabled
+  Scenario: Current language badge appears on all subrecords when mlc enabled
+    Given the Digital Object is opened in edit mode
+     When the user selects the Digital Object Component
+     Then the user should see language badges on all subrecords
+
+  Scenario: Current language badge does not appear when mlc disabled
+    Given the Digital Object is opened in edit mode
+     When the user selects the Digital Object Component
+     Then the user should not see a language badge

--- a/e2e-tests/staff_features/digital_objects/digital_object_component_mlc_content.feature
+++ b/e2e-tests/staff_features/digital_objects/digital_object_component_mlc_content.feature
@@ -30,7 +30,8 @@ Feature: MLC content display
 
   @mlc_enabled
   Scenario: Current language badge appears on all subrecords when mlc enabled
-    Given the Digital Object is opened in edit mode
+    Given a second language of description has been added to the Digital Object
+      And the Digital Object is opened in edit mode
      When the user selects the Digital Object Component
      Then the user should see language badges on all subrecords
 

--- a/e2e-tests/staff_features/digital_objects/digital_object_mlc_content.feature
+++ b/e2e-tests/staff_features/digital_objects/digital_object_mlc_content.feature
@@ -1,7 +1,9 @@
 Feature: MLC content display
+
   Background:
     Given an administrator user is logged in
       And a Digital Object has been created
+
   Scenario: Current Language selector from edit mode resource toolbar
     Given the Digital Object is opened in edit mode
      When the user clicks on "Current Language"
@@ -9,15 +11,18 @@ Feature: MLC content display
       And the user sees the "Spanish" option in the "Current Language" dropdown
       And the user sees the "French" option in the "Current Language" dropdown
       And the user sees the "German" option in the "Current Language" dropdown
+
   Scenario Outline: MLC default language preview appears on mlc content fields
     Given the Digital Object is opened in edit mode
      Then the user sees the MLC default language preview before the "<record_type>" "<field>" label
       And the user sees the default language preview summary text "SPA"
       And the default language preview should be present but hidden
       And the user sees a globe icon on the "<record_type>" "<field>" label
+
         Examples:
           | record_type    | field |
           | digital_object | title |
+
   Scenario: Current Language selector from view mode resource toolbar
     Given the Digital Object is opened in the view mode
      When the user clicks on "Current Language"
@@ -25,10 +30,21 @@ Feature: MLC content display
       And the user sees the "Spanish" option in the "Current Language" dropdown
       And the user sees the "French" option in the "Current Language" dropdown
       And the user sees the "German" option in the "Current Language" dropdown
+
   Scenario Outline: MLC badge does not appear in read mode
     Given the Digital Object is opened in the view mode
      Then the user should not see the MLC default language preview before the "<record_type>" "<field>" label
       And the user should not see a globe icon on the "<record_type>" "<field>" label
+
         Examples:
           | record_type    | field |
           | digital_object | title |
+
+  @mlc_enabled
+  Scenario: Current language badge appears on all subrecords when mlc enabled
+    Given the Digital Object is opened in edit mode
+     Then the user should see language badges on all subrecords
+
+  Scenario: Current language badge does not appear when mlc disabled
+    Given the Digital Object is opened in edit mode
+     Then the user should not see a language badge

--- a/e2e-tests/staff_features/digital_objects/digital_object_mlc_content.feature
+++ b/e2e-tests/staff_features/digital_objects/digital_object_mlc_content.feature
@@ -42,7 +42,8 @@ Feature: MLC content display
 
   @mlc_enabled
   Scenario: Current language badge appears on all subrecords when mlc enabled
-    Given the Digital Object is opened in edit mode
+    Given a second language of description has been added to the Digital Object
+      And the Digital Object is opened in edit mode
      Then the user should see language badges on all subrecords
 
   Scenario: Current language badge does not appear when mlc disabled

--- a/e2e-tests/staff_features/digital_objects/step_definitions/digital_object_shared.rb
+++ b/e2e-tests/staff_features/digital_objects/step_definitions/digital_object_shared.rb
@@ -6,6 +6,23 @@ Given 'a Digital Object has been created' do
   fill_in 'digital_object_digital_object_id_', with: "Digital Object Identifier #{@uuid}"
   fill_in 'digital_object_title_', with: "Digital Object Title #{@uuid}"
 
+  # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
+  if page.has_css?('#digital_object_lang_descriptions_')
+    within '#digital_object_lang_descriptions_' do
+      within 'li.sort-enabled.initialised' do
+        fill_in 'Language', with: 'English'
+        wait_for_ajax
+        find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
+        expect(page).to have_css('#digital_object_lang_descriptions_ .dropdown-item.active[data-value="English"]', visible: false)
+
+        fill_in 'Script', with: 'Latin'
+        wait_for_ajax
+        find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
+        expect(page).to have_css('#digital_object_lang_descriptions_ .dropdown-item.active[data-value="Latin"]', visible: false)
+      end
+    end
+  end
+
   click_on 'Add Date'
   select 'Single', from: 'digital_object_dates__0__date_type_'
   fill_in 'digital_object_dates__0__begin_', with: '2000-01-01'
@@ -194,6 +211,23 @@ Given 'a Digital Object with a Digital Object Component has been created' do
   fill_in 'digital_object_digital_object_id_', with: "Digital Object Identifier #{@uuid}"
   fill_in 'digital_object_title_', with: "Digital Object Title #{@uuid}"
 
+  # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
+  if page.has_css?('#digital_object_lang_descriptions_')
+    within '#digital_object_lang_descriptions_' do
+      within 'li.sort-enabled.initialised' do
+        fill_in 'Language', with: 'English'
+        wait_for_ajax
+        find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
+        expect(page).to have_css('#digital_object_lang_descriptions_ .dropdown-item.active[data-value="English"]', visible: false)
+
+        fill_in 'Script', with: 'Latin'
+        wait_for_ajax
+        find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
+        expect(page).to have_css('#digital_object_lang_descriptions_ .dropdown-item.active[data-value="Latin"]', visible: false)
+      end
+    end
+  end
+
   click_on 'Add Date'
   select 'Single', from: 'digital_object_dates__0__date_type_'
   fill_in 'digital_object_dates__0__begin_', with: '2000-01-01'
@@ -207,6 +241,24 @@ Given 'a Digital Object with a Digital Object Component has been created' do
   wait_for_ajax
 
   fill_in 'Label', with: "Digital Object Component Label #{@uuid}"
+
+  # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
+  if page.has_css?('#digital_object_component_lang_descriptions_')
+    within '#digital_object_component_lang_descriptions_' do
+      within 'li.sort-enabled.initialised' do
+        fill_in 'Language', with: 'English'
+        wait_for_ajax
+        find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
+        expect(page).to have_css('#digital_object_component_lang_descriptions_ .dropdown-item.active[data-value="English"]', visible: false)
+
+        fill_in 'Script', with: 'Latin'
+        wait_for_ajax
+        find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
+        expect(page).to have_css('digital_object_component_lang_descriptions_ .dropdown-item.active[data-value="Latin"]', visible: false)
+      end
+    end
+  end
+
   click_on 'Save'
   expect(page).to have_css('.alert.alert-success.with-hide-alert', text: "Digital Object Component created on Digital Object Digital Object Title #{@uuid}")
 end

--- a/e2e-tests/staff_features/digital_objects/step_definitions/digital_object_shared.rb
+++ b/e2e-tests/staff_features/digital_objects/step_definitions/digital_object_shared.rb
@@ -7,21 +7,7 @@ Given 'a Digital Object has been created' do
   fill_in 'digital_object_title_', with: "Digital Object Title #{@uuid}"
 
   # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
-  if page.has_css?('#digital_object_lang_descriptions_')
-    within '#digital_object_lang_descriptions_' do
-      within 'li.sort-enabled.initialised' do
-        fill_in 'Language', with: 'English'
-        wait_for_ajax
-        find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
-        expect(page).to have_css('#digital_object_lang_descriptions_ .dropdown-item.active[data-value="English"]', visible: false)
-
-        fill_in 'Script', with: 'Latin'
-        wait_for_ajax
-        find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
-        expect(page).to have_css('#digital_object_lang_descriptions_ .dropdown-item.active[data-value="Latin"]', visible: false)
-      end
-    end
-  end
+  create_lang_descriptions('digital_object') if page.has_css?('#digital_object_lang_descriptions_')
 
   click_on 'Add Date'
   select 'Single', from: 'digital_object_dates__0__date_type_'
@@ -212,21 +198,7 @@ Given 'a Digital Object with a Digital Object Component has been created' do
   fill_in 'digital_object_title_', with: "Digital Object Title #{@uuid}"
 
   # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
-  if page.has_css?('#digital_object_lang_descriptions_')
-    within '#digital_object_lang_descriptions_' do
-      within 'li.sort-enabled.initialised' do
-        fill_in 'Language', with: 'English'
-        wait_for_ajax
-        find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
-        expect(page).to have_css('#digital_object_lang_descriptions_ .dropdown-item.active[data-value="English"]', visible: false)
-
-        fill_in 'Script', with: 'Latin'
-        wait_for_ajax
-        find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
-        expect(page).to have_css('#digital_object_lang_descriptions_ .dropdown-item.active[data-value="Latin"]', visible: false)
-      end
-    end
-  end
+  create_lang_descriptions('digital_object') if page.has_css?('#digital_object_lang_descriptions_')
 
   click_on 'Add Date'
   select 'Single', from: 'digital_object_dates__0__date_type_'
@@ -241,23 +213,6 @@ Given 'a Digital Object with a Digital Object Component has been created' do
   wait_for_ajax
 
   fill_in 'Label', with: "Digital Object Component Label #{@uuid}"
-
-  # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
-  if page.has_css?('#digital_object_component_lang_descriptions_')
-    within '#digital_object_component_lang_descriptions_' do
-      within 'li.sort-enabled.initialised' do
-        fill_in 'Language', with: 'English'
-        wait_for_ajax
-        find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
-        expect(page).to have_css('#digital_object_component_lang_descriptions_ .dropdown-item.active[data-value="English"]', visible: false)
-
-        fill_in 'Script', with: 'Latin'
-        wait_for_ajax
-        find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
-        expect(page).to have_css('digital_object_component_lang_descriptions_ .dropdown-item.active[data-value="Latin"]', visible: false)
-      end
-    end
-  end
 
   click_on 'Save'
   expect(page).to have_css('.alert.alert-success.with-hide-alert', text: "Digital Object Component created on Digital Object Digital Object Title #{@uuid}")

--- a/e2e-tests/staff_features/digital_objects/step_definitions/digital_object_shared.rb
+++ b/e2e-tests/staff_features/digital_objects/step_definitions/digital_object_shared.rb
@@ -7,7 +7,7 @@ Given 'a Digital Object has been created' do
   fill_in 'digital_object_title_', with: "Digital Object Title #{@uuid}"
 
   # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
-  create_lang_descriptions('digital_object') if page.has_css?('#digital_object_lang_descriptions_')
+  add_lang_description('digital_object', language: 'English', script: 'Latin') if page.has_css?('#digital_object_lang_descriptions_')
 
   click_on 'Add Date'
   select 'Single', from: 'digital_object_dates__0__date_type_'
@@ -99,6 +99,13 @@ end
 
 Given 'the Digital Object is opened in the view mode' do
   visit "#{STAFF_URL}/digital_objects/#{@digital_object_id}"
+end
+
+Given 'a second language of description has been added to the Digital Object' do
+  visit "#{STAFF_URL}/digital_objects/#{@digital_object_id}/edit"
+  add_lang_description('digital_object', language: 'German', script: 'Latin')
+  click_on 'Save'
+  expect(page).to have_css('.alert.alert-success', text: /Digital Object.*updated/i)
 end
 
 Given 'the Digital Object is opened in edit mode' do
@@ -198,7 +205,7 @@ Given 'a Digital Object with a Digital Object Component has been created' do
   fill_in 'digital_object_title_', with: "Digital Object Title #{@uuid}"
 
   # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
-  create_lang_descriptions('digital_object') if page.has_css?('#digital_object_lang_descriptions_')
+  add_lang_description('digital_object', language: 'English', script: 'Latin') if page.has_css?('#digital_object_lang_descriptions_')
 
   click_on 'Add Date'
   select 'Single', from: 'digital_object_dates__0__date_type_'

--- a/e2e-tests/staff_features/resources/resource_archival_object_mlc_content.feature
+++ b/e2e-tests/staff_features/resources/resource_archival_object_mlc_content.feature
@@ -28,7 +28,8 @@ Feature: MLC content display
 
   @mlc_enabled
   Scenario: Current language badge appears on all subrecords when mlc enabled
-    Given the Resource is opened in edit mode
+    Given a second language of description has been added to the Resource
+      And the Resource is opened in edit mode
       And the user selects the Archival Object
      Then the user should see language badges on all subrecords
 

--- a/e2e-tests/staff_features/resources/resource_archival_object_mlc_content.feature
+++ b/e2e-tests/staff_features/resources/resource_archival_object_mlc_content.feature
@@ -1,7 +1,9 @@
 Feature: MLC content display
+
   Background:
     Given an administrator user is logged in
       And a Resource with an Archival Object has been created
+
   Scenario Outline: MLC badge appears on fields marked with mlc_content_badge across form contexts
     Given the Resource is opened in edit mode
       And the user selects the Archival Object
@@ -9,14 +11,28 @@ Feature: MLC content display
       And the user sees the default language preview summary text "SPA"
       And the default language preview should be present but hidden
       And the user sees a globe icon on the "<record_type>" "<field>" label
+
         Examples:
           | record_type     | field |
           | archival_object | title |
+
   Scenario Outline: MLC badge does not appear in read mode
     Given the Resource is opened in the view mode
       And the user selects the Archival Object
      Then the user should not see the MLC default language preview before the "<record_type>" "<field>" label
       And the user should not see a globe icon on the "<record_type>" "<field>" label
+
         Examples:
           | record_type     | field |
           | archival_object | title |
+
+  @mlc_enabled
+  Scenario: Current language badge appears on all subrecords when mlc enabled
+    Given the Resource is opened in edit mode
+      And the user selects the Archival Object
+     Then the user should see language badges on all subrecords
+
+  Scenario: Current language badge does not appear when mlc disabled
+    Given the Resource is opened in edit mode
+      And the user selects the Archival Object
+     Then the user should not see a language badge

--- a/e2e-tests/staff_features/resources/resource_mlc_content.feature
+++ b/e2e-tests/staff_features/resources/resource_mlc_content.feature
@@ -1,7 +1,9 @@
 Feature: MLC content display
+
   Background:
     Given an administrator user is logged in
     Given a Resource has been created
+
   Scenario: Current Language selector from edit mode resource toolbar
     Given the Resource is opened in edit mode
      When the user clicks on "Current Language"
@@ -9,12 +11,14 @@ Feature: MLC content display
       And the user sees the "Spanish" option in the "Current Language" dropdown
       And the user sees the "French" option in the "Current Language" dropdown
       And the user sees the "German" option in the "Current Language" dropdown
+
   Scenario Outline: MLC default language preview appears on mlc content fields
     Given the Resource is opened in edit mode
      Then the user sees the MLC default language preview before the "<record_type>" "<field>" label
       And the user sees the default language preview summary text "SPA"
       And the default language preview should be present but hidden
       And the user sees a globe icon on the "<record_type>" "<field>" label
+
         Examples:
           | record_type | field                         |
           | resource    | title                         |
@@ -27,6 +31,7 @@ Feature: MLC content display
           | resource    | finding_aid_note              |
           | resource    | repository_processing_note    |
           | resource    | finding_aid_filing_title      |
+
   Scenario: Current Language selector from view mode resource toolbar
     Given the Resource is opened in the view mode
      When the user clicks on "Current Language"
@@ -34,10 +39,12 @@ Feature: MLC content display
       And the user sees the "Spanish" option in the "Current Language" dropdown
       And the user sees the "French" option in the "Current Language" dropdown
       And the user sees the "German" option in the "Current Language" dropdown
+
   Scenario Outline: MLC badge does not appear in read mode
     Given the Resource is opened in the view mode
      Then the user should not see the MLC default language preview before the "<record_type>" "<field>" label
       And the user should not see a globe icon on the "<record_type>" "<field>" label
+
         Examples:
           | record_type | field                         |
           | resource    | title                         |
@@ -50,3 +57,12 @@ Feature: MLC content display
           | resource    | finding_aid_note              |
           | resource    | repository_processing_note    |
           | resource    | finding_aid_filing_title      |
+
+  @mlc_enabled
+  Scenario: Current language badge appears on all subrecords when mlc enabled
+    Given the Resource is opened in edit mode
+     Then the user should see language badges on all subrecords
+
+  Scenario: Current language badge does not appear when mlc disabled
+    Given the Resource is opened in edit mode
+     Then the user should not see a language badge

--- a/e2e-tests/staff_features/resources/resource_mlc_content.feature
+++ b/e2e-tests/staff_features/resources/resource_mlc_content.feature
@@ -60,7 +60,8 @@ Feature: MLC content display
 
   @mlc_enabled
   Scenario: Current language badge appears on all subrecords when mlc enabled
-    Given the Resource is opened in edit mode
+    Given a second language of description has been added to the Resource
+      And the Resource is opened in edit mode
      Then the user should see language badges on all subrecords
 
   Scenario: Current language badge does not appear when mlc disabled

--- a/e2e-tests/staff_features/resources/step_definitions/resource_archival_object_create.rb
+++ b/e2e-tests/staff_features/resources/step_definitions/resource_archival_object_create.rb
@@ -5,6 +5,24 @@ Given 'a Resource with an Archival Object has been created' do
 
   fill_in 'resource_title_', with: "Resource #{@uuid}"
   fill_in 'resource_id_0_', with: "Resource #{@uuid}"
+
+  # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
+  if page.has_css?('#resource_lang_descriptions_')
+    within '#resource_lang_descriptions_' do
+      within 'li.sort-enabled.initialised' do
+        fill_in 'Language', with: 'English'
+        wait_for_ajax
+        find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
+        expect(page).to have_css('#resource_lang_descriptions_ .dropdown-item.active[data-value="English"]', visible: false)
+
+        fill_in 'Script', with: 'Latin'
+        wait_for_ajax
+        find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
+        expect(page).to have_css('#resource_lang_descriptions_ .dropdown-item.active[data-value="Latin"]', visible: false)
+      end
+    end
+  end
+
   select 'Class', from: 'resource_level_'
   element = find('#resource_lang_materials__0__language_and_script__language_')
   element.send_keys('AU')
@@ -43,6 +61,23 @@ Given 'a Resource with an Archival Object has been created' do
   check 'Publish?'
   check 'Restrictions Apply?'
   fill_in 'Repository Processing Note', with: "Repository Processing Note #{@uuid}"
+
+  # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
+  if page.has_css?('#archival_object_lang_descriptions_')
+    within '#archival_object_lang_descriptions_' do
+      within 'li.sort-enabled.initialised' do
+        fill_in 'Language', with: 'English'
+        wait_for_ajax
+        find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
+        expect(page).to have_css('#archival_object_lang_descriptions_ .dropdown-item.active[data-value="English"]', visible: false)
+
+        fill_in 'Script', with: 'Latin'
+        wait_for_ajax
+        find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
+        expect(page).to have_css('#archival_object_lang_descriptions_ .dropdown-item.active[data-value="Latin"]', visible: false)
+      end
+    end
+  end
 
   click_on 'Add Language of Materials'
   within 'li.sort-enabled.initialised' do

--- a/e2e-tests/staff_features/resources/step_definitions/resource_archival_object_create.rb
+++ b/e2e-tests/staff_features/resources/step_definitions/resource_archival_object_create.rb
@@ -7,7 +7,7 @@ Given 'a Resource with an Archival Object has been created' do
   fill_in 'resource_id_0_', with: "Resource #{@uuid}"
 
   # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
-  create_lang_descriptions('resource') if page.has_css?('#resource_lang_descriptions_')
+  add_lang_description('resource', language: 'English', script: 'Latin') if page.has_css?('#resource_lang_descriptions_')
 
   select 'Class', from: 'resource_level_'
   element = find('#resource_lang_materials__0__language_and_script__language_')

--- a/e2e-tests/staff_features/resources/step_definitions/resource_archival_object_create.rb
+++ b/e2e-tests/staff_features/resources/step_definitions/resource_archival_object_create.rb
@@ -7,21 +7,7 @@ Given 'a Resource with an Archival Object has been created' do
   fill_in 'resource_id_0_', with: "Resource #{@uuid}"
 
   # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
-  if page.has_css?('#resource_lang_descriptions_')
-    within '#resource_lang_descriptions_' do
-      within 'li.sort-enabled.initialised' do
-        fill_in 'Language', with: 'English'
-        wait_for_ajax
-        find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
-        expect(page).to have_css('#resource_lang_descriptions_ .dropdown-item.active[data-value="English"]', visible: false)
-
-        fill_in 'Script', with: 'Latin'
-        wait_for_ajax
-        find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
-        expect(page).to have_css('#resource_lang_descriptions_ .dropdown-item.active[data-value="Latin"]', visible: false)
-      end
-    end
-  end
+  create_lang_descriptions('resource') if page.has_css?('#resource_lang_descriptions_')
 
   select 'Class', from: 'resource_level_'
   element = find('#resource_lang_materials__0__language_and_script__language_')
@@ -61,23 +47,6 @@ Given 'a Resource with an Archival Object has been created' do
   check 'Publish?'
   check 'Restrictions Apply?'
   fill_in 'Repository Processing Note', with: "Repository Processing Note #{@uuid}"
-
-  # Temporary guard until ANW-2772 adds lang description subrecord under all configurations
-  if page.has_css?('#archival_object_lang_descriptions_')
-    within '#archival_object_lang_descriptions_' do
-      within 'li.sort-enabled.initialised' do
-        fill_in 'Language', with: 'English'
-        wait_for_ajax
-        find('.typeahead.typeahead-long.dropdown-menu li.dropdown-item', exact_text: 'English', match: :first).click
-        expect(page).to have_css('#archival_object_lang_descriptions_ .dropdown-item.active[data-value="English"]', visible: false)
-
-        fill_in 'Script', with: 'Latin'
-        wait_for_ajax
-        find('.typeahead.typeahead-long.dropdown-menu .dropdown-item', exact_text: 'Latin', match: :first).click
-        expect(page).to have_css('#archival_object_lang_descriptions_ .dropdown-item.active[data-value="Latin"]', visible: false)
-      end
-    end
-  end
 
   click_on 'Add Language of Materials'
   within 'li.sort-enabled.initialised' do

--- a/e2e-tests/staff_features/resources/step_definitions/resource_shared.rb
+++ b/e2e-tests/staff_features/resources/step_definitions/resource_shared.rb
@@ -73,6 +73,13 @@ Given 'the Resource is opened in edit mode' do
   wait_for_ajax # still needed for dropdown menus to become active
 end
 
+Given 'a second language of description has been added to the Resource' do
+  visit "#{STAFF_URL}/resources/#{@resource_id}/edit"
+  add_lang_description('resource', language: 'German', script: 'Latin')
+  find('button', text: 'Save Resource', match: :first).click
+  expect(page).to have_css('.alert.alert-success', text: /Resource.*updated/i)
+end
+
 Given 'the Resource is published' do
   expect(find('#resource_publish_').checked?).to eq true
 end

--- a/e2e-tests/staff_features/shared/step_definitions.rb
+++ b/e2e-tests/staff_features/shared/step_definitions.rb
@@ -663,7 +663,7 @@ Then('the user sees the {string} option in the {string} dropdown') do |option, b
 end
 
 Then('the user should see language badges on all subrecords') do
-  page.all('.subrecord-form').each do |subrecord|
+  page.all(:xpath, '//section[contains(@class, "subrecord-form") and not(ancestor::section[contains(@class, "subrecord-form")])]').each do |subrecord|
     expect(subrecord).to have_css('.mlc-badge', visible: true)
   end
 end

--- a/e2e-tests/staff_features/shared/step_definitions.rb
+++ b/e2e-tests/staff_features/shared/step_definitions.rb
@@ -663,9 +663,9 @@ Then('the user sees the {string} option in the {string} dropdown') do |option, b
 end
 
 Then('the user should see language badges on all subrecords') do
-  page.all(:xpath, '//section[contains(@class, "subrecord-form") and not(ancestor::section[contains(@class, "subrecord-form")])]').each do |subrecord|
-    expect(subrecord).to have_css('.mlc-badge', visible: true)
-  end
+  subrecords = page.all(:xpath, '//section[contains(@class, "subrecord-form") and not(ancestor::section[contains(@class, "subrecord-form")])]')
+  expect(subrecords).not_to be_empty
+  subrecords.each { |s| expect(s).to have_css('.mlc-badge', visible: true) }
 end
 
 Then('the user should not see a language badge') do

--- a/e2e-tests/staff_features/shared/step_definitions.rb
+++ b/e2e-tests/staff_features/shared/step_definitions.rb
@@ -661,3 +661,13 @@ Then('the user sees the {string} option in the {string} dropdown') do |option, b
   dropdown = find('button', text: button_text).ancestor('.btn-group', match: :first)
   expect(dropdown).to have_css('span', text: option)
 end
+
+Then('the user should see language badges on all subrecords') do
+  page.all('.subrecord-form').each do |subrecord|
+    expect(subrecord).to have_css('.mlc-badge', visible: true)
+  end
+end
+
+Then('the user should not see a language badge') do
+  expect(page).to have_no_css('.mlc-badge', visible: true)
+end

--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -183,8 +183,16 @@ module ApplicationHelper
 
   def primary_language_badge(record)
     return unless AppConfig[:multilingual_content]
-    lang = record["lang_descriptions"]&.find { |ld| ld["is_primary"] }&.dig("language")
-    mlc_language_badge(lang) if lang
+    inherits_lang_descs = %w[archival_object digital_object_component].include?(record["jsonmodel_type"])
+    if inherits_lang_descs
+      parent = record["resource"]&.dig("_resolved") || record["digital_object"]&.dig("_resolved")
+      lang_descs = parent ? parent["lang_descriptions"].to_a : []
+    else
+      lang_descs = record["lang_descriptions"].to_a
+    end
+    return unless lang_descs.many?
+    lang = lang_descs.find { |ld| ld["is_primary"] }&.dig("language")
+    mlc_language_badge(lang)
   end
 
   def mlc_language_badge(langcode)

--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -181,6 +181,17 @@ module ApplicationHelper
     { prefix_html: prefix }
   end
 
+  def primary_language_badge(record)
+    return unless AppConfig[:multilingual_content]
+    lang = record["lang_descriptions"]&.find { |ld| ld["is_primary"] }&.dig("language")
+    mlc_language_badge(lang) if lang
+  end
+
+  def mlc_language_badge(langcode)
+    return unless AppConfig[:multilingual_content] && langcode
+    content_tag(:span, langcode.upcase, class: 'ml-2 fs-12px label badge mlc-badge') if edit_mode?
+  end
+
   def edit_mode?
     ['edit', 'update'].include?(controller.action_name)
   end

--- a/frontend/app/views/accessions/_form.html.erb
+++ b/frontend/app/views/accessions/_form.html.erb
@@ -5,10 +5,7 @@
     <div class="d-flex align-items-center border-bottom bg-asFormHeadingBg">
       <h3 class="flex-grow-1 d-flex align-items-center mb-0 border-0">
         <%= t "accession._frontend.section.basic_information" %>
-
-        <% if edit_mode? %>
-          <span class="ml-2 fs-12px label badge">ENG</span>
-        <% end %>
+        <%= primary_language_badge(@accession) %>
       </h3>
 
       <%= link_to_help :topic => "accession_basic_information" %>

--- a/frontend/app/views/archival_objects/_form_container.html.erb
+++ b/frontend/app/views/archival_objects/_form_container.html.erb
@@ -24,9 +24,7 @@
       <header class="d-flex align-items-center border-bottom bg-asFormHeadingBg">
         <h3 class="flex-grow-1 d-flex align-items-center mb-0 border-0">
           <%= t("archival_object._frontend.section.basic_information") %>
-          <% if edit_mode? %>
-            <span class="ml-2 fs-12px label badge">ENG</span>
-          <% end %>
+          <%= primary_language_badge(@archival_object) %>
         </h3>
         <%= link_to_help :topic => "archival_object_basic_information" %>
       </header>
@@ -52,7 +50,7 @@
         <%= render_aspace_partial :partial => "shared/slug", :locals => {:form => form, :record_type => @archival_object} if AppConfig[:use_human_readable_urls] %>
 
         <%= form.hidden_input "ref_id" %>
-        <%= form.label_and_textfield("component_id")%>
+        <%= form.label_and_textfield("component_id") %>
         <%= form.label_and_textfield "external_ark_url" if AppConfig[:arks_enabled] && AppConfig[:arks_allow_external_arks] %>
         <%= form.label_and_select "level", form.possible_options_for("level", true) %>
         <%= form.label_and_textfield "other_level", :required => true %>

--- a/frontend/app/views/digital_object_components/_form_container.html.erb
+++ b/frontend/app/views/digital_object_components/_form_container.html.erb
@@ -25,9 +25,7 @@
       <header class="d-flex align-items-center border-bottom bg-asFormHeadingBg">
         <h3 class="flex-grow-1 d-flex align-items-center mb-0 border-0">
           <%= t("digital_object_component._frontend.section.basic_information") %>
-          <% if edit_mode? %>
-            <span class="ml-2 fs-12px label badge">ENG</span>
-          <% end %>
+          <%= primary_language_badge(@digital_object_component) %>
         </h3>
         <%= link_to_help :topic => "digital_object_component_basic_information" %>
       </header>

--- a/frontend/app/views/digital_objects/_form_container.html.erb
+++ b/frontend/app/views/digital_objects/_form_container.html.erb
@@ -8,10 +8,7 @@
       <div class="d-flex align-items-center border-bottom bg-asFormHeadingBg">
         <h3 class="flex-grow-1 d-flex align-items-center mb-0 border-0">
           <%= t("digital_object._frontend.section.basic_information") %>
-
-          <% if edit_mode? %>
-            <span class="ml-2 fs-12px label badge">ENG</span>
-          <% end %>
+          <%= primary_language_badge(@digital_object) %>
         </h3>
 
         <%= link_to_help :topic => "digital_object_basic_information" %>

--- a/frontend/app/views/notes/_form.html.erb
+++ b/frontend/app/views/notes/_form.html.erb
@@ -23,6 +23,7 @@
   <div class="w-100 d-flex align-items-center border-bottom bg-asFormHeadingBg">
     <<%= header_size%> class="subrecord-form-heading flex-grow-1 mb-0 border-0">
       <%= wrap_with_tooltip(t("note._plural"), "#{form.i18n_for('notes')}_tooltip", "subrecord-form-heading-label") %>
+      <%= primary_language_badge(form.obj) %>
     </<%= header_size%>>
 
     <% if show_apply_note_order_action %>

--- a/frontend/app/views/resources/_form_container.html.erb
+++ b/frontend/app/views/resources/_form_container.html.erb
@@ -16,10 +16,7 @@
     <div class="w-100 d-flex align-items-center border-bottom bg-asFormHeadingBg">
       <h3 class="flex-grow-1 d-flex align-items-center mb-0 border-0">
         <%= t("resource._frontend.section.basic_information") %>
-
-        <% if edit_mode? %>
-          <span class="ml-2 fs-12px label badge">ENG</span>
-        <% end %>
+        <%= primary_language_badge(@resource) %>
       </h3>
 
       <%= link_to_help :topic => "resource_basic_information" %>
@@ -69,6 +66,7 @@
     <div class="d-flex align-items-center border-bottom bg-asFormHeadingBg">
       <h3 class="flex-grow-1 mb-0 border-0">
         <%= t("resource._frontend.section.finding_aid") %>
+        <%= primary_language_badge(@resource) %>
       </h3>
 
       <%= link_to_help :topic => "resource_finding_aid" %>
@@ -80,7 +78,7 @@
           <%= form.label_and_textfield "ead_id" %>
           <%= form.label_and_textfield "ead_location" %>
 
-          <hr />
+          <hr>
 
           <%= mlc_textarea_field(form, "finding_aid_title", :field_opts => {:class => "mixed-content"} ) %>
           <%= mlc_textarea_field(form, "finding_aid_subtitle", :field_opts => {:class => "mixed-content"}) %>

--- a/frontend/app/views/shared/_subrecord_form.html.erb
+++ b/frontend/app/views/shared/_subrecord_form.html.erb
@@ -37,6 +37,7 @@
   <% unless hidden %>
   <<%= heading_size %> class="subrecord-form-heading d-flex py-2 align-items-center">
     <%= wrap_with_tooltip(heading_text, "#{form.i18n_for(name)}_tooltip", "subrecord-form-heading-label") %>
+    <%= primary_language_badge(form.obj) %>
 
     <% if !form.readonly? %>
      <% if custom_action_template %>

--- a/frontend/spec/helpers/application_helper_spec.rb
+++ b/frontend/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_helper'
+
+describe ApplicationHelper do
+  describe '#primary_language_badge' do
+    let(:primary_lang_desc) { { 'is_primary' => true, 'language' => 'eng', 'script' => 'Latn' } }
+    let(:other_lang_desc)   { { 'is_primary' => false, 'language' => 'fra', 'script' => 'Latn' } }
+
+    context 'when multilingual content is enabled and in edit mode' do
+      before do
+        allow(helper).to receive(:edit_mode?).and_return(true)
+        allow(AppConfig).to receive(:[]).and_call_original
+        allow(AppConfig).to receive(:[]).with(:multilingual_content).and_return(true)
+      end
+
+      it 'renders a badge with the primary language code' do
+        record = { 'lang_descriptions' => [other_lang_desc, primary_lang_desc] }
+        result = helper.primary_language_badge(record)
+        expect(result).to include('ENG')
+        expect(result).not_to include('FRA')
+      end
+
+      it 'returns nil when no lang_descriptions are present' do
+        expect(helper.primary_language_badge({})).to be_nil
+      end
+    end
+
+    context 'when multilingual content is disabled' do
+      before do
+        allow(helper).to receive(:edit_mode?).and_return(true)
+        allow(AppConfig).to receive(:[]).and_call_original
+        allow(AppConfig).to receive(:[]).with(:multilingual_content).and_return(false)
+      end
+
+      it 'returns nil regardless of lang_descriptions' do
+        record = { 'lang_descriptions' => [primary_lang_desc] }
+        expect(helper.primary_language_badge(record)).to be_nil
+      end
+    end
+  end
+end

--- a/frontend/spec/helpers/application_helper_spec.rb
+++ b/frontend/spec/helpers/application_helper_spec.rb
@@ -15,15 +15,53 @@ describe ApplicationHelper do
         allow(AppConfig).to receive(:[]).with(:multilingual_content).and_return(true)
       end
 
-      it 'renders a badge with the primary language code' do
-        record = { 'lang_descriptions' => [other_lang_desc, primary_lang_desc] }
+      it 'renders a badge with the primary language code when a resource has multiple lang_descriptions' do
+        record = { 'jsonmodel_type' => 'resource', 'lang_descriptions' => [other_lang_desc, primary_lang_desc] }
         result = helper.primary_language_badge(record)
         expect(result).to include('ENG')
         expect(result).not_to include('FRA')
       end
 
-      it 'returns nil when no lang_descriptions are present' do
-        expect(helper.primary_language_badge({})).to be_nil
+      it 'returns nil for a resource with only one lang_description' do
+        record = { 'jsonmodel_type' => 'resource', 'lang_descriptions' => [primary_lang_desc] }
+        expect(helper.primary_language_badge(record)).to be_nil
+      end
+
+      it 'returns nil for a resource with no lang_descriptions' do
+        record = { 'jsonmodel_type' => 'resource', 'lang_descriptions' => [] }
+        expect(helper.primary_language_badge(record)).to be_nil
+      end
+
+      it 'does not inherit lang_descriptions from a parent for record types that carry their own' do
+        parent = { 'lang_descriptions' => [other_lang_desc, primary_lang_desc] }
+        record = { 'jsonmodel_type' => 'resource', 'lang_descriptions' => [], 'resource' => { '_resolved' => parent } }
+        expect(helper.primary_language_badge(record)).to be_nil
+      end
+
+      it 'uses the parent resource lang_descriptions for an archival_object' do
+        parent = { 'lang_descriptions' => [other_lang_desc, primary_lang_desc] }
+        record = { 'jsonmodel_type' => 'archival_object', 'resource' => { '_resolved' => parent } }
+        result = helper.primary_language_badge(record)
+        expect(result).to include('ENG')
+        expect(result).not_to include('FRA')
+      end
+
+      it 'uses the parent digital_object lang_descriptions for a digital_object_component' do
+        parent = { 'lang_descriptions' => [other_lang_desc, primary_lang_desc] }
+        record = { 'jsonmodel_type' => 'digital_object_component', 'digital_object' => { '_resolved' => parent } }
+        result = helper.primary_language_badge(record)
+        expect(result).to include('ENG')
+      end
+
+      it 'returns nil for an archival_object whose parent has only one lang_description' do
+        parent = { 'lang_descriptions' => [primary_lang_desc] }
+        record = { 'jsonmodel_type' => 'archival_object', 'resource' => { '_resolved' => parent } }
+        expect(helper.primary_language_badge(record)).to be_nil
+      end
+
+      it 'returns nil for an archival_object with no resolved parent' do
+        record = { 'jsonmodel_type' => 'archival_object', 'resource' => nil }
+        expect(helper.primary_language_badge(record)).to be_nil
       end
     end
 

--- a/mctf_implementation_plan.md
+++ b/mctf_implementation_plan.md
@@ -142,7 +142,7 @@ The changes outlined here are prototyped in [PR #4000](https://github.com/archiv
 
 ### 3.2 Subform heading — current-language badge
 
-- [ ] Render a small badge next to each subform heading that contains language-dependent fields
+- [x] Render a small badge next to each subform heading that contains language-dependent fields
   - Shows the ISO 639-2 code of the currently-selected editing language
   - Only shown when MLC is enabled and the record has > 1 language of description
   - `frontend/app/helpers/aspace_form_helper.rb` — extend `subrecord_form_heading` helper


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->
https://archivesspace.atlassian.net/browse/ANW-2732

## Summary
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->
This PR addresses two concerns.  I've kept them in separate commits for easier review (aka, I can remove the E2E testing approach for now if we need more time to discuss):

1. Multi-lingual content language badges — Extends and implements primary language badges on MLC subrecords, appending them to all subform headings
2. E2E test infrastructure for configuration-dependent features — Because MLC requires a specific app configuration, standard E2E test setup wasn't sufficient. This PR introduces a new mlc Cucumber profile and a corresponding GitHub Actions job that spins up a Docker container with MLC enabled before running that profile. This pattern serves as a proof-of-concept for testing other features that depend on non-default application configuration, both locally and in CI.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [x] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [x] Have you added tests to cover these changes? If not why:


[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ