### PR TITLE
ANW-2906 do not truncate highlighted titles in pui

### DIFF
--- a/backend/app/model/solr.rb
+++ b/backend/app/model/solr.rb
@@ -326,7 +326,7 @@ class Solr
         add_solr_param(:hl, "true")
         add_solr_param(:"hl.method", "original")
         add_solr_param(:"hl.fl", "*")
-        add_solr_param(:"hl.fragsize", "0")
+        add_solr_param(:"f.title.hl.fragsize", "0")
         add_solr_param(:"hl.simple.pre", '<span class="searchterm">')
         add_solr_param(:"hl.simple.post", "</span>")
       end

--- a/backend/app/model/solr.rb
+++ b/backend/app/model/solr.rb
@@ -326,6 +326,7 @@ class Solr
         add_solr_param(:hl, "true")
         add_solr_param(:"hl.method", "original")
         add_solr_param(:"hl.fl", "*")
+        add_solr_param(:"hl.fragsize", "0")
         add_solr_param(:"hl.simple.pre", '<span class="searchterm">')
         add_solr_param(:"hl.simple.post", "</span>")
       end

--- a/backend/spec/model_solr_spec.rb
+++ b/backend/spec/model_solr_spec.rb
@@ -77,7 +77,7 @@ describe 'Solr model' do
     expect(http.request.body).to match(/fq=types%3A%28?%22optional_record_type/)
     expect(http.request.body).to match(/-id%3A%28%22alpha%22\+OR\+%22omega/)
     expect(http.request.body).to match(/hl=true/)
-    expect(http.request.body).to match(/hl\.fragsize=0/)
+    expect(http.request.body).to match(/f\.title\.hl\.fragsize=0/)
     expect(http.request.body).to match(/bq=title%3A%22hello\+world%22\*/)
     expect(http.request.body).to match(/pf=title%5E10/)
     expect(http.request.body).to match(/ps=0/)

--- a/backend/spec/model_solr_spec.rb
+++ b/backend/spec/model_solr_spec.rb
@@ -77,6 +77,7 @@ describe 'Solr model' do
     expect(http.request.body).to match(/fq=types%3A%28?%22optional_record_type/)
     expect(http.request.body).to match(/-id%3A%28%22alpha%22\+OR\+%22omega/)
     expect(http.request.body).to match(/hl=true/)
+    expect(http.request.body).to match(/hl\.fragsize=0/)
     expect(http.request.body).to match(/bq=title%3A%22hello\+world%22\*/)
     expect(http.request.body).to match(/pf=title%5E10/)
     expect(http.request.body).to match(/ps=0/)

--- a/public/spec/features/search_spec.rb
+++ b/public/spec/features/search_spec.rb
@@ -338,6 +338,35 @@ describe 'Search', js: true do
         end
       end
 
+      context 'when the search term is in a long title and a long note' do
+        let(:now) { Time.now.to_i }
+        let(:search_term) { "zzuniqueterm#{now}" }
+
+        let(:long_title) { "#{search_term} " + ("alpha " * 50) + "TITLEENDMARKER" }
+        let(:long_note) { "#{search_term} " + ("beta " * 50) + "NOTEENDMARKER" }
+
+        let(:searched_record) do
+          create(:resource,
+                 :title => long_title,
+                 :publish => true,
+                 :notes => [
+                   build(:json_note_multipart,
+                         subnotes: [
+                           build(:json_note_text, publish: true, content: long_note)
+                         ])
+                 ])
+        end
+
+        it 'shows the full title but a truncated note in the found in section' do
+          expect(result_title.find('.searchterm').text).to eq search_term
+          expect(result_title.text).to include('TITLEENDMARKER')
+
+          found_in_notes = page.find('.highlighting', text: 'Found in Notes:')
+          expect(found_in_notes).to have_css('span.searchterm', text: search_term)
+          expect(found_in_notes).to have_no_content('NOTEENDMARKER')
+        end
+      end
+
       context 'when search terms found in finding aid filing title only' do
         let(:now) { now = Time.now.to_i }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-2906]
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->

## Summary

Set hl.fragsize=0 on the title field only so PUI search returns full titles. The Solr original highlighter defaults to a 100-character fragment. Because the PUI replaces a record's display_string with the highlighted value, titles longer than 100 characters were truncated to a fragment in keyword search results.

Adding to the title field (f.title.hl.fragsize=0) returns the full title while leaving the default fragment size in place for other fields, so their "Found in" snippets stay truncated. 

Fixes #4211.
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [ ] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:


[ANW-2906]: https://archivesspace.atlassian.net/browse/ANW-2906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ