### PR TITLE
ANW-2503 upgrade jruby-rack and add swallow_client_abort workaround

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     jdbc-derby (10.12.1.1)
     jdbc-mysql (9.1.0.1)
     jruby-jars (9.4.9.0)
-    jruby-rack (1.2.6)
+    jruby-rack (1.2.7)
     json (2.18.0-java)
     json-schema (1.0.12)
     jwt (2.10.2)

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
     jdbc-derby (10.12.1.1)
     jdbc-mysql (9.1.0.1)
     jruby-jars (9.4.9.0)
-    jruby-rack (1.2.6)
+    jruby-rack (1.2.7)
     json (2.18.0-java)
     json-schema (1.0.12)
     logger (1.7.0)

--- a/build/build.xml
+++ b/build/build.xml
@@ -13,7 +13,7 @@
   <property name="jruby_build_bin_path" value="./gems/jruby/${jruby_build_version}/bin" />
   <!-- Properties for ArchivesSpace build of the JRuby Rack jar -->
   <!-- The versions need to match the gem versions in: build/gems/jruby/$version  -->
-  <property name="jruby_rack_version" value="1.2.6" />
+  <property name="jruby_rack_version" value="1.2.7" />
   <property name="rack_version" value="2.2.21" />
   <property name="bundler_version" value="2.6.9" />
   <property name="jetty_version" value="10.0.26" />

--- a/launcher/archivesspace.bat
+++ b/launcher/archivesspace.bat
@@ -32,6 +32,6 @@ goto END
 :STARTUP
 
 echo Writing log file to logs\archivesspace.out
-java -Darchivesspace-daemon=yes %JAVA_OPTS% -XX:NewRatio=1 -Xss2m -Xmx1024m -Dfile.encoding=UTF-8 -cp "%GEM_HOME%\gems\jruby-rack-1.1.12\lib\*;lib\*;launcher\lib\*!JRUBY!" org.jruby.Main "launcher/launcher.rb" > "logs/archivesspace.out" 2>&1
+java -Darchivesspace-daemon=yes -Djruby.rack.response.swallow_client_abort=false %JAVA_OPTS% -XX:NewRatio=1 -Xss2m -Xmx1024m -Dfile.encoding=UTF-8 -cp "lib\*;launcher\lib\*!JRUBY!" org.jruby.Main "launcher/launcher.rb" > "logs/archivesspace.out" 2>&1
 
 :END

--- a/launcher/archivesspace.sh
+++ b/launcher/archivesspace.sh
@@ -96,7 +96,11 @@ if [ "$ARCHIVESSPACE_APPEND_LOGS" = "" ]; then
     ARCHIVESSPACE_APPEND_LOGS=
 fi
 
-export JAVA_OPTS="-Darchivesspace-daemon=yes $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom"
+# swallow_client_abort is disabled to avoid an infinite loop in jruby-rack's
+# client abort detection that pins a CPU core for the life of the process.
+# See https://github.com/jruby/jruby-rack/issues/449 - fixed upstream but not
+# yet in a release we can use.  Listed before $JAVA_OPTS so sites can override.
+export JAVA_OPTS="-Darchivesspace-daemon=yes -Djruby.rack.response.swallow_client_abort=false $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom"
 
 # Wow.  Not proud of this!
 export JAVA_OPTS="`echo $JAVA_OPTS | sed 's/\([#&;\`|*?~<>^(){}$\,]\)/\\\\\1/g'`"

--- a/launcher/service.bat
+++ b/launcher/service.bat
@@ -85,7 +85,7 @@ FOR /D %%c IN ("!GEM_HOME!\gems\jruby-*") DO (
 goto :doInstall
 
 :doInstall
-%INSTALL_PROCESS% //IS//ArchivesSpaceService --LogPath=%LOG_DIR% --LogPrefix=%LOG_PREFIX% --StdOutput=%AS_LOG% --StdError=%AS_ERROR_LOG%  --DisplayName="ArchivesSpaceService" --Startup=auto ++JvmOptions=-Darchivesspace-daemon=yes ++JvmOptions=%JAVA_OPTS% --JvmOptions=-Xss2m --JvmOptions=-Xmx1024m ++JvmOptions=-Dfile.encoding=UTF-8  --Install=%INSTALL_PROCESS% --StartMode=java --StopMode=java --Classpath="!AS_JARS!;!LAUNCHER_JARS!;!JRUBY!" ++StartParams="'%LAUNCHER_SCRIPT%'" --StartClass=org.jruby.Main ++StopParams="'%LAUNCHER_SCRIPT%'; stop" --StopTimeout=5  --StopClass=org.jruby.Main ++Environment='ASPACE_LAUNCHER_BASE=%ASPACE_LAUNCHER_BASE%'
+%INSTALL_PROCESS% //IS//ArchivesSpaceService --LogPath=%LOG_DIR% --LogPrefix=%LOG_PREFIX% --StdOutput=%AS_LOG% --StdError=%AS_ERROR_LOG%  --DisplayName="ArchivesSpaceService" --Startup=auto ++JvmOptions=-Darchivesspace-daemon=yes ++JvmOptions=-Djruby.rack.response.swallow_client_abort=false ++JvmOptions=%JAVA_OPTS% --JvmOptions=-Xss2m --JvmOptions=-Xmx1024m ++JvmOptions=-Dfile.encoding=UTF-8  --Install=%INSTALL_PROCESS% --StartMode=java --StopMode=java --Classpath="!AS_JARS!;!LAUNCHER_JARS!;!JRUBY!" ++StartParams="'%LAUNCHER_SCRIPT%'" --StartClass=org.jruby.Main ++StopParams="'%LAUNCHER_SCRIPT%'; stop" --StopTimeout=5  --StopClass=org.jruby.Main ++Environment='ASPACE_LAUNCHER_BASE=%ASPACE_LAUNCHER_BASE%'
 if not errorlevel 1 goto installed
 echo "There was a problem installing the service...please check the settings."
 goto end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-2503]
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->

## Summary

ArchivesSpace instances have reported a CPU core goes to 100% and stays there, one core at a time over days or weeks, with the application otherwise serving requests normally. Restarting is the only recovery, GC tuning makes no difference, and heap size is irrelevant.

The cause is a bug in jruby-rack, not in ArchivesSpace. Full details have been reported in jruby/jruby-rack#449.

The upstream fix jruby/jruby-rack/pull/450 is merged and backported to 1.2-stable, but it is not in any released version, so there is no upgrade that resolves this for us. The bug dates to 2013 and is present in every release to date.

This PR therefore applies the supported workaround setting jruby-rack's jruby.rack.response.swallow_client_abort property to false makes the endless loop causing the issue unreachable. The flag is added to all three launchers - Unix, Windows interactive, and the Windows service - positioned before the installations's own JAVA_OPTS so an administrator can still override it.

The trade-off is that genuine client aborts now propagate and are logged instead of being swallowed quietly, so installations may see stack traces when users cancel large downloads.

Furthermore:

- jruby-rack 1.2.6 upgraded to 1.2.7. Independently worthwhile as 1.2.7 does not contain the fix above and does not remove the need for the workaround.

- Removed a hardcoded classpath in archivesspace.bat pointing at jruby-rack-1.1.12, a directory that has not existed for many versions. It was silently ignored by the JVM and therefore harmless, but it was also redundant

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [ ] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:


[ANW-2503]: https://archivesspace.atlassian.net/browse/ANW-2503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ