### PR TITLE
ANW-2658: Update repositories show view for Bootstrap 5, fix navigati…

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -484,6 +484,11 @@ h5,
 
 .navbar-toggler {
   border: 0;
+
+  &:focus {
+    box-shadow: 0 0 0 var(--bs-navbar-toggler-focus-width)
+      rgba($primary-color, 0.5);
+  }
 }
 
 .spacer {

--- a/public/app/views/repositories/_badge.html.erb
+++ b/public/app/views/repositories/_badge.html.erb
@@ -2,7 +2,7 @@
 
 <div class="large-badge align-center <%= type %> border p-2 my-2 mx-2 ms-sm-0 me-sm-3">
   <form action="<%= app_prefix(@sublist_action) %><%= type %>s" method="get">
-    <button type="submit" class="btn btn-secondary <%= type %>" <%= 'disabled' if @counts[type] == 0 %>>
+    <button type="submit" class="btn <%= type %>" <%= 'disabled' if @counts[type] == 0 %>>
       <% case type %>
       <% when 'resource' %>
         <i class="fa fa-archive fa-4x"></i>

--- a/public/app/views/shared/_sorter.html.erb
+++ b/public/app/views/shared/_sorter.html.erb
@@ -1,14 +1,12 @@
-
 <% if defined?(@sort) && defined?(@sort_opts) && defined?(@base_search) %>
-
 
 <div class="sorter d-flex align-items-center justify-content-end">
  <%= form_tag(app_prefix("#{@base_search}"), method: 'get', :class=> "form-horizontal d-flex align-items-center justify-content-end") do %>
    <%= render partial: 'shared/hidden_params' %>
    <%= label_tag(:sort, "#{t('search_sorting.sort_by')}", :class=>'visually-hidden') %>
    <div class="input-group">
-    <%= select_tag(:sort, options_for_select(@sort_opts,@sort), :class=>'form-select') %>
-    <%= submit_tag(t('search_sorting.sort'), :class=>'btn btn-primary ml-2') %>
+      <%= select_tag(:sort, options_for_select(@sort_opts,@sort), :class=>'form-select') %>
+      <%= submit_tag(t('search_sorting.sort'), :class=>'btn btn-primary ml-2') %>
    </div>
  <% end %>
 </div>

--- a/public/app/views/shared/_sorter.html.erb
+++ b/public/app/views/shared/_sorter.html.erb
@@ -6,7 +6,7 @@
    <%= label_tag(:sort, "#{t('search_sorting.sort_by')}", :class=>'visually-hidden') %>
    <div class="input-group">
       <%= select_tag(:sort, options_for_select(@sort_opts,@sort), :class=>'form-select') %>
-      <%= submit_tag(t('search_sorting.sort'), :class=>'btn btn-primary ml-2') %>
+      <%= submit_tag(t('search_sorting.sort'), :class=>'btn btn-primary') %>
    </div>
  <% end %>
 </div>


### PR DESCRIPTION
## Summary
Completed Bootstrap 5 migration for the repositories show view and fixed several global issues affecting all PUI views.  Files changed/deleted in this ANW include:

**_navigation.html.erb**: Updated data-toggle/data-target to data-bs-toggle/data-bs-target, ml-auto to ms-auto, mr-auto to me-auto, and sr-only to visually-hidden
**_sorter.html.erb**: Updated custom-select to form-select, ml-2 to ms-2, and sr-only to visually-hidden
**show.html.erb**: Fixed text-sm-left to text-sm-start
**application.js**: Fixed Bootstrap JS require path from bootstrap/bootstrap.min.js to bootstrap.min to correctly load Bootstrap 5 from the gem
Removed **public/vendor/assets/javascripts/bootstrap/bootstrap.min.js**  This was a hardcoded Bootstrap 4 JS file that was overriding the gem, being called by application.js above (which itself is now updated)
Removed **bootstrap-accessibility** plugin/directory tree: This plugin is incompatible with Bootstrap 5, which now handles accessibility natively, so its unnecessary now anyway.


## Screenshots (if appropriate):
<img width="1191" height="660" alt="ANW-2658_Collection" src="https://github.com/user-attachments/assets/99d88563-c0c7-4733-84e8-7e3d7258ce5f" />
<img width="499" height="706" alt="ANW-2658_Menu" src="https://github.com/user-attachments/assets/facb1c78-f8a2-482f-a38d-2d7728ea9679" />
<img width="501" height="712" alt="ANW-2658_Search_Mobile_View" src="https://github.com/user-attachments/assets/400e002a-4017-479d-8123-907e40b4ed86" />



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [X] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:
