### PR TITLE
use nginx stable rather than 121

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -51,7 +51,7 @@ services:
       - as_test_solr-data:/var/solr
 
   proxy:
-    image: nginx:1.21
+    image: nginx:stable
     container_name: as_proxy
     ports:
       - "80:80"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -82,7 +82,7 @@ services:
       - solr-data:/var/solr
 
   proxy:
-    image: nginx:1.21
+    image: nginx:stable
     platform: linux/x86_64
     container_name: proxy
     restart: unless-stopped

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,6 +1,6 @@
-# docker build [--build-arg DEFAULT_CFG=default.conf] -t archivesspace/proxy:1.21 .
-# docker tag archivesspace/proxy:1.21 archivesspace/proxy:latest
-FROM nginx:1.21
+# docker build [--build-arg DEFAULT_CFG=default.conf] -t archivesspace/proxy:stable .
+# docker tag archivesspace/proxy:stable archivesspace/proxy:latest
+FROM nginx:stable
 LABEL maintainer="ArchivesSpaceHome@lyrasis.org"
 
 ARG DEFAULT_CFG=default.conf


### PR DESCRIPTION
nginx v1.21 is a few years old now, seems like it would be best to just use nginx:stable rather than any particular version. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [ ] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:
