### PR TITLE
ANW-2816 downloading Bulk AO updater spreadsheet times out for large resources

### DIFF
--- a/backend/app/controllers/bulk_archival_object_updater.rb
+++ b/backend/app/controllers/bulk_archival_object_updater.rb
@@ -2,7 +2,7 @@ class ArchivesSpaceService < Sinatra::Base
   Endpoint.post('/bulk_archival_object_updater/repositories/:repo_id/generate_spreadsheet')
     .description("Return XLSX")
     .params(["repo_id", :repo_id],
-            ["uri", [String], "The uris of the records to include in the report"],
+            ["uri", String, "A JSON-encoded array of the uris of the records to include in the report"],
             ["min_subrecords", Integer, "The minimum number of subrecords to include", :default => 0],
             ["extra_subrecords", Integer, "The number of extra subrecords to include", :default => 3],
             ["min_notes", Integer, "The minimum number of note subrecords to include", :default => 2],
@@ -12,8 +12,10 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:view_repository])
     .returns([200, "spreadsheet"]) \
   do
+    ao_uris = ASUtils.json_parse(params[:uri])
+
     builder = SpreadsheetBuilder.new(params[:resource_uri],
-                                     params[:uri],
+                                     ao_uris,
                                      params[:min_subrecords],
                                      params[:extra_subrecords],
                                      params[:min_notes],

--- a/backend/spec/controller_bulk_archival_object_updater_spec.rb
+++ b/backend/spec/controller_bulk_archival_object_updater_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe 'Bulk Archival Object Updater controller' do
+  let(:resource) { create(:json_resource) }
+  let!(:archival_object) do
+    create(:json_archival_object, resource: { ref: resource.uri })
+  end
+  let(:repo_id) { resource.repository['ref'].split('/').last }
+
+  let(:base_params) do
+    {
+      'resource_uri' => resource.uri,
+      'min_subrecords' => 0,
+      'extra_subrecords' => 0,
+      'min_notes' => 0
+    }
+  end
+
+  describe 'Download bulk_archival_object_updater spreadsheet' do
+    it 'accepts uri as a JSON-encoded array string and returns an XLSX spreadsheet' do
+      response = JSONModel::HTTP.post_form(
+        "/bulk_archival_object_updater/repositories/#{repo_id}/generate_spreadsheet",
+        base_params.merge('uri' => ASUtils.to_json([archival_object.uri]))
+      )
+
+      expect(response.code).to eq('200')
+      expect(response['Content-Type']).to include('spreadsheetml.sheet')
+    end
+
+    it 'accepts multiple uris in the JSON-encoded array' do
+      ao2 = create(:json_archival_object, resource: { ref: resource.uri })
+
+      response = JSONModel::HTTP.post_form(
+        "/bulk_archival_object_updater/repositories/#{repo_id}/generate_spreadsheet",
+        base_params.merge('uri' => ASUtils.to_json([archival_object.uri, ao2.uri]))
+      )
+
+      expect(response.code).to eq('200')
+      expect(response['Content-Type']).to include('spreadsheetml.sheet')
+    end
+
+    it 'returns a 400 error when uri is not valid JSON' do
+      archival_object
+
+      response = JSONModel::HTTP.post_form(
+        "/bulk_archival_object_updater/repositories/#{repo_id}/generate_spreadsheet",
+        base_params.merge('uri' => 'not-valid-json')
+      )
+
+      expect(response.code).to eq('400')
+    end
+  end
+end

--- a/frontend/app/controllers/bulk_archival_object_updater_controller.rb
+++ b/frontend/app/controllers/bulk_archival_object_updater_controller.rb
@@ -9,7 +9,7 @@ class BulkArchivalObjectUpdaterController < ApplicationController
   def download
     uri = "/bulk_archival_object_updater/repositories/#{session[:repo_id]}/generate_spreadsheet"
     args = {
-      'uri[]' => JSON.parse(params[:selected]),
+      'uri' => params[:selected],
       'resource_uri' => params[:resource],
       'min_subrecords' => params[:min_subrecords],
       'extra_subrecords' => params[:extra_subrecords],
@@ -109,6 +109,7 @@ class BulkArchivalObjectUpdaterController < ApplicationController
     req['X-ArchivesSpace-Session'] = JSONModel::HTTP::current_backend_session
 
     Net::HTTP.start(uri.host, uri.port) do |http|
+      http.read_timeout = 1200
       http.request(req, nil) do |response|
         if response.code =~ /^4/
           #JSONModel::handle_error(ASUtils.json_parse(response.body))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-2816]

<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->

## Summary
Generating a Bulk Archival Object Spreadsheet for large resources has been failing:

  1. Query parameter limit exceeded - the SUI rails app sent a request to the backend API with each archival object URI as a separate uri[] form parameter, which exceeded Rack's 4096-parameter limit on large resources. Fixed by JSON-encoding the URI array into a single uri string on the frontend and parsing it to the backend.
  2. Net::ReadTimeout - SpreadsheetBuilder#to_stream builds the entire spreadsheet in memory before sending anything, so large resources could exceed the default 60-second Net::HTTP read timeout. Fixed by setting read_timeout = 1200 in post_with_stream_response, matching the timeout already used by the JSONModel client in rest of the system.



<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [ ] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:


[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ANW-2816]: https://archivesspace.atlassian.net/browse/ANW-2816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ