### PR TITLE
ANW-2872 Update subrecord badge when language changed

### DIFF
--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -181,7 +181,7 @@ module ApplicationHelper
     { prefix_html: prefix }
   end
 
-  def primary_language_badge(record)
+  def description_language_badge(record)
     return unless AppConfig[:multilingual_content]
     inherits_lang_descs = %w[archival_object digital_object_component].include?(record["jsonmodel_type"])
     if inherits_lang_descs
@@ -191,8 +191,17 @@ module ApplicationHelper
       lang_descs = record["lang_descriptions"].to_a
     end
     return unless lang_descs.many?
-    lang = lang_descs.find { |ld| ld["is_primary"] }&.dig("language")
+    lang = selected_description_language(lang_descs)
     mlc_language_badge(lang)
+  end
+
+  def selected_description_language(lang_descs)
+    selected = params[:language_of_description].to_s.split('_', 2).first
+    if selected.present? && lang_descs.any? { |ld| ld["language"] == selected }
+      selected
+    else
+      lang_descs.find { |ld| ld["is_primary"] }&.dig("language")
+    end
   end
 
   def mlc_language_badge(langcode)

--- a/frontend/app/views/accessions/_form.html.erb
+++ b/frontend/app/views/accessions/_form.html.erb
@@ -5,7 +5,7 @@
     <div class="d-flex align-items-center border-bottom bg-asFormHeadingBg">
       <h3 class="flex-grow-1 d-flex align-items-center mb-0 border-0">
         <%= t "accession._frontend.section.basic_information" %>
-        <%= primary_language_badge(@accession) %>
+        <%= description_language_badge(@accession) %>
       </h3>
 
       <%= link_to_help :topic => "accession_basic_information" %>

--- a/frontend/app/views/archival_objects/_form_container.html.erb
+++ b/frontend/app/views/archival_objects/_form_container.html.erb
@@ -24,7 +24,7 @@
       <header class="d-flex align-items-center border-bottom bg-asFormHeadingBg">
         <h3 class="flex-grow-1 d-flex align-items-center mb-0 border-0">
           <%= t("archival_object._frontend.section.basic_information") %>
-          <%= primary_language_badge(@archival_object) %>
+          <%= description_language_badge(@archival_object) %>
         </h3>
         <%= link_to_help :topic => "archival_object_basic_information" %>
       </header>

--- a/frontend/app/views/digital_object_components/_form_container.html.erb
+++ b/frontend/app/views/digital_object_components/_form_container.html.erb
@@ -25,7 +25,7 @@
       <header class="d-flex align-items-center border-bottom bg-asFormHeadingBg">
         <h3 class="flex-grow-1 d-flex align-items-center mb-0 border-0">
           <%= t("digital_object_component._frontend.section.basic_information") %>
-          <%= primary_language_badge(@digital_object_component) %>
+          <%= description_language_badge(@digital_object_component) %>
         </h3>
         <%= link_to_help :topic => "digital_object_component_basic_information" %>
       </header>

--- a/frontend/app/views/digital_objects/_form_container.html.erb
+++ b/frontend/app/views/digital_objects/_form_container.html.erb
@@ -8,7 +8,7 @@
       <div class="d-flex align-items-center border-bottom bg-asFormHeadingBg">
         <h3 class="flex-grow-1 d-flex align-items-center mb-0 border-0">
           <%= t("digital_object._frontend.section.basic_information") %>
-          <%= primary_language_badge(@digital_object) %>
+          <%= description_language_badge(@digital_object) %>
         </h3>
 
         <%= link_to_help :topic => "digital_object_basic_information" %>

--- a/frontend/app/views/notes/_form.html.erb
+++ b/frontend/app/views/notes/_form.html.erb
@@ -23,7 +23,7 @@
   <div class="w-100 d-flex align-items-center border-bottom bg-asFormHeadingBg">
     <<%= header_size%> class="subrecord-form-heading flex-grow-1 mb-0 border-0">
       <%= wrap_with_tooltip(t("note._plural"), "#{form.i18n_for('notes')}_tooltip", "subrecord-form-heading-label") %>
-      <%= primary_language_badge(form.obj) %>
+      <%= description_language_badge(form.obj) %>
     </<%= header_size%>>
 
     <% if show_apply_note_order_action %>

--- a/frontend/app/views/resources/_form_container.html.erb
+++ b/frontend/app/views/resources/_form_container.html.erb
@@ -16,7 +16,7 @@
     <div class="w-100 d-flex align-items-center border-bottom bg-asFormHeadingBg">
       <h3 class="flex-grow-1 d-flex align-items-center mb-0 border-0">
         <%= t("resource._frontend.section.basic_information") %>
-        <%= primary_language_badge(@resource) %>
+        <%= description_language_badge(@resource) %>
       </h3>
 
       <%= link_to_help :topic => "resource_basic_information" %>
@@ -63,7 +63,7 @@
     <div class="d-flex align-items-center border-bottom bg-asFormHeadingBg">
       <h3 class="flex-grow-1 mb-0 border-0">
         <%= t("resource._frontend.section.finding_aid") %>
-        <%= primary_language_badge(@resource) %>
+        <%= description_language_badge(@resource) %>
       </h3>
 
       <%= link_to_help :topic => "resource_finding_aid" %>

--- a/frontend/app/views/shared/_subrecord_form.html.erb
+++ b/frontend/app/views/shared/_subrecord_form.html.erb
@@ -37,7 +37,7 @@
   <% unless hidden %>
   <<%= heading_size %> class="subrecord-form-heading d-flex py-2 align-items-center">
     <%= wrap_with_tooltip(heading_text, "#{form.i18n_for(name)}_tooltip", "subrecord-form-heading-label") %>
-    <%= primary_language_badge(form.obj) %>
+    <%= description_language_badge(form.obj) %>
 
     <% if !form.readonly? %>
      <% if custom_action_template %>

--- a/frontend/spec/features/resources_spec.rb
+++ b/frontend/spec/features/resources_spec.rb
@@ -1944,6 +1944,22 @@ describe 'Resources', js: true do
         expect(page.current_url).to include('language_of_description=fre_Latn')
       end
 
+      it 'updates the subrecord language badges to the selected language' do
+        within '#resource_dates_' do
+          expect(page).to have_css('.mlc-badge', text: 'ENG')
+        end
+
+        within '#language-of-description-dropdown' do
+          find('.dropdown-toggle').click
+          find('input[type="radio"][value="fre_Latn"]').choose
+        end
+        wait_for_ajax
+
+        within '#resource_dates_' do
+          expect(page).to have_css('.mlc-badge', text: 'FRE')
+        end
+      end
+
       it 'saves non-primary language edits to that language without modifying the primary language' do
         within '#language-of-description-dropdown' do
           find('.dropdown-toggle').click

--- a/frontend/spec/helpers/application_helper_spec.rb
+++ b/frontend/spec/helpers/application_helper_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'rails_helper'
 
 describe ApplicationHelper do
-  describe '#primary_language_badge' do
+  describe '#description_language_badge' do
     let(:primary_lang_desc) { { 'is_primary' => true, 'language' => 'eng', 'script' => 'Latn' } }
     let(:other_lang_desc)   { { 'is_primary' => false, 'language' => 'fra', 'script' => 'Latn' } }
 
@@ -15,33 +15,33 @@ describe ApplicationHelper do
         allow(AppConfig).to receive(:[]).with(:multilingual_content).and_return(true)
       end
 
-      it 'renders a badge with the primary language code when a resource has multiple lang_descriptions' do
+      it 'defaults to the primary language code when none is selected' do
         record = { 'jsonmodel_type' => 'resource', 'lang_descriptions' => [other_lang_desc, primary_lang_desc] }
-        result = helper.primary_language_badge(record)
+        result = helper.description_language_badge(record)
         expect(result).to include('ENG')
         expect(result).not_to include('FRA')
       end
 
       it 'returns nil for a resource with only one lang_description' do
         record = { 'jsonmodel_type' => 'resource', 'lang_descriptions' => [primary_lang_desc] }
-        expect(helper.primary_language_badge(record)).to be_nil
+        expect(helper.description_language_badge(record)).to be_nil
       end
 
       it 'returns nil for a resource with no lang_descriptions' do
         record = { 'jsonmodel_type' => 'resource', 'lang_descriptions' => [] }
-        expect(helper.primary_language_badge(record)).to be_nil
+        expect(helper.description_language_badge(record)).to be_nil
       end
 
       it 'does not inherit lang_descriptions from a parent for record types that carry their own' do
         parent = { 'lang_descriptions' => [other_lang_desc, primary_lang_desc] }
         record = { 'jsonmodel_type' => 'resource', 'lang_descriptions' => [], 'resource' => { '_resolved' => parent } }
-        expect(helper.primary_language_badge(record)).to be_nil
+        expect(helper.description_language_badge(record)).to be_nil
       end
 
       it 'uses the parent resource lang_descriptions for an archival_object' do
         parent = { 'lang_descriptions' => [other_lang_desc, primary_lang_desc] }
         record = { 'jsonmodel_type' => 'archival_object', 'resource' => { '_resolved' => parent } }
-        result = helper.primary_language_badge(record)
+        result = helper.description_language_badge(record)
         expect(result).to include('ENG')
         expect(result).not_to include('FRA')
       end
@@ -49,19 +49,34 @@ describe ApplicationHelper do
       it 'uses the parent digital_object lang_descriptions for a digital_object_component' do
         parent = { 'lang_descriptions' => [other_lang_desc, primary_lang_desc] }
         record = { 'jsonmodel_type' => 'digital_object_component', 'digital_object' => { '_resolved' => parent } }
-        result = helper.primary_language_badge(record)
+        result = helper.description_language_badge(record)
         expect(result).to include('ENG')
       end
 
       it 'returns nil for an archival_object whose parent has only one lang_description' do
         parent = { 'lang_descriptions' => [primary_lang_desc] }
         record = { 'jsonmodel_type' => 'archival_object', 'resource' => { '_resolved' => parent } }
-        expect(helper.primary_language_badge(record)).to be_nil
+        expect(helper.description_language_badge(record)).to be_nil
       end
 
       it 'returns nil for an archival_object with no resolved parent' do
         record = { 'jsonmodel_type' => 'archival_object', 'resource' => nil }
-        expect(helper.primary_language_badge(record)).to be_nil
+        expect(helper.description_language_badge(record)).to be_nil
+      end
+
+      it 'uses the selected non-primary language when language_of_description is set' do
+        allow(helper).to receive(:params).and_return(ActionController::Parameters.new(language_of_description: 'fra_Latn'))
+        record = { 'jsonmodel_type' => 'resource', 'lang_descriptions' => [other_lang_desc, primary_lang_desc] }
+        result = helper.description_language_badge(record)
+        expect(result).to include('FRA')
+        expect(result).not_to include('ENG')
+      end
+
+      it 'falls back to the primary language when the selected language does not match a lang_description' do
+        allow(helper).to receive(:params).and_return(ActionController::Parameters.new(language_of_description: 'spa_Latn'))
+        record = { 'jsonmodel_type' => 'resource', 'lang_descriptions' => [other_lang_desc, primary_lang_desc] }
+        result = helper.description_language_badge(record)
+        expect(result).to include('ENG')
       end
     end
 
@@ -74,7 +89,7 @@ describe ApplicationHelper do
 
       it 'returns nil regardless of lang_descriptions' do
         record = { 'lang_descriptions' => [primary_lang_desc] }
-        expect(helper.primary_language_badge(record)).to be_nil
+        expect(helper.description_language_badge(record)).to be_nil
       end
     end
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->
[ANW-2872](https://archivesspace.atlassian.net/browse/ANW-2872)

## Summary
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->
When the subrecord language badge (e.g. "ENG") was added in #4059 it was wired to always show the record's primary language, even after switching the language-of-description selector to a non-primary language (which at the time wasn't possible). Now that #4185 has wired up the current language picker, the badge is now being left out of sync with what is actually being edited.  This resolves that.

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/1bd6483e-71ea-422e-980b-2527ee330cbc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [x] Have you added tests to cover these changes? If not why:

[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-2872]: https://archivesspace.atlassian.net/browse/ANW-2872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ