### PR TITLE
ANW-2771 Current language selector

### DIFF
--- a/backend/app/controllers/digital_object.rb
+++ b/backend/app/controllers/digital_object.rb
@@ -168,7 +168,7 @@ class ArchivesSpaceService < Sinatra::Base
     digital_object = DigitalObject.get_or_die(params[:id])
 
     large_tree = LargeTree.new(digital_object, {:published_only => params[:published_only]}.merge(largetree_opts))
-    large_tree.add_decorator(LargeTreeDigitalObject.new)
+    large_tree.add_decorator(LargeTreeDigitalObject.new(digital_object))
 
     large_tree
   end

--- a/backend/app/lib/request_context.rb
+++ b/backend/app/lib/request_context.rb
@@ -46,21 +46,41 @@ class RequestContext
   end
 
 
+  # Returns the language/script pair set on the current request context, or
+  # +nil+ if none was set.  Does not fall back to AppConfig defaults.
+  #
+  # @return [Hash{Symbol=>Integer}, nil] +{ language_id:, script_id: }+, or +nil+
+  def self.requested_description_language
+    get(:language_of_description)
+  end
+
+
   # Resolves the active language/script pair for MLC field lookups.
   #
   # Returns the language set on the current request context if present,
   # otherwise falls back to the enumeration IDs for
-  # +AppConfig[:mlc_default_language]+ / +AppConfig[:mlc_default_script]+.
+  # +AppConfig[:mlc_default_language]+ / +AppConfig[:mlc_default_script]+,
+  # caching the AppConfig result under a separate key so the request-language
+  # key remains unambiguous.
   #
-  # @return Hash{Symbol=>Integer} +{ language_id:, script_id: }+
+  # @return [Hash{Symbol=>Integer}, nil] +{ language_id:, script_id: }+, or +nil+
   def self.description_language
-    lang = get(:language_of_description)
-    return lang if lang
+    get(:language_of_description) || default_description_language
+  end
 
-    resolved = resolve_language_pair(AppConfig[:mlc_default_language],
-                                     AppConfig[:mlc_default_script])
-    put(:language_of_description, resolved) if resolved && active?
-    resolved
+
+  # Resolves the AppConfig default language/script pair, regardless of any
+  # language set on the current request context.  Always the last-resort
+  # fallback in the MLC lookup chain.
+  #
+  # @return [Hash{Symbol=>Integer}, nil] +{ language_id:, script_id: }+, or +nil+
+  def self.default_description_language
+    get(:language_of_description_default) || begin
+      resolved = resolve_language_pair(AppConfig[:mlc_default_language],
+                                       AppConfig[:mlc_default_script])
+      put(:language_of_description_default, resolved) if resolved && active?
+      resolved
+    end
   end
 
 

--- a/backend/app/model/large_tree.rb
+++ b/backend/app/model/large_tree.rb
@@ -344,17 +344,28 @@ class LargeTree
   def mlc_display_strings(db, ids)
     return {} if ids.empty?
 
-    lang = RequestContext.description_language
-    return {} unless lang
-
     node_model = @root_record.class.node_model
     mlc_table = node_model.mlc_table
     mlc_fk    = :"#{@node_type}_id"
+    results   = {}
 
-    db[mlc_table]
-      .filter(mlc_fk => ids, :language_id => lang[:language_id], :script_id => lang[:script_id])
-      .select(mlc_fk, :display_string)
-      .each_with_object({}) { |row, h| h[row[mlc_fk]] = row[:display_string] }
+    [RequestContext.requested_description_language, root_primary_language, RequestContext.default_description_language].compact.uniq.each do |lang|
+      ids_without_lang = ids.reject { |id| results[id] }
+      break if ids_without_lang.empty?
+
+      db[mlc_table]
+        .filter(mlc_fk => ids_without_lang, :language_id => lang[:language_id], :script_id => lang[:script_id])
+        .select(mlc_fk, :display_string)
+        .each { |row| results[row[mlc_fk]] = row[:display_string] }
+    end
+
+    results
+  end
+
+  def root_primary_language
+    return @root_primary_language if defined?(@root_primary_language)
+    entry = @root_record.language_and_script_of_description.find { |ld| ld.is_primary == 1 }
+    @root_primary_language = entry ? { language_id: entry[:language_id], script_id: entry[:script_id] } : nil
   end
 
   def digital_instances(db, table, ids)

--- a/backend/app/model/large_tree_digital_object.rb
+++ b/backend/app/model/large_tree_digital_object.rb
@@ -1,5 +1,10 @@
 class LargeTreeDigitalObject
 
+  def initialize(root_record)
+    entry = root_record.language_and_script_of_description.find { |ld| ld.is_primary == 1 }
+    @primary_language = entry ? { language_id: entry[:language_id], script_id: entry[:script_id] } : nil
+  end
+
   def root(response, root_record)
     response['digital_object_type'] = root_record.digital_object_type
     response['file_uri_summary'] = root_record.file_version.map {|file_version|
@@ -16,11 +21,13 @@ class LargeTreeDigitalObject
   def waypoint(response, record_ids)
     file_uri_by_digital_object_component = {}
 
-    lang = RequestContext.description_language
+    ids_without_label = record_ids.dup
 
-    if lang
+    [RequestContext.requested_description_language, @primary_language, RequestContext.default_description_language].compact.uniq.each do |lang|
+      break if ids_without_label.empty?
+
       DigitalObjectComponent.db[:digital_object_component_mlc]
-        .filter(:digital_object_component_id => record_ids,
+        .filter(:digital_object_component_id => ids_without_label,
                 :language_id => lang[:language_id],
                 :script_id   => lang[:script_id])
         .where(Sequel.~(:label => nil))
@@ -29,6 +36,7 @@ class LargeTreeDigitalObject
           id = row[:digital_object_component_id]
           result_for_record = response.fetch(record_ids.index(id))
           result_for_record['label'] = row[:label]
+          ids_without_label.delete(id)
         end
     end
 

--- a/backend/app/model/mixins/multilingual_content.rb
+++ b/backend/app/model/mixins/multilingual_content.rb
@@ -40,11 +40,14 @@ module MultilingualContent
   end
 
   # Returns the value of +field_name+ for the current language context,
-  # falling back to the primary language, then to the configured
-  # +AppConfig[:mlc_default_language]+ / +AppConfig[:mlc_default_script]+.
+  # walking the MLC lookup chain (requested language → primary → AppConfig default).
+  #
+  # An explicit non-primary language request skips the primary/default
+  # fallback, so untranslated fields read as blank rather than
+  # prepopulating from the primary language.
   #
   # @param field_name [Symbol, String] the multilingual field to read
-  # @return [String, nil] the field value, or +nil+ if no matching row exists
+  # @return [String, nil] the field value, or +nil+ if no content exists anywhere
   def get_field_value(field_name)
     # For new (unsaved) records, values are buffered in @_mlc_pending — read
     # from there so that validation sees the in-flight value before the first save.
@@ -52,14 +55,13 @@ module MultilingualContent
       return @_mlc_pending[field_name.to_sym]
     end
 
-    lang = RequestContext.description_language
-    return nil unless lang
-    row = db_mlc_table.where(
-      :"#{self.class.table_name}_id" => id,
-      :language_id => lang[:language_id],
-      :script_id   => lang[:script_id]
-    ).first
-    row ? row[field_name.to_sym] : nil
+    mlc_lookup_chain.each do |lang|
+      row = mlc_row_for(lang[:language_id], lang[:script_id])
+      value = row ? row[field_name.to_sym] : nil
+      return value unless value.nil?
+    end
+
+    nil
   end
 
   # Upserts +value+ into the +_mlc+ table for +field_name+ under the current
@@ -78,7 +80,7 @@ module MultilingualContent
       return
     end
 
-    lang = RequestContext.description_language
+    lang = mlc_write_language
     return unless lang
     fk = :"#{self.class.table_name}_id"
     existing = db_mlc_table.where(
@@ -96,6 +98,8 @@ module MultilingualContent
         field_name.to_sym  => value
       )
     end
+
+    @_mlc_row_cache&.delete([lang[:language_id], lang[:script_id]])
   end
 
   # Flushes any field values buffered before the record was first saved.
@@ -103,6 +107,7 @@ module MultilingualContent
     return unless @_mlc_pending
     @_mlc_pending.each { |field_name, value| set_field_value(field_name, value) }
     @_mlc_pending = nil
+    remove_instance_variable(:@_primary_lang) if defined?(@_primary_lang)
   end
 
   # Overrides Sequel's raw column reader so that +record[:title]+ is equivalent
@@ -139,8 +144,47 @@ module MultilingualContent
 
   private
 
+  # Ordered language/script pairs to try when reading a multilingual field.
+  # An explicit non-primary request tries only that language, skipping the
+  # primary/default fallback.
+  def mlc_lookup_chain
+    requested = RequestContext.requested_description_language
+    primary   = primary_description_language
+
+    if requested && requested != primary
+      [requested]
+    else
+      [
+        requested,                                     # 1. explicit request header / URL param
+        primary,                                       # 2. record's own primary language
+        RequestContext.default_description_language    # 3. AppConfig default (last resort)
+      ].compact.uniq
+    end
+  end
+
+  def mlc_write_language
+    RequestContext.requested_description_language ||
+      primary_description_language ||
+      RequestContext.default_description_language
+  end
+
   def db_mlc_table
     self.class.db[self.class.mlc_table]
+  end
+
+  # Fetches and caches the MLC row for a given language/script pair.
+  # Multiple calls for the same pair within a request hit the DB only once.
+  def mlc_row_for(language_id, script_id)
+    @_mlc_row_cache ||= {}
+    cache_key = [language_id, script_id]
+    unless @_mlc_row_cache.key?(cache_key)
+      @_mlc_row_cache[cache_key] = db_mlc_table.where(
+        :"#{self.class.table_name}_id" => id,
+        :language_id => language_id,
+        :script_id   => script_id
+      ).first
+    end
+    @_mlc_row_cache[cache_key]
   end
 
   # Returns the language/script pair for the record's primary

--- a/backend/app/model/mixins/multilingual_content.rb
+++ b/backend/app/model/mixins/multilingual_content.rb
@@ -69,7 +69,8 @@ module MultilingualContent
   # configured +AppConfig[:mlc_default_language]+ / +AppConfig[:mlc_default_script]+.
   #
   # If the record has not yet been persisted (id is nil), the value is buffered
-  # and flushed to the database in +after_save+.
+  # and flushed to the database in +apply_nested_records+, once the record's own
+  # +lang_descriptions+ exist.
   #
   # @param field_name [Symbol, String] the multilingual field to write
   # @param value [String, nil] the value to store
@@ -102,12 +103,28 @@ module MultilingualContent
     @_mlc_row_cache&.delete([lang[:language_id], lang[:script_id]])
   end
 
-  # Flushes any field values buffered before the record was first saved.
+  # Applies nested records, then flushes any field values that were buffered
+  # before the record's first save.
+  #
+  # The flush has to happen here rather than in +after_save+.  Nested records --
+  # including the record's own +lang_descriptions+ -- are applied by
+  # +create_from_json+ *after* the row itself is inserted, so at +after_save+
+  # time no +language_and_script_of_description+ row exists yet.
+  # +mlc_write_language+ would find no primary language and fall through to
+  # +AppConfig[:mlc_default_language]+, storing the record's first-save content
+  # under the wrong language.
+  def apply_nested_records(json, new_record = false)
+    super
+    # The primary language may have just been created by the nested records above.
+    reset_mlc_memos
+    flush_mlc_pending
+  end
+
+  # Drops memoised language state after a save so that later reads in the same
+  # request reflect any change the save made.  Values buffered before the first
+  # save are flushed in +apply_nested_records+, not here -- see the comment there.
   def after_save
-    return unless @_mlc_pending
-    @_mlc_pending.each { |field_name, value| set_field_value(field_name, value) }
-    @_mlc_pending = nil
-    remove_instance_variable(:@_primary_lang) if defined?(@_primary_lang)
+    reset_mlc_memos
   end
 
   # Overrides Sequel's raw column reader so that +record[:title]+ is equivalent
@@ -166,6 +183,25 @@ module MultilingualContent
     RequestContext.requested_description_language ||
       primary_description_language ||
       RequestContext.default_description_language
+  end
+
+  # Writes out values buffered while the record had no id yet.
+  def flush_mlc_pending
+    return unless @_mlc_pending
+    pending = @_mlc_pending
+    # Cleared before writing so that the writes below read through to the
+    # database rather than seeing the buffer they are draining.
+    @_mlc_pending = nil
+    pending.each { |field_name, value| set_field_value(field_name, value) }
+  end
+
+  # Drops every memoised lookup that a save or a nested-record update can
+  # invalidate: the primary language pair, the per-language row cache, and
+  # Sequel's own cache of the language_and_script_of_description association.
+  def reset_mlc_memos
+    remove_instance_variable(:@_primary_lang) if defined?(@_primary_lang)
+    @_mlc_row_cache = nil
+    associations.delete(:language_and_script_of_description)
   end
 
   def db_mlc_table

--- a/backend/app/model/mixins/multilingual_content.rb
+++ b/backend/app/model/mixins/multilingual_content.rb
@@ -105,14 +105,6 @@ module MultilingualContent
 
   # Applies nested records, then flushes any field values that were buffered
   # before the record's first save.
-  #
-  # The flush has to happen here rather than in +after_save+.  Nested records --
-  # including the record's own +lang_descriptions+ -- are applied by
-  # +create_from_json+ *after* the row itself is inserted, so at +after_save+
-  # time no +language_and_script_of_description+ row exists yet.
-  # +mlc_write_language+ would find no primary language and fall through to
-  # +AppConfig[:mlc_default_language]+, storing the record's first-save content
-  # under the wrong language.
   def apply_nested_records(json, new_record = false)
     super
     # The primary language may have just been created by the nested records above.
@@ -121,8 +113,7 @@ module MultilingualContent
   end
 
   # Drops memoised language state after a save so that later reads in the same
-  # request reflect any change the save made.  Values buffered before the first
-  # save are flushed in +apply_nested_records+, not here -- see the comment there.
+  # request reflect any change the save made.
   def after_save
     reset_mlc_memos
   end
@@ -196,8 +187,7 @@ module MultilingualContent
   end
 
   # Drops every memoised lookup that a save or a nested-record update can
-  # invalidate: the primary language pair, the per-language row cache, and
-  # Sequel's own cache of the language_and_script_of_description association.
+  # invalidate.
   def reset_mlc_memos
     remove_instance_variable(:@_primary_lang) if defined?(@_primary_lang)
     @_mlc_row_cache = nil

--- a/backend/app/model/mixins/trees.rb
+++ b/backend/app/model/mixins/trees.rb
@@ -375,16 +375,22 @@ module Trees
         .each_with_object({}) { |row, h| h[row[:id]] = row[:display_string] }
     end
 
-    lang = RequestContext.description_language
-    return {} unless lang
+    mlc_fk  = :"#{self.class.node_type}_id"
+    results = {}
 
-    mlc_fk = :"#{self.class.node_type}_id"
-    node_model.db[node_model.mlc_table]
-      .filter(mlc_fk => node_ids,
-              :language_id => lang[:language_id],
-              :script_id   => lang[:script_id])
-      .select(mlc_fk, :display_string)
-      .each_with_object({}) { |row, h| h[row[mlc_fk]] = row[:display_string] }
+    [RequestContext.requested_description_language, primary_description_language, RequestContext.default_description_language].compact.uniq.each do |lang|
+      ids_without_lang = node_ids.reject { |id| results[id] }
+      break if ids_without_lang.empty?
+
+      node_model.db[node_model.mlc_table]
+        .filter(mlc_fk => ids_without_lang,
+                :language_id => lang[:language_id],
+                :script_id   => lang[:script_id])
+        .select(mlc_fk, :display_string)
+        .each { |row| results[row[mlc_fk]] = row[:display_string] }
+    end
+
+    results
   end
 
   def bulk_archival_object_updater_containers_ds

--- a/backend/spec/mixin_multilingual_content_spec.rb
+++ b/backend/spec/mixin_multilingual_content_spec.rb
@@ -17,6 +17,16 @@ describe 'MultilingualContent mixin' do
     EnumerationValue.filter(:enumeration_id => enum_id, :value => 'Latn').get(:id)
   end
 
+  def default_lang_id
+    enum_id = Enumeration.filter(:name => 'language_iso639_2').get(:id)
+    EnumerationValue.filter(:enumeration_id => enum_id, :value => AppConfig[:mlc_default_language]).get(:id)
+  end
+
+  def default_script_id
+    enum_id = Enumeration.filter(:name => 'script_iso15924').get(:id)
+    EnumerationValue.filter(:enumeration_id => enum_id, :value => AppConfig[:mlc_default_script]).get(:id)
+  end
+
   def resource_mlc
     Resource.db[:resource_mlc]
   end
@@ -48,12 +58,12 @@ describe 'MultilingualContent mixin' do
   end
 
   describe '.set_multilingual_fields' do
-    it "records declared field names on the class" do
+    it 'records declared field names on the class' do
       expect(Resource.get_multilingual_fields).to include(:title)
       expect(Resource.get_multilingual_fields).to include(:finding_aid_title)
     end
 
-    it "defines getter and setter instance methods for each field" do
+    it 'defines getter and setter instance methods for each field' do
       expect(Resource.instance_methods).to include(:title)
       expect(Resource.instance_methods).to include(:title=)
       expect(Resource.instance_methods).to include(:finding_aid_note)
@@ -62,7 +72,7 @@ describe 'MultilingualContent mixin' do
   end
 
   describe '.mlc_table' do
-    it "returns the correct _mlc table name for each model" do
+    it 'returns the correct _mlc table name for each model' do
       expect(Resource.mlc_table).to eq(:resource_mlc)
       expect(Accession.mlc_table).to eq(:accession_mlc)
       expect(ArchivalObject.mlc_table).to eq(:archival_object_mlc)
@@ -72,17 +82,8 @@ describe 'MultilingualContent mixin' do
   end
 
   describe '#get_field_value' do
-    context "when no mlc row exists for the record" do
-      it "returns nil" do
-        resource = create_resource_with_primary_lang
-        # after_save writes the factory title to resource_mlc; clear it to test the empty-row case
-        resource_mlc.where(:resource_id => resource.id).delete
-        expect(resource.get_field_value(:title)).to be_nil
-      end
-    end
-
-    context "when no language context is set" do
-      it "returns the value from the primary language" do
+    context 'when no language context is set' do
+      it 'returns the primary language value when it matches the AppConfig default' do
         resource = create_resource_with_primary_lang
         resource_mlc.where(:resource_id => resource.id).delete
         resource_mlc.insert(
@@ -96,10 +97,48 @@ describe 'MultilingualContent mixin' do
           expect(resource.get_field_value(:title)).to eq("Primary language title")
         end
       end
+
+      it 'returns the primary language value rather than the AppConfig default language value, when they differ' do
+        resource = create_resource(
+          :lang_descriptions => [{"language" => "fre", "script" => "Latn", "is_primary" => true}]
+        )
+        resource_mlc.where(:resource_id => resource.id).delete
+        resource_mlc.insert(
+          :resource_id => resource.id,
+          :language_id => fre_id,
+          :script_id   => latn_id,
+          :title       => "Titre principal"
+        )
+        resource_mlc.insert(
+          :resource_id => resource.id,
+          :language_id => eng_id,
+          :script_id   => latn_id,
+          :title       => "AppConfig default language title"
+        )
+
+        without_language_context do
+          expect(resource.get_field_value(:title)).to eq("Titre principal")
+        end
+      end
+
+      it 'returns the AppConfig default language value as a last resort when the record has no primary language' do
+        resource = create_resource(:lang_descriptions => [])
+        resource_mlc.where(:resource_id => resource.id).delete
+        resource_mlc.insert(
+          :resource_id => resource.id,
+          :language_id => default_lang_id,
+          :script_id   => default_script_id,
+          :title       => "Default language title"
+        )
+
+        without_language_context do
+          expect(resource.get_field_value(:title)).to eq("Default language title")
+        end
+      end
     end
 
-    context "when a language context is set" do
-      it "returns the value for that language" do
+    context 'when a language context is set' do
+      it 'returns the value for that language' do
         resource = create_resource_with_primary_lang
         resource_mlc.where(:resource_id => resource.id).delete
         resource_mlc.insert(
@@ -120,7 +159,7 @@ describe 'MultilingualContent mixin' do
         end
       end
 
-      it "falls back to the primary language when no row exists for that language" do
+      it 'returns nil so the field renders blank when no row exists for the requested non-primary language, even though a primary language row exists' do
         resource = create_resource_with_primary_lang
         resource_mlc.where(:resource_id => resource.id).delete
         resource_mlc.insert(
@@ -130,16 +169,88 @@ describe 'MultilingualContent mixin' do
           :title       => "English title"
         )
 
+        with_language_context(language_id: fre_id, script_id: latn_id) do
+          expect(resource.get_field_value(:title)).to be_nil
+        end
+      end
+
+      it 'returns nil so the field renders blank when the requested non-primary language row has a nil value' do
+        resource = create_resource_with_primary_lang
+        resource_mlc.where(:resource_id => resource.id).delete
+        resource_mlc.insert(
+          :resource_id => resource.id,
+          :language_id => eng_id,
+          :script_id   => latn_id,
+          :title       => "English title"
+        )
+        # French row exists but title has not been filled in yet
+        resource_mlc.insert(
+          :resource_id => resource.id,
+          :language_id => fre_id,
+          :script_id   => latn_id,
+          :title       => nil
+        )
+
+        with_language_context(language_id: fre_id, script_id: latn_id) do
+          expect(resource.get_field_value(:title)).to be_nil
+        end
+      end
+
+      it 'falls back to the AppConfig default language value when the requested language is explicitly the primary language and its row has no value' do
+        resource = create_resource(
+          :lang_descriptions => [{"language" => "fre", "script" => "Latn", "is_primary" => true}]
+        )
+        resource_mlc.where(:resource_id => resource.id).delete
+        resource_mlc.insert(
+          :resource_id => resource.id,
+          :language_id => fre_id,
+          :script_id   => latn_id,
+          :title       => nil
+        )
+        resource_mlc.insert(
+          :resource_id => resource.id,
+          :language_id => default_lang_id,
+          :script_id   => default_script_id,
+          :title       => "Default language title"
+        )
+
+        with_language_context(language_id: fre_id, script_id: latn_id) do
+          expect(resource.get_field_value(:title)).to eq("Default language title")
+        end
+      end
+    end
+  end
+
+  describe 'RequestContext.requested_description_language' do
+    context 'when no language has been explicitly set on the request context' do
+      it 'returns nil' do
         without_language_context do
-          expect(resource.get_field_value(:title)).to eq("English title")
+          expect(RequestContext.requested_description_language).to be_nil
+        end
+      end
+
+      it 'still returns nil after description_language has been called' do
+        without_language_context do
+          RequestContext.description_language
+          expect(RequestContext.requested_description_language).to be_nil
+        end
+      end
+    end
+
+    context 'when a language has been explicitly set' do
+      it 'returns that language' do
+        with_language_context(language_id: fre_id, script_id: latn_id) do
+          result = RequestContext.requested_description_language
+          expect(result[:language_id]).to eq(fre_id)
+          expect(result[:script_id]).to eq(latn_id)
         end
       end
     end
   end
 
   describe '#set_field_value' do
-    context "when no mlc row exists" do
-      it "inserts a new row" do
+    context 'when no mlc row exists' do
+      it 'inserts a new row' do
         resource = create_resource_with_primary_lang
         resource_mlc.where(:resource_id => resource.id).delete
 
@@ -151,8 +262,8 @@ describe 'MultilingualContent mixin' do
       end
     end
 
-    context "when an mlc row already exists" do
-      it "updates the existing row rather than inserting a duplicate" do
+    context 'when an mlc row already exists' do
+      it 'updates the existing row rather than inserting a duplicate' do
         resource = create_resource_with_primary_lang
         resource_mlc.where(:resource_id => resource.id).delete
         resource_mlc.insert(
@@ -170,7 +281,7 @@ describe 'MultilingualContent mixin' do
       end
     end
 
-    context "when a language context is set" do
+    context 'when a language context is set' do
       it "writes to that language's row without affecting other languages" do
         resource = create_resource_with_primary_lang
         resource_mlc.where(:resource_id => resource.id).delete
@@ -190,20 +301,13 @@ describe 'MultilingualContent mixin' do
       end
     end
 
-    context "when no language context or primary language is set" do
-      it "falls back to the AppConfig default language" do
+    context 'when no language context or primary language is set' do
+      it 'falls back to the AppConfig default language' do
         resource = create_resource(:lang_descriptions => [])
 
         without_language_context do
           resource.set_field_value(:title, "Default language title")
         end
-
-        default_lang_enum_id   = Enumeration.filter(:name => 'language_iso639_2').get(:id)
-        default_script_enum_id = Enumeration.filter(:name => 'script_iso15924').get(:id)
-        default_lang_id   = EnumerationValue.filter(:enumeration_id => default_lang_enum_id,
-                                                    :value => AppConfig[:mlc_default_language]).get(:id)
-        default_script_id = EnumerationValue.filter(:enumeration_id => default_script_enum_id,
-                                                    :value => AppConfig[:mlc_default_script]).get(:id)
 
         row = resource_mlc.where(
           :resource_id => resource.id,
@@ -212,6 +316,33 @@ describe 'MultilingualContent mixin' do
         ).first
         expect(row).not_to be_nil
         expect(row[:title]).to eq("Default language title")
+      end
+    end
+
+    context 'when no language context is set on an existing record with a non-default primary language' do
+      it 'writes to the primary language row rather than the AppConfig default' do
+        resource = create_resource(
+          :lang_descriptions => [{
+            "language"   => "fre",
+            "script"     => "Latn",
+            "is_primary" => true
+          }]
+        )
+        resource_mlc.where(:resource_id => resource.id).delete
+        resource_mlc.insert(
+          :resource_id => resource.id,
+          :language_id => fre_id,
+          :script_id   => latn_id,
+          :title       => "Titre original"
+        )
+
+        without_language_context do
+          resource.set_field_value(:title, "Titre modifié")
+        end
+
+        expect(resource_mlc.where(:resource_id => resource.id, :language_id => fre_id).first[:title])
+          .to eq("Titre modifié")
+        expect(resource_mlc.where(:resource_id => resource.id, :language_id => eng_id).first).to be_nil
       end
     end
   end

--- a/backend/spec/mixin_multilingual_content_spec.rb
+++ b/backend/spec/mixin_multilingual_content_spec.rb
@@ -347,4 +347,81 @@ describe 'MultilingualContent mixin' do
     end
   end
 
+  # The record's lang_descriptions are applied as nested records after the row
+  # itself is inserted, so the buffered first-save values have to be flushed
+  # after that point to land under the record's own primary language.
+  #
+  # Run against every record type that can declare its own primary language
+  # (ArchivalObject and DigitalObjectComponent have no lang_descriptions).
+  describe 'the first save of a new record' do
+    shared_examples 'a record saved under its own primary language' do |factory_method, model|
+      def mlc_rows_for(model, record)
+        model.db[model.mlc_table].where(:"#{model.table_name}_id" => record.id)
+      end
+
+      let(:record_with_french_primary) do
+        without_language_context do
+          send(factory_method,
+               :title => "Titre principal",
+               :lang_descriptions => [{
+                 "language"   => "fre",
+                 "script"     => "Latn",
+                 "is_primary" => true
+               }])
+        end
+      end
+
+      context 'when the record declares a primary language other than the AppConfig default' do
+        it 'writes the initial field values to the primary language row' do
+          row = mlc_rows_for(model, record_with_french_primary)
+                  .where(:language_id => fre_id, :script_id => latn_id).first
+
+          expect(row).not_to be_nil
+          expect(row[:title]).to eq("Titre principal")
+        end
+
+        it 'does not write the initial field values to the AppConfig default language row' do
+          row = mlc_rows_for(model, record_with_french_primary)
+                  .where(:language_id => default_lang_id, :script_id => default_script_id).first
+
+          expect(row).to be_nil
+        end
+
+        it 'reads the value back from the primary language' do
+          record = record_with_french_primary
+
+          without_language_context do
+            expect(record.get_field_value(:title)).to eq("Titre principal")
+          end
+        end
+      end
+
+      context 'when the record declares no primary language' do
+        it 'still falls back to the AppConfig default language row' do
+          record = without_language_context do
+            send(factory_method, :title => "Untranslated title", :lang_descriptions => [])
+          end
+
+          row = mlc_rows_for(model, record)
+                  .where(:language_id => default_lang_id, :script_id => default_script_id).first
+
+          expect(row).not_to be_nil
+          expect(row[:title]).to eq("Untranslated title")
+        end
+      end
+    end
+
+    describe 'a resource' do
+      it_behaves_like 'a record saved under its own primary language', :create_resource, Resource
+    end
+
+    describe 'an accession' do
+      it_behaves_like 'a record saved under its own primary language', :create_accession, Accession
+    end
+
+    describe 'a digital object' do
+      it_behaves_like 'a record saved under its own primary language', :create_digital_object, DigitalObject
+    end
+  end
+
 end

--- a/backend/spec/mixin_multilingual_content_spec.rb
+++ b/backend/spec/mixin_multilingual_content_spec.rb
@@ -347,12 +347,6 @@ describe 'MultilingualContent mixin' do
     end
   end
 
-  # The record's lang_descriptions are applied as nested records after the row
-  # itself is inserted, so the buffered first-save values have to be flushed
-  # after that point to land under the record's own primary language.
-  #
-  # Run against every record type that can declare its own primary language
-  # (ArchivalObject and DigitalObjectComponent have no lang_descriptions).
   describe 'the first save of a new record' do
     shared_examples 'a record saved under its own primary language' do |factory_method, model|
       def mlc_rows_for(model, record)

--- a/backend/spec/model_language_and_script_of_description_spec.rb
+++ b/backend/spec/model_language_and_script_of_description_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'LanguageAndScriptOfDescription model' do
-  it "requires language to be present" do
+  it 'requires language to be present' do
     expect {
       LanguageAndScriptOfDescription.create_from_json(
         JSONModel(:language_and_script_of_description).from_hash(
@@ -11,7 +11,7 @@ describe 'LanguageAndScriptOfDescription model' do
     }.to raise_error(JSONModel::ValidationException)
   end
 
-  it "requires script to be present" do
+  it 'requires script to be present' do
     expect {
       LanguageAndScriptOfDescription.create_from_json(
         JSONModel(:language_and_script_of_description).from_hash(

--- a/backend/spec/model_tree_mlc_spec.rb
+++ b/backend/spec/model_tree_mlc_spec.rb
@@ -1,0 +1,322 @@
+require 'spec_helper'
+
+describe 'MLC display string fallbacks in tree queries' do
+  def eng_id
+    enum_id = Enumeration.filter(:name => 'language_iso639_2').get(:id)
+    EnumerationValue.filter(:enumeration_id => enum_id, :value => 'eng').get(:id)
+  end
+
+  def fre_id
+    enum_id = Enumeration.filter(:name => 'language_iso639_2').get(:id)
+    EnumerationValue.filter(:enumeration_id => enum_id, :value => 'fre').get(:id)
+  end
+
+  def latn_id
+    enum_id = Enumeration.filter(:name => 'script_iso15924').get(:id)
+    EnumerationValue.filter(:enumeration_id => enum_id, :value => 'Latn').get(:id)
+  end
+
+  def default_lang_id
+    enum_id = Enumeration.filter(:name => 'language_iso639_2').get(:id)
+    EnumerationValue.filter(:enumeration_id => enum_id, :value => AppConfig[:mlc_default_language]).get(:id)
+  end
+
+  def default_script_id
+    enum_id = Enumeration.filter(:name => 'script_iso15924').get(:id)
+    EnumerationValue.filter(:enumeration_id => enum_id, :value => AppConfig[:mlc_default_script]).get(:id)
+  end
+
+  def with_language_context(language_id:, script_id:)
+    orig = RequestContext.get(:language_of_description)
+    RequestContext.put(:language_of_description, { language_id: language_id, script_id: script_id })
+    yield
+  ensure
+    RequestContext.put(:language_of_description, orig)
+  end
+
+  def without_language_context
+    orig = RequestContext.get(:language_of_description)
+    RequestContext.put(:language_of_description, nil)
+    yield
+  ensure
+    RequestContext.put(:language_of_description, orig)
+  end
+
+  let!(:resource) do
+    create_resource(
+      :lang_descriptions => [{
+        "language"   => "eng",
+        "script"     => "Latn",
+        "is_primary" => true
+      }]
+    )
+  end
+
+  let!(:ao_with_eng) do
+    ao = create_archival_object(:resource => {:ref => resource.uri}, :title => "AO with eng")
+    ArchivalObject.db[:archival_object_mlc].where(:archival_object_id => ao.id).delete
+    ArchivalObject.db[:archival_object_mlc].insert(
+      :archival_object_id => ao.id,
+      :language_id        => eng_id,
+      :script_id          => latn_id,
+      :display_string     => "English AO title"
+    )
+    ao
+  end
+
+  let!(:ao_with_fre) do
+    ao = create_archival_object(:resource => {:ref => resource.uri}, :title => "AO with fre")
+    ArchivalObject.db[:archival_object_mlc].where(:archival_object_id => ao.id).delete
+    ArchivalObject.db[:archival_object_mlc].insert(
+      :archival_object_id => ao.id,
+      :language_id        => fre_id,
+      :script_id          => latn_id,
+      :display_string     => "French AO title"
+    )
+    ao
+  end
+
+  let!(:ao_with_both) do
+    ao = create_archival_object(:resource => {:ref => resource.uri}, :title => "AO with both")
+    ArchivalObject.db[:archival_object_mlc].where(:archival_object_id => ao.id).delete
+    ArchivalObject.db[:archival_object_mlc].insert(
+      :archival_object_id => ao.id,
+      :language_id        => eng_id,
+      :script_id          => latn_id,
+      :display_string     => "Both: English title"
+    )
+    ArchivalObject.db[:archival_object_mlc].insert(
+      :archival_object_id => ao.id,
+      :language_id        => fre_id,
+      :script_id          => latn_id,
+      :display_string     => "Both: French title"
+    )
+    ao
+  end
+
+  let!(:ao_no_mlc) do
+    ao = create_archival_object(:resource => {:ref => resource.uri}, :title => "AO with no MLC")
+    ArchivalObject.db[:archival_object_mlc].where(:archival_object_id => ao.id).delete
+    ao
+  end
+
+  shared_examples 'a multilingual display string' do
+    context 'when the requested language row exists' do
+      it 'returns the title for the requested language' do
+        with_language_context(language_id: fre_id, script_id: latn_id) do
+          results = subject.call([ao_with_fre.id])
+          expect(results[ao_with_fre.id]).to eq("French AO title")
+        end
+      end
+
+      it "returns each node's title in the requested language when multiple rows match" do
+        with_language_context(language_id: fre_id, script_id: latn_id) do
+          results = subject.call([ao_with_fre.id, ao_with_both.id])
+          expect(results[ao_with_fre.id]).to eq("French AO title")
+          expect(results[ao_with_both.id]).to eq("Both: French title")
+        end
+      end
+    end
+
+    context 'when no row exists for the requested language' do
+      context "and a row exists for the parent record's primary language" do
+        it 'falls back to the primary language title' do
+          with_language_context(language_id: fre_id, script_id: latn_id) do
+            results = subject.call([ao_with_eng.id])
+            expect(results[ao_with_eng.id]).to eq("English AO title")
+          end
+        end
+      end
+
+      context 'and no primary language row exists but an AppConfig default row does' do
+        it 'falls back to the AppConfig default language title' do
+          ArchivalObject.db[:archival_object_mlc].insert(
+            :archival_object_id => ao_no_mlc.id,
+            :language_id        => default_lang_id,
+            :script_id          => default_script_id,
+            :display_string     => "AppConfig default AO title"
+          )
+
+          with_language_context(language_id: fre_id, script_id: latn_id) do
+            results = subject.call([ao_no_mlc.id])
+            expect(results[ao_no_mlc.id]).to eq("AppConfig default AO title")
+          end
+        end
+      end
+
+      context 'and no MLC rows exist at all' do
+        it 'returns nil for that node rather than raising' do
+          with_language_context(language_id: fre_id, script_id: latn_id) do
+            results = subject.call([ao_no_mlc.id])
+            expect(results[ao_no_mlc.id]).to be_nil
+          end
+        end
+      end
+    end
+
+    context 'when no language context is set' do
+      it 'returns the primary language title' do
+        without_language_context do
+          results = subject.call([ao_with_eng.id])
+          expect(results[ao_with_eng.id]).to eq("English AO title")
+        end
+      end
+    end
+
+    context 'with a mixed set of nodes' do
+      it 'returns the best available title for each node independently' do
+        with_language_context(language_id: fre_id, script_id: latn_id) do
+          results = subject.call([ao_with_fre.id, ao_with_eng.id, ao_no_mlc.id])
+
+          expect(results[ao_with_fre.id]).to eq("French AO title")
+          expect(results[ao_with_eng.id]).to eq("English AO title")
+          expect(results[ao_no_mlc.id]).to be_nil
+        end
+      end
+    end
+  end
+
+  describe 'Trees#node_display_strings called on the resource model directly' do
+    subject do
+      lambda { |node_ids| resource.send(:node_display_strings, node_ids) }
+    end
+
+    it_behaves_like 'a multilingual display string'
+  end
+
+  describe 'LargeTree#mlc_display_strings called via the large tree waypoint' do
+    subject do
+      lambda do |node_ids|
+        large_tree = LargeTree.new(resource, { :published_only => false })
+        large_tree.send(:mlc_display_strings, Resource.db, node_ids)
+      end
+    end
+
+    it_behaves_like 'a multilingual display string'
+  end
+
+  describe 'LargeTreeDigitalObject#waypoint label fallback for digital object components' do
+    let!(:digital_object) do
+      create_digital_object(
+        :lang_descriptions => [{
+          "language"   => "eng",
+          "script"     => "Latn",
+          "is_primary" => true
+        }]
+      )
+    end
+
+    let!(:doc_with_eng) do
+      doc = create_digital_object_component(
+        :digital_object => {:ref => digital_object.uri},
+        :title => "DOC with eng label"
+      )
+      DigitalObjectComponent.db[:digital_object_component_mlc].where(:digital_object_component_id => doc.id).delete
+      DigitalObjectComponent.db[:digital_object_component_mlc].insert(
+        :digital_object_component_id => doc.id,
+        :language_id                 => eng_id,
+        :script_id                   => latn_id,
+        :label                       => "English label"
+      )
+      doc
+    end
+
+    let!(:doc_with_fre) do
+      doc = create_digital_object_component(
+        :digital_object => {:ref => digital_object.uri},
+        :title => "DOC with fre label"
+      )
+      DigitalObjectComponent.db[:digital_object_component_mlc].where(:digital_object_component_id => doc.id).delete
+      DigitalObjectComponent.db[:digital_object_component_mlc].insert(
+        :digital_object_component_id => doc.id,
+        :language_id                 => fre_id,
+        :script_id                   => latn_id,
+        :label                       => "French label"
+      )
+      doc
+    end
+
+    let!(:doc_no_mlc) do
+      doc = create_digital_object_component(
+        :digital_object => {:ref => digital_object.uri},
+        :title => "DOC with no label"
+      )
+      DigitalObjectComponent.db[:digital_object_component_mlc].where(:digital_object_component_id => doc.id).delete
+      doc
+    end
+
+    def invoke_waypoint(doc_ids)
+      decorator = LargeTreeDigitalObject.new(digital_object)
+      response = doc_ids.map { |id| {} }
+      decorator.waypoint(response, doc_ids)
+      doc_ids.each_with_object({}).with_index do |(id, h), idx|
+        h[id] = response[idx]['label']
+      end
+    end
+
+    context 'when the requested language label row exists' do
+      it 'sets the label from the requested language' do
+        with_language_context(language_id: fre_id, script_id: latn_id) do
+          labels = invoke_waypoint([doc_with_fre.id])
+          expect(labels[doc_with_fre.id]).to eq("French label")
+        end
+      end
+    end
+
+    context 'when no row exists for the requested language' do
+      context 'and the root digital object has a primary language row' do
+        it 'falls back to the primary language label' do
+          with_language_context(language_id: fre_id, script_id: latn_id) do
+            labels = invoke_waypoint([doc_with_eng.id])
+            expect(labels[doc_with_eng.id]).to eq("English label")
+          end
+        end
+      end
+
+      context 'and no primary language row exists but an AppConfig default label row does' do
+        it 'falls back to the AppConfig default language label' do
+          DigitalObjectComponent.db[:digital_object_component_mlc].insert(
+            :digital_object_component_id => doc_no_mlc.id,
+            :language_id                 => default_lang_id,
+            :script_id                   => default_script_id,
+            :label                       => "AppConfig default label"
+          )
+
+          with_language_context(language_id: fre_id, script_id: latn_id) do
+            labels = invoke_waypoint([doc_no_mlc.id])
+            expect(labels[doc_no_mlc.id]).to eq("AppConfig default label")
+          end
+        end
+      end
+
+      context 'and no rows exist for any language in the fallback chain' do
+        it 'sets no label' do
+          with_language_context(language_id: fre_id, script_id: latn_id) do
+            labels = invoke_waypoint([doc_no_mlc.id])
+            expect(labels[doc_no_mlc.id]).to be_nil
+          end
+        end
+      end
+    end
+
+    context 'when no language context is set' do
+      it 'sets the label from the primary language row' do
+        without_language_context do
+          labels = invoke_waypoint([doc_with_eng.id])
+          expect(labels[doc_with_eng.id]).to eq("English label")
+        end
+      end
+    end
+
+    context 'with a mixed set of DOCs' do
+      it "resolves each DOC's label independently" do
+        with_language_context(language_id: fre_id, script_id: latn_id) do
+          labels = invoke_waypoint([doc_with_fre.id, doc_with_eng.id, doc_no_mlc.id])
+          expect(labels[doc_with_fre.id]).to eq("French label")
+          expect(labels[doc_with_eng.id]).to eq("English label")
+          expect(labels[doc_no_mlc.id]).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/common/jsonmodel_client.rb
+++ b/common/jsonmodel_client.rb
@@ -208,6 +208,16 @@ module JSONModel
     end
 
 
+    def self.current_description_language
+      Thread.current[:description_language]
+    end
+
+
+    def self.current_description_language=(val)
+      Thread.current[:description_language] = val
+    end
+
+
     def self.high_priority?
       if Thread.current[:request_priority]
         Thread.current[:request_priority] == :high
@@ -229,6 +239,10 @@ module JSONModel
 
       if high_priority?
         req['X-ArchivesSpace-Priority'] = "high"
+      end
+
+      if (lang = current_description_language)
+        req['X-ArchivesSpace-Description-Language'] = lang
       end
 
       response = http_conn.request(url, req, &block)

--- a/e2e-tests/staff_features/accessions/accession_mlc_content.feature
+++ b/e2e-tests/staff_features/accessions/accession_mlc_content.feature
@@ -4,12 +4,12 @@ Feature: MLC content display
     Given an administrator user is logged in
       And an Accession has been created
 
+  @mlc_enabled
   Scenario: Current Language selector from edit mode resource toolbar
-    Given the Accession is opened in edit mode
+    Given a second language of description has been added to the Accession
+      And the Accession is opened in edit mode
      When the user clicks on "Current Language"
      Then the user sees the "English" option in the "Current Language" dropdown
-      And the user sees the "Spanish" option in the "Current Language" dropdown
-      And the user sees the "French" option in the "Current Language" dropdown
       And the user sees the "German" option in the "Current Language" dropdown
 
   Scenario Outline: MLC default language preview appears on mlc content fields
@@ -31,12 +31,12 @@ Feature: MLC content display
           | accession   | access_restrictions_note |
           | accession   | use_restrictions_note    |
 
+  @mlc_enabled
   Scenario: Current Language selector from view mode resource toolbar
-    Given the Accession is opened in the view mode
+    Given a second language of description has been added to the Accession
+      And the Accession is opened in the view mode
      When the user clicks on "Current Language"
      Then the user sees the "English" option in the "Current Language" dropdown
-      And the user sees the "Spanish" option in the "Current Language" dropdown
-      And the user sees the "French" option in the "Current Language" dropdown
       And the user sees the "German" option in the "Current Language" dropdown
 
   Scenario Outline: MLC badge does not appear in read mode
@@ -61,6 +61,10 @@ Feature: MLC content display
     Given a second language of description has been added to the Accession
       And the Accession is opened in edit mode
      Then the user should see language badges on all subrecords
+
+  Scenario: Current Language selector does not appear when mlc disabled
+    Given the Accession is opened in edit mode
+     Then the user should not see the "Current Language" dropdown
 
   Scenario: Current language badge does not appear when mlc disabled
     Given the Accession is opened in edit mode

--- a/e2e-tests/staff_features/digital_objects/digital_object_mlc_content.feature
+++ b/e2e-tests/staff_features/digital_objects/digital_object_mlc_content.feature
@@ -4,12 +4,12 @@ Feature: MLC content display
     Given an administrator user is logged in
       And a Digital Object has been created
 
+  @mlc_enabled
   Scenario: Current Language selector from edit mode resource toolbar
-    Given the Digital Object is opened in edit mode
+    Given a second language of description has been added to the Digital Object
+      And the Digital Object is opened in edit mode
      When the user clicks on "Current Language"
      Then the user sees the "English" option in the "Current Language" dropdown
-      And the user sees the "Spanish" option in the "Current Language" dropdown
-      And the user sees the "French" option in the "Current Language" dropdown
       And the user sees the "German" option in the "Current Language" dropdown
 
   Scenario Outline: MLC default language preview appears on mlc content fields
@@ -23,12 +23,12 @@ Feature: MLC content display
           | record_type    | field |
           | digital_object | title |
 
+  @mlc_enabled
   Scenario: Current Language selector from view mode resource toolbar
-    Given the Digital Object is opened in the view mode
+    Given a second language of description has been added to the Digital Object
+      And the Digital Object is opened in the view mode
      When the user clicks on "Current Language"
      Then the user sees the "English" option in the "Current Language" dropdown
-      And the user sees the "Spanish" option in the "Current Language" dropdown
-      And the user sees the "French" option in the "Current Language" dropdown
       And the user sees the "German" option in the "Current Language" dropdown
 
   Scenario Outline: MLC badge does not appear in read mode
@@ -45,6 +45,10 @@ Feature: MLC content display
     Given a second language of description has been added to the Digital Object
       And the Digital Object is opened in edit mode
      Then the user should see language badges on all subrecords
+
+  Scenario: Current Language selector does not appear when mlc disabled
+    Given the Digital Object is opened in edit mode
+     Then the user should not see the "Current Language" dropdown
 
   Scenario: Current language badge does not appear when mlc disabled
     Given the Digital Object is opened in edit mode

--- a/e2e-tests/staff_features/resources/resource_mlc_content.feature
+++ b/e2e-tests/staff_features/resources/resource_mlc_content.feature
@@ -4,12 +4,12 @@ Feature: MLC content display
     Given an administrator user is logged in
     Given a Resource has been created
 
+  @mlc_enabled
   Scenario: Current Language selector from edit mode resource toolbar
-    Given the Resource is opened in edit mode
+    Given a second language of description has been added to the Resource
+      And the Resource is opened in edit mode
      When the user clicks on "Current Language"
      Then the user sees the "English" option in the "Current Language" dropdown
-      And the user sees the "Spanish" option in the "Current Language" dropdown
-      And the user sees the "French" option in the "Current Language" dropdown
       And the user sees the "German" option in the "Current Language" dropdown
 
   Scenario Outline: MLC default language preview appears on mlc content fields
@@ -32,12 +32,12 @@ Feature: MLC content display
           | resource    | repository_processing_note    |
           | resource    | finding_aid_filing_title      |
 
+  @mlc_enabled
   Scenario: Current Language selector from view mode resource toolbar
-    Given the Resource is opened in the view mode
+    Given a second language of description has been added to the Resource
+      And the Resource is opened in the view mode
      When the user clicks on "Current Language"
      Then the user sees the "English" option in the "Current Language" dropdown
-      And the user sees the "Spanish" option in the "Current Language" dropdown
-      And the user sees the "French" option in the "Current Language" dropdown
       And the user sees the "German" option in the "Current Language" dropdown
 
   Scenario Outline: MLC badge does not appear in read mode
@@ -63,6 +63,10 @@ Feature: MLC content display
     Given a second language of description has been added to the Resource
       And the Resource is opened in edit mode
      Then the user should see language badges on all subrecords
+
+  Scenario: Current Language selector does not appear when mlc disabled
+    Given the Resource is opened in edit mode
+     Then the user should not see the "Current Language" dropdown
 
   Scenario: Current language badge does not appear when mlc disabled
     Given the Resource is opened in edit mode

--- a/e2e-tests/staff_features/shared/step_definitions.rb
+++ b/e2e-tests/staff_features/shared/step_definitions.rb
@@ -677,3 +677,7 @@ end
 Then('the user should not see a language badge') do
   expect(page).to have_no_css('.mlc-badge', visible: true)
 end
+
+Then('the user should not see the {string} dropdown') do |button_text|
+  expect(page).to have_no_button(button_text)
+end

--- a/frontend/app/assets/javascripts/InfiniteTreeRecordPane.js
+++ b/frontend/app/assets/javascripts/InfiniteTreeRecordPane.js
@@ -32,7 +32,17 @@
      * @param {string} requestPath - The prefixed frontend URI to the record, e.g. "/resources/123"
      */
     async loadRecord(requestPath) {
-      const url = requestPath + '?inline=true';
+      const urlObj = new URL(requestPath, window.location.origin);
+      urlObj.searchParams.set('inline', 'true');
+
+      const lang = new URLSearchParams(window.location.search).get(
+        'language_of_description'
+      );
+      if (lang) {
+        urlObj.searchParams.set('language_of_description', lang);
+      }
+
+      const url = urlObj.pathname + urlObj.search;
 
       this.#blockUI();
 

--- a/frontend/app/assets/javascripts/ajaxtree.js.erb
+++ b/frontend/app/assets/javascripts/ajaxtree.js.erb
@@ -99,6 +99,11 @@ AjaxTree.prototype.loadPaneForId = function(tree_id) {
     params.inline = true;
     params[self.tree.large_tree.root_node_type + '_id'] = self.tree.large_tree.root_uri;
 
+    var currentLang = new URLSearchParams(window.location.search).get('language_of_description');
+    if (currentLang) {
+        params.language_of_description = currentLang;
+    }
+
     var parsed = TreeIds.parse_tree_id(tree_id);
     var row_type = parsed.type;
     var row_id = parsed.id;

--- a/frontend/app/assets/javascripts/digital_objects.crud.js.erb
+++ b/frontend/app/assets/javascripts/digital_objects.crud.js.erb
@@ -1,4 +1,5 @@
 //= require tree
+//= require language_selector
 //= require agents.crud
 //= require subjects.crud
 //= require dates.crud

--- a/frontend/app/assets/javascripts/language_selector.js
+++ b/frontend/app/assets/javascripts/language_selector.js
@@ -1,0 +1,48 @@
+(function () {
+  function initLanguageSelector(container) {
+    var root = container || document;
+    var dropdown = root.querySelector('#language-of-description-dropdown');
+    if (!dropdown) return;
+
+    var currentLang = new URLSearchParams(window.location.search).get(
+      'language_of_description'
+    );
+    if (currentLang) {
+      var match = dropdown.querySelector(
+        'input[type="radio"][value="' + currentLang + '"]'
+      );
+      if (match) {
+        dropdown
+          .querySelectorAll('input[type="radio"]')
+          .forEach(function (radio) {
+            radio.checked = false;
+          });
+        match.checked = true;
+      }
+    }
+
+    dropdown.querySelectorAll('input[type="radio"]').forEach(function (radio) {
+      radio.addEventListener('change', function () {
+        var url = new URL(window.location.href);
+        url.searchParams.set('language_of_description', this.value);
+        window.location.href = url.toString();
+      });
+    });
+  }
+
+  function ready(fn) {
+    if (document.readyState !== 'loading') {
+      fn();
+    } else {
+      document.addEventListener('DOMContentLoaded', fn);
+    }
+  }
+
+  ready(function () {
+    $(document).bind('loadedrecordform.aspace', function (event, $container) {
+      initLanguageSelector($container && $container[0]);
+    });
+
+    initLanguageSelector();
+  });
+})();

--- a/frontend/app/assets/javascripts/resources.crud.js.erb
+++ b/frontend/app/assets/javascripts/resources.crud.js.erb
@@ -23,6 +23,7 @@
 //= require slug
 //= require bulk_import
 //= require clipboard
+//= require language_selector
 
 $(function () {
   $.fn.init_resource_form = function () {

--- a/frontend/app/controllers/accessions_controller.rb
+++ b/frontend/app/controllers/accessions_controller.rb
@@ -135,7 +135,8 @@ class AccessionsController < ApplicationController
                     end
                     redirect_to(:controller => :accessions,
                                 :action => :edit,
-                                :id => id)
+                                :id => id,
+                                :language_of_description => params[:language_of_description])
                   end
                 })
   end
@@ -157,7 +158,10 @@ class AccessionsController < ApplicationController
                     flash[:warning] = t("slug.autogen_disabled")
                   end
 
-                  redirect_to :controller => :accessions, :action => :edit, :id => id
+                  # Unlike other record types, accessions update redirects rather than using
+                  # render_aspace_partial, so the language param must be threaded through explicitly.
+                  redirect_to :controller => :accessions, :action => :edit, :id => id,
+                              :language_of_description => params[:language_of_description]
                 })
   end
 

--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -35,6 +35,8 @@ class ApplicationController < ActionController::Base
 
   before_action :init_ancestor_titles
 
+  before_action :set_description_language
+
   around_action :set_locale
 
   def self.permission_mappings
@@ -742,6 +744,12 @@ class ApplicationController < ActionController::Base
 
       query
     }
+  end
+
+  def set_description_language
+    lang = params[:language_of_description]
+    JSONModel::HTTP.current_description_language =
+      (lang.present? && lang.match?(/\A[a-z]{3}_[A-Za-z]{4}\z/)) ? lang : nil
   end
 
   def set_locale(&action)

--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -19,38 +19,8 @@
         </div>
       <% end %>
       <div class="btn-group ml-auto" data-allow-disabled>
-        <div class="btn-group dropdown" id="language-of-description-dropdown">
-          <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <%= t('lang_description.current_language') %>
-          </button>
-          <ul class="dropdown-menu dropdown-menu-right">
-            <li class="dropdown-item p-0">
-              <label class="d-flex align-items-center gap-x-1 py-1 px-4 mb-0" for="language-description-eng">
-                <input type="radio" id="language-description-eng" name="language_of_description" value="eng" checked="checked" />
-                <span><%= t('lang_description.languages.eng') %></span>
-              </label>
-            </li>
-            <li class="dropdown-item p-0">
-              <label class="d-flex align-items-center gap-x-1 py-1 px-4 mb-0" for="language-description-spa">
-                <input type="radio" id="language-description-spa" name="language_of_description" value="spa" />
-                <span><%= t('lang_description.languages.spa') %></span>
-                <span class="ml-1 fs-10px label badge"><span><%= t('lang_description.default') %></span></span>
-              </label>
-            </li>
-            <li class="dropdown-item p-0">
-              <label class="d-flex align-items-center gap-x-1 py-1 px-4 mb-0" for="language-description-fre">
-                <input type="radio" id="language-description-fre" name="language_of_description" value="fre" />
-                <span><%= t('lang_description.languages.fre') %></span>
-              </label>
-            </li>
-            <li class="dropdown-item p-0">
-              <label class="d-flex align-items-center gap-x-1 py-1 px-4 mb-0" for="language-description-ger">
-                <input type="radio" id="language-description-ger" name="language_of_description" value="ger" />
-                <span><%= t('lang_description.languages.ger') %></span>
-              </label>
-            </li>
-          </ul>
-        </div>
+        <%= render_aspace_partial :partial => "shared/language_of_description_dropdown",
+            :locals => { :lang_descriptions => @accession['lang_descriptions'].to_a, :resource_id => @accession.id } %>
         <% if AppConfig[:enable_public] %>
           <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => @accession} %>
         <% end %>

--- a/frontend/app/views/shared/_component_toolbar.html.erb
+++ b/frontend/app/views/shared/_component_toolbar.html.erb
@@ -37,6 +37,9 @@
     <% end %>
 
     <div class="btn-group ml-auto" data-allow-disabled>
+      <% inherited_lang_descs = (record["resource"]&.dig("_resolved") || record["digital_object"]&.dig("_resolved"))&.dig("lang_descriptions").to_a %>
+      <%= render_aspace_partial :partial => "shared/language_of_description_dropdown",
+            :locals => { :lang_descriptions => inherited_lang_descs } %>
       <% if user_can?('update_event_record') && supports_events && ((suppressible && !record.suppressed) || !suppressible ) %>
         <%= render_aspace_partial :partial => "shared/event_dropdown", :locals => {:record => record} %>
       <% end %>

--- a/frontend/app/views/shared/_language_of_description_dropdown.html.erb
+++ b/frontend/app/views/shared/_language_of_description_dropdown.html.erb
@@ -1,0 +1,31 @@
+<% if AppConfig[:multilingual_content] && lang_descriptions.length > 1 %>
+  <div class="btn-group dropdown" id="language-of-description-dropdown" data-resource-id="<%= local_assigns[:resource_id] %>" data-no-change-tracking="true">
+    <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <%= t('lang_description.current_language') %>
+    </button>
+    <ul class="dropdown-menu dropdown-menu-right">
+      <% lang_descriptions.each_with_index do |ld, i|
+           lang_code = ld['language']
+           script_code = ld['script']
+           next unless lang_code && script_code
+           lang_script = "#{lang_code}_#{script_code}"
+           is_primary = ld['is_primary'] == true || ld['is_primary'] == 1
+      %>
+        <li class="dropdown-item p-0">
+          <label class="d-flex align-items-center gap-x-1 py-1 px-4 mb-0"
+                 for="language-description-<%= lang_script %>-<%= i %>">
+            <input type="radio"
+                   id="language-description-<%= lang_script %>-<%= i %>"
+                   name="language_of_description"
+                   value="<%= lang_script %>"
+                   <%= 'checked="checked"' if is_primary %>>
+            <span><%= t("enumerations.language_iso639_2.#{lang_code}", default: lang_code) %></span>
+            <% if is_primary %>
+              <span class="ml-1 fs-10px label badge"><%= t('lang_description.default') %></span>
+            <% end %>
+          </label>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/frontend/app/views/shared/_resource_toolbar.html.erb
+++ b/frontend/app/views/shared/_resource_toolbar.html.erb
@@ -21,38 +21,8 @@
       </div>
     <% end %>
     <div class="btn-group ml-auto" data-allow-disabled>
-      <div class="btn-group dropdown" id="language-of-description-dropdown">
-        <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <%= t('lang_description.current_language') %>
-        </button>
-        <ul class="dropdown-menu dropdown-menu-right">
-          <li class="dropdown-item p-0">
-            <label class="d-flex align-items-center gap-x-1 py-1 px-4 mb-0" for="language-description-eng">
-              <input type="radio" id="language-description-eng" name="language_of_description" value="eng" checked="checked" />
-              <span><%= t('lang_description.languages.eng') %></span>
-            </label>
-          </li>
-          <li class="dropdown-item p-0">
-            <label class="d-flex align-items-center gap-x-1 py-1 px-4 mb-0" for="language-description-spa">
-              <input type="radio" id="language-description-spa" name="language_of_description" value="spa" />
-              <span><%= t('lang_description.languages.spa') %></span>
-              <span class="ml-1 fs-10px label badge"><%= t('lang_description.default') %></span>
-            </label>
-          </li>
-          <li class="dropdown-item p-0">
-            <label class="d-flex align-items-center gap-x-1 py-1 px-4 mb-0" for="language-description-fre">
-              <input type="radio" id="language-description-fre" name="language_of_description" value="fre" />
-              <span><%= t('lang_description.languages.fre') %></span>
-            </label>
-          </li>
-          <li class="dropdown-item p-0">
-            <label class="d-flex align-items-center gap-x-1 py-1 px-4 mb-0" for="language-description-ger">
-              <input type="radio" id="language-description-ger" name="language_of_description" value="ger" />
-              <span><%= t('lang_description.languages.ger') %></span>
-            </label>
-          </li>
-        </ul>
-      </div>
+      <%= render_aspace_partial :partial => "shared/language_of_description_dropdown",
+      :locals => { :lang_descriptions => record['lang_descriptions'].to_a, :resource_id => record.id } %>
       <% if user_can?('update_event_record') && !record.suppressed %>
         <%= render_aspace_partial :partial => "shared/event_dropdown", :locals => {:record => record} %>
       <% end %>

--- a/frontend/config/locales/de.yml
+++ b/frontend/config/locales/de.yml
@@ -2872,11 +2872,6 @@ de:
     current_language: Aktuelle Sprache
     default: Standard
     icon: <span class="mlc-icon glyphicon glyphicon-globe"></span>
-    languages:
-      eng: Englisch
-      spa: Spanisch
-      fre: Französisch
-      ger: Deutsch
     mlc_field: >-
       Der Wert dieses Feldes kann sich je nach aktueller Beschreibungssprache
       ändern.

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -1164,11 +1164,6 @@ en:
     current_language: Current Language
     default: Default
     icon: <span class="mlc-icon glyphicon glyphicon-globe"></span>
-    languages:
-      eng: English
-      spa: Spanish
-      fre: French
-      ger: German
     mlc_field: >-
       The value of this field can change based on the current language of
       description.

--- a/frontend/config/locales/es.yml
+++ b/frontend/config/locales/es.yml
@@ -3416,11 +3416,6 @@ es:
     current_language: Idioma actual
     default: Por defecto
     icon: <span class="mlc-icon glyphicon glyphicon-globe"></span>
-    languages:
-      eng: Inglés
-      spa: Español
-      fre: Francés
-      ger: Alemán
     mlc_field: >-
       El valor de este campo puede cambiar según el idioma actual de
       descripción.

--- a/frontend/config/locales/fr.yml
+++ b/frontend/config/locales/fr.yml
@@ -3665,11 +3665,6 @@ fr:
     current_language: Langue actuelle
     default: Défaut
     icon: <span class="mlc-icon glyphicon glyphicon-globe"></span>
-    languages:
-      eng: Anglais
-      spa: Espagnol
-      fre: Français
-      ger: Allemand
     mlc_field: >-
       La valeur de ce champ peut changer en fonction de la langue actuelle de
       description.

--- a/frontend/config/locales/he.yml
+++ b/frontend/config/locales/he.yml
@@ -3,11 +3,6 @@ he:
     current_language: שפה נוכחית
     default: בְּרִירַת מֶחדָל
     icon: <span class="mlc-icon glyphicon glyphicon-globe"></span>
-    languages:
-      eng: אַנגְלִית
-      spa: סְפָרַדִית
-      fre: צָרְפָתִית
-      ger: גֶרמָנִיָת
     mlc_field: הערך של שדה זה יכול להשתנות בהתאם לשפת התיאור הנוכחית.
     _frontend:
       action:

--- a/frontend/config/locales/it.yml
+++ b/frontend/config/locales/it.yml
@@ -1768,11 +1768,6 @@ it:
     current_language: Lingua attuale
     default: Predefinito
     icon: <span class="mlc-icon glyphicon glyphicon-globe"></span>
-    languages:
-      eng: Inglese
-      spa: spagnolo
-      fre: francese
-      ger: tedesco
     mlc_field: >-
       Il valore di questo campo può cambiare in base alla lingua di descrizione
       corrente.

--- a/frontend/config/locales/ja.yml
+++ b/frontend/config/locales/ja.yml
@@ -3050,11 +3050,6 @@ ja:
     current_language: 現在の言語
     default: デフォルト
     icon: <span class="mlc-icon glyphicon glyphicon-globe"></span>
-    languages:
-      eng: 英語
-      spa: スペイン語
-      fre: フランス語
-      ger: ドイツ語
     mlc_field: このフィールドの値は、現在の説明言語に基づいて変更される可能性があります。
     _frontend:
       action:

--- a/frontend/config/locales/nl.yml
+++ b/frontend/config/locales/nl.yml
@@ -69,11 +69,6 @@ nl:
     current_language: Huidige taal
     default: Standaard
     icon: <span class="mlc-icon glyphicon glyphicon-globe"></span>
-    languages:
-      eng: Engels
-      spa: Spaans
-      fre: Frans
-      ger: Duits
     mlc_field: >-
       De waarde van dit veld kan veranderen op basis van de huidige
       beschrijvingstaal.

--- a/frontend/config/locales/pl.yml
+++ b/frontend/config/locales/pl.yml
@@ -1574,11 +1574,6 @@ pl:
     current_language: Aktualny język
     default: Domyślny
     icon: <span class="mlc-icon glyphicon glyphicon-globe"></span>
-    languages:
-      eng: angielski
-      spa: hiszpański
-      fre: francuski
-      ger: niemiecki
     mlc_field: >-
       Wartość tego pola może się zmieniać w zależności od bieżącego języka
       opisu.

--- a/frontend/config/locales/pt.yml
+++ b/frontend/config/locales/pt.yml
@@ -3,11 +3,6 @@ pt:
     current_language: Idioma atual
     default: Padrão
     icon: <span class="mlc-icon glyphicon glyphicon-globe"></span>
-    languages:
-      eng: Inglês
-      spa: Espanhol
-      fre: Francês
-      ger: Alemão
     mlc_field: O valor deste campo pode mudar com base no idioma de descrição atual.
     _frontend:
       action:

--- a/frontend/config/locales/uk.yml
+++ b/frontend/config/locales/uk.yml
@@ -2606,11 +2606,6 @@ uk:
     current_language: Поточна мова
     default: За замовчуванням
     icon: <span class="mlc-icon glyphicon glyphicon-globe"></span>
-    languages:
-      eng: англійська
-      spa: Іспанська
-      fre: французька
-      ger: Німецький
     mlc_field: Значення цього поля може змінюватися залежно від поточної мови опису.
     _frontend:
       action:

--- a/frontend/spec/controllers/accessions_controller_spec.rb
+++ b/frontend/spec/controllers/accessions_controller_spec.rb
@@ -118,4 +118,54 @@ describe AccessionsController, type: :controller do
       end
     end
   end
+
+  describe 'language_of_description redirect' do
+    before(:each) do
+      set_repo($repo)
+      session = User.login('admin', 'admin')
+      User.establish_session(controller, session, 'admin')
+      controller.session[:repo_id] = JSONModel.repository
+    end
+
+    describe 'POST update' do
+      let!(:existing_accession) { create(:json_accession) }
+
+      def full_accession_params(accession)
+        json = JSONModel(:accession).find(accession.id)
+        json.to_hash.merge('lock_version' => json.lock_version)
+      end
+
+      context 'with a language_of_description param' do
+        it 'preserves the param in the redirect to edit' do
+          post :update, params: {
+            id:                      existing_accession.id,
+            language_of_description: 'fre_Latn',
+            accession:               full_accession_params(existing_accession)
+          }
+
+          expect(response).to redirect_to(
+            controller: :accessions,
+            action:     :edit,
+            id:         existing_accession.id,
+            language_of_description: 'fre_Latn'
+          )
+        end
+      end
+
+      context 'without a language_of_description param' do
+        it 'redirects to edit without a language param' do
+          post :update, params: {
+            id:       existing_accession.id,
+            accession: full_accession_params(existing_accession)
+          }
+
+          expect(response).to redirect_to(
+            controller: :accessions,
+            action:     :edit,
+            id:         existing_accession.id
+          )
+        end
+      end
+    end
+  end
 end

--- a/frontend/spec/controllers/application_controller_spec.rb
+++ b/frontend/spec/controllers/application_controller_spec.rb
@@ -15,6 +15,58 @@ describe ApplicationController, type: :controller do
     clean_params = controller.send(:cleanup_params_for_schema, params , JSONModel(:file_version).schema)
     expect(clean_params["file_size_bytes"]).to eq 0
   end
+
+  describe '#set_description_language' do
+    controller do
+      skip_before_action :unauthorised_access
+
+      def index
+        head :ok
+      end
+    end
+
+    before(:each) do
+      apply_session_to_controller(controller, 'admin', 'admin')
+    end
+
+    after(:each) do
+      JSONModel::HTTP.current_description_language = nil
+    end
+
+    context 'when language_of_description param is present and valid' do
+      it 'sets current_description_language to the supplied value' do
+        get :index, params: { language_of_description: 'eng_Latn' }
+        expect(Thread.current[:description_language]).to eq('eng_Latn')
+      end
+
+      it 'accepts any valid three-letter language code with four-letter script code' do
+        get :index, params: { language_of_description: 'fre_Latn' }
+        expect(Thread.current[:description_language]).to eq('fre_Latn')
+      end
+    end
+
+    context 'when language_of_description param is absent' do
+      it 'sets current_description_language to nil' do
+        get :index
+        expect(Thread.current[:description_language]).to be_nil
+      end
+
+      it 'clears a language that was set on a previous request' do
+        JSONModel::HTTP.current_description_language = 'fre_Latn'
+        get :index
+        expect(Thread.current[:description_language]).to be_nil
+      end
+    end
+
+    context 'when language_of_description param has an invalid format' do
+      it 'sets current_description_language to nil' do
+        ['../../etc/passwd', 'english_Latin', ''].each do |invalid|
+          get :index, params: { language_of_description: invalid }
+          expect(Thread.current[:description_language]).to be_nil
+        end
+      end
+    end
+  end
 end
 
 describe GenericRecordController, type: :controller do

--- a/frontend/spec/controllers/resources_controller_spec.rb
+++ b/frontend/spec/controllers/resources_controller_spec.rb
@@ -84,6 +84,46 @@ describe ResourcesController, type: :controller do
     end
   end
 
+  describe '#set_description_language' do
+    before(:each) do
+      apply_session_to_controller(controller, 'admin', 'admin')
+    end
+
+    after(:each) do
+      JSONModel::HTTP.current_description_language = nil
+    end
+
+    context 'when a valid language_of_description param is present' do
+      it 'sets current_description_language' do
+        get :edit, params: { id: create(:json_resource).id, language_of_description: 'fre_Latn' }
+        expect(JSONModel::HTTP.current_description_language).to eq('fre_Latn')
+      end
+    end
+
+    context 'when no language_of_description param is present' do
+      it 'sets current_description_language to nil even when previously set' do
+        get :edit, params: { id: create(:json_resource).id }
+        expect(JSONModel::HTTP.current_description_language).to be_nil
+      end
+    end
+
+    context 'when the language_of_description param is invalid' do
+      context 'when the value is blank' do
+        it 'sets current_description_language to nil' do
+          get :edit, params: { id: create(:json_resource).id, language_of_description: '' }
+          expect(JSONModel::HTTP.current_description_language).to be_nil
+        end
+      end
+
+      context 'when the value is malformed' do
+        it 'sets current_description_language to nil' do
+          get :edit, params: { id: create(:json_resource).id, language_of_description: 'not-valid' }
+          expect(JSONModel::HTTP.current_description_language).to be_nil
+        end
+      end
+    end
+  end
+
   describe 'record title field' do
     before(:each) do
       session = User.login('admin', 'admin')

--- a/frontend/spec/features/accessions_spec.rb
+++ b/frontend/spec/features/accessions_spec.rb
@@ -980,6 +980,61 @@ describe 'Accessions', js: true do
 
       expect(page).to have_text "Accession MLC Accession created"
     end
+
+    context 'language selector dropdown' do
+      let(:now) { Time.now.to_i }
+      let(:english_title) { "English Accession Title #{now}" }
+
+      let(:accession) do
+        create(:json_accession,
+               title: english_title,
+               lang_descriptions: [
+                 JSONModel(:language_and_script_of_description).new(
+                   'language' => 'eng', 'script' => 'Latn', 'is_primary' => true
+                 ),
+                 JSONModel(:language_and_script_of_description).new(
+                   'language' => 'fre', 'script' => 'Latn', 'is_primary' => false
+                 )
+               ])
+      end
+
+      before do
+        visit "accessions/#{accession.id}/edit"
+      end
+
+      it 'shows the language selector dropdown, defaulting to the primary language value' do
+        expect(page).to have_css('#language-of-description-dropdown')
+        expect(page).to have_field('accession_title_', with: english_title)
+      end
+
+      it 'updates the URL when a non-primary language is selected from the dropdown' do
+        within '#language-of-description-dropdown' do
+          find('.dropdown-toggle').click
+          find('input[type="radio"][value="fre_Latn"]').choose
+        end
+
+        expect(page.current_url).to include('language_of_description=fre_Latn')
+      end
+
+      it 'saves non-primary language edits to that language without modifying the primary language' do
+        within '#language-of-description-dropdown' do
+          find('.dropdown-toggle').click
+          find('input[type="radio"][value="fre_Latn"]').choose
+        end
+
+        french_title = "French Accession Title #{now}"
+        fill_in 'accession_title_', with: french_title
+        click_on 'Save'
+
+        expect(page).to have_text "Accession #{french_title} updated"
+
+        visit "accessions/#{accession.id}/edit?language_of_description=eng_Latn"
+        expect(page).to have_field('accession_title_', with: english_title)
+
+        visit "accessions/#{accession.id}/edit?language_of_description=fre_Latn"
+        expect(page).to have_field('accession_title_', with: french_title)
+      end
+    end
   end
 
   context 'when multilingual content disabled' do

--- a/frontend/spec/features/archival_objects_spec.rb
+++ b/frontend/spec/features/archival_objects_spec.rb
@@ -496,4 +496,79 @@ describe 'Archival objects', js: true do
     it_behaves_like 'supporting is_primary on top-level linked agents'
     it_behaves_like 'not supporting is_primary on rights statement linked agents'
   end
+
+  context 'when multilingual content enabled' do
+    before do
+      AppConfig[:multilingual_content] = true
+    end
+
+    after do
+      AppConfig[:multilingual_content] = false
+    end
+
+    let(:now) { Time.now.to_i }
+    let(:english_resource_title) { "English Resource Title #{now}" }
+    let(:english_ao_title) { "English Archival Object Title #{now}" }
+
+    let(:resource) do
+      create(:json_resource,
+             title: english_resource_title,
+             instances: [],
+             dates: [build(:json_date, date_type: 'single')],
+             lang_descriptions: [
+               JSONModel(:language_and_script_of_description).new(
+                 'language' => 'eng', 'script' => 'Latn', 'is_primary' => true
+               ),
+               JSONModel(:language_and_script_of_description).new(
+                 'language' => 'fre', 'script' => 'Latn', 'is_primary' => false
+               )
+             ])
+    end
+
+    let(:archival_object) do
+      create(:json_archival_object,
+             title: english_ao_title,
+             dates: [],
+             resource: { 'ref' => resource.uri })
+    end
+
+    before do
+      archival_object
+      run_index_round
+      visit "resources/#{resource.id}/edit#tree::archival_object_#{archival_object.id}"
+    end
+
+    it 'shows the language selector dropdown inherited from the parent resource, defaulting to the primary language value' do
+      expect(page).to have_css('#language-of-description-dropdown')
+      expect(page).to have_field('archival_object_title_', with: english_ao_title)
+    end
+
+    it 'updates the URL when a non-primary language is selected from the dropdown' do
+      within '#language-of-description-dropdown' do
+        find('.dropdown-toggle').click
+        find('input[type="radio"][value="fre_Latn"]').choose
+      end
+
+      expect(page.current_url).to include('language_of_description=fre_Latn')
+    end
+
+    it 'saves non-primary language edits to that language without modifying the primary language' do
+      within '#language-of-description-dropdown' do
+        find('.dropdown-toggle').click
+        find('input[type="radio"][value="fre_Latn"]').choose
+      end
+
+      french_ao_title = "French Archival Object Title #{now}"
+      fill_in 'archival_object_title_', with: french_ao_title
+      find('button', text: 'Save Archival Object', match: :first).click
+
+      expect(page).to have_text "Archival Object #{french_ao_title} updated"
+
+      visit "resources/#{resource.id}/edit?language_of_description=eng_Latn#tree::archival_object_#{archival_object.id}"
+      expect(page).to have_field('archival_object_title_', with: english_ao_title)
+
+      visit "resources/#{resource.id}/edit?language_of_description=fre_Latn#tree::archival_object_#{archival_object.id}"
+      expect(page).to have_field('archival_object_title_', with: french_ao_title)
+    end
+  end
 end

--- a/frontend/spec/features/digital_object_components_spec.rb
+++ b/frontend/spec/features/digital_object_components_spec.rb
@@ -1,0 +1,265 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Digital Object Components', js: true do
+  before(:all) do
+    @repository = create(:repo, repo_code: "digital_object_components_test_#{Time.now.to_i}")
+    set_repo @repository
+
+    @user = create_user(@repository => ['repository-archivists'])
+  end
+
+  before(:each) do
+    login_user(@user)
+    select_repository(@repository)
+  end
+
+  it 'reports errors if adding a child with no title to a Digital Object' do
+    now = Time.now.to_i
+    digital_object = create(:digital_object, title: "Digital Object Title #{now}")
+    run_index_round
+
+    visit "digital_objects/#{digital_object.id}/edit"
+
+    expect(page).to have_selector('h2', visible: true, text: "#{digital_object.title} Digital Object")
+
+    click_on 'Add Child'
+
+    wait_for_ajax
+
+    element = find('h2')
+    expect(element.text).to eq "Digital Object Component Digital Object Component"
+
+    fill_in 'digital_object_component_component_id_', with: "Digital Object Identifier #{now}"
+
+    find('#createPlusOne').click
+
+    element = find('.alert.alert-danger.with-hide-alert')
+    expect(element.text).to eq "Dates - you must provide a Label, Title or Date\nTitle - you must provide a Label, Title or Date\nLabel - you must provide a Label, Title or Date"
+  end
+
+  it 'can populate the digital object component tree' do
+    now = Time.now.to_i
+    digital_object = create(:digital_object, title: "Digital Object Title #{now}", dates: [], extents: [])
+    run_index_round
+
+    visit "digital_objects/#{digital_object.id}/edit"
+
+    expect(page).to have_selector('h2', visible: true, text: "#{digital_object.title} Digital Object")
+
+    click_on 'Add Child'
+
+    fill_in 'digital_object_component_component_id_', with: "Child 1 #{now}"
+    fill_in 'digital_object_component_title_', with: "Child 1 #{now}"
+
+    find('#createPlusOne').click
+    wait_for_ajax
+
+    expect(page).to have_selector('h2', visible: true, text: "Digital Object Component Digital Object Component")
+    expect(page).to have_content "Digital Object Component Child 1 #{now} created on Digital Object Digital Object Title #{now}"
+
+    fill_in 'digital_object_component_component_id_', with: "Child 2 #{now}"
+    fill_in 'digital_object_component_title_', with: "Child 2 #{now}"
+
+    find('#createPlusOne').click
+    wait_for_ajax
+
+    expect(page).to have_selector('h2', visible: true, text: "Digital Object Component Digital Object Component")
+    expect(page).to have_content "Digital Object Component Child 2 #{now} created on Digital Object Digital Object Title #{now}"
+
+    fill_in 'digital_object_component_component_id_', with: "Child 3 #{now}"
+    fill_in 'digital_object_component_title_', with: "Child 3 #{now}"
+
+    # Click on save
+    find('button', text: 'Save Digital Object', match: :first).click
+
+    expect(page).to have_selector('h2', visible: true, text: "Digital Object Component Digital Object Component")
+    expect(page).to have_content "Digital Object Component Child 3 #{now} created on Digital Object Digital Object Title #{now}"
+
+    elements = all('.largetree-node.indent-level-1')
+    expect(elements.length).to eq 3
+    expect(elements[0]).to have_text "Child 1 #{now}"
+    expect(elements[1]).to have_text "Child 2 #{now}"
+    expect(elements[2]).to have_text "Child 3 #{now}"
+  end
+
+  it 'provides alt text for Digital Object Component file version images based on caption or title' do
+    now = Time.now.to_i
+    digital_object = create(
+      :digital_object,
+      title: "Digital Object Title #{now}",
+      file_versions: [
+        {
+          file_uri: "File URI 1 #{now}",
+          file_format_name: "jpeg",
+          caption: "File Format Caption 1 #{now}"
+        },
+        {
+          file_uri: "File URI 2 #{now}",
+          file_format_name: "jpeg",
+          caption: "File Format Caption 2 #{now}"
+        }
+      ]
+    )
+
+    digital_object_component = create(
+      :digital_object_component,
+      digital_object: { ref: digital_object.uri },
+      title: "Digital Object Component Title #{now}",
+      file_versions: [
+        {
+          file_uri: "File URI 1 #{now}",
+          file_format_name: "jpeg",
+          caption: "File Format Caption 1 #{now}"
+        },
+        {
+          file_uri: "File URI 2 #{now}",
+          file_format_name: "jpeg",
+          caption: "File Format Caption 2 #{now}"
+        }
+      ]
+    )
+
+    run_index_round
+
+    visit "digital_objects/#{digital_object.id}/#tree::digital_object_component_#{digital_object_component.id}"
+
+    expect(page).to have_selector('h2', visible: true, text: "#{digital_object_component.title} Digital Object Component")
+
+    expect(page).to have_css('#digital_object_component_file_versions__file_version_0', visible: false, text: "File Format Caption 1 #{now}")
+    expect(page).to have_css('#digital_object_component_file_versions__file_version_1', visible: false, text: "File Format Caption 2 #{now}")
+  end
+
+  describe 'title field mixed content validation' do
+    let(:digital_object) { create(:digital_object, title: 'Digital Object') }
+
+    context 'for a child Digital Object Component' do
+      let(:digital_object_component) { create(:digital_object_component, title: 'Digital Object Component', digital_object: { ref: digital_object.uri }) }
+      let(:edit_path) { "digital_objects/#{digital_object.id}/edit#tree::digital_object_component_#{digital_object_component.id}" }
+      let(:input_field_id) { 'digital_object_component_title_' }
+
+      it_behaves_like 'validating mixed content'
+    end
+  end
+
+  describe 'Linked Agents is_primary behavior' do
+    let(:agent) { create(:agent_person) }
+
+    before do
+      set_repo @repository
+      login_admin
+      select_repository(@repository)
+    end
+
+    context 'for child Digital Object Components' do
+      let(:record_type) { 'digital_object_component' }
+      let(:parent_digital_object) do
+        create(
+          :digital_object,
+          title: "Digital Object Title #{Time.now.to_i}"
+        )
+      end
+      let(:record) do
+        create(
+          :digital_object_component,
+          digital_object: { ref: parent_digital_object.uri },
+          title: "Digital Object Component Title #{Time.now.to_i}",
+          linked_agents: [
+            { ref: agent.uri, role: 'creator' }
+          ],
+          rights_statements: [
+            build(
+              :json_rights_statement,
+              rights_type: 'copyright',
+              status: 'copyrighted',
+              jurisdiction: 'AU',
+              start_date: Time.now.strftime('%Y-%m-%d'),
+              linked_agents: [
+                { ref: agent.uri, role: 'rights_holder' }
+              ]
+            )
+          ]
+        )
+      end
+      let(:edit_path) { "/digital_objects/#{parent_digital_object.id}/edit#tree::digital_object_component_#{record.id}" }
+
+      it_behaves_like 'supporting is_primary on top-level linked agents'
+      it_behaves_like 'not supporting is_primary on rights statement linked agents'
+    end
+  end
+
+  context 'when multilingual content enabled' do
+    before do
+      AppConfig[:multilingual_content] = true
+    end
+
+    after do
+      AppConfig[:multilingual_content] = false
+    end
+
+    let(:now) { Time.now.to_i }
+    let(:english_digital_object_title) { "English Digital Object Title #{now}" }
+    let(:english_doc_title) { "English Digital Object Component Title #{now}" }
+
+    let(:digital_object) do
+      create(:json_digital_object,
+             title: english_digital_object_title,
+             dates: [],
+             lang_descriptions: [
+               JSONModel(:language_and_script_of_description).new(
+                 'language' => 'eng', 'script' => 'Latn', 'is_primary' => true
+               ),
+               JSONModel(:language_and_script_of_description).new(
+                 'language' => 'fre', 'script' => 'Latn', 'is_primary' => false
+               )
+             ])
+    end
+
+    let(:digital_object_component) do
+      create(:json_digital_object_component,
+             title: english_doc_title,
+             digital_object: { 'ref' => digital_object.uri })
+    end
+
+    before do
+      digital_object_component
+      run_index_round
+      visit "digital_objects/#{digital_object.id}/edit#tree::digital_object_component_#{digital_object_component.id}"
+    end
+
+    it 'shows the language selector dropdown inherited from the parent digital object, defaulting to the primary language value' do
+      expect(page).to have_css('#language-of-description-dropdown')
+      expect(page).to have_field('digital_object_component_title_', with: english_doc_title)
+    end
+
+    it 'updates the URL when a non-primary language is selected from the dropdown' do
+      within '#language-of-description-dropdown' do
+        find('.dropdown-toggle').click
+        find('input[type="radio"][value="fre_Latn"]').choose
+      end
+
+      expect(page.current_url).to include('language_of_description=fre_Latn')
+    end
+
+    it 'saves non-primary language edits to that language without modifying the primary language' do
+      within '#language-of-description-dropdown' do
+        find('.dropdown-toggle').click
+        find('input[type="radio"][value="fre_Latn"]').choose
+      end
+
+      french_doc_title = "French Digital Object Component Title #{now}"
+      fill_in 'digital_object_component_title_', with: french_doc_title
+      find('button', text: 'Save Digital Object Component', match: :first).click
+
+      expect(page).to have_text "Digital Object Component #{french_doc_title} updated"
+
+      visit "digital_objects/#{digital_object.id}/edit?language_of_description=eng_Latn#tree::digital_object_component_#{digital_object_component.id}"
+      expect(page).to have_field('digital_object_component_title_', with: english_doc_title)
+
+      visit "digital_objects/#{digital_object.id}/edit?language_of_description=fre_Latn#tree::digital_object_component_#{digital_object_component.id}"
+      expect(page).to have_field('digital_object_component_title_', with: french_doc_title)
+    end
+  end
+end

--- a/frontend/spec/features/digital_objects_spec.rb
+++ b/frontend/spec/features/digital_objects_spec.rb
@@ -113,75 +113,6 @@ describe 'Digital Objects', js: true do
     end
   end
 
-  it 'reports errors if adding a child with no title to a Digital Object' do
-    now = Time.now.to_i
-    digital_object = create(:digital_object, title: "Digital Object Title #{now}")
-    run_index_round
-
-    visit "digital_objects/#{digital_object.id}/edit"
-
-    expect(page).to have_selector('h2', visible: true, text: "#{digital_object.title} Digital Object")
-
-    click_on 'Add Child'
-
-    wait_for_ajax
-
-    element = find('h2')
-    expect(element.text).to eq "Digital Object Component Digital Object Component"
-
-    fill_in 'digital_object_component_component_id_', with: "Digital Object Identifier #{now}"
-
-    find('#createPlusOne').click
-
-    element = find('.alert.alert-danger.with-hide-alert')
-    expect(element.text).to eq "Dates - you must provide a Label, Title or Date\nTitle - you must provide a Label, Title or Date\nLabel - you must provide a Label, Title or Date"
-  end
-
-  it 'can populate the digital object component tree' do
-    now = Time.now.to_i
-    digital_object = create(:digital_object, title: "Digital Object Title #{now}", dates: [], extents: [])
-    run_index_round
-
-    visit "digital_objects/#{digital_object.id}/edit"
-
-    expect(page).to have_selector('h2', visible: true, text: "#{digital_object.title} Digital Object")
-
-    click_on 'Add Child'
-
-    fill_in 'digital_object_component_component_id_', with: "Child 1 #{now}"
-    fill_in 'digital_object_component_title_', with: "Child 1 #{now}"
-
-    find('#createPlusOne').click
-    wait_for_ajax
-
-    expect(page).to have_selector('h2', visible: true, text: "Digital Object Component Digital Object Component")
-    expect(page).to have_content "Digital Object Component Child 1 #{now} created on Digital Object Digital Object Title #{now}"
-
-    fill_in 'digital_object_component_component_id_', with: "Child 2 #{now}"
-    fill_in 'digital_object_component_title_', with: "Child 2 #{now}"
-
-    find('#createPlusOne').click
-    wait_for_ajax
-
-    expect(page).to have_selector('h2', visible: true, text: "Digital Object Component Digital Object Component")
-    expect(page).to have_content "Digital Object Component Child 2 #{now} created on Digital Object Digital Object Title #{now}"
-
-    fill_in 'digital_object_component_component_id_', with: "Child 3 #{now}"
-    fill_in 'digital_object_component_title_', with: "Child 3 #{now}"
-
-    # Click on save
-    find('button', text: 'Save Digital Object', match: :first).click
-
-    expect(page).to have_selector('h2', visible: true, text: "Digital Object Component Digital Object Component")
-    expect(page).to have_content "Digital Object Component Child 3 #{now} created on Digital Object Digital Object Title #{now}"
-
-    elements = all('.largetree-node.indent-level-1')
-    expect(elements.length).to eq 3
-    expect(elements[0]).to have_text "Child 1 #{now}"
-    expect(elements[1]).to have_text "Child 2 #{now}"
-    expect(elements[2]).to have_text "Child 3 #{now}"
-  end
-
   it 'can drag and drop reorder a Digital Object' do
     now = Time.now.to_i
     digital_object = create(:digital_object, title: "Digital Object Title #{now}")
@@ -305,67 +236,12 @@ describe 'Digital Objects', js: true do
     expect(element).to have_text "File Format Caption 2 #{now}"
   end
 
-  it 'provides alt text for Digital Object Component file version images based on caption or title' do
-    now = Time.now.to_i
-    digital_object = create(
-      :digital_object,
-      title: "Digital Object Title #{now}",
-      file_versions: [
-        {
-          file_uri: "File URI 1 #{now}",
-          file_format_name: "jpeg",
-          caption: "File Format Caption 1 #{now}"
-        },
-        {
-          file_uri: "File URI 2 #{now}",
-          file_format_name: "jpeg",
-          caption: "File Format Caption 2 #{now}"
-        }
-      ]
-    )
-
-    digital_object_component = create(
-      :digital_object_component,
-      digital_object: { ref: digital_object.uri },
-      title: "Digital Object Component Title #{now}",
-      file_versions: [
-        {
-          file_uri: "File URI 1 #{now}",
-          file_format_name: "jpeg",
-          caption: "File Format Caption 1 #{now}"
-        },
-        {
-          file_uri: "File URI 2 #{now}",
-          file_format_name: "jpeg",
-          caption: "File Format Caption 2 #{now}"
-        }
-      ]
-    )
-
-    run_index_round
-
-    visit "digital_objects/#{digital_object.id}/#tree::digital_object_component_#{digital_object_component.id}"
-
-    expect(page).to have_selector('h2', visible: true, text: "#{digital_object_component.title} Digital Object Component")
-
-    expect(page).to have_css('#digital_object_component_file_versions__file_version_0', visible: false, text: "File Format Caption 1 #{now}")
-    expect(page).to have_css('#digital_object_component_file_versions__file_version_1', visible: false, text: "File Format Caption 2 #{now}")
-  end
-
   describe 'title field mixed content validation' do
     let(:digital_object) { create(:digital_object, title: 'Digital Object') }
 
     context 'for a parent Digital Object' do
       let(:edit_path) { "digital_objects/#{digital_object.id}/edit" }
       let(:input_field_id) { 'digital_object_title_' }
-
-      it_behaves_like 'validating mixed content'
-    end
-
-    context 'for a child Digital Object Component' do
-      let(:digital_object_component) { create(:digital_object_component, title: 'Digital Object Component', digital_object: { ref: digital_object.uri }) }
-      let(:edit_path) { "digital_objects/#{digital_object.id}/edit#tree::digital_object_component_#{digital_object_component.id}" }
-      let(:input_field_id) { 'digital_object_component_title_' }
 
       it_behaves_like 'validating mixed content'
     end
@@ -570,42 +446,6 @@ describe 'Digital Objects', js: true do
       it_behaves_like 'supporting is_primary on top-level linked agents'
       it_behaves_like 'not supporting is_primary on rights statement linked agents'
     end
-
-    context 'for child Digital Object Components' do
-      let(:record_type) { 'digital_object_component' }
-      let(:parent_digital_object) do
-        create(
-          :digital_object,
-          title: "Digital Object Title #{Time.now.to_i}"
-        )
-      end
-      let(:record) do
-        create(
-          :digital_object_component,
-          digital_object: { ref: parent_digital_object.uri },
-          title: "Digital Object Component Title #{Time.now.to_i}",
-          linked_agents: [
-            { ref: agent.uri, role: 'creator' }
-          ],
-          rights_statements: [
-            build(
-              :json_rights_statement,
-              rights_type: 'copyright',
-              status: 'copyrighted',
-              jurisdiction: 'AU',
-              start_date: Time.now.strftime('%Y-%m-%d'),
-              linked_agents: [
-                { ref: agent.uri, role: 'rights_holder' }
-              ]
-            )
-          ]
-        )
-      end
-      let(:edit_path) { "/digital_objects/#{parent_digital_object.id}/edit#tree::digital_object_component_#{record.id}" }
-
-      it_behaves_like 'supporting is_primary on top-level linked agents'
-      it_behaves_like 'not supporting is_primary on rights statement linked agents'
-    end
   end
 
   context 'when multilingual content enabled' do
@@ -642,6 +482,68 @@ describe 'Digital Objects', js: true do
       click_on('Save')
 
       expect(page).to have_text "Digital Object MLC Digital Object created"
+    end
+
+    context 'language selector dropdown' do
+      let(:now) { Time.now.to_i }
+      let(:english_title) { "English Digital Object Title #{now}" }
+
+      let(:digital_object) do
+        create(:json_digital_object,
+               title: english_title,
+               dates: [],
+               lang_descriptions: [
+                 JSONModel(:language_and_script_of_description).new(
+                   'language' => 'eng', 'script' => 'Latn', 'is_primary' => true
+                 ),
+                 JSONModel(:language_and_script_of_description).new(
+                   'language' => 'fre', 'script' => 'Latn', 'is_primary' => false
+                 )
+               ])
+      end
+
+      before do
+        visit "digital_objects/#{digital_object.id}/edit"
+        wait_for_ajax
+      end
+
+      it 'shows the language selector dropdown, defaulting to the primary language value' do
+        expect(page).to have_css('#language-of-description-dropdown')
+        expect(page).to have_field('digital_object_title_', with: english_title)
+      end
+
+      it 'updates the URL when a non-primary language is selected from the dropdown' do
+        within '#language-of-description-dropdown' do
+          find('.dropdown-toggle').click
+          find('input[type="radio"][value="fre_Latn"]').choose
+        end
+        wait_for_ajax
+
+        expect(page.current_url).to include('language_of_description=fre_Latn')
+      end
+
+      it 'saves non-primary language edits to that language without modifying the primary language' do
+        within '#language-of-description-dropdown' do
+          find('.dropdown-toggle').click
+          find('input[type="radio"][value="fre_Latn"]').choose
+        end
+        wait_for_ajax
+
+        french_title = "French Digital Object Title #{now}"
+        fill_in 'digital_object_title_', with: french_title
+        find('button', text: 'Save Digital Object', match: :first).click
+        wait_for_ajax
+
+        expect(page).to have_text "Digital Object #{french_title} updated"
+
+        visit "digital_objects/#{digital_object.id}/edit?language_of_description=eng_Latn"
+        wait_for_ajax
+        expect(page).to have_field('digital_object_title_', with: english_title)
+
+        visit "digital_objects/#{digital_object.id}/edit?language_of_description=fre_Latn"
+        wait_for_ajax
+        expect(page).to have_field('digital_object_title_', with: french_title)
+      end
     end
   end
 

--- a/frontend/spec/features/resources_spec.rb
+++ b/frontend/spec/features/resources_spec.rb
@@ -1837,6 +1837,147 @@ describe 'Resources', js: true do
     end
   end
 
+  context 'when multilingual content enabled' do
+    before do
+      AppConfig[:multilingual_content] = true
+    end
+
+    after do
+      AppConfig[:multilingual_content] = false
+    end
+
+    it_behaves_like 'a multilingual parent record', 'resource'
+
+    it 'can create a resource, but lang_description is required' do
+      now = Time.now.to_i
+
+      click_on 'Create'
+      click_on 'Resource'
+      fill_in 'resource_title_', with: "MLC Resource Title #{now}"
+      fill_in 'resource_id_0_', with: "mlc #{now}"
+      fill_in 'resource_id_1_', with: "1 #{now}"
+
+      element = find('#resource_lang_materials__0__language_and_script__language_')
+      element.click
+      element.send_keys('AU')
+      element.send_keys(:tab)
+
+      element = find('#resource_finding_aid_language_')
+      element.click
+      element.send_keys('ENG')
+      element.send_keys(:tab)
+
+      element = find('#resource_finding_aid_script_')
+      element.click
+      element.send_keys('Latin')
+      element.send_keys(:tab)
+
+      select 'Single', from: 'resource_dates__0__date_type_'
+      wait_for_ajax
+      fill_in 'resource_dates__0__begin_', with: '2000'
+      select 'Collection', from: 'resource_level_'
+      fill_in 'resource_extents__0__number_', with: '1'
+      select 'Cubic Feet', from: 'resource_extents__0__extent_type_'
+
+      # Click on save
+      find('button', text: 'Save Resource', match: :first).click
+
+      expect(page).to have_text "Language - Property is required but was missing"
+      expect(page).to have_text "Script - Property is required but was missing"
+
+      element = find('#resource_lang_descriptions__0__language_')
+      element.click
+      element.send_keys('Eng')
+      element.send_keys(:tab)
+
+      element = find('#resource_lang_descriptions__0__script_')
+      element.click
+      element.send_keys('Lat')
+      element.send_keys(:tab)
+
+      find('button', text: 'Save Resource', match: :first).click
+
+      expect(page).to have_text "Resource MLC Resource Title #{now} created"
+    end
+
+    context 'language selector dropdown' do
+      let(:now) { Time.now.to_i }
+      let(:english_title) { "English Title #{now}" }
+
+      let(:resource) do
+        create(:json_resource,
+               title: english_title,
+               instances: [],
+               dates: [build(:json_date, date_type: 'single')],
+               lang_descriptions: [
+                 JSONModel(:language_and_script_of_description).new(
+                   'language' => 'eng', 'script' => 'Latn', 'is_primary' => true
+                 ),
+                 JSONModel(:language_and_script_of_description).new(
+                   'language' => 'fre', 'script' => 'Latn', 'is_primary' => false
+                 )
+               ])
+      end
+
+      before do
+        set_repo @repository
+        login_user(@user)
+        ensure_repository_access
+        select_repository(@repository)
+
+        visit "resources/#{resource.id}/edit"
+        wait_for_ajax
+      end
+
+      it 'shows the language selector dropdown, defaulting to the primary language value' do
+        expect(page).to have_css('#language-of-description-dropdown')
+        expect(page).to have_field('resource_title_', with: english_title)
+      end
+
+      it 'updates the URL when a non-primary language is selected from the dropdown' do
+        within '#language-of-description-dropdown' do
+          find('.dropdown-toggle').click
+          find('input[type="radio"][value="fre_Latn"]').choose
+        end
+        wait_for_ajax
+
+        expect(page.current_url).to include('language_of_description=fre_Latn')
+      end
+
+      it 'saves non-primary language edits to that language without modifying the primary language' do
+        within '#language-of-description-dropdown' do
+          find('.dropdown-toggle').click
+          find('input[type="radio"][value="fre_Latn"]').choose
+        end
+        wait_for_ajax
+
+        french_title = "French Title #{now}"
+        fill_in 'resource_title_', with: french_title
+        find('button', text: 'Save Resource', match: :first).click
+        wait_for_ajax
+
+        expect(page).to have_text "Resource #{french_title} updated"
+
+        visit "resources/#{resource.id}/edit?language_of_description=eng_Latn"
+        wait_for_ajax
+        expect(page).to have_field('resource_title_', with: english_title)
+
+        visit "resources/#{resource.id}/edit?language_of_description=fre_Latn"
+        wait_for_ajax
+        expect(page).to have_field('resource_title_', with: french_title)
+      end
+    end
+  end
+
+  context 'when multilingual content disabled' do
+    before do
+      AppConfig[:multilingual_content] = false
+    end
+
+    it_behaves_like 'a non-multilingual parent record', 'resource'
+
+  end
+
   describe 'view-only permissions' do
     before(:all) do
       @view_only_repo = create(:repo, repo_code: "view_only_resources_#{Time.now.to_i}", publish: true)
@@ -1911,78 +2052,5 @@ describe 'Resources', js: true do
         expect(page).not_to have_css('.inline-tc-edit-btn')
       end
     end
-  end
-
-  context 'when multilingual content enabled' do
-    before do
-      AppConfig[:multilingual_content] = true
-    end
-
-    after do
-      AppConfig[:multilingual_content] = false
-    end
-
-    it_behaves_like 'a multilingual parent record', 'resource'
-
-    it 'can create a resource, but lang_description is required' do
-      now = Time.now.to_i
-
-      click_on 'Create'
-      click_on 'Resource'
-      fill_in 'resource_title_', with: "MLC Resource Title #{now}"
-      fill_in 'resource_id_0_', with: "mlc #{now}"
-      fill_in 'resource_id_1_', with: "1 #{now}"
-
-      element = find('#resource_lang_materials__0__language_and_script__language_')
-      element.click
-      element.send_keys('AU')
-      element.send_keys(:tab)
-
-      element = find('#resource_finding_aid_language_')
-      element.click
-      element.send_keys('ENG')
-      element.send_keys(:tab)
-
-      element = find('#resource_finding_aid_script_')
-      element.click
-      element.send_keys('Latin')
-      element.send_keys(:tab)
-
-      select 'Single', from: 'resource_dates__0__date_type_'
-      wait_for_ajax
-      fill_in 'resource_dates__0__begin_', with: '2000'
-      select 'Collection', from: 'resource_level_'
-      fill_in 'resource_extents__0__number_', with: '1'
-      select 'Cubic Feet', from: 'resource_extents__0__extent_type_'
-
-      # Click on save
-      find('button', text: 'Save Resource', match: :first).click
-
-      expect(page).to have_text "Language - Property is required but was missing"
-      expect(page).to have_text "Script - Property is required but was missing"
-
-      element = find('#resource_lang_descriptions__0__language_')
-      element.click
-      element.send_keys('Eng')
-      element.send_keys(:tab)
-
-      element = find('#resource_lang_descriptions__0__script_')
-      element.click
-      element.send_keys('Lat')
-      element.send_keys(:tab)
-
-      find('button', text: 'Save Resource', match: :first).click
-
-      expect(page).to have_text "Resource MLC Resource Title #{now} created"
-    end
-  end
-
-  context 'when multilingual content disabled' do
-    before do
-      AppConfig[:multilingual_content] = false
-    end
-
-    it_behaves_like 'a non-multilingual parent record', 'resource'
-
   end
 end

--- a/mctf_implementation_plan.md
+++ b/mctf_implementation_plan.md
@@ -132,14 +132,15 @@ The changes outlined here are prototyped in [PR #4000](https://github.com/archiv
 
 ### 3.1 Record toolbar — current-language selector
 
-- [ ] Add "Descriptions" dropdown button to the resource record toolbar
+- [x] Add "Descriptions" dropdown button to the resource record toolbar
   - `frontend/app/views/shared/_resource_toolbar.html.erb`
   - Lists all languages recorded in `lang_descriptions` using ISO 639-2 codes
     - Use the translations available in the current locale files for the language labels
   - Primary language entry carries a badge (reuse existing Bootstrap badge component)
   - Selecting a language sets a client-side state (JS) and triggers a form reload or in-place re-render for that language
-    - Switching from one language to the other while having unsaved changes should give a warning
-- [ ] Same toolbar addition for archival object, accession, digital object toolbars
+    - [ ] Switching from one language to the other while having unsaved changes should give a warning
+- [x] Same toolbar addition for archival object, accession, digital object toolbars
+- [ ] Component tree (archival objects / digital object components) reloads when the language is switched.
 
 ### 3.2 Subform heading — current-language badge
 
@@ -172,7 +173,7 @@ reads the `X-ArchivesSpace-Description-Language` header and puts the resolved pa
 is purely about sending that header from the frontend Rails controllers when they proxy to
 the backend.
 
-- [ ] Frontend Rails controllers forward the currently-selected language as
+- [x] Frontend Rails controllers forward the currently-selected language as
   `X-ArchivesSpace-Description-Language: <iso639_2>_<iso15924>` on every request that creates
   or updates an MLC-backed record
   - `frontend/app/controllers/resources_controller.rb` (and equivalent for archival object,
@@ -181,6 +182,11 @@ the backend.
     in 3.1; the form submit handler passes it through to the Rails controller via a hidden
     field (`language_of_description[language]` + `language_of_description[script]`) which the
     controller reads and sets on the outgoing backend HTTP request's headers
+    - Note: Actual implementation moved away from the hidden field approach
+    to solve the problem of how to have access to the language values on 
+    the initial page edit/load via GET where those hidden form fields
+    aren't available. Implemented instead as a URL-param with logic from
+    `language_selector.js`.  This also satisfied the read requirement below.
   - Read operations (record fetch for the edit form) must send the same header so the backend
     returns the matching `_mlc` row in the scalar field values
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Begins the implementation of the Current Language selector in the SUI edit form.

## Related Ticket (JIRA or GitHub Issue)
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->
https://archivesspace.atlassian.net/browse/ANW-2771

## Summary
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->
This includes the *initial* implementation of both wiring up the staff side UI language selector, and also form submission and retrieval with alternate languages of description (so parts of 3.1 and 3.5 as listed in the mctf_implementation_plan.md

Some functionality is not fully implemented, and follow-on tasks have been created to track these issues.  These include:
- [Define and implement behavior when a primary language of description is added to a record for the first time](https://archivesspace.atlassian.net/browse/ANW-2832)
- [Refresh subrecord language badge when active language selection changes](https://archivesspace.atlassian.net/browse/ANW-2872)
- [Refresh the tree to show correct display strings (when available) when current language dropdown is changed ](https://archivesspace.atlassian.net/browse/ANW-2873)
- [Indexer should use primary language of description title for browse results](https://archivesspace.atlassian.net/browse/ANW-2876)
- [Fix incorrect language written to resource_mlc row on first save of a new record](https://archivesspace.atlassian.net/browse/ANW-2878)

This also takes the opportunity to extract all digital object component tests out of `frontend/spec/features/digital_objects_spec.rb` and into it's own `frontend/spec/features/digital_object_components_spec.rb`.  This work has and will continue to grow DOC related tests, so this felt like a good move (and it will treat DOCs as akin to how AOs are already handled in the frontend test suite).

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/bb0ef38f-6fe6-4eff-92fc-abf63c2db832



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [x] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [x] Have you added tests to cover these changes? If not why:


[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ