### PR TITLE
ANW-1860 Fix missing templates in war file

### DIFF
--- a/frontend/config/warble.rb
+++ b/frontend/config/warble.rb
@@ -36,7 +36,7 @@ Warbler::Config.new do |config|
   #
   # config.ru is needed here because Rails looks for it when trying to determine
   # its root directory.
-  config.includes = FileList["Gemfile", "Gemfile.lock", "config.ru"]
+  config.includes = FileList["Gemfile", "Gemfile.lock", "config.ru", "public/bulk_import_templates/*"]
 
   # Additional files/directories to exclude
   # config.excludes = FileList["lib/tasks/*"]
@@ -129,6 +129,8 @@ Warbler::Config.new do |config|
   # Files to be included in the root of the webapp.  Note that files in public
   # will have the leading 'public/' part of the path stripped during staging.
   # config.public_html = FileList["public/**/*", "doc/**/*"]
+  # exclude templates from WAR root; they're bundled under WEB-INF via config.includes
+  config.public_html = FileList["public/**/*"].exclude("public/bulk_import_templates", "public/bulk_import_templates/**/*")
 
   # Pathmaps for controlling how public HTML files are copied into the .war
   # config.pathmaps.public_html = ["%{public/,}p"]

--- a/frontend/config/warble.rb
+++ b/frontend/config/warble.rb
@@ -129,8 +129,6 @@ Warbler::Config.new do |config|
   # Files to be included in the root of the webapp.  Note that files in public
   # will have the leading 'public/' part of the path stripped during staging.
   # config.public_html = FileList["public/**/*", "doc/**/*"]
-  # exclude templates from WAR root; they're bundled under WEB-INF via config.includes
-  config.public_html = FileList["public/**/*"].exclude("public/bulk_import_templates", "public/bulk_import_templates/**/*")
 
   # Pathmaps for controlling how public HTML files are copied into the .war
   # config.pathmaps.public_html = ["%{public/,}p"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-1860]

## Summary
The consolidation PR (#4116) moved bulk import templates from `frontend/docs/` to `frontend/public/bulk_import_templates/` and updated the controller's `send_file` path accordingly, but did not update `warble.rb`. In a deployed WAR, Rails.root resolves to WEB-INF/, so the templates needed to be explicitly bundled under:

`WEB-INF/public/bulk_import_templates/` 

Done via config.includes. Without this, the download action couldn't find the files and returned a 500 error. Also removes the duplicate WAR-root copy that Warbler was generating by default from public/.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:
I'm unaware of a practical way to test build tooling, specifically a WAR file build.


[ANW-1860]: https://archivesspace.atlassian.net/browse/ANW-1860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ