### PR TITLE
Fix contributing links in `PULL_REQUEST_TEMPLATE.md`

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,6 @@ Summarize the context the reviewer should have in mind.
 ## Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
-- [ ] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
+- [ ] I have read and agree to the [**CONTRIBUTING** document](https://github.com/archivesspace/archivesspace/blob/master/CONTRIBUTING.md).
+- [ ] I have authority to submit this code. - See our [licensing](https://github.com/archivesspace/archivesspace/blob/master/contribution_files/CONTRIBUTING_README.md)
 - [ ] Have you added tests to cover these changes? If not why:


### PR DESCRIPTION

## Related Ticket (JIRA or GitHub Issue)

\-

## Summary

While submitting #4217 I noticed that the two contributing links in the pull request template don't link where they are supposed to .

* `https://github.com/CONTRIBUTING.md` redirects to `https://www.github.careers/careers-home`
* `https://github.com/contribution_files/CONTRIBUTING_README.md` 404s

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:

- [x] I have read and agree to the [**CONTRIBUTING** document](/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:
