### PR TITLE
Two changes to bulk archival object updater

### DIFF
--- a/backend/app/lib/bulk_archival_object_updater.rb
+++ b/backend/app/lib/bulk_archival_object_updater.rb
@@ -71,6 +71,8 @@ class BulkArchivalObjectUpdater
         @digital_object_id_to_uri_map = apply_digital_objects_changes(digital_objects_in_sheet, db)
       end
 
+      unlinked_top_container_ids = Set.new
+
       batch_rows(filename) do |batch|
         to_process = batch.map {|row| [Integer(row.fetch('id')), row]}.to_h
 
@@ -78,7 +80,19 @@ class BulkArchivalObjectUpdater
         ao_jsons = ArchivalObject.sequel_to_jsonmodel(ao_objs)
 
         ao_objs.zip(ao_jsons).each do |ao, ao_json|
+          tc_ids_before = ao_json.instances
+                            .select { |instance| instance['instance_type'] != 'digital_object' }
+                            .map { |instance|
+            JSONModel(:top_container).id_for(instance['sub_container']['top_container']['ref'])
+          }.compact
           process_row(to_process.fetch(ao.id), ao, ao_json, column_by_path, subrecord_columns)
+          tc_ids_after = ao_json.instances
+                           .select { |instance| instance['instance_type'] != 'digital_object' }
+                           .select { |instance| instance['sub_container'].has_key?('top_container') }
+                           .map { |instance|
+            JSONModel(:top_container).id_for(instance['sub_container']['top_container']['ref'])
+          }.compact
+          unlinked_top_container_ids += (tc_ids_before - tc_ids_after)
         end
       end
 
@@ -86,8 +100,8 @@ class BulkArchivalObjectUpdater
         raise BulkUpdateFailed.new(errors)
       end
 
-      if updated_uris.length
-        Resource[resource_id].reindex_top_containers
+      if updated_uris.any? || unlinked_top_container_ids.any?
+        Resource[resource_id].reindex_top_containers(unlinked_top_container_ids)
       end
     end
 

--- a/backend/app/lib/bulk_archival_object_updater.rb
+++ b/backend/app/lib/bulk_archival_object_updater.rb
@@ -42,6 +42,7 @@ class BulkArchivalObjectUpdater
     @errors = []
     @info_messages = []
     @updated_uris = []
+    @attached_top_containers_have_been_reported = false
   end
 
   def run
@@ -83,6 +84,10 @@ class BulkArchivalObjectUpdater
 
       if errors.length > 0
         raise BulkUpdateFailed.new(errors)
+      end
+
+      if updated_uris.length
+        Resource[resource_id].reindex_top_containers
       end
     end
 
@@ -201,7 +206,7 @@ class BulkArchivalObjectUpdater
       # Apply changes to the Archival Object!
       if record_changed
         ao_json['position'] = nil
-        ao.update_from_json(ao_json)
+        ao.update_from_json(ao_json, skip_reindex_top_containers: true)
 
         info_messages.push("Updated archival object #{ao.id} - #{ao_json.display_string}")
 
@@ -1362,11 +1367,13 @@ class BulkArchivalObjectUpdater
 
     message += "Top container not found attached within resource: #{container.inspect}\n"
     message += "Set 'create_missing_top_containers' to true inside AppConfig, to create Top Containers that do not exist.\n"
-    message += "The following top containers are attached within this resource:\n"
-    message += available_top_containers.map do |tc|
-      "#{ tc.inspect }\n"
-    end.join("")
-
+    unless @attached_top_containers_have_been_reported
+      message += "The following top containers are attached within this resource:\n"
+      message += available_top_containers.map do |tc|
+        "#{ tc.inspect }\n"
+      end.join("")
+    end
+    @attached_top_containers_have_been_reported = true
     message
   end
 end

--- a/backend/app/model/mixins/reindex_top_containers.rb
+++ b/backend/app/model/mixins/reindex_top_containers.rb
@@ -20,9 +20,6 @@ module ReindexTopContainers
     if root_record.is_a?(Resource)
       resource_instance_update(root_record.id)
       ao_instance_root_record_update(root_record.id)
-    elsif root_record.is_a?(ArchivalObject)
-      Log.warn("Invoking slow path for reindexing top containers")
-      reindex_top_containers_by_any_means_necessary(extra_ids)
     elsif root_record.is_a?(Accession)
       accession_instance_root_record_update(root_record.id)
     end

--- a/backend/spec/lib_bulk_archival_object_updater_spec.rb
+++ b/backend/spec/lib_bulk_archival_object_updater_spec.rb
@@ -713,8 +713,10 @@ describe 'Bulk Archival Object Updater' do
       tc_mtime_1 = TopContainer[top_container.id][:system_mtime]
       tc_mtime_2 = TopContainer[top_container_2.id][:system_mtime]
 
+      # if the updater runs too quickly, the top container mtimes
+      # will not have advanced a whole second, so sleep is needed.
+      sleep(1)
       bulk_archival_object_updater.run
-      sleep(0.1)
 
       expect(bulk_archival_object_updater.errors).to eq []
       expect(TopContainer[top_container.id][:system_mtime] > tc_mtime_1).to be_truthy
@@ -732,8 +734,10 @@ describe 'Bulk Archival Object Updater' do
       tc_mtime_1 = TopContainer[top_container.id][:system_mtime]
       tc_mtime_2 = TopContainer[top_container_2.id][:system_mtime]
 
+      # if the updater runs too quickly, the top container mtimes
+      # will not have advanced a whole second, so sleep is needed.
+      sleep(1)
       bulk_archival_object_updater.run
-      sleep(0.1)
 
       expect(bulk_archival_object_updater.errors).to eq []
       expect(TopContainer[top_container.id][:system_mtime] > tc_mtime_1).to be_falsey
@@ -771,8 +775,10 @@ describe 'Bulk Archival Object Updater' do
       tc_mtime_1 = TopContainer[top_container.id][:system_mtime]
       tc_mtime_2 = TopContainer[top_container_2.id][:system_mtime]
 
+      # if the updater runs too quickly, the top container mtimes
+      # will not have advanced a whole second, so sleep is needed.
+      sleep(1)
       bulk_archival_object_updater.run
-      sleep(0.1)
 
       expect(bulk_archival_object_updater.errors).to eq []
       updated = ArchivalObject.to_jsonmodel(archival_object_3.id)

--- a/backend/spec/lib_bulk_archival_object_updater_spec.rb
+++ b/backend/spec/lib_bulk_archival_object_updater_spec.rb
@@ -408,6 +408,53 @@ describe 'Bulk Archival Object Updater' do
         total_records_count_after = total_records_count
         expect(total_records_count_before).to eq total_records_count_after
       end
+
+      it 'only lists all the top container condidates one time' do
+        expect(bulk_archival_object_updater.create_missing_top_containers?).to eq false
+
+        # Change the title of achival objects in the downloaded excel.
+        title_index = column_names.find_index('title')
+        sheet[2][title_index].change_contents('Updated Archival Object Title 1')
+        sheet[3][title_index].change_contents('Updated Archival Object Title 2')
+
+        record_number = 1
+        2.times do |i|
+          update_empty_sheet_columns(row: i+2, columns_to_update: {
+            "instances/#{record_number}/instance_type" => 'Books [books]',
+            "instances/#{record_number}/top_container_type" => 'Box [box]',
+            "instances/#{record_number}/top_container_indicator" => "Container to be created #{i} Indicator",
+            "instances/#{record_number}/top_container_barcode" => "Container to be created #{i} Barcode",
+            "instances/#{record_number}/sub_container_type_2" => 'Folder [folder]',
+            "instances/#{record_number}/sub_container_indicator_2" => "Child Indicator #{uuid}",
+          })
+        end
+        # Save excel file after updates
+        excel_file.write(excel_filename)
+
+        updated_records = {}
+
+        expect do
+          bulk_archival_object_updater.run
+        end.to raise_error BulkArchivalObjectUpdater::BulkUpdateFailed do |bulk_update_failed|
+          expect(bulk_update_failed.errors[0]).to eq({
+            :sheet => "Updates",
+            :column=>"instances/1/top_container_indicator",
+            :row => 3,
+            :errors=> [
+              "Top container not found attached within resource: #<BulkArchivalObjectUpdater::TopContainerCandidate {:top_container_type=>\"box\", :top_container_indicator=>\"Container to be created 0 Indicator\", :top_container_barcode=>\"Container to be created 0 Barcode\"}>\nSet 'create_missing_top_containers' to true inside AppConfig, to create Top Containers that do not exist.\nThe following top containers are attached within this resource:\n[#<BulkArchivalObjectUpdater::TopContainerCandidate {:top_container_type=>\"box\", :top_container_indicator=>\"#{top_container.indicator}\", :top_container_barcode=>\"#{top_container.barcode}\"}>, \"/repositories/#{resource_repository_id}/top_containers/#{top_container.id}\"]\n"
+            ]
+          })
+
+          expect(bulk_update_failed.errors[2]).to eq({
+            :sheet => "Updates",
+            :column=>"instances/1/top_container_indicator",
+            :row => 4,
+            :errors=> [
+              "Top container not found attached within resource: #<BulkArchivalObjectUpdater::TopContainerCandidate {:top_container_type=>\"box\", :top_container_indicator=>\"Container to be created 1 Indicator\", :top_container_barcode=>\"Container to be created 1 Barcode\"}>\nSet 'create_missing_top_containers' to true inside AppConfig, to create Top Containers that do not exist.\n"
+            ]
+          })
+        end
+      end
     end
 
     context 'because the accession id provided does not belong to an existing accession' do
@@ -613,6 +660,56 @@ describe 'Bulk Archival Object Updater' do
         total_records_count_after = total_records_count
         expect(total_records_count_before).to eq total_records_count_after
       end
+    end
+  end
+
+  context 'when the bulk updater triggers a reindex of top containers' do
+    let(:resource_obj) { Resource[resource.id] }
+    let(:top_container_2) { create(:json_top_container) }
+    let(:archival_object_3) do
+      create(:json_archival_object,
+             title: "Archival Object Title 3",
+             resource: { ref: resource.uri },
+             instances: [ build(:json_instance,
+                                sub_container: build(:json_sub_container,
+                                                     top_container: {
+                                                       ref: top_container_2.uri })) ])
+    end
+
+    let(:spreadsheet_builder) do
+      SpreadsheetBuilder.new(
+        resource.uri,
+        [
+          archival_object_1.uri,
+          archival_object_2.uri,
+          archival_object_3.uri
+        ],
+        min_subrecords,
+        extra_subrecords,
+        min_notes,
+        selected_columns
+      )
+    end
+
+    it 'triggers a top container reindex for the resource and its children one time' do
+      tc_mtime_1 = TopContainer[top_container.id][:system_mtime]
+      tc_mtime_2 = TopContainer[top_container_2.id][:system_mtime]
+
+      allow(Resource).to receive(:[]).with(resource.id).and_return(resource_obj)
+      expect(resource_obj).to receive(:reindex_top_containers).once.and_call_original
+      expect(resource_obj).to receive(:resource_instance_update).once.and_call_original
+      expect(resource_obj).to receive(:ao_instance_root_record_update).once.and_call_original
+      # Change the title of achival objects in the downloaded excel.
+      title_index = column_names.find_index('title')
+      sheet[2][title_index].change_contents('Updated Archival Object Title 1')
+      sheet[3][title_index].change_contents('Updated Archival Object Title 2')
+      sheet[4][title_index].change_contents('Updated Archival Object Title 3')
+      excel_file.write(excel_filename)
+      bulk_archival_object_updater.run
+
+      expect(bulk_archival_object_updater.errors).to eq []
+      expect(TopContainer[top_container.id][:system_mtime] > tc_mtime_1).to be_truthy
+      expect(TopContainer[top_container_2.id][:system_mtime] > tc_mtime_2).to be_truthy
     end
   end
 

--- a/backend/spec/lib_bulk_archival_object_updater_spec.rb
+++ b/backend/spec/lib_bulk_archival_object_updater_spec.rb
@@ -409,7 +409,7 @@ describe 'Bulk Archival Object Updater' do
         expect(total_records_count_before).to eq total_records_count_after
       end
 
-      it 'only lists all the top container condidates one time' do
+      it 'only lists all the top container candidates one time' do
         expect(bulk_archival_object_updater.create_missing_top_containers?).to eq false
 
         # Change the title of achival objects in the downloaded excel.
@@ -443,6 +443,13 @@ describe 'Bulk Archival Object Updater' do
             :errors=> [
               "Top container not found attached within resource: #<BulkArchivalObjectUpdater::TopContainerCandidate {:top_container_type=>\"box\", :top_container_indicator=>\"Container to be created 0 Indicator\", :top_container_barcode=>\"Container to be created 0 Barcode\"}>\nSet 'create_missing_top_containers' to true inside AppConfig, to create Top Containers that do not exist.\nThe following top containers are attached within this resource:\n[#<BulkArchivalObjectUpdater::TopContainerCandidate {:top_container_type=>\"box\", :top_container_indicator=>\"#{top_container.indicator}\", :top_container_barcode=>\"#{top_container.barcode}\"}>, \"/repositories/#{resource_repository_id}/top_containers/#{top_container.id}\"]\n"
             ]
+          })
+
+          expect(bulk_update_failed.errors[1]).to eq({
+            :sheet => "Updates",
+            :json_property => "instances/2/sub_container/top_container",
+            :row => 3,
+            :errors => ["Property is required but was missing"]
           })
 
           expect(bulk_update_failed.errors[2]).to eq({
@@ -692,9 +699,6 @@ describe 'Bulk Archival Object Updater' do
     end
 
     it 'triggers a top container reindex for the resource and its children one time' do
-      tc_mtime_1 = TopContainer[top_container.id][:system_mtime]
-      tc_mtime_2 = TopContainer[top_container_2.id][:system_mtime]
-
       allow(Resource).to receive(:[]).with(resource.id).and_return(resource_obj)
       expect(resource_obj).to receive(:reindex_top_containers).once.and_call_original
       expect(resource_obj).to receive(:resource_instance_update).once.and_call_original
@@ -705,9 +709,73 @@ describe 'Bulk Archival Object Updater' do
       sheet[3][title_index].change_contents('Updated Archival Object Title 2')
       sheet[4][title_index].change_contents('Updated Archival Object Title 3')
       excel_file.write(excel_filename)
+
+      tc_mtime_1 = TopContainer[top_container.id][:system_mtime]
+      tc_mtime_2 = TopContainer[top_container_2.id][:system_mtime]
+
       bulk_archival_object_updater.run
+      sleep(0.1)
 
       expect(bulk_archival_object_updater.errors).to eq []
+      expect(TopContainer[top_container.id][:system_mtime] > tc_mtime_1).to be_truthy
+      expect(TopContainer[top_container_2.id][:system_mtime] > tc_mtime_2).to be_truthy
+    end
+
+    it 'does not reindex top containers if there are no changes' do
+      allow(Resource).to receive(:[]).with(resource.id).and_return(resource_obj)
+      expect(resource_obj).to_not receive(:reindex_top_containers)
+      expect(resource_obj).to_not receive(:resource_instance_update)
+      expect(resource_obj).to_not receive(:ao_instance_root_record_update)
+
+      excel_file.write(excel_filename)
+
+      tc_mtime_1 = TopContainer[top_container.id][:system_mtime]
+      tc_mtime_2 = TopContainer[top_container_2.id][:system_mtime]
+
+      bulk_archival_object_updater.run
+      sleep(0.1)
+
+      expect(bulk_archival_object_updater.errors).to eq []
+      expect(TopContainer[top_container.id][:system_mtime] > tc_mtime_1).to be_falsey
+      expect(TopContainer[top_container_2.id][:system_mtime] > tc_mtime_2).to be_falsey
+    end
+
+    it 'includes unlinked containers in the top container reindex' do
+      allow(Resource).to receive(:[]).with(resource.id).and_return(resource_obj)
+      allow(AppConfig).to receive(:[]).and_call_original
+      allow(AppConfig).to receive(:[]).with(:bulk_archival_object_updater_apply_deletes).and_return(true)
+      expect(resource_obj).to receive(:reindex_top_containers).once.and_call_original
+      expect(resource_obj).to receive(:resource_instance_update).once.and_call_original
+      expect(resource_obj).to receive(:ao_instance_root_record_update).once.and_call_original
+      # Change the title of achival objects in the downloaded excel.
+      title_index = column_names.find_index('title')
+      sheet[2][title_index].change_contents('Updated Archival Object Title 1')
+      sheet[3][title_index].change_contents('Updated Archival Object Title 2')
+      sheet[4][title_index].change_contents('Updated Archival Object Title 3')
+      [
+        'instances/0/instance_type',
+        'instances/0/top_container_type',
+        'instances/0/top_container_indicator',
+        'instances/0/top_container_barcode',
+        'instances/0/sub_container_type_2',
+        'instances/0/sub_container_indicator_2',
+        'instances/0/sub_container_barcode_2',
+        'instances/0/sub_container_type_3',
+        'instances/0/sub_container_indicator_3'
+      ].each do |instance_field|
+        index = column_names.find_index(instance_field)
+        sheet[4][index].change_contents(nil)
+      end
+      excel_file.write(excel_filename)
+
+      tc_mtime_1 = TopContainer[top_container.id][:system_mtime]
+      tc_mtime_2 = TopContainer[top_container_2.id][:system_mtime]
+
+      bulk_archival_object_updater.run
+      sleep(0.1)
+
+      expect(bulk_archival_object_updater.errors).to eq []
+      updated = ArchivalObject.to_jsonmodel(archival_object_3.id)
       expect(TopContainer[top_container.id][:system_mtime] > tc_mtime_1).to be_truthy
       expect(TopContainer[top_container_2.id][:system_mtime] > tc_mtime_2).to be_truthy
     end


### PR DESCRIPTION
This addresses two problems that arise in cases where 1) a resource tree contains a large number of container relationships and 2) a spreadsheet contains a large number of rows.

This problem has been documented here:
https://archivesspace.atlassian.net/browse/ANW-2617

I believe the core issue causing databases to lock up is a scenario like this. Say a resource tree points to 100 top containers, and a spreadsheet has 100 updates to archival objects in that tree. Currently, this will result in 100^2 updates to `system_mtime` in the top container table, because each archival object change triggers a reindex for the whole tree. When an error arises and the transaction rolls back, there are now 100^2 updates to rollback in the top container table. This change just turns off reindexing for each archival object and sends a single reindex directive when the processing is complete.

A smaller issue is that in cases like this the output log grows to unmanageable size because it reports every top container in the tree for every row with a non-existent container (when not configured to create missing top containers). With this change the full list of existing containers will only be reported once.

<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->

## Summary
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [ ] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:


[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ