### PR TITLE
ANW-2831 Add job_types stub to ResourcesController spec

### DIFF
--- a/backend/spec/model_print_to_pdf_job_spec.rb
+++ b/backend/spec/model_print_to_pdf_job_spec.rb
@@ -38,6 +38,10 @@ describe "Print to PDF job model" do
 
   let(:user) { create_nobody_user }
 
+  it "is registered as an available job type" do
+    expect(JobRunner.registered_job_types).to have_key('print_to_pdf_job')
+  end
+
   it "can create a print to pdf job" do
     opts = {:title => generate(:generic_title)}
     resource = create_resource(opts)

--- a/frontend/app/views/resources/_toolbar.html.erb
+++ b/frontend/app/views/resources/_toolbar.html.erb
@@ -65,7 +65,7 @@
       <li><%= link_to t("actions.container_template"), {:controller => :exports, :action => :container_template, :id => @resource.id}, :id => 'container-template-link', :target => "_self", :class => "dropdown-item" %></li>
       <li><%= link_to t("actions.digital_object_template"), {:controller => :exports, :action => :digital_object_template, :id => @resource.id}, :id => 'digital-object-template-link', :target => "_self", :class => "dropdown-item" %></li>
       <% if user_can?('create_job') %>
-        <% if job_types['print_to_pdf_job']['create_permissions'].reject{|perm| user_can?(perm)}.empty? %>
+        <% if job_types.dig('print_to_pdf_job', 'create_permissions')&.reject{|perm| user_can?(perm)}&.empty? %>
 
           <li class="dropdown-item p-0 dropdown-submenu" id="print-to-pdf-dropdown" data-print-to-pdf-url="<%= url_for(:controller => :exports, :action => :print_to_pdf, :id => @resource.id, :include_unpublished => "${include_unpublished}", :include_uris => "${include_uris}")%>">
             <a href="#" data-toggle="dropdown" data-display="static" class="py-1 px-4 d-block text-decoration-none menu-with-options print-to-pdf-action" title="<%= t("actions.print_to_pdf") %>"><%= t("actions.print_to_pdf") %></a>

--- a/frontend/spec/controllers/resources_controller_spec.rb
+++ b/frontend/spec/controllers/resources_controller_spec.rb
@@ -7,6 +7,8 @@ describe ResourcesController, type: :controller do
   render_views
 
   before(:each) do
+    allow(MemoryLeak::Resources).to receive(:get).and_call_original
+    allow(MemoryLeak::Resources).to receive(:get).with(:job_types).and_return({'print_to_pdf_job' => {'create_permissions' => []}})
     set_repo($repo)
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-2831]

## Summary
ResourcesController spec was failing intermittently in CI with `undefined method '[]' for nil:NilClass` at `resources/_toolbar.html.erb:68`, which accesses: 

`job_types['print_to_pdf_job']['create_permissions']`

`job_types` is backed by MemoryLeak::Resources, a TTL-based in-memory cache that makes a live HTTP call to the backend every 60 seconds to refresh. Best guess right now is that when the cache happens to expire at the wrong moment during a test render in CI, the refresh may return a hash that's missing `print_to_pdf_job`, causing the `nil` crash. I spent some time trying to pin down exactly what's happening but couldn't force the failure to reproduce consistently enough to catch it in the act.

The fix stubs `:job_types` in the spec's `before(:each)` so the test doesn't depend on cache state or backend timing at all. This is a usable workaround regardless of the exact root cause.

See failure at:
https://github.com/archivesspace/archivesspace/actions/runs/28180571110/job/83469475574

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:  
  - It is a spec change.


[ANW-2831]: https://archivesspace.atlassian.net/browse/ANW-2831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ