### PR TITLE
ANW-2899 ensure suppressed records are not exported in subreports to …

### DIFF
--- a/backend/app/model/reports/abstract_report.rb
+++ b/backend/app/model/reports/abstract_report.rb
@@ -1,10 +1,12 @@
 require_relative 'report_manager'
+require_relative 'report_suppression'
 require_relative '../../lib/reports/report_utils'
 require 'erb'
 
 class AbstractReport
   include ReportManager::Mixin
   include JSONModel
+  include ReportSuppression
 
   attr_accessor :repo_id
   attr_accessor :format
@@ -14,7 +16,6 @@ class AbstractReport
   attr_accessor :info
   attr_accessor :page_break
   attr_accessor :expand_csv
-  attr_accessor :include_suppressed
 
   def initialize(params, job, db)
     @repo_id = params[:repo_id] if params.has_key?(:repo_id) && params[:repo_id] != ''
@@ -25,10 +26,6 @@ class AbstractReport
     @db = db
     @job = job
     @info = {}
-  end
-
-  def suppressed_filter(table_name)
-    @include_suppressed ? '' : " AND #{table_name}.suppressed = 0"
   end
 
   def page_break

--- a/backend/app/model/reports/abstract_subreport.rb
+++ b/backend/app/model/reports/abstract_subreport.rb
@@ -1,9 +1,11 @@
 require_relative '../../lib/reports/report_utils'
 require_relative 'custom_field'
+require_relative 'report_suppression'
 
 class AbstractSubreport
 
   include CustomField::Mixin
+  include ReportSuppression
 
   attr_accessor :repo_id
   attr_accessor :db
@@ -15,6 +17,7 @@ class AbstractSubreport
     @db = parent_report.db
     @job = parent_report.job
     @format = parent_report.format
+    @include_suppressed = parent_report.include_suppressed
   end
 
   def get_content

--- a/backend/app/model/reports/report_suppression.rb
+++ b/backend/app/model/reports/report_suppression.rb
@@ -1,0 +1,14 @@
+# Suppression filtering shared by reports and subreports.
+#
+# Reports only export suppressed records when the user holds the
+# view_suppressed permission and has explicitly asked for them (see
+# ReportsRunner), so every query joining a suppressible table needs this filter.
+# Subreports inherit the setting from the report that spawned them.
+module ReportSuppression
+
+  attr_accessor :include_suppressed
+
+  def suppressed_filter(table_name)
+    include_suppressed ? '' : " AND ifnull(#{table_name}.suppressed, 0) = 0"
+  end
+end

--- a/backend/spec/report_suppression_spec.rb
+++ b/backend/spec/report_suppression_spec.rb
@@ -16,7 +16,7 @@ describe 'Report suppression filtering' do
       let(:params) { { repo_id: $repo_id, format: 'html' } }
 
       it 'appends a suppression clause' do
-        expect(report.suppressed_filter('resource')).to eq(' AND resource.suppressed = 0')
+        expect(report.suppressed_filter('resource')).to eq(' AND ifnull(resource.suppressed, 0) = 0')
       end
     end
 
@@ -40,7 +40,7 @@ describe 'Report suppression filtering' do
       let(:params) { { repo_id: $repo_id, format: 'html', 'include_suppressed' => false } }
 
       it 'appends the suppression clause' do
-        expect(report.suppressed_filter('resource')).to eq(' AND resource.suppressed = 0')
+        expect(report.suppressed_filter('resource')).to eq(' AND ifnull(resource.suppressed, 0) = 0')
       end
     end
   end

--- a/backend/spec/report_suppression_subreport_spec.rb
+++ b/backend/spec/report_suppression_subreport_spec.rb
@@ -1,0 +1,624 @@
+require 'spec_helper'
+
+describe 'Report suppression filtering, subreports' do
+  def parent_report(db, include_suppressed, record_type)
+    double('ParentReport',
+           repo_id: $repo_id,
+           db: db,
+           job: double('Job', write_output: nil),
+           format: 'html',
+           include_suppressed: include_suppressed,
+           record_type: record_type,
+           subreports: [])
+  end
+
+  def subreport_rows(subreport_class, *args, include_suppressed: false, record_type: nil)
+    DB.open do |db|
+      subreport = subreport_class.new(parent_report(db, include_suppressed, record_type), *args)
+      db.fetch(subreport.query_string).map(&:to_hash)
+    end
+  end
+
+  shared_examples 'a subreport that omits suppressed records by default' do
+    it 'drops the record once suppressed and reports it again when include_suppressed is set' do
+      expect(reported_values)
+        .to include(expected_value), 'expected the linked record to be reported before it is suppressed'
+
+      record_to_suppress.set_suppressed(true)
+
+      expect(reported_values).to_not include(expected_value)
+      expect(reported_values(include_suppressed: true)).to include(expected_value)
+    end
+  end
+
+  describe 'the include_suppressed setting' do
+    let(:report) do
+      AccessionReport.new({ repo_id: $repo_id, format: 'html', 'include_suppressed' => '1' },
+                          double('Job', write_output: nil),
+                          nil)
+    end
+
+    it 'is inherited from the report that spawned the subreport' do
+      subreport = AccessionResourcesSubreport.new(report, 1)
+
+      expect(subreport.include_suppressed).to eq('1')
+    end
+
+    it 'is inherited through nested subreports' do
+      nested = LocationAccessionsContainersSubreport.new(
+        LocationAccessionsSubreport.new(report, 1), 1, 2)
+
+      expect(nested.include_suppressed).to eq('1')
+    end
+
+    it 'is off by default, so the filters are applied' do
+      subreport = AccessionResourcesSubreport.new(
+        AccessionReport.new({ repo_id: $repo_id, format: 'html' }, double('Job'), nil), 1)
+
+      expect(subreport.include_suppressed).to be_falsey
+      expect(subreport.suppressed_filter('resource'))
+        .to eq(' AND ifnull(resource.suppressed, 0) = 0')
+    end
+  end
+
+  describe AccessionResourcesSubreport do
+    let(:accession) { Accession.create_from_json(build(:json_accession), repo_id: $repo_id) }
+    let(:expected_value) { "Spawned Resource #{SecureRandom.hex(6)}" }
+    let!(:resource) do
+      Resource.create_from_json(
+        build(:json_resource,
+              title: expected_value,
+              related_accessions: [{ 'ref' => accession.uri }]),
+        repo_id: $repo_id)
+    end
+    let(:record_to_suppress) { resource }
+
+    def reported_values(include_suppressed: false)
+      subreport_rows(AccessionResourcesSubreport, accession.id,
+                     include_suppressed: include_suppressed).map { |row| row[:title] }
+    end
+
+    it_behaves_like 'a subreport that omits suppressed records by default'
+  end
+
+  describe AccessionLinkedAccessionsSubreport do
+    let(:related) { Accession.create_from_json(build(:json_accession), repo_id: $repo_id) }
+    let!(:accession) do
+      Accession.create_from_json(
+        build(:json_accession,
+              related_accessions: [{ 'ref' => related.uri,
+                                     'relator' => 'sibling_of',
+                                     'relator_type' => 'bound_with',
+                                     'jsonmodel_type' => 'accession_sibling_relationship' }]),
+        repo_id: $repo_id)
+    end
+    let(:record_to_suppress) { related }
+    let(:expected_value) { related.identifier }
+
+    def reported_values(include_suppressed: false)
+      subreport_rows(AccessionLinkedAccessionsSubreport, accession.id,
+                     include_suppressed: include_suppressed)
+        .flat_map { |row| [row[:id0], row[:id1]] }
+    end
+
+    it_behaves_like 'a subreport that omits suppressed records by default'
+  end
+
+  describe AccessionClassificationsSubreport do
+    let(:expected_value) { "Suppressible Classification #{SecureRandom.hex(6)}" }
+    let(:classification) do
+      Classification.create_from_json(build(:json_classification, title: expected_value),
+                                      repo_id: $repo_id)
+    end
+    let!(:accession) do
+      Accession.create_from_json(
+        build(:json_accession, classifications: [{ 'ref' => classification.uri }]),
+        repo_id: $repo_id)
+    end
+    let(:record_to_suppress) { classification }
+
+    def reported_values(include_suppressed: false)
+      subreport_rows(AccessionClassificationsSubreport, accession.id,
+                     include_suppressed: include_suppressed).map { |row| row[:title] }
+    end
+
+    it_behaves_like 'a subreport that omits suppressed records by default'
+  end
+
+  describe ClassificationSubreport do
+    let(:expected_value) { "Suppressible Classification #{SecureRandom.hex(6)}" }
+    let(:classification) do
+      Classification.create_from_json(build(:json_classification, title: expected_value),
+                                      repo_id: $repo_id)
+    end
+    let!(:accession) do
+      Accession.create_from_json(
+        build(:json_accession, classifications: [{ 'ref' => classification.uri }]),
+        repo_id: $repo_id)
+    end
+    let(:record_to_suppress) { classification }
+
+    def reported_values(include_suppressed: false)
+      subreport_rows(ClassificationSubreport, accession.id,
+                     include_suppressed: include_suppressed,
+                     record_type: 'accession').map { |row| row[:title] }
+    end
+
+    it_behaves_like 'a subreport that omits suppressed records by default'
+  end
+
+  describe ClassificationTermSubreport do
+    let(:classification) do
+      Classification.create_from_json(build(:json_classification), repo_id: $repo_id)
+    end
+    let(:expected_value) { "Suppressible Term #{SecureRandom.hex(6)}" }
+    let!(:term) do
+      ClassificationTerm.create_from_json(
+        build(:json_classification_term,
+              title: expected_value,
+              classification: { 'ref' => classification.uri }),
+        repo_id: $repo_id)
+    end
+    let(:record_to_suppress) { term }
+
+    def reported_values(include_suppressed: false)
+      subreport_rows(ClassificationTermSubreport, classification.id,
+                     include_suppressed: include_suppressed).map { |row| row[:title] }
+    end
+
+    it_behaves_like 'a subreport that omits suppressed records by default'
+  end
+
+  describe AssessmentLinkedRecordsSubreport do
+    def reported_values(include_suppressed: false)
+      subreport_rows(AssessmentLinkedRecordsSubreport, assessment.id,
+                     include_suppressed: include_suppressed).map { |row| row[:record_title] }
+    end
+
+    def assessment_for(uri)
+      Assessment.create_from_json(build(:json_assessment, records: [{ 'ref' => uri }]),
+                                  repo_id: $repo_id)
+    end
+
+    describe 'a linked resource' do
+      let(:expected_value) { "Suppressible Resource #{SecureRandom.hex(6)}" }
+      let(:resource) do
+        Resource.create_from_json(build(:json_resource, title: expected_value), repo_id: $repo_id)
+      end
+      let!(:assessment) { assessment_for(resource.uri) }
+      let(:record_to_suppress) { resource }
+
+      it_behaves_like 'a subreport that omits suppressed records by default'
+    end
+
+    describe 'a linked archival object' do
+      let(:expected_value) { "Suppressible Archival Object #{SecureRandom.hex(6)}" }
+      let(:archival_object) do
+        ArchivalObject.create_from_json(build(:json_archival_object, title: expected_value),
+                                        repo_id: $repo_id)
+      end
+      let!(:assessment) { assessment_for(archival_object.uri) }
+      let(:record_to_suppress) { archival_object }
+
+      it_behaves_like 'a subreport that omits suppressed records by default'
+    end
+
+    describe 'a linked accession' do
+      let(:expected_value) { "Suppressible Accession #{SecureRandom.hex(6)}" }
+      let(:accession) do
+        Accession.create_from_json(build(:json_accession, title: expected_value), repo_id: $repo_id)
+      end
+      let!(:assessment) { assessment_for(accession.uri) }
+      let(:record_to_suppress) { accession }
+
+      it_behaves_like 'a subreport that omits suppressed records by default'
+    end
+
+    describe 'a linked digital object' do
+      let(:expected_value) { "Suppressible Digital Object #{SecureRandom.hex(6)}" }
+      let(:digital_object) do
+        DigitalObject.create_from_json(build(:json_digital_object, title: expected_value),
+                                       repo_id: $repo_id)
+      end
+      let!(:assessment) { assessment_for(digital_object.uri) }
+      let(:record_to_suppress) { digital_object }
+
+      it_behaves_like 'a subreport that omits suppressed records by default'
+    end
+  end
+
+  describe DigitalObjectFileVersionsListSubreport do
+    let(:digital_object) do
+      DigitalObject.create_from_json(
+        build(:json_digital_object, file_versions: [build(:json_file_version)]),
+        repo_id: $repo_id)
+    end
+    let(:expected_value) { "Suppressible Component #{SecureRandom.hex(6)}" }
+    let!(:component) do
+      DigitalObjectComponent.create_from_json(
+        build(:json_digital_object_component,
+              title: expected_value,
+              digital_object: { 'ref' => digital_object.uri },
+              file_versions: [build(:json_file_version)]),
+        repo_id: $repo_id)
+    end
+    let(:record_to_suppress) { component }
+
+    def reported_values(include_suppressed: false)
+      subreport_rows(DigitalObjectFileVersionsListSubreport, digital_object.id,
+                     include_suppressed: include_suppressed)
+        .map { |row| row[:digital_object_component_title] }
+    end
+
+    it_behaves_like 'a subreport that omits suppressed records by default'
+
+    it 'still reports the file versions of the unsuppressed digital object' do
+      component.set_suppressed(true)
+
+      expect(subreport_rows(DigitalObjectFileVersionsListSubreport, digital_object.id))
+        .to_not be_empty
+    end
+  end
+
+  describe EventSubreport do
+    let(:accession) { Accession.create_from_json(build(:json_accession), repo_id: $repo_id) }
+    let!(:event) do
+      Event.create_from_json(
+        build(:json_event,
+              linked_records: [{ 'ref' => accession.uri, 'role' => 'source' }]),
+        repo_id: $repo_id)
+    end
+    let(:record_to_suppress) { event }
+    let(:expected_value) { event.id }
+
+    def reported_values(include_suppressed: false)
+      subreport_rows(EventSubreport, accession.id,
+                     include_suppressed: include_suppressed,
+                     record_type: 'accession').map { |row| row[:id] }
+    end
+
+    it_behaves_like 'a subreport that omits suppressed records by default'
+  end
+
+  describe LinkedAccessionSubreport do
+    let(:expected_value) { "Suppressible Accession #{SecureRandom.hex(6)}" }
+    let(:accession) do
+      Accession.create_from_json(build(:json_accession, title: expected_value), repo_id: $repo_id)
+    end
+    let!(:event) do
+      Event.create_from_json(
+        build(:json_event, linked_records: [{ 'ref' => accession.uri, 'role' => 'source' }]),
+        repo_id: $repo_id)
+    end
+    let(:record_to_suppress) { accession }
+
+    def reported_values(include_suppressed: false)
+      subreport_rows(LinkedAccessionSubreport, event.id,
+                     include_suppressed: include_suppressed,
+                     record_type: 'event').map { |row| row[:title] }
+    end
+
+    it_behaves_like 'a subreport that omits suppressed records by default'
+  end
+
+  describe LinkedResourceSubreport do
+    let(:expected_value) { "Suppressible Resource #{SecureRandom.hex(6)}" }
+    let(:resource) do
+      Resource.create_from_json(build(:json_resource, title: expected_value), repo_id: $repo_id)
+    end
+    let!(:event) do
+      Event.create_from_json(
+        build(:json_event, linked_records: [{ 'ref' => resource.uri, 'role' => 'source' }]),
+        repo_id: $repo_id)
+    end
+    let(:record_to_suppress) { resource }
+
+    def reported_values(include_suppressed: false)
+      subreport_rows(LinkedResourceSubreport, event.id,
+                     include_suppressed: include_suppressed,
+                     record_type: 'event').map { |row| row[:title] }
+    end
+
+    it_behaves_like 'a subreport that omits suppressed records by default'
+  end
+
+  describe LinkedArchivalObjectSubreport do
+    let(:expected_value) { "Suppressible Archival Object #{SecureRandom.hex(6)}" }
+    let(:archival_object) do
+      ArchivalObject.create_from_json(build(:json_archival_object, title: expected_value),
+                                      repo_id: $repo_id)
+    end
+    let!(:event) do
+      Event.create_from_json(
+        build(:json_event, linked_records: [{ 'ref' => archival_object.uri, 'role' => 'source' }]),
+        repo_id: $repo_id)
+    end
+    let(:record_to_suppress) { archival_object }
+
+    def reported_values(include_suppressed: false)
+      subreport_rows(LinkedArchivalObjectSubreport, event.id,
+                     include_suppressed: include_suppressed,
+                     record_type: 'event').map { |row| row[:title] }
+    end
+
+    it_behaves_like 'a subreport that omits suppressed records by default'
+  end
+
+  describe LinkedDigitalObjectSubreport do
+    let(:expected_value) { "Suppressible Digital Object #{SecureRandom.hex(6)}" }
+    let(:digital_object) do
+      DigitalObject.create_from_json(build(:json_digital_object, title: expected_value),
+                                     repo_id: $repo_id)
+    end
+    let!(:event) do
+      Event.create_from_json(
+        build(:json_event, linked_records: [{ 'ref' => digital_object.uri, 'role' => 'source' }]),
+        repo_id: $repo_id)
+    end
+    let(:record_to_suppress) { digital_object }
+
+    def reported_values(include_suppressed: false)
+      subreport_rows(LinkedDigitalObjectSubreport, event.id,
+                     include_suppressed: include_suppressed,
+                     record_type: 'event').map { |row| row[:title] }
+    end
+
+    it_behaves_like 'a subreport that omits suppressed records by default'
+  end
+
+  describe LinkedDigitalObjectComponentSubreport do
+    let(:expected_value) { "Suppressible Component #{SecureRandom.hex(6)}" }
+    let(:component) do
+      DigitalObjectComponent.create_from_json(build(:json_digital_object_component,
+                                                    title: expected_value),
+                                              repo_id: $repo_id)
+    end
+    let!(:event) do
+      Event.create_from_json(
+        build(:json_event, linked_records: [{ 'ref' => component.uri, 'role' => 'source' }]),
+        repo_id: $repo_id)
+    end
+    let(:record_to_suppress) { component }
+
+    def reported_values(include_suppressed: false)
+      subreport_rows(LinkedDigitalObjectComponentSubreport, event.id,
+                     include_suppressed: include_suppressed,
+                     record_type: 'event').map { |row| row[:title] }
+    end
+
+    it_behaves_like 'a subreport that omits suppressed records by default'
+  end
+
+  describe 'location and container subreports' do
+    let(:location) { create(:json_location) }
+    let(:top_container) do
+      create(:json_top_container,
+             container_locations: [{ 'ref' => location.uri,
+                                     'status' => 'current',
+                                     'start_date' => generate(:yyyy_mm_dd) }])
+    end
+    let(:instance) do
+      build(:json_instance,
+            instance_type: 'text',
+            sub_container: build(:json_sub_container,
+                                 top_container: { 'ref' => top_container.uri }))
+    end
+
+    describe LocationAccessionsSubreport do
+      let(:expected_value) { "Suppressible Accession #{SecureRandom.hex(6)}" }
+      let!(:accession) do
+        Accession.create_from_json(
+          build(:json_accession, title: expected_value, instances: [instance]),
+          repo_id: $repo_id)
+      end
+      let(:record_to_suppress) { accession }
+
+      def reported_values(include_suppressed: false)
+        subreport_rows(LocationAccessionsSubreport, Location[location.id].id,
+                       include_suppressed: include_suppressed).map { |row| row[:title] }
+      end
+
+      it_behaves_like 'a subreport that omits suppressed records by default'
+    end
+
+    describe LocationResourcesSubreport do
+      let(:expected_value) { "Suppressible Resource #{SecureRandom.hex(6)}" }
+      let!(:resource) do
+        Resource.create_from_json(
+          build(:json_resource, title: expected_value, instances: [instance]),
+          repo_id: $repo_id)
+      end
+      let(:record_to_suppress) { resource }
+
+      def reported_values(include_suppressed: false)
+        subreport_rows(LocationResourcesSubreport, Location[location.id].id,
+                       include_suppressed: include_suppressed).map { |row| row[:title] }
+      end
+
+      it_behaves_like 'a subreport that omits suppressed records by default'
+
+      describe 'when the instance hangs off an archival object' do
+        let(:resource) do
+          Resource.create_from_json(build(:json_resource, title: expected_value), repo_id: $repo_id)
+        end
+        let!(:archival_object) do
+          ArchivalObject.create_from_json(
+            build(:json_archival_object,
+                  resource: { 'ref' => resource.uri },
+                  instances: [instance]),
+            repo_id: $repo_id)
+        end
+        let(:record_to_suppress) { archival_object }
+
+        it_behaves_like 'a subreport that omits suppressed records by default'
+      end
+    end
+
+    describe ContainerResourcesAccessionsSubreport do
+      def reported_values(include_suppressed: false)
+        subreport_rows(ContainerResourcesAccessionsSubreport, TopContainer[top_container.id].id,
+                       include_suppressed: include_suppressed).map { |row| row[:record_title] }
+      end
+
+      describe 'a linked accession' do
+        let(:expected_value) { "Suppressible Accession #{SecureRandom.hex(6)}" }
+        let!(:accession) do
+          Accession.create_from_json(
+            build(:json_accession, title: expected_value, instances: [instance]),
+            repo_id: $repo_id)
+        end
+        let(:record_to_suppress) { accession }
+
+        it_behaves_like 'a subreport that omits suppressed records by default'
+      end
+
+      describe 'a linked resource' do
+        let(:expected_value) { "Suppressible Resource #{SecureRandom.hex(6)}" }
+        let!(:resource) do
+          Resource.create_from_json(
+            build(:json_resource, title: expected_value, instances: [instance]),
+            repo_id: $repo_id)
+        end
+        let(:record_to_suppress) { resource }
+
+        it_behaves_like 'a subreport that omits suppressed records by default'
+      end
+
+      describe 'a resource reached through an archival object' do
+        let(:expected_value) { "Suppressible Resource #{SecureRandom.hex(6)}" }
+        let(:resource) do
+          Resource.create_from_json(build(:json_resource, title: expected_value), repo_id: $repo_id)
+        end
+        let!(:archival_object) do
+          ArchivalObject.create_from_json(
+            build(:json_archival_object,
+                  resource: { 'ref' => resource.uri },
+                  instances: [instance]),
+            repo_id: $repo_id)
+        end
+        let(:record_to_suppress) { archival_object }
+
+        it_behaves_like 'a subreport that omits suppressed records by default'
+      end
+    end
+
+    describe ResourceLocationsSubreport do
+      let(:resource) { Resource.create_from_json(build(:json_resource), repo_id: $repo_id) }
+      let!(:archival_object) do
+        ArchivalObject.create_from_json(
+          build(:json_archival_object,
+                resource: { 'ref' => resource.uri },
+                instances: [instance]),
+          repo_id: $repo_id)
+      end
+      let(:record_to_suppress) { archival_object }
+      let(:expected_value) { Location[location.id].title }
+
+      def reported_values(include_suppressed: false)
+        subreport_rows(ResourceLocationsSubreport, resource.id,
+                       include_suppressed: include_suppressed).map { |row| row[:location] }
+      end
+
+      it_behaves_like 'a subreport that omits suppressed records by default'
+    end
+
+    describe ResourceInstancesSubreport do
+      let(:resource) { Resource.create_from_json(build(:json_resource), repo_id: $repo_id) }
+      let!(:archival_object) do
+        ArchivalObject.create_from_json(
+          build(:json_archival_object,
+                resource: { 'ref' => resource.uri },
+                instances: [instance]),
+          repo_id: $repo_id)
+      end
+      let(:record_to_suppress) { archival_object }
+      let(:expected_value) { TopContainer[top_container.id].indicator }
+
+      def reported_values(include_suppressed: false)
+        subreport_rows(ResourceInstancesSubreport, resource.id,
+                       include_suppressed: include_suppressed).map { |row| row[:indicator_1] }
+      end
+
+      it_behaves_like 'a subreport that omits suppressed records by default'
+    end
+
+    describe LocationResourcesContainersSubreport do
+      let(:resource) { Resource.create_from_json(build(:json_resource), repo_id: $repo_id) }
+      let!(:archival_object) do
+        ArchivalObject.create_from_json(
+          build(:json_archival_object,
+                resource: { 'ref' => resource.uri },
+                instances: [instance]),
+          repo_id: $repo_id)
+      end
+      let(:record_to_suppress) { archival_object }
+      let(:expected_value) { TopContainer[top_container.id].indicator }
+
+      def reported_values(include_suppressed: false)
+        subreport_rows(LocationResourcesContainersSubreport,
+                       Location[location.id].id, resource.id,
+                       include_suppressed: include_suppressed).map { |row| row[:indicator] }
+      end
+
+      it_behaves_like 'a subreport that omits suppressed records by default'
+    end
+  end
+
+  # The instances subreports roll the titles of any linked digital objects into
+  # a single column, which leaked suppressed digital objects the same way.
+  describe 'digital objects linked to an instance' do
+    let(:expected_value) { "Suppressible Digital Object #{SecureRandom.hex(6)}" }
+    let(:digital_object) do
+      DigitalObject.create_from_json(build(:json_digital_object, title: expected_value),
+                                     repo_id: $repo_id)
+    end
+    let(:instance) do
+      build(:json_instance,
+            instance_type: 'digital_object',
+            digital_object: { 'ref' => digital_object.uri },
+            sub_container: nil)
+    end
+    let(:record_to_suppress) { digital_object }
+
+    describe AccessionInstancesSubreport do
+      let!(:accession) do
+        Accession.create_from_json(build(:json_accession, instances: [instance]),
+                                   repo_id: $repo_id)
+      end
+
+      def reported_values(include_suppressed: false)
+        subreport_rows(AccessionInstancesSubreport, accession.id,
+                       include_suppressed: include_suppressed).map { |row| row[:digital_object] }
+      end
+
+      it_behaves_like 'a subreport that omits suppressed records by default'
+    end
+
+    describe ArchivalObjectInstancesSubreport do
+      let!(:archival_object) do
+        ArchivalObject.create_from_json(build(:json_archival_object, instances: [instance]),
+                                        repo_id: $repo_id)
+      end
+
+      def reported_values(include_suppressed: false)
+        subreport_rows(ArchivalObjectInstancesSubreport, archival_object.id,
+                       include_suppressed: include_suppressed).map { |row| row[:digital_object] }
+      end
+
+      it_behaves_like 'a subreport that omits suppressed records by default'
+    end
+
+    describe ResourceInstancesSubreport do
+      let!(:resource) do
+        Resource.create_from_json(build(:json_resource, instances: [instance]), repo_id: $repo_id)
+      end
+
+      def reported_values(include_suppressed: false)
+        subreport_rows(ResourceInstancesSubreport, resource.id,
+                       include_suppressed: include_suppressed).map { |row| row[:digital_object] }
+      end
+
+      it_behaves_like 'a subreport that omits suppressed records by default'
+    end
+  end
+end

--- a/reports/accessions/accession_classifications_subreport/accession_classifications_subreport.rb
+++ b/reports/accessions/accession_classifications_subreport/accession_classifications_subreport.rb
@@ -17,7 +17,9 @@ class AccessionClassificationsSubreport < AbstractSubreport
           = classification_rlshp.classification_id
         left outer join classification_term on classification_term.id
           = classification_rlshp.classification_term_id
-    where accession_id = #{db.literal(@accession_id)}"
+    where accession_id = #{db.literal(@accession_id)}
+      #{suppressed_filter('classification')}
+      #{suppressed_filter('classification_term')}"
   end
 
 end

--- a/reports/accessions/accession_instances_subreport/accession_instances_subreport.rb
+++ b/reports/accessions/accession_instances_subreport/accession_instances_subreport.rb
@@ -68,6 +68,7 @@ class AccessionInstancesSubreport < AbstractSubreport
           group_concat(digital_object.title separator '; ') as digital_object
         from instance_do_link_rlshp, digital_object
         where instance_do_link_rlshp.digital_object_id = digital_object.id
+          #{suppressed_filter('digital_object')}
         group by instance_do_link_rlshp.instance_id) as digital_objects
       on digital_objects.instance_id = instances.id"
   end

--- a/reports/accessions/accession_linked_accessions_subreport/accession_linked_accessions_subreport.rb
+++ b/reports/accessions/accession_linked_accessions_subreport/accession_linked_accessions_subreport.rb
@@ -16,8 +16,10 @@ class AccessionLinkedAccessionsSubreport < AbstractSubreport
     from related_accession_rlshp
       join accession as accession0 on accession_id_0 = accession0.id
       join accession as accession1 on accession_id_1 = accession1.id
-    where accession_id_0 = #{db.literal(@accession_id)}
-      or accession_id_1 = #{db.literal(@accession_id)}"
+    where (accession_id_0 = #{db.literal(@accession_id)}
+      or accession_id_1 = #{db.literal(@accession_id)})
+      #{suppressed_filter('accession0')}
+      #{suppressed_filter('accession1')}"
   end
 
   def fix_row(row)

--- a/reports/accessions/accession_resources_subreport/accession_resources_subreport.rb
+++ b/reports/accessions/accession_resources_subreport/accession_resources_subreport.rb
@@ -9,7 +9,8 @@ class AccessionResourcesSubreport < AbstractSubreport
     "select identifier, title
     from resource, spawned_rlshp
     where spawned_rlshp.accession_id = #{db.literal(@accession_id)}
-      and spawned_rlshp.resource_id = resource.id"
+      and spawned_rlshp.resource_id = resource.id
+      #{suppressed_filter('resource')}"
   end
 
   def fix_row(row)

--- a/reports/assessments/assessment_linked_records_subreport/assessment_linked_records_subreport.rb
+++ b/reports/assessments/assessment_linked_records_subreport/assessment_linked_records_subreport.rb
@@ -13,7 +13,8 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
       resource.identifier as identifier
     from assessment_rlshp
       join resource on assessment_rlshp.resource_id = resource.id
-    where assessment_rlshp.assessment_id = #{db.literal(@assessment_id)})
+    where assessment_rlshp.assessment_id = #{db.literal(@assessment_id)}
+      #{suppressed_filter('resource')})
 
     union
 
@@ -25,7 +26,9 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
     from assessment_rlshp
       join archival_object on assessment_rlshp.archival_object_id = archival_object.id
       join resource on archival_object.root_record_id = resource.id
-    where assessment_rlshp.assessment_id = #{db.literal(@assessment_id)})
+    where assessment_rlshp.assessment_id = #{db.literal(@assessment_id)}
+      #{suppressed_filter('archival_object')}
+      #{suppressed_filter('resource')})
 
     union
 
@@ -36,7 +39,8 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
       accession.identifier as identifier
     from assessment_rlshp
       join accession on assessment_rlshp.accession_id = accession.id
-    where assessment_rlshp.assessment_id = #{db.literal(@assessment_id)})
+    where assessment_rlshp.assessment_id = #{db.literal(@assessment_id)}
+      #{suppressed_filter('accession')})
 
     union
 
@@ -47,7 +51,8 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
       digital_object.digital_object_id as identifier
     from assessment_rlshp
       join digital_object on assessment_rlshp.digital_object_id = digital_object.id
-    where assessment_rlshp.assessment_id = #{db.literal(@assessment_id)})"
+    where assessment_rlshp.assessment_id = #{db.literal(@assessment_id)}
+      #{suppressed_filter('digital_object')})"
   end
 
   def fix_row(row)

--- a/reports/custom/classification_subreport.rb
+++ b/reports/custom/classification_subreport.rb
@@ -30,7 +30,9 @@ class ClassificationSubreport < AbstractSubreport
 		    left outer join classification as root_record
 				on root_record.id = classification_term.root_record_id
 
-		where classification_rlshp.#{@id_type}_id = #{db.literal(@id)}"
+		where classification_rlshp.#{@id_type}_id = #{db.literal(@id)}
+			#{suppressed_filter('classification')}
+			#{suppressed_filter('classification_term')}"
 	end
 
 	def fix_row(row)

--- a/reports/custom/classification_term_subreport.rb
+++ b/reports/custom/classification_term_subreport.rb
@@ -23,7 +23,8 @@ class ClassificationTermSubreport < AbstractSubreport
 			description
 		from classification_term
 		where root_record_id = #{db.literal(@classification_id)}
-			and #{parent_condition}"
+			and #{parent_condition}
+			#{suppressed_filter('classification_term')}"
 	end
 
 	def fix_row(row)

--- a/reports/custom/event_subreport.rb
+++ b/reports/custom/event_subreport.rb
@@ -19,7 +19,8 @@ class EventSubreport < AbstractSubreport
 	    event.timestamp
 		from event, event_link_rlshp
 		where event.id = event_link_rlshp.event_id
-			and #{@id_type}_id = #{db.literal(@id)}"
+			and #{@id_type}_id = #{db.literal(@id)}
+			#{suppressed_filter('event')}"
 	end
 
 	def fix_row(row)

--- a/reports/custom/linked_accession_subreport.rb
+++ b/reports/custom/linked_accession_subreport.rb
@@ -43,7 +43,8 @@ class LinkedAccessionSubreport < AbstractSubreport
 		from accession, #{@link_table}
 		where #{@link_table}.#{@id_field} = #{db.literal(@id)}
 		and #{@link_table}.accession_id = accession.id
-		and accession.repo_id = #{db.literal(@repo_id)}"
+		and accession.repo_id = #{db.literal(@repo_id)}
+		#{suppressed_filter('accession')}"
 	end
 
 	def fix_row(row)

--- a/reports/custom/linked_archival_object_subreport.rb
+++ b/reports/custom/linked_archival_object_subreport.rb
@@ -36,6 +36,8 @@ class LinkedArchivalObjectSubreport < AbstractSubreport
 			from_string += ", resource"
 			where_string += " and #{@link_table}.archival_object_id = archival_object.id"
 		end
+		where_string += suppressed_filter('archival_object')
+		where_string += suppressed_filter('resource')
 
 		fields = ['archival_object.component_id',
 							'archival_object.title',

--- a/reports/custom/linked_digital_object.rb
+++ b/reports/custom/linked_digital_object.rb
@@ -35,7 +35,8 @@ class LinkedDigitalObjectSubreport < AbstractSubreport
 		from digital_object, #{@link_table}
 		where #{@link_table}.#{@id_field} = #{db.literal(@id)}
 		and #{@link_table}.digital_object_id = digital_object.id
-		and digital_object.repo_id = #{db.literal(@repo_id)}"
+		and digital_object.repo_id = #{db.literal(@repo_id)}
+		#{suppressed_filter('digital_object')}"
 	end
 
 	def fix_row(row)

--- a/reports/custom/linked_digital_object_component.rb
+++ b/reports/custom/linked_digital_object_component.rb
@@ -39,7 +39,9 @@ class LinkedDigitalObjectComponentSubreport < AbstractSubreport
 			and #{@link_table}.digital_object_component_id
 			= digital_object_component.id
 			and digital_object_component.root_record_id = digital_object.id
-			and digital_object_component.repo_id = #{db.literal(@repo_id)}"
+			and digital_object_component.repo_id = #{db.literal(@repo_id)}
+			#{suppressed_filter('digital_object_component')}
+			#{suppressed_filter('digital_object')}"
 	end
 
 	def fix_row(row)

--- a/reports/custom/linked_resource_subreport.rb
+++ b/reports/custom/linked_resource_subreport.rb
@@ -45,7 +45,8 @@ class LinkedResourceSubreport < AbstractSubreport
 		from resource, #{@link_table}
 		where #{@link_table}.#{@id_field} = #{db.literal(@id)}
 		and #{@link_table}.#{@resource_id_field} = resource.id
-		and resource.repo_id = #{db.literal(@repo_id)}"
+		and resource.repo_id = #{db.literal(@repo_id)}
+		#{suppressed_filter('resource')}"
 	end
 
 	def fix_row(row)

--- a/reports/digital_objects/digital_object_file_versions_list_subreport/digital_object_file_versions_list_subreport.rb
+++ b/reports/digital_objects/digital_object_file_versions_list_subreport/digital_object_file_versions_list_subreport.rb
@@ -16,8 +16,10 @@ class DigitalObjectFileVersionsListSubreport < AbstractSubreport
     left outer join digital_object
       on file_version.digital_object_id = digital_object.id
     left outer join digital_object_component on file_version.digital_object_component_id = digital_object_component.id
-    where digital_object.id = #{db.literal(@digital_object_id)}
-    or root_record_id = #{db.literal(@digital_object_id)}"
+    where (digital_object.id = #{db.literal(@digital_object_id)}
+    or root_record_id = #{db.literal(@digital_object_id)})
+    #{suppressed_filter('digital_object')}
+    #{suppressed_filter('digital_object_component')}"
   end
 
   def self.field_name

--- a/reports/locations/container_resources_accessions_subreport/container_resources_accessions_subreport.rb
+++ b/reports/locations/container_resources_accessions_subreport/container_resources_accessions_subreport.rb
@@ -20,12 +20,12 @@ class ContainerResourcesAccessionsSubreport < AbstractSubreport
         join instance on sub_container.instance_id = instance.id
         
         left outer join archival_object
-        on instance.archival_object_id = archival_object.id
-      
+        on instance.archival_object_id = archival_object.id#{suppressed_filter('archival_object')}
+
         join resource
-        on resource.id = instance.resource_id
-          or resource.id = archival_object.root_record_id
-                
+        on (resource.id = instance.resource_id
+          or resource.id = archival_object.root_record_id)#{suppressed_filter('resource')}
+
     union
 
     select
@@ -36,7 +36,8 @@ class ContainerResourcesAccessionsSubreport < AbstractSubreport
         join instance on accession.id = accession_id
         join sub_container on instance.id = instance_id
         join top_container_link_rlshp on sub_container.id = sub_container_id
-    where top_container_id = #{db.literal(@container_id)}"
+    where top_container_id = #{db.literal(@container_id)}
+      #{suppressed_filter('accession')}"
   end
 
   def fix_row(row)

--- a/reports/locations/location_accessions_subreport/location_accessions_subreport.rb
+++ b/reports/locations/location_accessions_subreport/location_accessions_subreport.rb
@@ -30,7 +30,8 @@ class LocationAccessionsSubreport < AbstractSubreport
       join instance on instance.id = sub_container.instance_id
         join accession on accession.id = instance.accession_id
 
-    where accession.repo_id = #{db.literal(@repo_id)}"
+    where accession.repo_id = #{db.literal(@repo_id)}
+      #{suppressed_filter('accession')}"
   end
 
   def fix_row(row)

--- a/reports/locations/location_resources_containers_subreport/location_resources_containers_subreport.rb
+++ b/reports/locations/location_resources_containers_subreport/location_resources_containers_subreport.rb
@@ -38,8 +38,8 @@ class LocationResourcesContainersSubreport < AbstractSubreport
 			join instance on instance.id = sub_container.instance_id
 			
 			left outer join archival_object on archival_object.id
-				= instance.archival_object_id
-			
+				= instance.archival_object_id#{suppressed_filter('archival_object')}
+
 		where top_container_housed_at_rlshp.location_id
 			= #{db.literal(@location_id)}
 			and (instance.resource_id = #{db.literal(@resource_id)}

--- a/reports/locations/location_resources_subreport/location_resources_subreport.rb
+++ b/reports/locations/location_resources_subreport/location_resources_subreport.rb
@@ -29,13 +29,14 @@ class LocationResourcesSubreport < AbstractSubreport
       join instance on instance.id = sub_container.instance_id
       
       left outer join archival_object on archival_object.id
-        = instance.archival_object_id
+        = instance.archival_object_id#{suppressed_filter('archival_object')}
 
       join resource on resource.id = archival_object.root_record_id
         or resource.id = instance.resource_id
-    
+
     where top_container_housed_at_rlshp.location_id = #{db.literal(@location_id)}
-      and resource.repo_id = #{db.literal(@repo_id)}"
+      and resource.repo_id = #{db.literal(@repo_id)}
+      #{suppressed_filter('resource')}"
   end
 
   def fix_row(row)

--- a/reports/resources/archival_object_instances_subreport/archival_object_instances_subreport.rb
+++ b/reports/resources/archival_object_instances_subreport/archival_object_instances_subreport.rb
@@ -68,6 +68,7 @@ class ArchivalObjectInstancesSubreport < AbstractSubreport
           group_concat(digital_object.title separator '; ') as digital_object
         from instance_do_link_rlshp, digital_object
         where instance_do_link_rlshp.digital_object_id = digital_object.id
+          #{suppressed_filter('digital_object')}
         group by instance_do_link_rlshp.instance_id) as digital_objects
       on digital_objects.instance_id = instances.id"
   end

--- a/reports/resources/resource_instances_subreport/resource_instances_subreport.rb
+++ b/reports/resources/resource_instances_subreport/resource_instances_subreport.rb
@@ -53,7 +53,8 @@ class ResourceInstancesSubreport < AbstractSubreport
       (select instance.id, instance_type_id, is_representative
       from instance
         left outer join archival_object
-          on instance.archival_object_id = archival_object.id
+          on instance.archival_object_id
+          = archival_object.id#{suppressed_filter('archival_object')}
       where instance.resource_id = #{db.literal(@resource_id)}
         or archival_object.root_record_id
         = #{db.literal(@resource_id)}) as instances
@@ -72,6 +73,7 @@ class ResourceInstancesSubreport < AbstractSubreport
           group_concat(digital_object.title separator '; ') as digital_object
         from instance_do_link_rlshp, digital_object
         where instance_do_link_rlshp.digital_object_id = digital_object.id
+          #{suppressed_filter('digital_object')}
         group by instance_do_link_rlshp.instance_id) as digital_objects
       on digital_objects.instance_id = instances.id"
   end

--- a/reports/resources/resource_locations_subreport/resource_locations_subreport.rb
+++ b/reports/resources/resource_locations_subreport/resource_locations_subreport.rb
@@ -17,7 +17,8 @@ class ResourceLocationsSubreport < AbstractSubreport
 	    (select instance.id as instance_id from instance
 
       left outer join archival_object
-        on instance.archival_object_id = archival_object.id
+        on instance.archival_object_id
+        = archival_object.id#{suppressed_filter('archival_object')}
 
       where instance.resource_id = #{db.literal(@resource_id)}
         or archival_object.root_record_id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-2899] 
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->

## Summary

ANW-2210 (https://archivesspace.atlassian.net/browse/ANW-2210) (#3974) stopped reports from exporting suppressed records, but the filter was only applied to the top-level record of each report. Linked records pulled in by subreports were still queried with no suppression condition, so suppressed accessions, resources, archival objects, digital objects, classifications, and events continued to be exposed in report output.

This PR extends the same suppression rule to every subreport query that joins a suppressible table.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [ ] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:


[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ANW-2899]: https://archivesspace.atlassian.net/browse/ANW-2899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ