### PR TITLE
ANW-2672 and ANW-2658: Update repositories index and show views for Bootstrap 5

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -259,6 +259,12 @@ a img {
 
 #whats-in-container {
   border: 1px solid $border;
+
+  .btn:disabled,
+  .btn.disabled {
+    --bs-btn-disabled-border-color: transparent;
+  }
+
   > h3 {
     margin-top: 0;
     margin-left: rem-calc(-20);

--- a/public/app/views/repositories/_badge.html.erb
+++ b/public/app/views/repositories/_badge.html.erb
@@ -2,7 +2,7 @@
 
 <div class="large-badge align-center <%= type %> border p-2 my-2 mx-2 ms-sm-0 me-sm-3">
   <form action="<%= app_prefix(@sublist_action) %><%= type %>s" method="get">
-    <button type="submit" class="btn btn-secondary <%= type %>" <%= @counts[type] == 0 ? 'disabled="disabled"' : '' %>  >
+    <button type="submit" class="btn btn-secondary <%= type %>" <%= 'disabled' if @counts[type] == 0 %>>
       <% case type %>
       <% when 'resource' %>
         <i class="fa fa-archive fa-4x"></i>

--- a/public/app/views/repositories/_badge.html.erb
+++ b/public/app/views/repositories/_badge.html.erb
@@ -1,8 +1,8 @@
 <%# the "badges" for resources, records, etc.  Expects one local: type[ of badge]. @sublist_action, @counts, and @result carry through %>
 
-<div class="large-badge align-center <%= type %> border p-2 my-2 mx-2 ml-sm-0 mr-sm-4">
+<div class="large-badge align-center <%= type %> border p-2 my-2 mx-2 ms-sm-0 me-sm-4">
   <form action="<%= app_prefix(@sublist_action) %><%= type %>s" method="get">
-    <button type="submit" class="btn btn-default <%= type %>" <%= @counts[type] == 0 ? 'disabled="disabled"' : '' %>  >
+    <button type="submit" class="btn btn-secondary <%= type %>" <%= @counts[type] == 0 ? 'disabled="disabled"' : '' %>  >
       <% case type %>
       <% when 'resource' %>
         <i class="fa fa-archive fa-4x"></i>

--- a/public/app/views/repositories/_badge.html.erb
+++ b/public/app/views/repositories/_badge.html.erb
@@ -1,6 +1,6 @@
 <%# the "badges" for resources, records, etc.  Expects one local: type[ of badge]. @sublist_action, @counts, and @result carry through %>
 
-<div class="large-badge align-center <%= type %> border p-2 my-2 mx-2 ms-sm-0 me-sm-4">
+<div class="large-badge align-center <%= type %> border p-2 my-2 mx-2 ms-sm-0 me-sm-3">
   <form action="<%= app_prefix(@sublist_action) %><%= type %>s" method="get">
     <button type="submit" class="btn btn-secondary <%= type %>" <%= @counts[type] == 0 ? 'disabled="disabled"' : '' %>  >
       <% case type %>

--- a/public/app/views/repositories/_repository.html.erb
+++ b/public/app/views/repositories/_repository.html.erb
@@ -17,25 +17,9 @@
 			<div class="record-type-badge repository col-12">
 				<i class="fa fa-home"></i>&#160;<%= t('repository._singular') %>
 			</div>
-			<div class="<%= (full ? 'clear' : 'recordsummary') %>">
-				<% if result['parent_institution_name'].present? %>
-					<div>
-						<strong><%= t('parent_inst') %>:</strong>
-						<%= result['parent_institution_name'] %>
-					</div>
-				<% end %>
-				<% if full %>
-					<%= render partial: 'repositories/full_repo', locals: {:info => result['repo_info'], :url => result['url']} %>
-				<% else %>
-					<div class="my-2">
-						<strong><%= t('resource._plural', :count => result['count']) %>:</strong> <%= result['count'] %>
-					</div>
-					<% if result.dig('repo_info', 'top', 'description').present? %>
-					<div class="repository-description d-flex flex-column m-0">
-						<strong><%= t('repositories._public.about', default: "About:") %></strong>
-						<%= simple_format(result.dig('repo_info', 'top', 'description')) %>
-					</div>
-					<% end %>
+			<div class="d-flex d-sm-none justify-content-center col-12">
+				<% if result.has_key?('image_url') %>
+					<%= link_to image_tag(result['image_url'], :alt => "#{t('repository._singular')}: #{result['name']}"), app_prefix(result['uri']), {:class => 'repository-logo'} %>
 				<% end %>
 			</div>
 		</div>
@@ -49,9 +33,15 @@
 			<% if full %>
 				<%= render partial: 'repositories/full_repo', locals: {:info => result['repo_info'], :url => result['url']} %>
 			<% else %>
-				<div>
-					<strong>Number of <%= t('resource._plural') %>:</strong> <%= result['count'] %>
+				<div class="my-2">
+					<strong><%= t('resource._plural', :count => result['count']) %>:</strong> <%= result['count'] %>
 				</div>
+				<% if result.dig('repo_info', 'top', 'description').present? %>
+				<div class="repository-description d-flex flex-column m-0">
+					<strong><%= t('repositories._public.about', default: "About:") %></strong>
+					<%= simple_format(result.dig('repo_info', 'top', 'description')) %>
+				</div>
+				<% end %>
 			<% end %>
 		</div>
 	</div>

--- a/public/app/views/repositories/show.html.erb
+++ b/public/app/views/repositories/show.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <div id="whats-in-container" class="p-4 my-4">
-    <<h2 class="text-center text-sm-start"><%= t('repository.what') %> </h2>
+    <h2 class="text-center text-sm-start"><%= t('repository.what') %> </h2>
     <div>
       <div class="list-inline d-flex flex-wrap justify-content-center justify-content-sm-start">
         <% @badges.each do |type| %>

--- a/public/app/views/repositories/show.html.erb
+++ b/public/app/views/repositories/show.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <div id="whats-in-container" class="p-4 my-4">
-    <h2 class="text-center text-sm-left"><%= t('repository.what') %> </h2>
+    <<h2 class="text-center text-sm-start"><%= t('repository.what') %> </h2>
     <div>
       <div class="list-inline d-flex flex-wrap justify-content-center justify-content-sm-start">
         <% @badges.each do |type| %>

--- a/public/spec/features/accessions_spec.rb
+++ b/public/spec/features/accessions_spec.rb
@@ -36,7 +36,7 @@ describe 'Accessions', js: true do
 
       click_on 'Repositories'
       click_on 'Test Repo 1'
-      find('#whats-in-container form .btn.btn-default.accession').click
+      find('#whats-in-container form .btn.accession').click
 
       expect(page).to_not have_text Pathname.new(current_path).parent.to_s
     end

--- a/public/spec/features/agents_spec.rb
+++ b/public/spec/features/agents_spec.rb
@@ -31,7 +31,7 @@ describe 'Agents', js: true do
 
     click_on 'Repositories'
     click_on 'Test Repo 1'
-    find('#whats-in-container form .btn.btn-default.agent').click
+    find('#whats-in-container form .btn.agent').click
 
     expect(page).to_not have_text Pathname.new(current_path).parent.to_s
   end

--- a/public/spec/features/classifications_spec.rb
+++ b/public/spec/features/classifications_spec.rb
@@ -29,7 +29,7 @@ describe 'Classifications', js: true do
 
     click_on 'Repositories'
     click_on 'Test Repo 1'
-    find('#whats-in-container form .btn.btn-default.classification').click
+    find('#whats-in-container form .btn.classification').click
 
     expect(page).to_not have_text Pathname.new(current_path).parent.to_s
   end

--- a/public/spec/features/digital_objects_spec.rb
+++ b/public/spec/features/digital_objects_spec.rb
@@ -40,7 +40,7 @@ describe 'Digital Objects', js: true do
 
     click_on 'Repositories'
     click_on 'Test Repo 1'
-    find('#whats-in-container form .btn.btn-default.digital_object').click
+    find('#whats-in-container form .btn.digital_object').click
 
     expect(page).to_not have_text Pathname.new(current_path).parent.to_s
   end

--- a/public/spec/features/resources_spec.rb
+++ b/public/spec/features/resources_spec.rb
@@ -23,7 +23,7 @@ describe 'Resources', js: true do
 
     click_on 'Repositories'
     click_on 'Test Repo 1'
-    find('#whats-in-container form .btn.btn-default.resource').click
+    find('#whats-in-container form .btn.resource').click
 
     expect(page).to_not have_text Pathname.new(current_path).parent.to_s
   end

--- a/public/spec/features/subjects_spec.rb
+++ b/public/spec/features/subjects_spec.rb
@@ -34,7 +34,7 @@ describe 'Subjects', js: true do
 
       click_on 'Repositories'
       click_on 'Test Repo 1'
-      find('#whats-in-container form .btn.btn-default.subject').click
+      find('#whats-in-container form .btn.subject').click
 
       expect(page).to_not have_text Pathname.new(current_path).parent.to_s
     end


### PR DESCRIPTION
## Summary
Fixed Bootstrap 5 incompatibilities in the repositories index view. 

Also, the WIP commit on the parent branch had introduced a duplicate content block in _repository.html.erb while attempting the BS4 to BS5 migration. This PR corrects that as well.

Files updates:
**_repository.html.erb**: Fixed text-sm-left to text-sm-start, removed unnecessary row mx-0 wrapper, restored missing mobile image block, removed duplicated recordsummary block.
**_badge.html.erb**: Replaced removed BS5 btn-default with btn-secondary, updated ml-sm-0/mr-sm-4 to ms-sm-0/me-sm-4

Further updates:
**show.html-erb**:  Changed text-sm-left to text-sm-start (also fixed a stray "<" character I left in after this change)
**_badge.html.erb**:   Badge spacing fix.



## Screenshots (if appropriate):
Repository Before:
<img width="1212" height="704" alt="ANW-2672_Repository_Before" src="https://github.com/user-attachments/assets/6de6cbb6-77ec-48c5-99c7-15bc70516d19" />

Repository Show Before:
<img width="1218" height="691" alt="ANW-2672_Repository_Show_Before" src="https://github.com/user-attachments/assets/6b086c83-9b58-4a99-8635-9eee4d3bd875" />

Repository After:
<img width="1218" height="681" alt="ANW-2672_Repository_After" src="https://github.com/user-attachments/assets/04ae477a-ff88-44a9-8fe8-36f1793a60ce" />

Repository Show After:
<img width="1219" height="672" alt="ANW-2672_Repository_Show_After_Round_2" src="https://github.com/user-attachments/assets/7229537b-eb1b-4777-b1a9-0a3e1b696441" />



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [X] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:
Template and CSS class changes only with no logic changes, as such, no tests required.