### PR TITLE
ANW-2772 Always show languages of description subrecord

### DIFF
--- a/frontend/app/views/accessions/_form.html.erb
+++ b/frontend/app/views/accessions/_form.html.erb
@@ -54,10 +54,7 @@
 
 <% form.emit_template("accession") %>
 
-<% if AppConfig[:multilingual_content] %>
-  <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "lang_descriptions"} %>
-<% end %>
-
+<%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "lang_descriptions"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "lang_materials", :custom_action_template => "lang_materials/subrecord_form_action"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "dates", :template => "archival_record_date"} %>
 <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "extents"} %>

--- a/frontend/app/views/accessions/_sidebar.html.erb
+++ b/frontend/app/views/accessions/_sidebar.html.erb
@@ -3,10 +3,8 @@
              :record_type => 'accession',
              :record => @accession
            }) do |sidebar| %>
-  <% if AppConfig[:multilingual_content] %>
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'lang_description', :property => 'lang_descriptions') %>
-  <% end %>
 
+  <%= sidebar.render_for_view_and_edit(:subrecord_type => 'lang_description', :property => 'lang_descriptions') %>
   <%= sidebar.render_for_view_and_edit(:subrecord_type => 'lang_material', :property => 'lang_materials') %>
   <%= sidebar.render_for_view_and_edit(:subrecord_type => 'date', :property => 'dates') %>
   <%= sidebar.render_for_view_and_edit(:subrecord_type => 'extent', :property => 'extents') %>

--- a/frontend/app/views/accessions/show.html.erb
+++ b/frontend/app/views/accessions/show.html.erb
@@ -59,7 +59,7 @@
 
         <% readonly.emit_template("accession") %>
 
-        <% if AppConfig[:multilingual_content] && @accession.lang_descriptions.length > 0 %>
+        <% if @accession.lang_descriptions.length > 0 %>
           <%= render_aspace_partial :partial => "lang_descriptions/show", :locals => { :lang_descriptions => @accession.lang_descriptions, :section_id => "accession_lang_descriptions_" } %>
         <% end %>
 

--- a/frontend/app/views/digital_objects/_form_container.html.erb
+++ b/frontend/app/views/digital_objects/_form_container.html.erb
@@ -42,10 +42,7 @@
 
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "file_versions"} %>
 
-  <% if AppConfig[:multilingual_content] %>
-    <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "lang_descriptions"} %>
-  <% end %>
-
+  <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "lang_descriptions"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "lang_materials", :custom_action_template => "lang_materials/subrecord_form_action"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "dates", :template => "archival_record_date"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "extents"} %>

--- a/frontend/app/views/digital_objects/_show_inline.html.erb
+++ b/frontend/app/views/digital_objects/_show_inline.html.erb
@@ -42,7 +42,7 @@
           <%= render_aspace_partial :partial => "file_versions/show", :locals => { :file_versions => digital_object.file_versions, :section_id => "digital_object_file_versions_", :title => digital_object.title } %>
         <% end %>
 
-        <% if AppConfig[:multilingual_content] && digital_object.lang_descriptions.length > 0 %>
+        <% if digital_object.lang_descriptions.length > 0 %>
           <%= render_aspace_partial :partial => "lang_descriptions/show", :locals => { :lang_descriptions => digital_object.lang_descriptions, :section_id => "digital_object_lang_descriptions_" } %>
         <% end %>
 

--- a/frontend/app/views/digital_objects/_sidebar.html.erb
+++ b/frontend/app/views/digital_objects/_sidebar.html.erb
@@ -5,10 +5,7 @@
            }) do |sidebar| %>
   <%= sidebar.render_for_view_and_edit(:subrecord_type => 'file_version', :property => 'file_versions') %>
 
-  <% if AppConfig[:multilingual_content] %>
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'lang_description', :property => 'lang_descriptions') %>
-  <% end %>
-
+  <%= sidebar.render_for_view_and_edit(:subrecord_type => 'lang_description', :property => 'lang_descriptions') %>
   <%= sidebar.render_for_view_and_edit(:subrecord_type => 'lang_material', :property => 'lang_materials') %>
   <%= sidebar.render_for_view_and_edit(:subrecord_type => 'date', :property => 'dates') %>
   <%= sidebar.render_for_view_and_edit(:subrecord_type => 'extent', :property => 'extents') %>

--- a/frontend/app/views/resources/_form_container.html.erb
+++ b/frontend/app/views/resources/_form_container.html.erb
@@ -54,10 +54,7 @@
     </fieldset>
   </section>
 
-  <% if AppConfig[:multilingual_content] %>
-    <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "lang_descriptions"} %>
-  <% end %>
-
+  <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "lang_descriptions"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "lang_materials", :custom_action_template => "lang_materials/subrecord_form_action"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "dates", :template => "archival_record_date"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "extents"} %>

--- a/frontend/app/views/resources/_show_inline.html.erb
+++ b/frontend/app/views/resources/_show_inline.html.erb
@@ -43,7 +43,7 @@
             </div>
           </section>
 
-          <% if AppConfig[:multilingual_content] && @resource.lang_descriptions.length > 0 %>
+          <% if @resource.lang_descriptions.length > 0 %>
             <%= render_aspace_partial :partial => "lang_descriptions/show", :locals => { :lang_descriptions => @resource.lang_descriptions, :section_id => "resource_lang_descriptions_" } %>
           <% end %>
 

--- a/frontend/app/views/resources/_sidebar.html.erb
+++ b/frontend/app/views/resources/_sidebar.html.erb
@@ -3,10 +3,8 @@
              :record_type => 'resource',
              :record => @resource
            }) do |sidebar| %>
-  <% if AppConfig[:multilingual_content] %>
-    <%= sidebar.render_for_view_and_edit(:subrecord_type => 'lang_description', :property => 'lang_descriptions') %>
-  <% end %>
 
+  <%= sidebar.render_for_view_and_edit(:subrecord_type => 'lang_description', :property => 'lang_descriptions') %>
   <%= sidebar.render_for_view_and_edit(:subrecord_type => 'lang_material', :property => 'lang_materials') %>
   <%= sidebar.render_for_view_and_edit(:subrecord_type => 'date', :property => 'dates') %>
   <%= sidebar.render_for_view_and_edit(:subrecord_type => 'extent', :property => 'extents') %>

--- a/frontend/spec/features/add_as_you_go_spec.rb
+++ b/frontend/spec/features/add_as_you_go_spec.rb
@@ -118,9 +118,9 @@ describe 'Add As You Go buttons', js: true do
       end
     end
 
-    it_behaves_like 'and when editing a top-level non-Notes subform', 'accession', 14, 16
-    it_behaves_like 'and when editing a top-level non-Notes subform', 'resource', 13, 15
-    it_behaves_like 'and when editing a top-level non-Notes subform', 'digital_object', 10, 11
+    it_behaves_like 'and when editing a top-level non-Notes subform', 'accession', 15, 17
+    it_behaves_like 'and when editing a top-level non-Notes subform', 'resource', 14, 16
+    it_behaves_like 'and when editing a top-level non-Notes subform', 'digital_object', 11, 12
     it_behaves_like 'and when editing a top-level non-Notes subform', 'subject', 3, 3
     it_behaves_like 'and when editing a top-level non-Notes subform', 'location', 1, 1
     it_behaves_like 'and when editing a top-level non-Notes subform', 'location_batch', 1, 1

--- a/frontend/spec/shared/multilingual_content_examples.rb
+++ b/frontend/spec/shared/multilingual_content_examples.rb
@@ -26,12 +26,16 @@ RSpec.shared_examples 'a multilingual parent record' do |record_type|
 end
 
 RSpec.shared_examples 'a non-multilingual parent record' do |record_type|
-  it 'does not show Langauges of Description subrecord on create' do
+  it 'does not expand Langauges of Description subrecord on create' do
     click_on 'Create'
     click_on "#{record_type.split('_').map(&:capitalize).join(' ')}"
 
-    within "#form_#{record_type}" do
-      expect(page).not_to have_text 'Languages of Description'
+    expect(page).to have_text 'Languages of Description'
+
+    within "##{record_type}_lang_descriptions_" do
+      expect(page).not_to have_field('Language', type: 'text')
+      expect(page).not_to have_field('Script', type: 'text')
+      expect(page).not_to have_css('li.is-representative')
     end
   end
 end

--- a/mctf_implementation_plan.md
+++ b/mctf_implementation_plan.md
@@ -118,7 +118,8 @@ in, and which one is primary, before entering language-specific field content. S
       - script dropdown (ISO 15924),
       - "Primary" checkbox
     - Only one entry may be marked primary (enforce client-side)
-- [x] Config flag `AppConfig[:multilingual_content]` gates all MLC UI; when disabled the subrecord panel is hidden and behaviour is identical to pre-MLC
+- [x] Config flag `AppConfig[:multilingual_content]` gates all MLC UI; ~~when disabled the subrecord panel is hidden and behaviour is identical to pre-MLC~~
+  - Amended in 5/28 check-in meeting: Subrecord panel should be present whether or not MLC is enabled
 
 ---
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->
https://archivesspace.atlassian.net/browse/ANW-2772

## Summary
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->
Simply removes the AppConfig check that was hiding the languages of description subrecord when MLC was disabled.  Now, the primary difference in record behavior is:

- When MLC enabled:
  - Newly created accession, digital object, and resource records will have the "Languages of Description" subrecord expanded by default
- When MLC disabled:
  - All new record creations will have "Languages of Description" collapsed

Otherwise, there is no difference between MLC and non-MLC instances when it comes to this new subrecord.

## Screenshots (if appropriate):
"Languages of Description" is available as a (collapsed) subrecord on accessions, digital objects, and resources, even if MLC is disabled:
<img width="1389" height="325" alt="Screenshot 2026-06-25 at 4 42 10 PM" src="https://github.com/user-attachments/assets/803279a2-d1c9-4709-8440-86f9f9120b62" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [x] Have you added tests to cover these changes? If not why:


[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ