### PR TITLE
ANW-2791 fix top containers csv export when extended csv export is enabled

### DIFF
--- a/backend/app/model/search.rb
+++ b/backend/app/model/search.rb
@@ -169,11 +169,22 @@ class Search
   end
 
   def self.search_csv( params, repo_id )
-    if AppConfig[:extended_csv_export_enabled]
+    if use_extended_csv_export?(params)
       extended_csv_export(params, repo_id)
     else
       search_csv_solr(params, repo_id)
     end
+  end
+
+  # A request for specific fields (e.g. the top container browse column
+  # picker) expects Solr index field names as CSV headers so the frontend can
+  # map them back to columns, See ANW-2791.
+  def self.use_extended_csv_export?(params)
+    return false unless AppConfig[:extended_csv_export_enabled]
+
+    field_limited = !Array(params[:fields]).empty?
+
+    !field_limited
   end
 
   def self.extended_csv_export(params, repo_id)

--- a/backend/spec/model_search_spec.rb
+++ b/backend/spec/model_search_spec.rb
@@ -151,5 +151,15 @@ describe Search do
       expect(csv).to include("dates::0::")
     end
 
+    it "uses the Solr CSV writer for field-limited requests even when extended export is enabled (ANW-2791)" do
+      allow(AppConfig).to receive(:[]).and_call_original
+      allow(AppConfig).to receive(:[]).with(:extended_csv_export_enabled).and_return(true)
+
+      expect(Search).to receive(:search_csv_solr).with(hash_including(:fields => ['barcode_u_sstr']), repo.id)
+      expect(Search).not_to receive(:extended_csv_export)
+
+      Search.search_csv({:fields => ['barcode_u_sstr'], :dt => 'csv'}, repo.id)
+    end
+
   end
 end


### PR DESCRIPTION


## Related Ticket (JIRA or GitHub Issue)
[ANW-2791]
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->

## Summary
The top container export is the only CSV download that sends an explicit fields[] list and then remaps the response in csv_export_with_mappings, which locates each requested column by its Solr index field-name header. The extended CSV export ignores fields[], flattens  whole records, and emits headers keyed by JSONModel property names instead. Every header lookup misses, so all values resolve to "".

 This Pull Request fixes the issue so that field-limited CSV requests are forwarded to the Solr CSV writer regardless of the extended-export setting, since extended export does not honor field selection. 

<!--

Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [ ] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:


[ANW-2791]: https://archivesspace.atlassian.net/browse/ANW-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ