### PR TITLE
ANW-2669, ANW-2670: Update classifications show view for Bootstrap 5, plus more removal of dead Bootstrap 3 leftover classes

### DIFF
--- a/public/app/views/classifications/show.html.erb
+++ b/public/app/views/classifications/show.html.erb
@@ -15,7 +15,7 @@
       <% end %>
       <% if @result.creator %>
         <div class="mb-2 px-3 creator">
-          <span class="inline-label clear"><%= t('classification.creator') %>: </span>
+          <span class="inline-label"><%= t('classification.creator') %>: </span>
           <%= link_to @result.creator.display_string, app_prefix(@result.creator.uri) %>
         </div>
       <% end %>


### PR DESCRIPTION
This PR closes https://github.com/archivesspace/archivesspace/pull/4206