### PR TITLE
ANW-2661: Update digital objects index view for Bootstrap 5

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -1099,3 +1099,8 @@ span.head {
     }
   }
 }
+
+.record-count.badge {
+  color: #fff;
+  background-color: $darkest;
+}

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -1099,8 +1099,3 @@ span.head {
     }
   }
 }
-
-.record-count.badge {
-  color: #fff;
-  background-color: $darkest;
-}

--- a/public/app/views/search/search_results.html.erb
+++ b/public/app/views/search/search_results.html.erb
@@ -24,9 +24,9 @@
 
   <% unless defined?(@no_statement) %>
     <div class="searchstatement">
-      <div class="btn btn-group pull-right">
-        <%= link_to I18n.t('actions.new_search'), (defined?(@new_search) ? @new_search : root_path), :class => "btn btn-sm btn--default" %>
-        <button class="btn btn-sm btn--default" id="toggleRefineSearch" aria-expanded="false" aria-controls="refineSearchPanel"><%= I18n.t('actions.refine_search') %></button>
+      <div class="btn btn-group float-end">
+        <%= link_to I18n.t('actions.new_search'), (defined?(@new_search) ? @new_search : root_path), :class => "btn btn-sm btn-secondary" %>
+        <button class="btn btn-sm btn-secondary" id="toggleRefineSearch" aria-expanded="false" aria-controls="refineSearchPanel"><%= I18n.t('actions.refine_search') %></button>
       </div>
 
       <% if defined?(@search) %>

--- a/public/app/views/shared/_facet_description.html.erb
+++ b/public/app/views/shared/_facet_description.html.erb
@@ -3,6 +3,6 @@
     rel="nofollow"
     title="<%= t('search_results.filter_by')%> '<%= facet.label %>'">
     <%= facet.label %>
-    <span class="record-count badge badge-pill badge-dark"><%= facet.count %></span>
+    <span class="record-count badge rounded-pill text-bg-dark"><%= facet.count %></span>
   </a>
 </dd>

--- a/public/spec/controllers/objects_controller_spec.rb
+++ b/public/spec/controllers/objects_controller_spec.rb
@@ -8,7 +8,7 @@ describe ObjectsController, type: :controller do
   img_uri5 = 'http://foo.com/image5.jpg'
   caption1 = 'caption1'
   caption2 = 'caption2'
-  additional_file_versions_accordion_css = '#res_accordion > .card > #additional_file_versions_list'
+  additional_file_versions_accordion_css = '#res_accordion > .accordion-item > #additional_file_versions_list'
   additional_file_version_css = '#additional_file_versions_list li[data-additional-file-version]'
 
   before(:all) do
@@ -175,7 +175,7 @@ describe ObjectsController, type: :controller do
 
       page = response.body
 
-      additional_file_versions_accordion_css = '#res_accordion > .card > #additional_file_versions_list'
+      additional_file_versions_accordion_css = '#res_accordion > .accordion-item > #additional_file_versions_list'
       additional_file_version_css = '#additional_file_versions_list li[data-additional-file-version]'
 
       expect(page).to have_css(additional_file_versions_accordion_css)


### PR DESCRIPTION
## Summary
Completed Bootstrap 5 migration for the digital objects index view and related shared search/filter components.

Files updated:
**search_results.html.erb**: pull-right to float-end, btn--default to btn-secondary.
**_facets.html.erb**: sr-only to visually-hidden, pr-md-1 to pe-md-1, pl-md-1 to ps-md-1.
**_facet_description.html.erb**: badge-pill to rounded-pill, badge-dark to text-bg-dark.
**aspace.scss**: Added .record-count.badge override to restore dark background with white text on the facet count badges. NOTE:  I played around with badge spacing a bit by adding ms-1 to the badges, but decided against it to keep visual consistency between versions.
**application.js**: Fixed Bootstrap JS require path to bootstrap-min from bootstrap/bootstrap.min.js (again again again, as this reverts on branch switching.  NOTE: doing this causes AS to use the Bootstrap5 gem as its bootstrap source, rather than a self-managed file.)
Removed Bootstrap 4 **bootstrap.mins.js** vendor file and the **bootstrap-accessibility** plugin (again, as these revert on branch switching)

## Screenshots (if appropriate):
<img width="1214" height="676" alt="ANW-2661_Digital_Objects" src="https://github.com/user-attachments/assets/5e22398f-84b9-426a-b571-c407a7284be5" />


NOTE: The Sort dropdown styling and black text on blue buttons are handled in ANW-2658 and the black text in the blue buttons are handles in ANW-2659.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [X] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:
Template and CSS changes only.