### PR TITLE
ANW-2740 Change frontend keyboard commands for "close record" and "save record" so they don't override Windows & Linux browser keyboard commands for "cut text" and "save page"

### DIFF
--- a/frontend/app/assets/javascripts/form.js
+++ b/frontend/app/assets/javascripts/form.js
@@ -165,8 +165,12 @@ $(function () {
         if ($this.data('form_changed') === true) {
           event.stopPropagation();
         } else {
-          $(document).bind('keydown', 'ctrl+s', submitParentForm);
-          $(':input', event.target).bind('keydown', 'ctrl+s', submitParentForm);
+          $(document).bind('keydown', 'ctrl+shift+s', submitParentForm);
+          $(':input', event.target).bind(
+            'keydown',
+            'ctrl+shift+s',
+            submitParentForm
+          );
         }
         $this.data('form_changed', true);
         $('.record-toolbar', $this).addClass('formchanged');

--- a/frontend/app/assets/javascripts/utils.js
+++ b/frontend/app/assets/javascripts/utils.js
@@ -1062,27 +1062,29 @@ $(function () {
   });
 
   $(window).bind('keydown', function (event) {
-    if (event.ctrlKey) {
-      switch (String.fromCharCode(event.which).toLowerCase()) {
-        case 's': {
-          event.preventDefault();
-          const $form = $('form.aspace-record-form');
-          if ($form.length) {
-            var input = $('<input>')
-              .attr('type', 'hidden')
-              .attr('name', 'ignorewarnings')
-              .val('true');
-            $form.append($(input));
-            $form.submit();
-          }
-          break;
+    if (!event.ctrlKey || !event.shiftKey) {
+      return;
+    }
+
+    switch (String.fromCharCode(event.which).toLowerCase()) {
+      case 's': {
+        event.preventDefault();
+        const $form = $('form.aspace-record-form');
+        if ($form.length) {
+          var input = $('<input>')
+            .attr('type', 'hidden')
+            .attr('name', 'ignorewarnings')
+            .val('true');
+          $form.append($(input));
+          $form.submit();
         }
-        case 'x': {
-          event.preventDefault();
-          const readonlyPath = location.pathname.replace(/\/edit$/, '');
-          window.location.href = readonlyPath + location.hash;
-          break;
-        }
+        break;
+      }
+      case 'x': {
+        event.preventDefault();
+        const readonlyPath = location.pathname.replace(/\/edit$/, '');
+        window.location.href = readonlyPath + location.hash;
+        break;
       }
     }
   });

--- a/frontend/app/views/shared/_shortcuts.html.erb
+++ b/frontend/app/views/shared/_shortcuts.html.erb
@@ -2,8 +2,8 @@
   cuts = [
           ["this_reference", "Shift ?"],
           ["close_modal", "ESC"],
-          ["save_record", "Ctrl S"],
-          ["close_record", "Ctrl X"],
+          ["save_record", "Shift Ctrl S"],
+          ["close_record", "Shift Ctrl X"],
           ["open_browse", "Shift B"],
           ["open_create", "Shift C"]
           ]

--- a/frontend/config/locales/de.yml
+++ b/frontend/config/locales/de.yml
@@ -435,12 +435,12 @@ de:
   shortcuts:
     actions:
       toggle_shortcuts: Tastenkürzel aktivieren / deaktivieren
-      open_create: Erstellen-Menü öffnen
+      open_create: Erstellen-Menü umschalten
       this_reference: Diese Tastenkürzel-Referenz
       close_modal: Ein Dialogfenster schließen (z.B. dieses hier)
       save_record: Die derzeit bearbeitete Aufzeichnung speichern
-      close_record: Eine gerade bearbeitete Aufzeichnung schließen
-      open_browse: Durchsuchen-Menu öffnen
+      close_record: Die bearbeitete Aufzeichnung schließen
+      open_browse: Durchsuchen-Menü umschalten
     quick_reference_window: 'Kurzanleitung: Tastenkürzel'
   states:
     auto_generated: Wird vom System beim Speichern erzeugt

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1601,9 +1601,9 @@ en:
       close_modal: "Close a modal window (e.g., this one)"
       toggle_shortcuts: "Enable / disable keyboard shortcuts"
       save_record: "Save the record being edited"
-      close_record: "Close a record being edited"
-      open_browse: "Open Browse menu"
-      open_create: "Open Create menu"
+      close_record: "Close the record being edited"
+      open_browse: "Toggle the Browse menu"
+      open_create: "Toggle the Create menu"
 
   instance_container:
     container: Container

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -1609,8 +1609,8 @@ es:
       toggle_shortcuts: "Activar / desactivar accesos directos del teclado"
       save_record: "Guardar el registro que se está editando"
       close_record: "Cerrar el registro que se está editando"
-      open_browse: "Abrir el menú de navegación"
-      open_create: "Abrir el menú de creación"
+      open_browse: "Alternar el menú de navegación"
+      open_create: "Alternar el menú de creación"
 
   instance_container:
     container: Container

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -1781,8 +1781,8 @@ fr:
       toggle_shortcuts: "Activer / désactiver raccourcis clavier"
       save_record: "Sauvegarder la notice en cours d'édition"
       close_record: "Fermer une notice en cours d'édition"
-      open_browse: "Ouvrir menu parcourir"
-      open_create: "Ouvrir menu créer"
+      open_browse: "Basculer le menu parcourir"
+      open_create: "Basculer le menu créer"
 
   instance_container:
     container: Conditionnement

--- a/frontend/config/locales/it.yml
+++ b/frontend/config/locales/it.yml
@@ -762,6 +762,16 @@ it:
   job:
     _frontend:
       audit_data: Dati dell'audit
+  shortcuts:
+    quick_reference_window: "Riferimento rapido: scorciatoie da tastiera"
+    actions:
+      this_reference: "Questo riferimento alle scorciatoie"
+      close_modal: "Chiudi una finestra modale (ad es., questa)"
+      toggle_shortcuts: "Attiva / disattiva scorciatoie da tastiera"
+      save_record: "Salva il record in modifica"
+      close_record: "Chiudi il record in modifica"
+      open_browse: "Alterna il menu Naviga"
+      open_create: "Alterna il menu Crea"
   agent_identifier:
     identifier_type: Tipo di identificativo
   agent_gender:

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -1492,8 +1492,8 @@ ja:
       toggle_shortcuts: キーボードショートカットを有効/無効にする
       save_record: 編集中のレコードを保存する
       close_record: 編集中のレコードを閉じる
-      open_browse: ブラウズメニューを開く
-      open_create: 作成メニューを開く
+      open_browse: ブラウズメニューを切り替える
+      open_create: 作成メニューを切り替える
 
   instance_container:
     container: コンテナ

--- a/frontend/config/locales/pl.yml
+++ b/frontend/config/locales/pl.yml
@@ -1436,6 +1436,16 @@ pl:
         p_one: Wyróżnione kolumny są „przyklejone” i zostaną powielone po 
           dodaniu nowych wierszy. Funkcję „przyklejania” można włączyć lub 
           wyłączyć, klikając odpowiedni nagłówek tabeli.
+  shortcuts:
+    quick_reference_window: "Skrótowy przewodnik: skróty klawiaturowe"
+    actions:
+      this_reference: "Ten przewodnik skrótów"
+      close_modal: "Zamknij okno modalne (np. to)"
+      toggle_shortcuts: "Włącz / wyłącz skróty klawiaturowe"
+      save_record: "Zapisz edytowany rekord"
+      close_record: "Zamknij edytowany rekord"
+      open_browse: "Przełącz menu Przeglądaj"
+      open_create: "Przełącz menu Utwórz"
   structured_date_single_fields:
     date_expression: Wyrażenie daty
     date_standardized: Znormalizowana data

--- a/frontend/config/locales/uk.yml
+++ b/frontend/config/locales/uk.yml
@@ -1756,9 +1756,9 @@ uk:
       close_modal: Закрити модальне вікно (наприклад, це)
       toggle_shortcuts: Увімкнути/вимкнути комбінації клавіш
       save_record: Збережіть запис, що редагується
-      close_record: Закриття запису, що редагується
-      open_browse: Відкрити меню «Огляд»
-      open_create: Відкрити меню «Створити»
+      close_record: Закрити запис, що редагується
+      open_browse: Перемкнути меню «Огляд»
+      open_create: Перемкнути меню «Створити»
   instance_container:
     container: Контейнер
   container_profile:

--- a/frontend/spec/features/keyboard_shortcuts_spec.rb
+++ b/frontend/spec/features/keyboard_shortcuts_spec.rb
@@ -17,8 +17,8 @@ describe 'Keyboard Shortcuts', js: true do
       within '#ASModal' do
         expect(page).to have_content('Shift ?')
         expect(page).to have_content('ESC')
-        expect(page).to have_content('Ctrl S')
-        expect(page).to have_content('Ctrl X')
+        expect(page).to have_content('Shift Ctrl S')
+        expect(page).to have_content('Shift Ctrl X')
         expect(page).to have_content('Shift B')
         expect(page).to have_content('Shift C')
       end
@@ -62,14 +62,30 @@ describe 'Keyboard Shortcuts', js: true do
       expect(page).to have_field('accession_title_', with: accession.title)
 
       fill_in 'accession_title_', with: updated_text
-      page.driver.browser.action.key_down(:control).send_keys('s').key_up(:control).perform
+      page.driver.browser.action
+        .key_down(:control).key_down(:shift).send_keys('s')
+        .key_up(:shift).key_up(:control).perform
       expect(page).to have_content("Accession #{updated_text} updated")
       expect(page).to have_field('accession_title_', with: updated_text)
     end
 
+    it 'does not save the record with Ctrl S alone' do
+      fill_in 'accession_title_', with: updated_text
+      page.driver.browser.action.key_down(:control).send_keys('s').key_up(:control).perform
+      expect(page).not_to have_content("Accession #{updated_text} updated")
+      expect(page).to have_field('accession_title_', with: updated_text)
+    end
+
     it 'can close the record' do
-      page.driver.browser.action.key_down(:control).send_keys('x').key_up(:control).perform
+      page.driver.browser.action
+        .key_down(:control).key_down(:shift).send_keys('x')
+        .key_up(:shift).key_up(:control).perform
       expect(page).to have_current_path("/accessions/#{accession.id}")
+    end
+
+    it 'does not close the record with Ctrl X alone' do
+      page.driver.browser.action.key_down(:control).send_keys('x').key_up(:control).perform
+      expect(page).to have_current_path("/accessions/#{accession.id}/edit")
     end
   end
 end


### PR DESCRIPTION
[ANW-2740](https://archivesspace.atlassian.net/browse/ANW-2740)

This PR fixes a bug where the frontend keyboard shortcuts for closing a record in edit mode (CTRL + X) and saving a record in edit mode (CTRL + S) overrode the native browser shortcuts for cutting text and saving a page on Windows and Linux.

The new shortcuts add the SHIFT key to each shortcut, so close is SHIFT + CTRL + X and save is SHIFT + CTRL + S.

<img width="1480" height="806" alt="ANW-2740-solution" src="https://github.com/user-attachments/assets/9d89f405-c357-4ced-a952-72c51f500f32" />

[ANW-2740]: https://archivesspace.atlassian.net/browse/ANW-2740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ