### PR TITLE
ANW-2664: Update accessions show view for Bootstrap 5

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -640,6 +640,7 @@ button.subject {
 .page_action:focus {
   color: $accent_color;
   background-color: $light-neutral;
+  text-decoration: none;
 }
 
 .top_container {

--- a/public/app/views/shared/_staff_link_action.html.erb
+++ b/public/app/views/shared/_staff_link_action.html.erb
@@ -1,5 +1,5 @@
 <% if AppConfig[:pui_enable_staff_link] %>
-    <a id="staff-link" href="#" class="btn btn-secondary page_action staff d-none" target="_blank">
+    <a id="staff-link" href="#" class="btn page_action staff d-none" target="_blank">
         <i class="fa fa-pencil fa-3x"></i>
         <br/>
         <%= t('actions.staff_link') %>


### PR DESCRIPTION
## Related Ticket (JIRA or GitHub Issue)
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->

## Summary
Verified the accessions show view for Bootstrap 5 compatibility. The view template itself relies entirely on shared partials already fixed in prior PRs (aka _idbadge, _page_actions, _breadcrumbs, _record_innards, _modal_actions) and required no BS4 to BS5 class changes.

I did find one inconsistency: the "Staff Only" link button (_staff_link_action.html.erb) still had a leftover btn-secondary class from earlier PR work, giving it a bordered/dark appearance inconsistent with the other page action buttons (Cite, Print, Request) which no longer use that class per recent parent-branch cleanup. I removed btn-secondary from the staff link button to restore visual consistency.

NOTE: ANW-2663 (Accessions index view) was also verified during this session.  It renders entirely through search/search_results.html.erb and shared search/facet partials already fixed in prior PRs, with no accessions-specific BS4 classes found. No code changes were needed for that view.

## Screenshots (if appropriate):
<img width="959" height="729" alt="ANW-2664_Accessions" src="https://github.com/user-attachments/assets/528a32bb-2956-4529-b610-16c0c1d8b348" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [X] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:  Single CSS class change, no logic changes, no tests required.


[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ