### PR TITLE
Resolve LD_PRELOAD independent of architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ ENV ARCHIVESSPACE_LOGS=/dev/null \
   DEBIAN_FRONTEND=noninteractive \
   JDK_JAVA_OPTIONS="--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED" \
   LANG=C.UTF-8 \
-  LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+  LD_PRELOAD="/usr/local/lib/libjemalloc.so" \
   TZ=UTC
 
 COPY --from=build_release /archivesspace /archivesspace
@@ -68,6 +68,7 @@ RUN apt-get update && \
   nodejs \
   unzip && \
   rm -rf /var/lib/apt/lists/* && \
+  ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
   chown -R 1000:1000 /archivesspace
 
 USER 1000:1000


### PR DESCRIPTION
This copies the Rails core approach to setting LD_PRELOAD independently of the cpu architecture:

https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt#L20-L28

Currently arm builds are not using jemalloc because of the hard-coded x86 path and it creates noise in the logs.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
- [x] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:
