### PR TITLE
ANW-2902 ANW-2823 avoid hitting rack request size limit when editing records with many linked records

### DIFF
--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -516,7 +516,7 @@ $(function () {
               .children('.icon-token')
               .addClass(config.span_class);
             $('input[name*=resolved]', tokenEl).val(
-              JSON.stringify(omitLinkedRecords(item.json))
+              JSON.stringify(omitNestedRecords(item.json))
             );
             return tokenEl;
           },
@@ -678,24 +678,19 @@ $(function () {
     }
   }
 
-  // ANW-2762: A token only needs a record's identity/display fields
-  function omitLinkedRecords(json) {
-    if (!json) {
+  function omitNestedRecords(json) {
+    if (!json || typeof json !== 'object') {
       return json;
     }
 
-    const trimmed = { ...json };
-    delete trimmed.linked_records;
-
-    if (typeof trimmed.json === 'string') {
-      const inner = JSON.parse(trimmed.json);
-      if (inner) {
-        delete inner.linked_records;
-        trimmed.json = JSON.stringify(inner);
+    return Object.keys(json).reduce(function (trimmed, key) {
+      var value = json[key];
+      var isSubrecord = value !== null && typeof value === 'object';
+      if (key !== 'json' && !isSubrecord) {
+        trimmed[key] = value;
       }
-    }
-
-    return trimmed;
+      return trimmed;
+    }, {});
   }
 });
 

--- a/frontend/app/views/accessions/_linker.html.erb
+++ b/frontend/app/views/accessions/_linker.html.erb
@@ -9,19 +9,6 @@
 
 %>
 <div class="form-group required row">
-    <% if form.obj.has_key?('_resolved') %>
-    
-      <input type="text" 
-        class='prelinker' 
-        name="<%= form.path %>[_resolved]"
-        value="<%= selected_json %>" />
-        
-      <input type="text" 
-        class='prelinker' 
-        name="<%= form.path %>[ref]"
-        value="<%= form.obj["ref"] %>" />
-
-    <% end %>
    <label class="control-label text-right col-sm-2"
           id="<%= form.id_for("ref") %>_label"
           for="<%= form.id_for("ref") %>">

--- a/frontend/spec/features/classifications_spec.rb
+++ b/frontend/spec/features/classifications_spec.rb
@@ -182,6 +182,11 @@ describe 'Classifications', js: true do
     expect(resolved).not_to include('linked_records')
     expect(resolved).not_to include(linked_resource.uri)
 
+    parsed = JSON.parse(resolved)
+    expect(parsed).not_to have_key('json')
+    nested = parsed.select { |_key, value| value.is_a?(Array) || value.is_a?(Hash) }
+    expect(nested).to be_empty
+
     find('button', text: 'Save Accession', match: :first).click
     expect(page).to have_text "Accession Accession Title #{now} created"
 

--- a/frontend/spec/features/resources_spec.rb
+++ b/frontend/spec/features/resources_spec.rb
@@ -621,6 +621,38 @@ describe 'Resources', js: true do
     end
   end
 
+  it 'keeps a linked accession token when a save fails validation' do
+    now = Time.now.to_i
+    accession = create(:accession, title: "Linked Accession #{now}")
+    resource = create(
+      :resource,
+      title: "Resource Title #{now}",
+      related_accessions: [{ 'ref' => accession.uri }]
+    )
+
+    visit "resources/#{resource.id}/edit"
+    expect(page).to have_selector('h2', visible: true, text: "#{resource.title} Resource")
+
+    within '#resource_related_accessions_' do
+      expect(page).to have_css('.token-input-token', text: "Linked Accession #{now}")
+    end
+
+    fill_in 'resource_title_', with: ''
+    find('button', text: 'Save Resource', match: :first).click
+
+    within '#form_messages' do
+      expect(page).to have_selector(
+        '.alert.alert-danger.with-hide-alert',
+        visible: true,
+        text: 'Title - Property is required but was missing'
+      )
+    end
+
+    within '#resource_related_accessions_' do
+      expect(page).to have_css('.token-input-token', text: "Linked Accession #{now}")
+    end
+  end
+
   it 'reports errors if adding an empty child to a Resource' do
     now = Time.now.to_i
     resource = create(:resource, title: "Resource Title #{now}")
@@ -844,116 +876,127 @@ describe 'Resources', js: true do
     expect(element).to have_text "Digital Object Title #{now}"
   end
 
-  it 'can create and link a related accession from a resource form' do
-    now = Time.now.to_i
-    resource = create(:resource, title: "Resource Title #{now}")
+  describe 'creating and linking a related accession from a resource form' do
+    it 'can create and link a related accession from a resource form' do
+      now = Time.now.to_i
+      resource = create(:resource, title: "Resource Title #{now}")
 
-    visit "resources/#{resource.id}/edit"
+      visit "resources/#{resource.id}/edit"
 
-    expect(page).to have_selector('h2', visible: true, text: "#{resource.title} Resource")
+      expect(page).to have_selector('h2', visible: true, text: "#{resource.title} Resource")
 
-    click_on 'Add Related Accession'
+      click_on 'Add Related Accession'
 
-    find('#resource_related_accessions_ .linker-wrapper .dropdown-toggle').click
-    wait_for_ajax
-    find('#resource_related_accessions_ .linker-create-btn').click
-
-    within '#resource_related_accessions__0__ref__modal' do
-      fill_in 'Identifier', with: "ACC_#{now}"
-      fill_in 'Title', with: "Related Accession #{now}"
-      fill_in 'Accession Date', with: '2026-01-05'
-
-      click_on 'Create and Link'
-    end
-
-    expect(page).not_to have_css('#resource_related_accessions__0__ref__modal')
-
-    element = find('#resource_related_accessions_ .token-input-token')
-    expect(element).to have_text("Related Accession #{now}")
-
-    find('button', text: 'Save Resource', match: :first).click
-    expect(page).to have_text "Resource #{resource.title} updated"
-  end
-
-  it 'shows validation errors when creating related accession with invalid data' do
-    now = Time.now.to_i
-    resource = create(:resource, title: "Resource Title #{now}")
-
-    visit "resources/#{resource.id}/edit"
-    expect(page).to have_selector('h2', visible: true, text: "#{resource.title} Resource")
-
-    click_on 'Add Related Accession'
-
-    find('#resource_related_accessions_ .linker-wrapper .dropdown-toggle').click
-    wait_for_ajax
-    find('#resource_related_accessions_ .linker-create-btn').click
-
-    within '#resource_related_accessions__0__ref__modal' do
-      fill_in 'Title', with: "Invalid Accession #{now}"
-      click_on 'Create and Link'
-    end
-
-    within '#resource_related_accessions__0__ref__modal' do
-      expect(page).to have_css('.alert.alert-danger', text: /Identifier.*required/i)
-      expect(page).to have_field('Title', with: "Invalid Accession #{now}")
-    end
-
-    within '#resource_related_accessions__0__ref__modal' do
-      fill_in 'Identifier', with: "ACC_#{now}"
-      fill_in 'Accession Date', with: '2026-01-05'
-      click_on 'Create and Link'
-    end
-
-    expect(page).not_to have_css('#resource_related_accessions__0__ref__modal')
-
-    element = find('#resource_related_accessions_ .token-input-token')
-    expect(element).to have_text("Invalid Accession #{now}")
-  end
-
-  it 'can create multiple related accessions for a resource' do
-    now = Time.now.to_i
-    resource = create(:resource, title: "Resource Title #{now}")
-
-    visit "resources/#{resource.id}/edit"
-    expect(page).to have_selector('h2', visible: true, text: "#{resource.title} Resource")
-
-    click_on 'Add Related Accession'
-
-    within '#resource_related_accessions_' do
-      all('.linker-wrapper').first.find('.dropdown-toggle').click
+      find('#resource_related_accessions_ .linker-wrapper .dropdown-toggle').click
       wait_for_ajax
-      all('.linker-create-btn').first.click
+      find('#resource_related_accessions_ .linker-create-btn').click
+
+      within '#resource_related_accessions__0__ref__modal' do
+        fill_in 'Identifier', with: "ACC_#{now}"
+        fill_in 'Title', with: "Related Accession #{now}"
+        fill_in 'Accession Date', with: '2026-01-05'
+
+        click_on 'Create and Link'
+      end
+
+      expect(page).not_to have_css('#resource_related_accessions__0__ref__modal')
+
+      element = find('#resource_related_accessions_ .token-input-token')
+      expect(element).to have_text("Related Accession #{now}")
+
+      find('button', text: 'Save Resource', match: :first).click
+      expect(page).to have_text "Resource #{resource.title} updated"
+
+      expect(page).to have_selector(
+        "input[name='resource[related_accessions][0][_resolved]']",
+        count: 1, visible: :all
+      )
+      expect(page).to have_selector(
+        "input[name='resource[related_accessions][0][ref]']",
+        count: 1, visible: :all
+      )
     end
 
-    within '#resource_related_accessions__0__ref__modal' do
-      fill_in 'Identifier', with: "ACC1_#{now}"
-      fill_in 'Title', with: "First Accession #{now}"
-      fill_in 'Accession Date', with: '2026-01-05'
-      click_on 'Create and Link'
-    end
+    it 'shows validation errors when creating related accession with invalid data' do
+      now = Time.now.to_i
+      resource = create(:resource, title: "Resource Title #{now}")
 
-    click_on 'Add Related Accession'
+      visit "resources/#{resource.id}/edit"
+      expect(page).to have_selector('h2', visible: true, text: "#{resource.title} Resource")
 
-    within '#resource_related_accessions_' do
-      all('.linker-wrapper').last.find('.dropdown-toggle').click
+      click_on 'Add Related Accession'
+
+      find('#resource_related_accessions_ .linker-wrapper .dropdown-toggle').click
       wait_for_ajax
-      all('.linker-create-btn').last.click
+      find('#resource_related_accessions_ .linker-create-btn').click
+
+      within '#resource_related_accessions__0__ref__modal' do
+        fill_in 'Title', with: "Invalid Accession #{now}"
+        click_on 'Create and Link'
+      end
+
+      within '#resource_related_accessions__0__ref__modal' do
+        expect(page).to have_css('.alert.alert-danger', text: /Identifier.*required/i)
+        expect(page).to have_field('Title', with: "Invalid Accession #{now}")
+      end
+
+      within '#resource_related_accessions__0__ref__modal' do
+        fill_in 'Identifier', with: "ACC_#{now}"
+        fill_in 'Accession Date', with: '2026-01-05'
+        click_on 'Create and Link'
+      end
+
+      expect(page).not_to have_css('#resource_related_accessions__0__ref__modal')
+
+      element = find('#resource_related_accessions_ .token-input-token')
+      expect(element).to have_text("Invalid Accession #{now}")
     end
 
-    within '#resource_related_accessions__1__ref__modal' do
-      fill_in 'Identifier', with: "ACC2_#{now}"
-      fill_in 'Title', with: "Second Accession #{now}"
-      fill_in 'Accession Date', with: '2026-01-05'
-      click_on 'Create and Link'
-    end
+    it 'can create multiple related accessions for a resource' do
+      now = Time.now.to_i
+      resource = create(:resource, title: "Resource Title #{now}")
 
-    find('button', text: 'Save Resource', match: :first).click
-    expect(page).to have_text "Resource #{resource.title} updated"
+      visit "resources/#{resource.id}/edit"
+      expect(page).to have_selector('h2', visible: true, text: "#{resource.title} Resource")
 
-    within '#resource_related_accessions_' do
-      tokens = all('.token-input-token')
-      expect(tokens[0]).to have_text("First Accession #{now}")
-      expect(tokens[1]).to have_text("Second Accession #{now}")
+      click_on 'Add Related Accession'
+
+      within '#resource_related_accessions_' do
+        all('.linker-wrapper').first.find('.dropdown-toggle').click
+        wait_for_ajax
+        all('.linker-create-btn').first.click
+      end
+
+      within '#resource_related_accessions__0__ref__modal' do
+        fill_in 'Identifier', with: "ACC1_#{now}"
+        fill_in 'Title', with: "First Accession #{now}"
+        fill_in 'Accession Date', with: '2026-01-05'
+        click_on 'Create and Link'
+      end
+
+      click_on 'Add Related Accession'
+
+      within '#resource_related_accessions_' do
+        all('.linker-wrapper').last.find('.dropdown-toggle').click
+        wait_for_ajax
+        all('.linker-create-btn').last.click
+      end
+
+      within '#resource_related_accessions__1__ref__modal' do
+        fill_in 'Identifier', with: "ACC2_#{now}"
+        fill_in 'Title', with: "Second Accession #{now}"
+        fill_in 'Accession Date', with: '2026-01-05'
+        click_on 'Create and Link'
+      end
+
+      find('button', text: 'Save Resource', match: :first).click
+      expect(page).to have_text "Resource #{resource.title} updated"
+
+      within '#resource_related_accessions_' do
+        tokens = all('.token-input-token')
+        expect(tokens[0]).to have_text("First Accession #{now}")
+        expect(tokens[1]).to have_text("Second Accession #{now}")
+      end
     end
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-2902], [ANW-2823]
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->

## Summary

Editing and saving a Resource on SUI that has many linked records (Accessions, Agents etc.) would fail with Rack::QueryParser::QueryLimitError (total query size exceeds limit (4194304)) because the form's POST body exceeded Rack's 4 MB limit and was rejected before ArchivesSpace could handle it. 

Two independent problems inflated the request and are fixed in this PR:

### [ANW-2902] the accessions linker serialized every link twice:

frontend/app/views/accessions/_linker.html.erb emitted the hidden [_resolved] and [ref] prelinker inputs twice under the same if form.obj.has_key?('_resolved') condition. Every related accession was therefore sent two times, doubling the payload. This has been present since at least v4.1.1. The duplicated block is removed, leaving the single canonical block (the issue was found only in the linker partial used for linked Accessions, the other linker partials do not have this duplication).

### [ANW-2823] each linker token carried the entire resolved record.

When the linker stashes a picked/loaded record into a token's submitted [_resolved] field, it serialized the whole resolved record including all nested records: notes, dates, extents, linked agents, user-defined data, and for classifications the full linked_records list. The token only ever reads a record's identity/display fields, and the backend drops the submitted _resolved as a read-only resolve artifact..

The solution here drops every nested subrecord (arrays and objects) and the serialized json blob from the post request, keeping only the scalar fields. 

Tested manually by creating a resource with 600 linked accessions. I was able to reproduce the error on the main branch and confirm it saves successfully with the current changes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [ ] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:


[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ANW-2902]: https://archivesspace.atlassian.net/browse/ANW-2902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-2823]: https://archivesspace.atlassian.net/browse/ANW-2823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ