### PR TITLE
ANW-2717 fix linking agents to resources on derby embedded demo db

### DIFF
--- a/backend/app/model/ASModel_database_mapping.rb
+++ b/backend/app/model/ASModel_database_mapping.rb
@@ -2,30 +2,34 @@ module ASModel
   # Some low-level details of mapping certain Ruby types to database types.
   module DatabaseMapping
 
+    JSON_TO_DB_MAPPINGS = {
+      'boolean' => {
+        :description => "JSON booleans become DB integers",
+        :json_to_db => ->(bool) { bool ? 1 : 0 },
+        :db_to_json => ->(int) { int === 1 }
+      },
+      'date' => {
+        :description => "Date strings become dates",
+        :json_to_db => ->(s) { s.nil? ? s : Date.parse(s) },
+        :db_to_json => ->(date) { date.nil? ? date : date.strftime('%Y-%m-%d') }
+      }
+    }
+
+    def self.prepare_booleans_for_db(hash)
+      bool_to_int = JSON_TO_DB_MAPPINGS['boolean'][:json_to_db]
+      hash.transform_values { |v| [true, false].include?(v) ? bool_to_int.call(v) : v }
+    end
+
     def self.included(base)
       base.extend(ClassMethods)
     end
 
     module ClassMethods
-      JSON_TO_DB_MAPPINGS = {
-        'boolean' => {
-          :description => "JSON booleans become DB integers",
-          :json_to_db => ->(bool) { bool ? 1 : 0 },
-          :db_to_json => ->(int) { int === 1 }
-        },
-        'date' => {
-          :description => "Date strings become dates",
-          :json_to_db => ->(s) { s.nil? ? s : Date.parse(s) },
-          :db_to_json => ->(date) { date.nil? ? date : date.strftime('%Y-%m-%d') }
-        }
-      }
-
-
       def prepare_for_db(jsonmodel_class, hash)
         schema = jsonmodel_class.schema
         hash = hash.clone
         schema['properties'].each do |property, definition|
-          mapping = JSON_TO_DB_MAPPINGS[definition['type']]
+          mapping = ASModel::DatabaseMapping::JSON_TO_DB_MAPPINGS[definition['type']]
           if mapping && hash.has_key?(property)
             hash[property] = mapping[:json_to_db].call(hash[property])
           end
@@ -45,7 +49,7 @@ module ASModel
       def map_db_types_to_json(schema, hash)
         hash = hash.clone
         schema['properties'].each do |property, definition|
-          mapping = JSON_TO_DB_MAPPINGS[definition['type']]
+          mapping = ASModel::DatabaseMapping::JSON_TO_DB_MAPPINGS[definition['type']]
 
           property = property.intern
           if mapping && hash.has_key?(property)

--- a/backend/app/model/mixins/agents.rb
+++ b/backend/app/model/mixins/agents.rb
@@ -21,7 +21,7 @@ module Agents
                                  plugin :validation_helpers
 
                                  define_method(:validate) do
-                                   if self[:is_primary]
+                                   if self[:is_primary] == 1
                                      validates_unique(
                                        [:is_primary, id_field],
                                        message: "A #{type} can have only one primary linked agent")

--- a/backend/app/model/mixins/relationships.rb
+++ b/backend/app/model/mixins/relationships.rb
@@ -61,7 +61,7 @@ AbstractRelationship = Class.new(Sequel::Model) do
              "  (Have you created the '#{table_name}' table?)")
     end
 
-    values = Hash[columns.zip([obj1.id, obj2.id])].merge(properties)
+    values = Hash[columns.zip([obj1.id, obj2.id])].merge(ASModel::DatabaseMapping.prepare_booleans_for_db(properties))
 
     if [obj1, obj2].any? {|obj| obj.class.suppressible? && obj.suppressed == 1}
       # Suppress this new relationship if it points to a suppressed record

--- a/backend/spec/controller_resource_spec.rb
+++ b/backend/spec/controller_resource_spec.rb
@@ -439,6 +439,17 @@ describe 'Resources controller' do
   end
 
 
+  it "allows a resource to be created with a linked agent carrying is_primary: false" do
+    agent = create(:json_agent_person)
+
+    expect {
+      create(:json_resource, :linked_agents => [
+        { :ref => agent.uri, :role => 'source', 'is_primary' => false }
+      ])
+    }.not_to raise_error
+  end
+
+
   it "publishes the resource, subrecords and components when /publish is POSTed" do
     resource = create(:json_resource, {
       :publish => false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-2717]
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->

## Summary

Fix SQLSyntaxErrorException when linking an agent to a resource on Derby.

Creating a resource with a linked agent failed on the Derby embedded database.

Columns of type 'INTEGER' cannot hold values of type 'BOOLEAN'. The frontend always submits is_primary as a boolean on linked agent forms, which MySQL silently transforms to 0 while Derby rejects it.

Root cause: Relationship rows are built directly in AbstractRelationship.relate from raw JSON reference properties, bypassing the ASModel::DatabaseMapping boolean conversion that is applied top-level model properties and takes care of converting booleans to integers.

Extracted a method to apply the logic in relationship boolean properties as well.
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [ ] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:


[ANW-2717]: https://archivesspace.atlassian.net/browse/ANW-2717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ