### PR TITLE
ANW-2660: Update resources show view for Bootstrap 5

### DIFF
--- a/public/app/assets/javascripts/handle_accordion.js
+++ b/public/app/assets/javascripts/handle_accordion.js
@@ -18,7 +18,7 @@ function initialize_accordion(what, ex_text, col_text, expand_all) {
       $(what)
         .parents('.acc_holder')
         .prepend(
-          "<a class='btn btn-primary acc_button mb-2' role='button' ></a>"
+          "<a class='btn btn-primary acc_button mb-2' role='button'></a>"
         );
     }
     expandAllByDefault(what, expand_all);

--- a/public/app/assets/javascripts/handle_accordion.js
+++ b/public/app/assets/javascripts/handle_accordion.js
@@ -1,79 +1,141 @@
 /* handle the accordions */
 /* we need to pass in the text that is obtained via the config/locales/*yml file */
-var expand_text = '';
-var collapse_text = '';
+let expandLabel = '';
+let collapseLabel = '';
 /* we don't provide a button if there's only one panel; neither do we collapse that one panel */
 
 /**
- * @param {string} what accordion panels selector
- * @param {string} ex_text 'expand text' i18n
- * @param {string} col_text 'collapse text' i18n
- * @param {boolean} expand_all
+ * @param {string} accordionCollapseSelector accordion collapse selector
+ * @param {string} expandLabelText expand text from i18n
+ * @param {string} collapseLabelText collapse text from i18n
+ * @param {boolean} expandOnLoad
  */
-function initialize_accordion(what, ex_text, col_text, expand_all) {
-  expand_text = ex_text;
-  collapse_text = col_text;
-  if ($(what).length > 1 && $(what).parents('.acc_holder').length === 1) {
-    if ($(what).parents('.acc_holder').children('.acc_button').length === 0) {
-      $(what)
-        .parents('.acc_holder')
-        .prepend(
-          "<a class='btn btn-primary acc_button mb-2' role='button'></a>"
-        );
-    }
-    expandAllByDefault(what, expand_all);
-  }
-}
+function initialize_accordion(
+  accordionCollapseSelector,
+  expandLabelText,
+  collapseLabelText,
+  expandOnLoad
+) {
+  expandLabel = expandLabelText;
+  collapseLabel = collapseLabelText;
 
-/**
- * @param {string} what accordion panels selector
- * @param {boolean} expand to expand or not
- */
-function expandAllByDefault(what, expand) {
-  $(what).each(function () {
-    toggleCollapsePanel(this, expand);
-  });
-  set_button(what, !expand);
-}
+  const collapseElements = getAccordionCollapseElements(
+    accordionCollapseSelector
+  );
+  const accordionHolder = getSingleAccordionHolder(collapseElements);
 
-/**
- * @param {HTMLElement} panel collapse panel element
- * @param {boolean} expand to expand or not
- */
-function toggleCollapsePanel(panel, expand) {
-  // Bootstrap 5 API
-  if (window.bootstrap && window.bootstrap.Collapse) {
-    const instance = window.bootstrap.Collapse.getOrCreateInstance(panel, {
-      toggle: false,
-    });
-
-    if (expand) {
-      instance.show();
-    } else {
-      instance.hide();
-    }
-
+  if (collapseElements.length <= 1 || !accordionHolder) {
     return;
   }
 
-  // Bootstrap 4/jQuery plugin compatibility
-  if (typeof $(panel).collapse === 'function') {
-    $(panel).collapse(expand ? 'show' : 'hide');
+  if (!accordionHolder.querySelector(':scope > .acc_button')) {
+    const button = document.createElement('a');
+    button.className = 'btn btn-primary acc_button mb-2';
+    button.setAttribute('role', 'button');
+    button.setAttribute('href', '#');
+    accordionHolder.prepend(button);
+  }
+
+  expandAllByDefault(accordionCollapseSelector, expandOnLoad);
+}
+
+/**
+ * @param {string} accordionCollapseSelector accordion collapse selector
+ * @returns {HTMLElement[]} matching accordion collapse elements
+ */
+function getAccordionCollapseElements(accordionCollapseSelector) {
+  return Array.from(document.querySelectorAll(accordionCollapseSelector));
+}
+
+/**
+ * @param {HTMLElement[]} collapseElements accordion collapse elements
+ * @returns {HTMLElement|null} shared accordion holder when exactly one is present
+ */
+function getSingleAccordionHolder(collapseElements) {
+  const holders = Array.from(
+    new Set(
+      collapseElements
+        .map(collapseElement => collapseElement.closest('.acc_holder'))
+        .filter(holder => holder !== null)
+    )
+  );
+
+  return holders.length === 1 ? holders[0] : null;
+}
+
+/**
+ * @param {string} accordionCollapseSelector accordion collapse selector
+ * @param {boolean} shouldExpand whether accordion should expand
+ */
+function expandAllByDefault(accordionCollapseSelector, shouldExpand) {
+  setAccordionExpandedState(accordionCollapseSelector, shouldExpand);
+}
+
+/**
+ * @param {string} accordionCollapseSelector accordion collapse selector
+ * @param {boolean} shouldExpand whether accordion should expand
+ */
+function setAccordionExpandedState(accordionCollapseSelector, shouldExpand) {
+  const collapseElements = getAccordionCollapseElements(
+    accordionCollapseSelector
+  );
+
+  collapseElements.forEach(collapseElement => {
+    toggleAccordionCollapse(collapseElement, shouldExpand);
+  });
+
+  updateAccordionToggleButton(
+    collapseElements,
+    accordionCollapseSelector,
+    !shouldExpand
+  );
+}
+
+/**
+ * @param {HTMLElement} collapseElement accordion collapse element
+ * @param {boolean} shouldExpand whether element should expand
+ */
+function toggleAccordionCollapse(collapseElement, shouldExpand) {
+  const instance = window.bootstrap.Collapse.getOrCreateInstance(
+    collapseElement,
+    {
+      toggle: false,
+    }
+  );
+
+  if (shouldExpand) {
+    instance.show();
+  } else {
+    instance.hide();
   }
 }
 
 /**
- * @param {string} what accordion panels selector
- * @param {boolean} expand to expand or not
+ * @param {HTMLElement[]} collapseElements accordion collapse elements
+ * @param {string} accordionCollapseSelector accordion collapse selector
+ * @param {boolean} shouldExpand whether button should trigger expand
  */
-function set_button(what, expand) {
-  const $holder = $(what).parents('.acc_holder');
-  const $btn = $holder.children('.acc_button');
-  if ($btn.length === 1) {
-    $btn.text(expand ? expand_text : collapse_text);
-    $btn.attr(
-      'href',
-      "javascript:expandAllByDefault('" + what + "'," + expand + ')'
-    );
+function updateAccordionToggleButton(
+  collapseElements,
+  accordionCollapseSelector,
+  shouldExpand
+) {
+  const accordionHolder = getSingleAccordionHolder(collapseElements);
+
+  if (!accordionHolder) {
+    return;
   }
+
+  const toggleButton = accordionHolder.querySelector(':scope > .acc_button');
+
+  if (!toggleButton) {
+    return;
+  }
+
+  toggleButton.textContent = shouldExpand ? expandLabel : collapseLabel;
+  toggleButton.setAttribute('href', '#');
+  toggleButton.onclick = event => {
+    event.preventDefault();
+    setAccordionExpandedState(accordionCollapseSelector, shouldExpand);
+  };
 }

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -138,16 +138,15 @@ a img {
 
 .tabbing.nav-pills > li.nav-item.disabled > a.nav-link:hover,
 .tabbing.nav-pills > li.nav-item.disabled > a.nav-link:focus {
-  color: $white;
+  color: #777;
   text-decoration: none;
-  background-color: $secondary-color;
+  background-color: transparent;
   cursor: not-allowed;
 }
 
 .tabbing.nav-pills > li > a.active:hover,
 .tabbing.nav-pills > li > a.active:focus {
-  background-color: $accent-color !important;
-  color: $white !important;
+  cursor: default;
 }
 
 /* this enables customization of the nav bar. h/t to zessx (http://stackoverflow.com/users/1238019/zessx)
@@ -1099,19 +1098,4 @@ span.head {
       border: none;
     }
   }
-}
-
-.acc_button,
-.acc_button:hover,
-.acc_button:focus,
-.acc_button:active,
-.acc_button:visited {
-  color: #fff !important;
-}
-
-.btn.btn-primary,
-.btn.btn-primary:hover,
-.btn.btn-primary:focus,
-.btn.btn-primary:active {
-  color: #fff !important;
 }

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -138,10 +138,16 @@ a img {
 
 .tabbing.nav-pills > li.nav-item.disabled > a.nav-link:hover,
 .tabbing.nav-pills > li.nav-item.disabled > a.nav-link:focus {
-  color: #777;
+  color: $white;
   text-decoration: none;
-  background-color: transparent;
+  background-color: $secondary-color;
   cursor: not-allowed;
+}
+
+.tabbing.nav-pills > li > a.active:hover,
+.tabbing.nav-pills > li > a.active:focus {
+  background-color: $accent-color !important;
+  color: $white !important;
 }
 
 /* this enables customization of the nav bar. h/t to zessx (http://stackoverflow.com/users/1238019/zessx)
@@ -1093,4 +1099,19 @@ span.head {
       border: none;
     }
   }
+}
+
+.acc_button,
+.acc_button:hover,
+.acc_button:focus,
+.acc_button:active,
+.acc_button:visited {
+  color: #fff !important;
+}
+
+.btn.btn-primary,
+.btn.btn-primary:hover,
+.btn.btn-primary:focus,
+.btn.btn-primary:active {
+  color: #fff !important;
 }

--- a/public/app/assets/stylesheets/archivesspace/bootstrap-overrides.scss
+++ b/public/app/assets/stylesheets/archivesspace/bootstrap-overrides.scss
@@ -4,24 +4,23 @@
   border: var(--default-border);
 }
 
-.acc_holder > .accordion > .card {
+.acc_holder > .accordion > .accordion-item {
+  border: 0;
   margin-bottom: 0;
   border-radius: 0;
-  border-bottom: 0;
+  border-left: var(--default-border);
+  border-right: var(--default-border);
 }
 
-.acc_holder > .accordion > .card:first-of-type {
-  border-top-left-radius: var(--bootstrap-rounded-border-radius);
-  border-top-right-radius: var(--bootstrap-rounded-border-radius);
+.acc_holder > .accordion > .accordion-item:first-of-type {
+  border-top: var(--default-border);
+  border-top-left-radius: var(--bs-accordion-border-radius);
+  border-top-right-radius: var(--bs-accordion-border-radius);
 }
 
-.acc_holder > .accordion > .card + .card {
-  margin-top: -1px;
-}
-
-.acc_holder > .accordion > .card:last-of-type {
-  border-bottom-left-radius: var(--bootstrap-rounded-border-radius);
-  border-bottom-right-radius: var(--bootstrap-rounded-border-radius);
+.acc_holder > .accordion > .accordion-item:last-of-type {
+  border-bottom-left-radius: var(--bs-accordion-border-radius);
+  border-bottom-right-radius: var(--bs-accordion-border-radius);
 }
 
 /* Bootstrap v4 removed .btn-default but they were not removed or patched in
@@ -64,9 +63,44 @@
   text-decoration: none;
 }
 
-.acc_holder .accordion .accordion-toggle:hover,
-.acc_holder .accordion .accordion-toggle:focus {
+.acc_holder .accordion .accordion-button:hover,
+.acc_holder .accordion .accordion-button:focus {
   text-decoration: none;
+}
+
+.acc_holder .accordion .accordion-button,
+.acc_holder .accordion .accordion-button:not(.collapsed) {
+  background-color: var(--bs-tertiary-bg);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: $primary-color;
+  border-bottom: var(--default-border);
+  box-shadow: none;
+}
+
+.acc_holder .accordion .accordion-button:focus {
+  box-shadow: none;
+}
+
+.acc_holder > .accordion > .accordion-item > .accordion-collapse.show {
+  border-bottom: var(--default-border);
+}
+
+.acc_holder
+  > .accordion
+  > .accordion-item:last-of-type
+  > .accordion-header
+  > .accordion-button.collapsed {
+  border-bottom-left-radius: var(--bs-accordion-inner-border-radius);
+  border-bottom-right-radius: var(--bs-accordion-inner-border-radius);
+}
+
+.acc_holder
+  > .accordion
+  > .accordion-item:last-of-type
+  > .accordion-collapse.show {
+  border-bottom-left-radius: var(--bs-accordion-inner-border-radius);
+  border-bottom-right-radius: var(--bs-accordion-inner-border-radius);
 }
 
 .page-link {

--- a/public/app/views/agents/show.html.erb
+++ b/public/app/views/agents/show.html.erb
@@ -37,7 +37,7 @@
     <div id="sidebar" class="sidebar sidebar-container">
       <h3><%= t('more_about') %> '<%== process_mixed_content(@result.display_string) %>'</h3>
       <div class="acc_holder clear" >
-        <div class="panel-group" id="agent_accordion">
+        <div class="accordion" id="agent_accordion">
 
           <% n = render partial: 'name', locals: {:result => @result} %>
           <%= render partial: 'shared/accordion_panel', locals:

--- a/public/app/views/resources/_resource_tab.erb
+++ b/public/app/views/resources/_resource_tab.erb
@@ -1,6 +1,6 @@
 <% active = (action.to_s == controller.action_name) %>
 <% unless hidden && !active %>
-  <li class="<%= enabled ? 'nav-item' : 'nav-item disabled' %>">
+  <li class="<%= (enabled || active) ? 'nav-item' : 'nav-item disabled' %>">
   	<% case action
   		 when :show
          url = app_prefix("/repositories/#{params[:rid]}/resources/#{params[:id]}")

--- a/public/app/views/resources/show.html.erb
+++ b/public/app/views/resources/show.html.erb
@@ -25,7 +25,7 @@
 <div class="row mt-5 flex-column flex-lg-row" id="notes_row">
   <div
     id="sidebar"
-    class="h-max col-12 col-lg-3 sidebar sidebar-container resizable-sidebar <%= sidebar_position == 'left' ? 'resizable-sidebar-left' : 'order-1' %> infinite-tree-sidebar"
+    class="h-max col-12 col-lg-3 sidebar sidebar-container infinite-tree-sidebar<%= @has_children ? " resizable-sidebar #{sidebar_position == 'left' ? 'resizable-sidebar-left' : 'order-1'}" : '' %>"
     data-sidebar-position="<%= sidebar_position %>"
     <% unless @has_children %>style="display: none"<% end %>
   >

--- a/public/app/views/shared/_accordion_panel.html.erb
+++ b/public/app/views/shared/_accordion_panel.html.erb
@@ -1,14 +1,12 @@
 <% if !p_body.strip.blank? %>
-  <div class="card">
-    <div class="card-header">
-      <h2 class="card-title mb-0">
-        <a class="accordion-toggle" href="#<%= p_id %>" role="button" data-bs-toggle="collapse" data-bs-target="#<%= p_id %>" aria-controls="<%= p_id %>" aria-expanded="true">
-          <%= p_title %>
-        </a>
-      </h2>
-    </div>
-    <div id="<%= p_id %>" class="collapse show note_panel">
-      <div class="card-body">
+  <div class="accordion-item">
+    <h2 class="accordion-header">
+      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#<%= p_id %>" aria-controls="<%= p_id %>" aria-expanded="true">
+        <%= p_title %>
+      </button>
+    </h2>
+    <div id="<%= p_id %>" class="accordion-collapse collapse show note_panel">
+      <div class="accordion-body">
         <%= p_body %>
       </div>
     </div>

--- a/public/app/views/shared/_search_collection_form.html.erb
+++ b/public/app/views/shared/_search_collection_form.html.erb
@@ -7,7 +7,7 @@
       <%= label_tag('filter_q0',
                     "#{t('actions.search_in',
                     :type => t('resource._singular'))}",
-                    :class => 'sr-only') %>
+                    :class => 'visually-hidden') %>
       <%= text_field_tag('filter_q[]',
                          nil,
                          :id => 'filter_q0',
@@ -24,7 +24,7 @@
       <div class="year_from p-0 flex-grow-1">
         <%= label_tag('filter_from_year', 
                       "#{t('search_results.filter.from_year')}", 
-                      :class => 'sr-only') %>
+                      :class => 'visually-hidden') %>
         <%= text_field_tag(:filter_from_year,
                            nil,
                            :id => 'filter_from_year',
@@ -37,7 +37,7 @@
       <div class="year_to p-0 flex-grow-1">
         <%= label_tag('filter_to_year', 
                       "#{t('search_results.filter.to_year')}",
-                      :class=> 'sr-only') %>
+                      :class=> 'visually-hidden') %>
         <%= text_field_tag(:filter_to_year,
                            nil,
                            :id => 'filter_to_year',

--- a/public/app/views/subjects/show.html.erb
+++ b/public/app/views/subjects/show.html.erb
@@ -30,7 +30,7 @@
     <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
       <h3><%= t('more_about') %> '<%== process_mixed_content(@result.display_string) %>'</h3>
       <div class="acc_holder clear" >
-        <div class="panel-group" id="res_accordion">
+        <div class="accordion" id="res_accordion">
           <% if !(terms = ASUtils.wrap(@result['json']['terms'])).empty? %>
             <% x = render partial: 'subjects/terms', locals: {:terms =>  terms, :list_clss => 'terms'} %>
             <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('subject_term_type'), :p_id => 'subject_terms', :p_body => x} %>


### PR DESCRIPTION
## Summary
Completed Bootstrap 5 migration for the resources show view including accordion, tab bar, and collection search form.

Files changed:
**_accordion_panel.html.erb**: Updated data-toggle to data-bs-toggle and data-target to data-bs-target
**handle_accordion.js**: Updated Bootstrap 4 jQuery collapse API to Bootstrap 5, fixed $.fn.size()
**_resource_tab.html.erb**: Fixed active tab incorrectly inheriting disabled class -- active tabs now always render as enabled
**_search_collection_form.html.erb**: Updated sr-only to visually-hidden
**aspace.scss**: Added button color overrides for btn-primary, acc_button, and active/disabled tab hover states (NOTE: these use !important since the default Bootstrap5 css has current precedence  over the local aspace.scss file.  Might be worth considering changing the order in which these are loaded) 
**application.js**: Fixed Bootstrap JS require path (again again, as this reverts on branch switching)
Removed Bootstrap 4 **bootstrap.min.js** vendor file and **bootstrap-accessibility** plugin (again again, as this reverts on branch switching)


## Screenshots (if appropriate):
<img width="1212" height="683" alt="ANW-2660_Resource_Top" src="https://github.com/user-attachments/assets/5766eb39-0989-4060-93f2-4e3023d69961" />

<img width="1207" height="687" alt="ANW-2660_Resource_Bottom" src="https://github.com/user-attachments/assets/2c817868-9ad2-445b-9fc2-4912c4a82862" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [X] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:
Template, JS, and CSS changes only, As there are no logic changes, no tests are required.