### PR TITLE
Set hl.fragsize=0 so PUI search highlighting returns full titles

### DIFF
--- a/backend/app/model/solr.rb
+++ b/backend/app/model/solr.rb
@@ -326,6 +326,7 @@ class Solr
         add_solr_param(:hl, "true")
         add_solr_param(:"hl.method", "original")
         add_solr_param(:"hl.fl", "*")
+        add_solr_param(:"hl.fragsize", "0")
         add_solr_param(:"hl.simple.pre", '<span class="searchterm">')
         add_solr_param(:"hl.simple.post", "</span>")
       end

--- a/backend/spec/model_solr_spec.rb
+++ b/backend/spec/model_solr_spec.rb
@@ -77,6 +77,7 @@ describe 'Solr model' do
     expect(http.request.body).to match(/fq=types%3A%28?%22optional_record_type/)
     expect(http.request.body).to match(/-id%3A%28%22alpha%22\+OR\+%22omega/)
     expect(http.request.body).to match(/hl=true/)
+    expect(http.request.body).to match(/hl\.fragsize=0/)
     expect(http.request.body).to match(/bq=title%3A%22hello\+world%22\*/)
     expect(http.request.body).to match(/pf=title%5E10/)
     expect(http.request.body).to match(/ps=0/)


### PR DESCRIPTION
## Related Ticket (JIRA or GitHub Issue)
#4211

## Summary
The Solr original highlighter (`hl.method=original`, added in 05e918780e and first shipped in 4.2.0) defaults to a 100-character fragment. In the PUI the highlighted value replaces the record's `display_string`, so record titles longer than ~100 characters were truncated to a fragment in keyword search results, while the full record view still showed the complete title. Setting `hl.fragsize=0` makes the highlighter return the whole field value. See #4211 for before/after screenshots and reproduction steps.

## Screenshots (if appropriate):
See #4211.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
- [x] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [x] Have you added tests to cover these changes? If not why: