### PR TITLE
ANW-2671: Update welcome show view for Bootstrap 5

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/variables.scss
+++ b/public/app/assets/stylesheets/archivesspace/variables.scss
@@ -1,11 +1,8 @@
-$theme-colors: (
-  'primary': #3a87ad,
-);
-
 $sans-font: 'PT Sans', 'Helvetica Neue', helvetica, arial, sans-serif;
 $serif-font: 'Roboto Slab', serif;
 $font-family-serif: $serif-font;
 
+$primary: $primary-color;
 $text-color: $darkest;
 $input-color-placeholder: #767676;
 

--- a/public/app/views/shared/_language_select.html.erb
+++ b/public/app/views/shared/_language_select.html.erb
@@ -1,20 +1,16 @@
 <% if AppConfig[:allow_pui_language_selection] %>
-  <div class="row">
-    <div class="col-sm-12">
-      <div id="language_select">
-        <% current_locale = session[:locale] ? session[:locale] : AppConfig[:locale].to_s %>
-        <% language_options = I18n.supported_locales.map{ |k, v| [k.to_s, t("enumerations.language_iso639_2.#{v}")] }.to_h %>
+  <div id="language_select">
+    <% current_locale = session[:locale] ? session[:locale] : AppConfig[:locale].to_s %>
+    <% language_options = I18n.supported_locales.map{ |k, v| [k.to_s, t("enumerations.language_iso639_2.#{v}")] }.to_h %>
 
-        <form action="/locale" method="post" id="language_select_form">
-          <label for="language_select_dropdown"><%= I18n.t('languages.select') %>:</label> 
-          <select name="locale" id="language_select_dropdown">
-            <% language_options.each do |code, name| %>
-              <% is_selected = (code == current_locale ? "selected" : "") %>
-              <option value='<%= code %>' <%= is_selected %>><%= name %></option>
-            <% end %>
-          </select>
-        </form>   
-      </div>
-    </div>
+    <form action="/locale" method="post" id="language_select_form" class="d-flex align-items-center gap-2">
+      <label class="form-label mb-0" for="language_select_dropdown"><%= I18n.t('languages.select') %>:</label> 
+      <select name="locale" id="language_select_dropdown" class="form-select w-auto">
+        <% language_options.each do |code, name| %>
+          <% is_selected = (code == current_locale ? "selected" : "") %>
+          <option value='<%= code %>' <%= is_selected %>><%= name %></option>
+        <% end %>
+      </select>
+    </form>   
   </div>
 <% end %>

--- a/public/app/views/shared/_search.html.erb
+++ b/public/app/views/shared/_search.html.erb
@@ -50,9 +50,9 @@
                           :class=> 'form-control repeats', :placeholder => t('search_results.filter.to')) %>
       </div>
       <div class="d-flex flex-column col-sm-2 form-group text-left align-self-end">
-          <span class="mb-2 d-inline-block repeats plusminus_label fw-bold"><%= t('advanced_search.add_row') %></span><br />
+          <span class="mb-2 d-inline-block repeats plusminus_label fw-bold"><%= t('advanced_search.add_row') %></span>
           <button type="button"
-                  class="btn btn-light border plusminus-btn"
+                  class="align-self-start btn btn-light border plusminus-btn"
                   id="plusminus<%= i %>"
                   data-action="add"
                   title="<%= t('advanced_search.add_row') %>"

--- a/public/app/views/welcome/show.html.erb
+++ b/public/app/views/welcome/show.html.erb
@@ -1,4 +1,6 @@
-<%= render partial: 'shared/language_select' %>
+<div class="d-flex justify-content-end mb-2">
+  <%= render partial: 'shared/language_select' %>
+</div>
 
 <div class="row">
   <div class="col-sm-12">


### PR DESCRIPTION
## Summary
The Bootstrap 4 to Bootstrap 5 migration left the welcome show view with layout issues affecting the language selector. The language selector dropdown had no Bootstrap 5 form styling and was rendering as a full-width block element dropped to a new line.
This PR adds form-select and form-label classes to the language selector form elements in _language_select.html.erb, removes the unnecessary row/col-sm-12 wrapper from the language selector partial since layout is now controlled by the parent view, and wraps the language selector in a d-flex justify-content-end container in show.html.erb to position it correctly in the top right

## Screenshots (if appropriate):
BEFORE:
<img width="1218" height="707" alt="ANW-2671_Before" src="https://github.com/user-attachments/assets/69f97f51-9c89-428a-b5b1-47cf6ab2fb99" />

AFTER:
<img width="1497" height="799" alt="ANW-2671-solution" src="https://github.com/user-attachments/assets/2b4d7e3e-2f78-4c38-b669-85a2fea0d081" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [X] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:
These are template/CSS class changes only with no logic changes, as such, no tests are required.
