### PR TITLE
ANW-2706 Fix Softserv-related button color bug when reorder mode auto-expand all is enabled

### DIFF
--- a/frontend/app/assets/javascripts/tree_toolbar.js.erb
+++ b/frontend/app/assets/javascripts/tree_toolbar.js.erb
@@ -374,7 +374,8 @@ var EXPAND_MODE_ACTIONS = [
             cssClasses: 'btn-default btn-expand-tree-mode',
             onClick: function(event, btn, node, tree, toolbarRenderer) {
                 $(tree.large_tree.elt).toggleClass('expand-all');
-                $(event.target).toggleClass('btn-success');
+                $(btn).toggleClass('btn-success');
+                $(btn).toggleClass('btn-default');
 
                 if ($(tree.large_tree.elt).is('.expand-all')) {
                     $(btn).text('<%= I18n.t('actions.expand_tree_mode_off') %>');


### PR DESCRIPTION
[ANW-2706](https://archivesspace.atlassian.net/browse/ANW-2706)

This PR fixes a minor Softserv-related bug where the "Auto-Expand All" button background color did not turn green when enabled. This bug happened due to Bootstrap v4's changes to the `.btn-default` class.

<img width="1000" height="817" alt="ANW-2706-solution" src="https://github.com/user-attachments/assets/f3256a5d-8464-40ce-9666-3ea1cad33343" />


[ANW-2706]: https://archivesspace.atlassian.net/browse/ANW-2706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ