### PR TITLE
ANW-2662: Update digital objects show view for Bootstrap 5

### DIFF
--- a/public/app/views/shared/_infinite_tree.html.erb
+++ b/public/app/views/shared/_infinite_tree.html.erb
@@ -54,7 +54,7 @@
     aria-controls
   >
     <i class="node-expand-icon fa fa-chevron-right"></i>
-    <span class="sr-only"></span>
+    <span class="visually-hidden"></span>
   </button>
 </template>
 

--- a/public/app/views/shared/_skipnav.html.erb
+++ b/public/app/views/shared/_skipnav.html.erb
@@ -1,14 +1,14 @@
 <div class="skipnav">
-  <%= link_to I18n.t('skipnav.main_content'), '#maincontent', :class => 'sr-only sr-only-focusable' %>
+  <%= link_to I18n.t('skipnav.main_content'), '#maincontent', :class => 'visually-hidden visually-hidden-focusable' %>
   <% unless ['inventory', 'term'].include?(action_name) || (action_name == 'show' && controller_name != 'repositories') %>
     <% if defined?(@search) %>
       <% if defined?(@results) %>
         <% unless defined?(@no_statement) %>
-          <%= link_to I18n.t('skipnav.search'), '#toggleRefineSearch', :class => 'sr-only sr-only-focusable' %>
+          <%= link_to I18n.t('skipnav.search'), '#toggleRefineSearch', :class => 'visually-hidden visually-hidden-focusable' %>
         <% end %>
-        <%= link_to I18n.t('skipnav.search_results'), '#searchresults', :class => 'sr-only sr-only-focusable' %>
+        <%= link_to I18n.t('skipnav.search_results'), '#searchresults', :class => 'visually-hidden visually-hidden-focusable' %>
       <% else %>
-        <%= link_to I18n.t('skipnav.search'), '#search', :class => 'sr-only sr-only-focusable' %>
+        <%= link_to I18n.t('skipnav.search'), '#search', :class => 'visually-hidden visually-hidden-focusable' %>
       <% end %>
     <% end %>
   <% end %>


### PR DESCRIPTION
## Summary
**_modal.html.erb**: class="close" to class="btn-close", data-dismiss to data-bs-dismiss, removed "&times;"
**_modal_actions.html.erb**: Wrapped setupCite() and setupRequest() in $(document).ready() (Repeat from previous PRs)
**cite.js**: Updated Bootstrap 4 jQuery modal API to Bootstrap 5, added backdrop cleanup (Repeat from previous PRs)
**request.js**: Updated Bootstrap 4 jQuery modal API to Bootstrap 5  (Repeat from previous PRs)
**_request_form.html.erb**: sr-only to visually-hidden, removed input-group-append wrapper (removed in BS5)
**_skipnav.html.erb**: sr-only to visually-hidden, sr-only-focusable to visually-hidden-focusable
**_infinite_tree.html.erb**: sr-only to visually-hidden
**application.js**: Fixed Bootstrap JS require path from hardcoded bootstrap/bootstrap.min.js to bootstrap.min ruby gem pointer (again again again again, this always reverts on branch switching)
Removed Bootstrap 4 **bootstrap.min,.js** vendor file and **bootstrap-accessibility** plugin (again again again again, this always reverts on branch switching)

## Screenshots (if appropriate):
<img width="498" height="573" alt="ANW-2662_Citation_Menu" src="https://github.com/user-attachments/assets/8ad8434f-6e67-46bc-9dbd-0e26bf3557f8" />

<img width="500" height="369" alt="ANW-2662_Request_Menu" src="https://github.com/user-attachments/assets/ee17c875-dc42-4f1b-a537-1ca58b5e5e87" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [X] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:
CSS, JS and template changes only.  No logic changes.