### PR TITLE
ANW-2907 Make reports mlc aware

### DIFF
--- a/backend/app/model/reports/abstract_report.rb
+++ b/backend/app/model/reports/abstract_report.rb
@@ -1,5 +1,6 @@
 require_relative 'report_manager'
 require_relative 'report_suppression'
+require_relative 'report_mlc'
 require_relative '../../lib/reports/report_utils'
 require 'erb'
 
@@ -7,6 +8,7 @@ class AbstractReport
   include ReportManager::Mixin
   include JSONModel
   include ReportSuppression
+  include ReportMlc
 
   attr_accessor :repo_id
   attr_accessor :format

--- a/backend/app/model/reports/abstract_subreport.rb
+++ b/backend/app/model/reports/abstract_subreport.rb
@@ -1,11 +1,13 @@
 require_relative '../../lib/reports/report_utils'
 require_relative 'custom_field'
 require_relative 'report_suppression'
+require_relative 'report_mlc'
 
 class AbstractSubreport
 
   include CustomField::Mixin
   include ReportSuppression
+  include ReportMlc
 
   attr_accessor :repo_id
   attr_accessor :db

--- a/backend/app/model/reports/report_mlc.rb
+++ b/backend/app/model/reports/report_mlc.rb
@@ -1,0 +1,21 @@
+# MLC join helper shared by reports and subreports.
+#
+# Migration 177 moves `title` and other multilingual fields from the base
+# record type tables and into per-language `*_mlc` tables. Any query that
+# wants one of those fields needs to join to the record's own `_mlc` row.
+#
+# ANW-2907: As initial MVP have reports always use the AppConfig default
+# language/script. Per-run language selection is out of scope for now.
+module ReportMlc
+
+  def mlc_lang_condition(table_name)
+    lang = RequestContext.default_description_language
+    "#{table_name}_mlc.language_id = #{db.literal(lang[:language_id])}" \
+      " and #{table_name}_mlc.script_id = #{db.literal(lang[:script_id])}"
+  end
+
+  def mlc_join(table_name, id_column = "#{table_name}.id")
+    "left join #{table_name}_mlc on #{table_name}_mlc.#{table_name}_id = #{id_column}" \
+      " and #{mlc_lang_condition(table_name)}"
+  end
+end

--- a/reports/accessions/accession_deaccessions_list_report/accession_deaccessions_list_report.rb
+++ b/reports/accessions/accession_deaccessions_list_report/accession_deaccessions_list_report.rb
@@ -14,14 +14,16 @@ class AccessionDeaccessionsListReport < AbstractReport
 
   def query_string
     "select
-      id as accession_id,
+      accession.id as accession_id,
       identifier as accession_number,
-      title as record_title,
+      accession_mlc.title as record_title,
       accession_date,
       container_summary,
       extent_number,
       extent_type
-    from accession natural join
+    from accession
+      #{mlc_join('accession')}
+      natural join
       (select
         accession_id as id,
         sum(number) as extent_number,

--- a/reports/accessions/accession_instances_subreport/accession_instances_subreport.rb
+++ b/reports/accessions/accession_instances_subreport/accession_instances_subreport.rb
@@ -65,8 +65,9 @@ class AccessionInstancesSubreport < AbstractSubreport
       left outer join
         (select
           instance_do_link_rlshp.instance_id,
-          group_concat(digital_object.title separator '; ') as digital_object
-        from instance_do_link_rlshp, digital_object
+          group_concat(digital_object_mlc.title separator '; ') as digital_object
+        from (instance_do_link_rlshp, digital_object)
+        #{mlc_join('digital_object')}
         where instance_do_link_rlshp.digital_object_id = digital_object.id
           #{suppressed_filter('digital_object')}
         group by instance_do_link_rlshp.instance_id) as digital_objects

--- a/reports/accessions/accession_inventory_report/accession_inventory_report.rb
+++ b/reports/accessions/accession_inventory_report/accession_inventory_report.rb
@@ -20,11 +20,11 @@ class AccessionInventoryReport < AbstractReport
 
   def query_string
     "select
-      id,
+      accession.id as id,
       identifier as accession_number,
-      title as record_title,
+      accession_mlc.title as record_title,
       accession_date as accession_date,
-      inventory,
+      accession_mlc.inventory as inventory,
       date_expression,
       begin_date,
       end_date,
@@ -36,8 +36,10 @@ class AccessionInventoryReport < AbstractReport
 
     from accession
 
+      #{mlc_join('accession')}
+
       natural left outer join
-  
+
       (select
         accession_id as id,
         sum(number) as extent_number,
@@ -45,7 +47,7 @@ class AccessionInventoryReport < AbstractReport
         GROUP_CONCAT(distinct extent.container_summary SEPARATOR ', ') as container_summary
       from extent
       group by accession_id) as extent_cnt
-      
+
       natural left outer join
       (select
         accession_id as id,
@@ -65,8 +67,7 @@ class AccessionInventoryReport < AbstractReport
       where date.date_type_id = enumeration_value.id and enumeration_value.value = 'bulk'
       group by accession_id) as bulk_date
 
-    where accession.repo_id = #{db.literal(@repo_id)} and not accession.inventory is null#{suppressed_filter('accession')}"
-        
+    where accession.repo_id = #{db.literal(@repo_id)} and not accession_mlc.inventory is null#{suppressed_filter('accession')}"
   end
 
   def page_break

--- a/reports/accessions/accession_receipt_report/accession_receipt_report.rb
+++ b/reports/accessions/accession_receipt_report/accession_receipt_report.rb
@@ -34,9 +34,6 @@ class AccessionReceiptReport < AbstractReport
                        '1=1'
                      end
 
-    lang = RequestContext.description_language
-    lang_condition = "accession_mlc.language_id = #{db.literal(lang[:language_id])} and accession_mlc.script_id = #{db.literal(lang[:script_id])}"
-
     "select
       accession.id as id,
       identifier as accession_number,
@@ -46,7 +43,7 @@ class AccessionReceiptReport < AbstractReport
       extent_number,
       extent_type
     from accession
-      left join accession_mlc on accession_mlc.accession_id = accession.id and #{lang_condition}
+      #{mlc_join('accession')}
       left outer join
         (select
           accession_id as accession_id,
@@ -55,7 +52,7 @@ class AccessionReceiptReport < AbstractReport
           GROUP_CONCAT(distinct extent.container_summary SEPARATOR ', ')
             as container_summary
         from extent
-        group by accession_id) as extent_cnt
+        group by accession_id) as extent_cnt on extent_cnt.accession_id = accession.id
     where repo_id = #{db.literal(@repo_id)} and #{date_condition}#{suppressed_filter('accession')}"
   end
 

--- a/reports/accessions/accession_report/accession_report.rb
+++ b/reports/accessions/accession_report/accession_report.rb
@@ -15,18 +15,15 @@ class AccessionReport < AbstractReport
   end
 
   def query_string
-    lang = RequestContext.description_language
-    lang_condition = "accession_mlc.language_id = #{db.literal(lang[:language_id])} and accession_mlc.script_id = #{db.literal(lang[:script_id])}"
-
     "select
       accession.id as accession_id,
       identifier as accession_number,
       accession_mlc.title as record_title,
       accession_date as accession_date,
-      provenance as provenance,
+      accession_mlc.provenance as provenance,
       extent_number,
       extent_type,
-      general_note,
+      accession_mlc.general_note as general_note,
       container_summary,
       date_expression,
       begin_date,
@@ -35,20 +32,20 @@ class AccessionReport < AbstractReport
       bulk_end_date,
       acquisition_type_id as acquisition_type,
       retention_rule,
-      content_description as description_note,
-      condition_description as condition_note,
-      inventory,
-      disposition as disposition_note,
+      accession_mlc.content_description as description_note,
+      accession_mlc.condition_description as condition_note,
+      accession_mlc.inventory as inventory,
+      accession_mlc.disposition as disposition_note,
       restrictions_apply,
       access_restrictions,
-      access_restrictions_note,
+      accession_mlc.access_restrictions_note as access_restrictions_note,
       use_restrictions,
-      use_restrictions_note,
+      accession_mlc.use_restrictions_note as use_restrictions_note,
       ifnull(rights_transferred, false) as rights_transferred,
       rights_transferred_note,
       ifnull(acknowledgement_sent, false) as acknowledgement_sent
     from accession
-      left join accession_mlc on accession_mlc.accession_id = accession.id and #{lang_condition}
+      #{mlc_join('accession')}
       left outer join
         (select
           accession_id as id,

--- a/reports/accessions/accession_resources_subreport/accession_resources_subreport.rb
+++ b/reports/accessions/accession_resources_subreport/accession_resources_subreport.rb
@@ -6,8 +6,9 @@ class AccessionResourcesSubreport < AbstractSubreport
   end
 
   def query_string
-    "select identifier, title
-    from resource, spawned_rlshp
+    "select identifier, resource_mlc.title as title
+    from (resource, spawned_rlshp)
+      #{mlc_join('resource')}
     where spawned_rlshp.accession_id = #{db.literal(@accession_id)}
       and spawned_rlshp.resource_id = resource.id
       #{suppressed_filter('resource')}"

--- a/reports/accessions/accession_resources_subreport/accession_resources_subreport.rb
+++ b/reports/accessions/accession_resources_subreport/accession_resources_subreport.rb
@@ -6,8 +6,9 @@ class AccessionResourcesSubreport < AbstractSubreport
   end
 
   def query_string
-    "select identifier, title
+    "select identifier, resource_mlc.title as title
     from resource, spawned_rlshp
+      #{mlc_join('resource')}
     where spawned_rlshp.accession_id = #{db.literal(@accession_id)}
       and spawned_rlshp.resource_id = resource.id
       #{suppressed_filter('resource')}"

--- a/reports/accessions/accession_rights_transferred_report/accession_rights_transferred_report.rb
+++ b/reports/accessions/accession_rights_transferred_report/accession_rights_transferred_report.rb
@@ -11,15 +11,15 @@ class AccessionRightsTransferredReport < AbstractReport
 
   def query_string
     "select
-      id,
+      accession.id as id,
       identifier as accession_number,
-      title as record_title,
+      accession_mlc.title as record_title,
       accession_date,
       restrictions_apply,
       access_restrictions,
-      access_restrictions_note,
+      accession_mlc.access_restrictions_note as access_restrictions_note,
       use_restrictions,
-      use_restrictions_note,
+      accession_mlc.use_restrictions_note as use_restrictions_note,
       container_summary,
       ifnull(accession_processed, false) as accession_processed,
       accession_processed_date,
@@ -30,6 +30,8 @@ class AccessionRightsTransferredReport < AbstractReport
       rights_transferred_note
 
     from accession
+
+      #{mlc_join('accession')}
 
       natural join
 
@@ -51,9 +53,9 @@ class AccessionRightsTransferredReport < AbstractReport
         GROUP_CONCAT(distinct extent.container_summary SEPARATOR ', ') as container_summary
       from extent
       group by accession_id) as extent_cnt
-      
+
       natural left outer join
-     
+
      (select
         id,
         accession_processed,
@@ -68,16 +70,16 @@ class AccessionRightsTransferredReport < AbstractReport
         where event_link_rlshp.event_id = event.id
           and event.event_type_id = enumeration_value.id and enumeration_value.value = 'processed'
           and not event_link_rlshp.accession_id is null) as processed
-       
+
         natural left outer join
-       
-        (select 
+
+        (select
           event_id,
           ifnull(date.expression, if(date.end is null, date.begin, concat(date.begin, ' - ', date.end)))
             as accession_processed_date
         from date
           where not event_id is null) as dates
-     
+
       group by id) as processed_info
 
       natural left outer join

--- a/reports/accessions/accession_subjects_names_classifications_list_report/accession_subjects_names_classifications_list_report.rb
+++ b/reports/accessions/accession_subjects_names_classifications_list_report/accession_subjects_names_classifications_list_report.rb
@@ -6,15 +6,15 @@ class AccessionSubjectsNamesClassificationsListReport < AbstractReport
 
   def query_string
     "select
-      id,
+      accession.id as id,
       identifier as accession_number,
-      title as record_title,
+      accession_mlc.title as record_title,
       accession_date,
       restrictions_apply,
       access_restrictions,
-      access_restrictions_note,
+      accession_mlc.access_restrictions_note as access_restrictions_note,
       use_restrictions,
-      use_restrictions_note,
+      accession_mlc.use_restrictions_note as use_restrictions_note,
       container_summary,
       ifnull(accession_processed, false) as accession_processed,
       accession_processed_date,
@@ -24,6 +24,8 @@ class AccessionSubjectsNamesClassificationsListReport < AbstractReport
       ifnull(rights_transferred, false) as rights_transferred,
       rights_transferred_note
     from accession
+
+      #{mlc_join('accession')}
 
       natural left outer join
 
@@ -45,9 +47,9 @@ class AccessionSubjectsNamesClassificationsListReport < AbstractReport
         GROUP_CONCAT(distinct extent.container_summary SEPARATOR ', ') as container_summary
       from extent
       group by accession_id) as extent_cnt
-      
+
       natural left outer join
-     
+
       (select
         id,
         accession_processed,
@@ -62,16 +64,16 @@ class AccessionSubjectsNamesClassificationsListReport < AbstractReport
         where event_link_rlshp.event_id = event.id
           and event.event_type_id = enumeration_value.id and enumeration_value.value = 'processed'
           and not event_link_rlshp.accession_id is null) as processed
-       
+
         natural left outer join
-       
-        (select 
+
+        (select
           event_id,
           ifnull(date.expression, if(date.end is null, date.begin, concat(date.begin, ' - ', date.end)))
             as accession_processed_date
         from date
           where not event_id is null) as dates
-     
+
       group by id) as processed_info
 
       natural left outer join

--- a/reports/accessions/accession_unprocessed_report/accession_unprocessed_report.rb
+++ b/reports/accessions/accession_unprocessed_report/accession_unprocessed_report.rb
@@ -16,9 +16,9 @@ class AccessionUnprocessedReport < AbstractReport
 
   def query_string
     "select
-      id,
+      accession.id as id,
       identifier as accession_number,
-      title as record_title,
+      accession_mlc.title as record_title,
       accession_date,
       container_summary,
       ifnull(cataloged, false) as cataloged,
@@ -26,9 +26,11 @@ class AccessionUnprocessedReport < AbstractReport
       extent_type
 
     from accession
-  
+
+      #{mlc_join('accession')}
+
       natural left outer join
-      
+
       (select
         accession_id as id,
         true as processed
@@ -37,9 +39,9 @@ class AccessionUnprocessedReport < AbstractReport
         and event.event_type_id = enumeration_value.id
         and enumeration_value.value = 'processed'
       group by accession_id) as processed
-      
+
       natural left outer join
-      
+
       (select
           accession_id as id,
           sum(number) as extent_number,
@@ -48,9 +50,9 @@ class AccessionUnprocessedReport < AbstractReport
             as container_summary
       from extent
       group by accession_id) as extent_cnt
-        
+
       natural left outer join
-      
+
       (select
         event_link_rlshp.accession_id as id,
         count(*) != 0 as cataloged
@@ -59,7 +61,7 @@ class AccessionUnprocessedReport < AbstractReport
         and event.event_type_id = enumeration_value.id
         and enumeration_value.value = 'cataloged'
       group by event_link_rlshp.accession_id) as cataloged
-      
+
     where repo_id = #{db.literal(@repo_id)}
       and processed is null#{suppressed_filter('accession')}"
   end

--- a/reports/accessions/created_accessions_report/created_accessions_report.rb
+++ b/reports/accessions/created_accessions_report/created_accessions_report.rb
@@ -26,9 +26,10 @@ class CreatedAccessionsReport < AbstractReport
   def query_string
     "select
       identifier as accession_number,
-      title as record_title,
+      accession_mlc.title as record_title,
       accession_date
     from accession
+      #{mlc_join('accession')}
     where accession_date > #{db.literal(@from.split(' ')[0].gsub('-', ''))}
       and accession_date < #{db.literal(@to.split(' ')[0].gsub('-', ''))}
       and repo_id = #{db.literal(@repo_id)}#{suppressed_filter('accession')}

--- a/reports/assessments/assessment_linked_records_subreport/assessment_linked_records_subreport.rb
+++ b/reports/assessments/assessment_linked_records_subreport/assessment_linked_records_subreport.rb
@@ -9,10 +9,11 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
     "(select
       resource.id as record_id,
       'Resource' as linked_record_type,
-      resource.title as record_title,
+      resource_mlc.title as record_title,
       resource.identifier as identifier
     from assessment_rlshp
       join resource on assessment_rlshp.resource_id = resource.id
+      #{mlc_join('resource')}
     where assessment_rlshp.assessment_id = #{db.literal(@assessment_id)}
       #{suppressed_filter('resource')})
 
@@ -21,11 +22,12 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
     (select
       archival_object.id as record_id,
       'Archival Object' as linked_record_type,
-      ifnull(archival_object.title, archival_object.display_string) as record_title,
+      ifnull(archival_object_mlc.title, archival_object_mlc.display_string) as record_title,
       archival_object.component_id as identifier
     from assessment_rlshp
       join archival_object on assessment_rlshp.archival_object_id = archival_object.id
       join resource on archival_object.root_record_id = resource.id
+      #{mlc_join('archival_object')}
     where assessment_rlshp.assessment_id = #{db.literal(@assessment_id)}
       #{suppressed_filter('archival_object')}
       #{suppressed_filter('resource')})
@@ -35,10 +37,11 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
     (select
       accession.id as record_id,
       'Accession' as linked_record_type,
-      accession.title as record_title,
+      accession_mlc.title as record_title,
       accession.identifier as identifier
     from assessment_rlshp
       join accession on assessment_rlshp.accession_id = accession.id
+      #{mlc_join('accession')}
     where assessment_rlshp.assessment_id = #{db.literal(@assessment_id)}
       #{suppressed_filter('accession')})
 
@@ -47,10 +50,11 @@ class AssessmentLinkedRecordsSubreport < AbstractSubreport
     (select
       digital_object.id as record_id,
       'Digital Object' as linked_record_type,
-      digital_object.title as record_title,
+      digital_object_mlc.title as record_title,
       digital_object.digital_object_id as identifier
     from assessment_rlshp
       join digital_object on assessment_rlshp.digital_object_id = digital_object.id
+      #{mlc_join('digital_object')}
     where assessment_rlshp.assessment_id = #{db.literal(@assessment_id)}
       #{suppressed_filter('digital_object')})"
   end

--- a/reports/custom/custom_report.rb
+++ b/reports/custom/custom_report.rb
@@ -6,6 +6,21 @@ class CustomReport < AbstractReport
 
   attr_accessor :record_type, :subreports
 
+  # Fields that migration 177 moved off the base table and into a
+  # per-language `<record_type>_mlc` table.
+  MLC_FIELDS = {
+    'resource' => %w[title finding_aid_title finding_aid_subtitle finding_aid_author
+                      finding_aid_sponsor finding_aid_edition_statement
+                      finding_aid_series_statement finding_aid_note
+                      repository_processing_note finding_aid_filing_title],
+    'accession' => %w[title display_string content_description condition_description disposition
+                       inventory provenance general_note
+                       access_restrictions_note use_restrictions_note],
+    'archival_object' => %w[title display_string],
+    'digital_object' => %w[title],
+    'digital_object_component' => %w[title label display_string],
+  }.freeze
+
   def initialize(params, job, db)
     super
 
@@ -39,6 +54,9 @@ class CustomReport < AbstractReport
               @record_type.to_sym
             end
     @possible_fields = db[table].columns.collect {|c| c.to_s}
+
+    @mlc_fields = MLC_FIELDS[@record_type] || []
+    @possible_fields += @mlc_fields
 
     @possible_fields.push('name') if @record_type == 'agent'
 
@@ -138,8 +156,18 @@ class CustomReport < AbstractReport
 
     "select id#{select_fields}
 		from #{@record_type}
+		#{mlc_join_if_needed}
 		where #{where}
 		#{order_by}"
+  end
+
+  # Only join `<record_type>_mlc` when one of the report's included fields
+  # actually lives there.
+  def mlc_join_if_needed
+    return '' if @mlc_fields.empty?
+    return '' if (@fields.collect {|f| f[:name]} & @mlc_fields).empty?
+
+    mlc_join(@record_type)
   end
 
   def agent_query_string
@@ -220,7 +248,8 @@ class CustomReport < AbstractReport
     select_fields = ''
     columns.each do |column, column_alias|
       if @possible_fields.include? column
-        select_fields += ", #{@record_type}.#{column} as #{column_alias}"
+        table = @mlc_fields.include?(column) ? "#{@record_type}_mlc" : @record_type
+        select_fields += ", #{table}.#{column} as #{column_alias}"
       else
         msg = "#{@record_type} does not have field '#{column}'. Skipping."
         job.write_output(msg)

--- a/reports/custom/linked_accession_subreport.rb
+++ b/reports/custom/linked_accession_subreport.rb
@@ -1,69 +1,70 @@
 class LinkedAccessionSubreport < AbstractSubreport
 
-	@@link_tables ||= {'assessment' => 'assessment_rlshp',
-		'deaccession' => 'deaccession', 'subject' => 'subject_rlshp',
-		'classification' => 'classification_rlshp',
-		'rights_statement' => 'rights_statement', 'agent' => 'linked_agents_rlshp',
-		'event' => 'event_link_rlshp', 'resource' => 'spawned_rlshp'
-	}
+  @@link_tables ||= {'assessment' => 'assessment_rlshp',
+    'deaccession' => 'deaccession', 'subject' => 'subject_rlshp',
+    'classification' => 'classification_rlshp',
+    'rights_statement' => 'rights_statement', 'agent' => 'linked_agents_rlshp',
+    'event' => 'event_link_rlshp', 'resource' => 'spawned_rlshp'
+  }
 
-	@@extra_fields ||= {'agent' => [{:field => 'role_id as role',
-		:type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
-		'event' => [{:field => 'role_id as role', :type => 'Enum'}]
-	}
+  @@extra_fields ||= {'agent' => [{:field => 'role_id as role',
+    :type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
+    'event' => [{:field => 'role_id as role', :type => 'Enum'}]
+  }
 
-	register_subreport('accession', @@link_tables.keys)
+  register_subreport('accession', @@link_tables.keys)
 
-	def initialize(parent_custom_report, id)
-		super(parent_custom_report)
+  def initialize(parent_custom_report, id)
+    super(parent_custom_report)
 
-		id_type = parent_custom_report.record_type
-		record_type = if id_type.include?('agent')
-			'agent'
-		elsif id_type.include?('classification')
-			'classification'
-		else
-			id_type
-		end
-		@link_table = @@link_tables[record_type]
-		@link_fields = @@extra_fields[record_type] || []
-		@id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
-		@id = id
-	end
+    id_type = parent_custom_report.record_type
+    record_type = if id_type.include?('agent')
+                    'agent'
+                  elsif id_type.include?('classification')
+                    'classification'
+                  else
+                    id_type
+                  end
+    @link_table = @@link_tables[record_type]
+    @link_fields = @@extra_fields[record_type] || []
+    @id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
+    @id = id
+  end
 
-	def query
-		db.fetch(query_string)
-	end
+  def query
+    db.fetch(query_string)
+  end
 
-	def query_string
-		fields = ['accession.identifier', 'accession.title']
-		fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
-		"select
+  def query_string
+    fields = ['accession.identifier', 'accession_mlc.title as title']
+    fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
+    "select
 			#{fields.join(', ')}
 		from accession, #{@link_table}
+		#{mlc_join('accession')}
 		where #{@link_table}.#{@id_field} = #{db.literal(@id)}
 		and #{@link_table}.accession_id = accession.id
 		and accession.repo_id = #{db.literal(@repo_id)}
 		#{suppressed_filter('accession')}"
-	end
+  end
 
-	def fix_row(row)
-		ReportUtils.fix_identifier_format(row)
-		@link_fields.each do |field|
-			field_name = field[:field].split(' ')[-1].to_sym
-			case field[:type]
-			when 'Enum'
-				ReportUtils.get_enum_values(row, [field_name])
-			when 'Boolean'
-				ReportUtils.fix_boolean_fields(row, [field_name])
-			when 'Decimal'
-				ReportUtils.fix_decimal_format(row, [field_name])
-			end
-		end
-	end
+  def fix_row(row)
+    ReportUtils.fix_identifier_format(row)
+    @link_fields.each do |field|
+      field_name = field[:field].split(' ')[-1].to_sym
+      case field[:type]
+      when 'Enum'
+        ReportUtils.get_enum_values(row, [field_name])
+      when 'Boolean'
+        ReportUtils.fix_boolean_fields(row, [field_name])
+      when 'Decimal'
+        ReportUtils.fix_decimal_format(row, [field_name])
+      end
+    end
+  end
 
-	def self.field_name
-		'accession'
-	end
+  def self.field_name
+    'accession'
+  end
 
 end

--- a/reports/custom/linked_accession_subreport.rb
+++ b/reports/custom/linked_accession_subreport.rb
@@ -1,69 +1,70 @@
 class LinkedAccessionSubreport < AbstractSubreport
 
-	@@link_tables ||= {'assessment' => 'assessment_rlshp',
-		'deaccession' => 'deaccession', 'subject' => 'subject_rlshp',
-		'classification' => 'classification_rlshp',
-		'rights_statement' => 'rights_statement', 'agent' => 'linked_agents_rlshp',
-		'event' => 'event_link_rlshp', 'resource' => 'spawned_rlshp'
-	}
+  @@link_tables ||= {'assessment' => 'assessment_rlshp',
+    'deaccession' => 'deaccession', 'subject' => 'subject_rlshp',
+    'classification' => 'classification_rlshp',
+    'rights_statement' => 'rights_statement', 'agent' => 'linked_agents_rlshp',
+    'event' => 'event_link_rlshp', 'resource' => 'spawned_rlshp'
+  }
 
-	@@extra_fields ||= {'agent' => [{:field => 'role_id as role',
-		:type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
-		'event' => [{:field => 'role_id as role', :type => 'Enum'}]
-	}
+  @@extra_fields ||= {'agent' => [{:field => 'role_id as role',
+    :type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
+    'event' => [{:field => 'role_id as role', :type => 'Enum'}]
+  }
 
-	register_subreport('accession', @@link_tables.keys)
+  register_subreport('accession', @@link_tables.keys)
 
-	def initialize(parent_custom_report, id)
-		super(parent_custom_report)
+  def initialize(parent_custom_report, id)
+    super(parent_custom_report)
 
-		id_type = parent_custom_report.record_type
-		record_type = if id_type.include?('agent')
-			'agent'
-		elsif id_type.include?('classification')
-			'classification'
-		else
-			id_type
-		end
-		@link_table = @@link_tables[record_type]
-		@link_fields = @@extra_fields[record_type] || []
-		@id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
-		@id = id
-	end
+    id_type = parent_custom_report.record_type
+    record_type = if id_type.include?('agent')
+                    'agent'
+                  elsif id_type.include?('classification')
+                    'classification'
+                  else
+                    id_type
+                  end
+    @link_table = @@link_tables[record_type]
+    @link_fields = @@extra_fields[record_type] || []
+    @id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
+    @id = id
+  end
 
-	def query
-		db.fetch(query_string)
-	end
+  def query
+    db.fetch(query_string)
+  end
 
-	def query_string
-		fields = ['accession.identifier', 'accession.title']
-		fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
-		"select
+  def query_string
+    fields = ['accession.identifier', 'accession_mlc.title as title']
+    fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
+    "select
 			#{fields.join(', ')}
-		from accession, #{@link_table}
+		from (accession, #{@link_table})
+		#{mlc_join('accession')}
 		where #{@link_table}.#{@id_field} = #{db.literal(@id)}
 		and #{@link_table}.accession_id = accession.id
 		and accession.repo_id = #{db.literal(@repo_id)}
 		#{suppressed_filter('accession')}"
-	end
+  end
 
-	def fix_row(row)
-		ReportUtils.fix_identifier_format(row)
-		@link_fields.each do |field|
-			field_name = field[:field].split(' ')[-1].to_sym
-			case field[:type]
-			when 'Enum'
-				ReportUtils.get_enum_values(row, [field_name])
-			when 'Boolean'
-				ReportUtils.fix_boolean_fields(row, [field_name])
-			when 'Decimal'
-				ReportUtils.fix_decimal_format(row, [field_name])
-			end
-		end
-	end
+  def fix_row(row)
+    ReportUtils.fix_identifier_format(row)
+    @link_fields.each do |field|
+      field_name = field[:field].split(' ')[-1].to_sym
+      case field[:type]
+      when 'Enum'
+        ReportUtils.get_enum_values(row, [field_name])
+      when 'Boolean'
+        ReportUtils.fix_boolean_fields(row, [field_name])
+      when 'Decimal'
+        ReportUtils.fix_decimal_format(row, [field_name])
+      end
+    end
+  end
 
-	def self.field_name
-		'accession'
-	end
+  def self.field_name
+    'accession'
+  end
 
 end

--- a/reports/custom/linked_archival_object_subreport.rb
+++ b/reports/custom/linked_archival_object_subreport.rb
@@ -1,74 +1,74 @@
 class LinkedArchivalObjectSubreport < AbstractSubreport
 
-	@@link_tables ||= {'assessment' => 'assessment_rlshp',
-		'subject' => 'subject_rlshp', 'rights_statement' => 'rights_statement',
-		'agent' => 'linked_agents_rlshp', 'event' => 'event_link_rlshp',
-		'resource' => 'resource'
-	}
+  @@link_tables ||= {'assessment' => 'assessment_rlshp',
+    'subject' => 'subject_rlshp', 'rights_statement' => 'rights_statement',
+    'agent' => 'linked_agents_rlshp', 'event' => 'event_link_rlshp',
+    'resource' => 'resource'
+  }
 
-	@@extra_fields ||= {'agent' => [{:field => 'role_id as role',
-		:type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
-		'event' => [{:field => 'role_id as role', :type => 'Enum'}]
-	}
+  @@extra_fields ||= {'agent' => [{:field => 'role_id as role',
+    :type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
+    'event' => [{:field => 'role_id as role', :type => 'Enum'}]
+  }
 
-	register_subreport('archival_object', @@link_tables.keys)
+  register_subreport('archival_object', @@link_tables.keys)
 
-	def initialize(parent_custom_report, id)
-		super(parent_custom_report)
+  def initialize(parent_custom_report, id)
+    super(parent_custom_report)
 
-		id_type = parent_custom_report.record_type
-		record_type = if id_type.include?('agent')
-			'agent'
-		else
-			id_type
-		end
-		@link_table = @@link_tables[record_type]
-		@link_fields = @@extra_fields[record_type] || []
-		@id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
-		@id = id
-	end
+    id_type = parent_custom_report.record_type
+    record_type = if id_type.include?('agent')
+                    'agent'
+                  else
+                    id_type
+                  end
+    @link_table = @@link_tables[record_type]
+    @link_fields = @@extra_fields[record_type] || []
+    @id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
+    @id = id
+  end
 
-	def query_string
+  def query_string
+    from_string = "archival_object, #{@link_table}"
+    where_string = "#{@link_table}.#{@id_field} = #{db.literal(@id)} and archival_object.root_record_id = resource.id and archival_object.repo_id = #{db.literal(@repo_id)}"
+    unless @link_table == 'resource'
+      from_string += ", resource"
+      where_string += " and #{@link_table}.archival_object_id = archival_object.id"
+    end
+    where_string += suppressed_filter('archival_object')
+    where_string += suppressed_filter('resource')
 
-		from_string = "archival_object, #{@link_table}"
-		where_string = "#{@link_table}.#{@id_field} = #{db.literal(@id)} and archival_object.root_record_id = resource.id and archival_object.repo_id = #{db.literal(@repo_id)}"
-		unless @link_table == 'resource'
-			from_string += ", resource"
-			where_string += " and #{@link_table}.archival_object_id = archival_object.id"
-		end
-		where_string += suppressed_filter('archival_object')
-		where_string += suppressed_filter('resource')
-
-		fields = ['archival_object.component_id',
-							'archival_object.title',
-							'archival_object.ref_id',
-							'archival_object.level_id as level',
-							'resource.identifier as root_record']
-		fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
-		"select
+    fields = ['archival_object.component_id',
+              'archival_object_mlc.title as title',
+              'archival_object.ref_id',
+              'archival_object.level_id as level',
+              'resource.identifier as root_record']
+    fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
+    "select
 			#{fields.join(', ')}
-		from #{from_string}
+		from (#{from_string})
+		#{mlc_join('archival_object')}
 		where #{where_string}"
-	end
+  end
 
-	def fix_row(row)
-		ReportUtils.fix_identifier_format(row, :root_record)
-		ReportUtils.get_enum_values(row, [:level])
-		@link_fields.each do |field|
-			field_name = field[:field].split(' ')[-1].to_sym
-			case field[:type]
-			when 'Enum'
-				ReportUtils.get_enum_values(row, [field_name])
-			when 'Boolean'
-				ReportUtils.fix_boolean_fields(row, [field_name])
-			when 'Decimal'
-				ReportUtils.fix_decimal_format(row, [field_name])
-			end
-		end
-	end
+  def fix_row(row)
+    ReportUtils.fix_identifier_format(row, :root_record)
+    ReportUtils.get_enum_values(row, [:level])
+    @link_fields.each do |field|
+      field_name = field[:field].split(' ')[-1].to_sym
+      case field[:type]
+      when 'Enum'
+        ReportUtils.get_enum_values(row, [field_name])
+      when 'Boolean'
+        ReportUtils.fix_boolean_fields(row, [field_name])
+      when 'Decimal'
+        ReportUtils.fix_decimal_format(row, [field_name])
+      end
+    end
+  end
 
-	def self.field_name
-		'archival_object'
-	end
+  def self.field_name
+    'archival_object'
+  end
 
 end

--- a/reports/custom/linked_archival_object_subreport.rb
+++ b/reports/custom/linked_archival_object_subreport.rb
@@ -1,74 +1,74 @@
 class LinkedArchivalObjectSubreport < AbstractSubreport
 
-	@@link_tables ||= {'assessment' => 'assessment_rlshp',
-		'subject' => 'subject_rlshp', 'rights_statement' => 'rights_statement',
-		'agent' => 'linked_agents_rlshp', 'event' => 'event_link_rlshp',
-		'resource' => 'resource'
-	}
+  @@link_tables ||= {'assessment' => 'assessment_rlshp',
+    'subject' => 'subject_rlshp', 'rights_statement' => 'rights_statement',
+    'agent' => 'linked_agents_rlshp', 'event' => 'event_link_rlshp',
+    'resource' => 'resource'
+  }
 
-	@@extra_fields ||= {'agent' => [{:field => 'role_id as role',
-		:type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
-		'event' => [{:field => 'role_id as role', :type => 'Enum'}]
-	}
+  @@extra_fields ||= {'agent' => [{:field => 'role_id as role',
+    :type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
+    'event' => [{:field => 'role_id as role', :type => 'Enum'}]
+  }
 
-	register_subreport('archival_object', @@link_tables.keys)
+  register_subreport('archival_object', @@link_tables.keys)
 
-	def initialize(parent_custom_report, id)
-		super(parent_custom_report)
+  def initialize(parent_custom_report, id)
+    super(parent_custom_report)
 
-		id_type = parent_custom_report.record_type
-		record_type = if id_type.include?('agent')
-			'agent'
-		else
-			id_type
-		end
-		@link_table = @@link_tables[record_type]
-		@link_fields = @@extra_fields[record_type] || []
-		@id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
-		@id = id
-	end
+    id_type = parent_custom_report.record_type
+    record_type = if id_type.include?('agent')
+                    'agent'
+                  else
+                    id_type
+                  end
+    @link_table = @@link_tables[record_type]
+    @link_fields = @@extra_fields[record_type] || []
+    @id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
+    @id = id
+  end
 
-	def query_string
+  def query_string
+    from_string = "archival_object, #{@link_table}"
+    where_string = "#{@link_table}.#{@id_field} = #{db.literal(@id)} and archival_object.root_record_id = resource.id and archival_object.repo_id = #{db.literal(@repo_id)}"
+    unless @link_table == 'resource'
+      from_string += ", resource"
+      where_string += " and #{@link_table}.archival_object_id = archival_object.id"
+    end
+    where_string += suppressed_filter('archival_object')
+    where_string += suppressed_filter('resource')
 
-		from_string = "archival_object, #{@link_table}"
-		where_string = "#{@link_table}.#{@id_field} = #{db.literal(@id)} and archival_object.root_record_id = resource.id and archival_object.repo_id = #{db.literal(@repo_id)}"
-		unless @link_table == 'resource'
-			from_string += ", resource"
-			where_string += " and #{@link_table}.archival_object_id = archival_object.id"
-		end
-		where_string += suppressed_filter('archival_object')
-		where_string += suppressed_filter('resource')
-
-		fields = ['archival_object.component_id',
-							'archival_object.title',
-							'archival_object.ref_id',
-							'archival_object.level_id as level',
-							'resource.identifier as root_record']
-		fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
-		"select
+    fields = ['archival_object.component_id',
+              'archival_object_mlc.title as title',
+              'archival_object.ref_id',
+              'archival_object.level_id as level',
+              'resource.identifier as root_record']
+    fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
+    "select
 			#{fields.join(', ')}
 		from #{from_string}
+		#{mlc_join('archival_object')}
 		where #{where_string}"
-	end
+  end
 
-	def fix_row(row)
-		ReportUtils.fix_identifier_format(row, :root_record)
-		ReportUtils.get_enum_values(row, [:level])
-		@link_fields.each do |field|
-			field_name = field[:field].split(' ')[-1].to_sym
-			case field[:type]
-			when 'Enum'
-				ReportUtils.get_enum_values(row, [field_name])
-			when 'Boolean'
-				ReportUtils.fix_boolean_fields(row, [field_name])
-			when 'Decimal'
-				ReportUtils.fix_decimal_format(row, [field_name])
-			end
-		end
-	end
+  def fix_row(row)
+    ReportUtils.fix_identifier_format(row, :root_record)
+    ReportUtils.get_enum_values(row, [:level])
+    @link_fields.each do |field|
+      field_name = field[:field].split(' ')[-1].to_sym
+      case field[:type]
+      when 'Enum'
+        ReportUtils.get_enum_values(row, [field_name])
+      when 'Boolean'
+        ReportUtils.fix_boolean_fields(row, [field_name])
+      when 'Decimal'
+        ReportUtils.fix_decimal_format(row, [field_name])
+      end
+    end
+  end
 
-	def self.field_name
-		'archival_object'
-	end
+  def self.field_name
+    'archival_object'
+  end
 
 end

--- a/reports/custom/linked_digital_object.rb
+++ b/reports/custom/linked_digital_object.rb
@@ -1,60 +1,61 @@
 class LinkedDigitalObjectSubreport < AbstractSubreport
 
-	@@link_tables ||= {'assessment' => 'assessment_rlshp',
-		'subject' => 'subject_rlshp', 'rights_statement' => 'rights_statement',
-		'agent' => 'linked_agents_rlshp', 'event' => 'event_link_rlshp'
-	}
+  @@link_tables ||= {'assessment' => 'assessment_rlshp',
+    'subject' => 'subject_rlshp', 'rights_statement' => 'rights_statement',
+    'agent' => 'linked_agents_rlshp', 'event' => 'event_link_rlshp'
+  }
 
-	@@extra_fields ||= {'agent' => [{:field => 'role_id as role',
-		:type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
-		'event' => [{:field => 'role_id as role', :type => 'Enum'}]
-	}
+  @@extra_fields ||= {'agent' => [{:field => 'role_id as role',
+    :type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
+    'event' => [{:field => 'role_id as role', :type => 'Enum'}]
+  }
 
-	register_subreport('digital_object', @@link_tables.keys)
+  register_subreport('digital_object', @@link_tables.keys)
 
-	def initialize(parent_custom_report, id)
-		super(parent_custom_report)
+  def initialize(parent_custom_report, id)
+    super(parent_custom_report)
 
-		id_type = parent_custom_report.record_type
-		record_type = if id_type.include?('agent')
-			'agent'
-		else
-			id_type
-		end
-		@link_table = @@link_tables[record_type]
-		@link_fields = @@extra_fields[record_type] || []
-		@id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
-		@id = id
-	end
+    id_type = parent_custom_report.record_type
+    record_type = if id_type.include?('agent')
+                    'agent'
+                  else
+                    id_type
+                  end
+    @link_table = @@link_tables[record_type]
+    @link_fields = @@extra_fields[record_type] || []
+    @id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
+    @id = id
+  end
 
-	def query_string
-		fields = ['digital_object.digital_object_id', 'digital_object.title']
-		fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
-		"select
+  def query_string
+    fields = ['digital_object.digital_object_id', 'digital_object_mlc.title as title']
+    fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
+    "select
 			#{fields.join(', ')}
-		from digital_object, #{@link_table}
+		from (digital_object, #{@link_table})
+		#{mlc_join('digital_object')}
 		where #{@link_table}.#{@id_field} = #{db.literal(@id)}
 		and #{@link_table}.digital_object_id = digital_object.id
 		and digital_object.repo_id = #{db.literal(@repo_id)}
 		#{suppressed_filter('digital_object')}"
-	end
+  end
 
-	def fix_row(row)
-		@link_fields.each do |field|
-			field_name = field[:field].split(' ')[-1].to_sym
-			case field[:type]
-			when 'Enum'
-				ReportUtils.get_enum_values(row, [field_name])
-			when 'Boolean'
-				ReportUtils.fix_boolean_fields(row, [field_name])
-			when 'Decimal'
-				ReportUtils.fix_decimal_format(row, [field_name])
-			end
-		end
-	end
+  def fix_row(row)
+    @link_fields.each do |field|
+      field_name = field[:field].split(' ')[-1].to_sym
+      case field[:type]
+      when 'Enum'
+        ReportUtils.get_enum_values(row, [field_name])
+      when 'Boolean'
+        ReportUtils.fix_boolean_fields(row, [field_name])
+      when 'Decimal'
+        ReportUtils.fix_decimal_format(row, [field_name])
+      end
+    end
+  end
 
-	def self.field_name
-		'digital_object'
-	end
+  def self.field_name
+    'digital_object'
+  end
 
 end

--- a/reports/custom/linked_digital_object.rb
+++ b/reports/custom/linked_digital_object.rb
@@ -1,60 +1,61 @@
 class LinkedDigitalObjectSubreport < AbstractSubreport
 
-	@@link_tables ||= {'assessment' => 'assessment_rlshp',
-		'subject' => 'subject_rlshp', 'rights_statement' => 'rights_statement',
-		'agent' => 'linked_agents_rlshp', 'event' => 'event_link_rlshp'
-	}
+  @@link_tables ||= {'assessment' => 'assessment_rlshp',
+    'subject' => 'subject_rlshp', 'rights_statement' => 'rights_statement',
+    'agent' => 'linked_agents_rlshp', 'event' => 'event_link_rlshp'
+  }
 
-	@@extra_fields ||= {'agent' => [{:field => 'role_id as role',
-		:type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
-		'event' => [{:field => 'role_id as role', :type => 'Enum'}]
-	}
+  @@extra_fields ||= {'agent' => [{:field => 'role_id as role',
+    :type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
+    'event' => [{:field => 'role_id as role', :type => 'Enum'}]
+  }
 
-	register_subreport('digital_object', @@link_tables.keys)
+  register_subreport('digital_object', @@link_tables.keys)
 
-	def initialize(parent_custom_report, id)
-		super(parent_custom_report)
+  def initialize(parent_custom_report, id)
+    super(parent_custom_report)
 
-		id_type = parent_custom_report.record_type
-		record_type = if id_type.include?('agent')
-			'agent'
-		else
-			id_type
-		end
-		@link_table = @@link_tables[record_type]
-		@link_fields = @@extra_fields[record_type] || []
-		@id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
-		@id = id
-	end
+    id_type = parent_custom_report.record_type
+    record_type = if id_type.include?('agent')
+                    'agent'
+                  else
+                    id_type
+                  end
+    @link_table = @@link_tables[record_type]
+    @link_fields = @@extra_fields[record_type] || []
+    @id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
+    @id = id
+  end
 
-	def query_string
-		fields = ['digital_object.digital_object_id', 'digital_object.title']
-		fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
-		"select
+  def query_string
+    fields = ['digital_object.digital_object_id', 'digital_object_mlc.title as title']
+    fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
+    "select
 			#{fields.join(', ')}
 		from digital_object, #{@link_table}
+		#{mlc_join('digital_object')}
 		where #{@link_table}.#{@id_field} = #{db.literal(@id)}
 		and #{@link_table}.digital_object_id = digital_object.id
 		and digital_object.repo_id = #{db.literal(@repo_id)}
 		#{suppressed_filter('digital_object')}"
-	end
+  end
 
-	def fix_row(row)
-		@link_fields.each do |field|
-			field_name = field[:field].split(' ')[-1].to_sym
-			case field[:type]
-			when 'Enum'
-				ReportUtils.get_enum_values(row, [field_name])
-			when 'Boolean'
-				ReportUtils.fix_boolean_fields(row, [field_name])
-			when 'Decimal'
-				ReportUtils.fix_decimal_format(row, [field_name])
-			end
-		end
-	end
+  def fix_row(row)
+    @link_fields.each do |field|
+      field_name = field[:field].split(' ')[-1].to_sym
+      case field[:type]
+      when 'Enum'
+        ReportUtils.get_enum_values(row, [field_name])
+      when 'Boolean'
+        ReportUtils.fix_boolean_fields(row, [field_name])
+      when 'Decimal'
+        ReportUtils.fix_decimal_format(row, [field_name])
+      end
+    end
+  end
 
-	def self.field_name
-		'digital_object'
-	end
+  def self.field_name
+    'digital_object'
+  end
 
 end

--- a/reports/custom/linked_digital_object_component.rb
+++ b/reports/custom/linked_digital_object_component.rb
@@ -1,40 +1,41 @@
 class LinkedDigitalObjectComponentSubreport < AbstractSubreport
 
-	@@link_tables ||= {'subject' => 'subject_rlshp',
-		'rights_statement' => 'rights_statement', 'agent' => 'linked_agents_rlshp',
-		'event' => 'event_link_rlshp'
-	}
+  @@link_tables ||= {'subject' => 'subject_rlshp',
+    'rights_statement' => 'rights_statement', 'agent' => 'linked_agents_rlshp',
+    'event' => 'event_link_rlshp'
+  }
 
-	@@extra_fields ||= {'agent' => [{:field => 'role_id as role',
-		:type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
-		'event' => [{:field => 'role_id as role', :type => 'Enum'}]
-	}
+  @@extra_fields ||= {'agent' => [{:field => 'role_id as role',
+    :type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
+    'event' => [{:field => 'role_id as role', :type => 'Enum'}]
+  }
 
-	register_subreport('digital_object_component', @@link_tables.keys)
+  register_subreport('digital_object_component', @@link_tables.keys)
 
-	def initialize(parent_custom_report, id)
-		super(parent_custom_report)
+  def initialize(parent_custom_report, id)
+    super(parent_custom_report)
 
-		id_type = parent_custom_report.record_type
-		record_type = if id_type.include?('agent')
-			'agent'
-		else
-			id_type
-		end
-		@link_table = @@link_tables[record_type]
-		@link_fields = @@extra_fields[record_type] || []
-		@id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
-		@id = id
-	end
+    id_type = parent_custom_report.record_type
+    record_type = if id_type.include?('agent')
+                    'agent'
+                  else
+                    id_type
+                  end
+    @link_table = @@link_tables[record_type]
+    @link_fields = @@extra_fields[record_type] || []
+    @id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
+    @id = id
+  end
 
-	def query_string
-		fields = ['digital_object_component.component_id',
-			'digital_object_component.title',
-			'digital_object.digital_object_id as root_record']
-		fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
-		"select
+  def query_string
+    fields = ['digital_object_component.component_id',
+      'digital_object_component_mlc.title as title',
+      'digital_object.digital_object_id as root_record']
+    fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
+    "select
 			#{fields.join(', ')}
-		from digital_object_component, #{@link_table}, digital_object
+		from (digital_object_component, #{@link_table}, digital_object)
+		#{mlc_join('digital_object_component')}
 		where #{@link_table}.#{@id_field} = #{db.literal(@id)}
 			and #{@link_table}.digital_object_component_id
 			= digital_object_component.id
@@ -42,24 +43,24 @@ class LinkedDigitalObjectComponentSubreport < AbstractSubreport
 			and digital_object_component.repo_id = #{db.literal(@repo_id)}
 			#{suppressed_filter('digital_object_component')}
 			#{suppressed_filter('digital_object')}"
-	end
+  end
 
-	def fix_row(row)
-		@link_fields.each do |field|
-			field_name = field[:field].split(' ')[-1].to_sym
-			case field[:type]
-			when 'Enum'
-				ReportUtils.get_enum_values(row, [field_name])
-			when 'Boolean'
-				ReportUtils.fix_boolean_fields(row, [field_name])
-			when 'Decimal'
-				ReportUtils.fix_decimal_format(row, [field_name])
-			end
-		end
-	end
+  def fix_row(row)
+    @link_fields.each do |field|
+      field_name = field[:field].split(' ')[-1].to_sym
+      case field[:type]
+      when 'Enum'
+        ReportUtils.get_enum_values(row, [field_name])
+      when 'Boolean'
+        ReportUtils.fix_boolean_fields(row, [field_name])
+      when 'Decimal'
+        ReportUtils.fix_decimal_format(row, [field_name])
+      end
+    end
+  end
 
-	def self.field_name
-		'digital_object_component'
-	end
+  def self.field_name
+    'digital_object_component'
+  end
 
 end

--- a/reports/custom/linked_digital_object_component.rb
+++ b/reports/custom/linked_digital_object_component.rb
@@ -1,40 +1,41 @@
 class LinkedDigitalObjectComponentSubreport < AbstractSubreport
 
-	@@link_tables ||= {'subject' => 'subject_rlshp',
-		'rights_statement' => 'rights_statement', 'agent' => 'linked_agents_rlshp',
-		'event' => 'event_link_rlshp'
-	}
+  @@link_tables ||= {'subject' => 'subject_rlshp',
+    'rights_statement' => 'rights_statement', 'agent' => 'linked_agents_rlshp',
+    'event' => 'event_link_rlshp'
+  }
 
-	@@extra_fields ||= {'agent' => [{:field => 'role_id as role',
-		:type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
-		'event' => [{:field => 'role_id as role', :type => 'Enum'}]
-	}
+  @@extra_fields ||= {'agent' => [{:field => 'role_id as role',
+    :type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
+    'event' => [{:field => 'role_id as role', :type => 'Enum'}]
+  }
 
-	register_subreport('digital_object_component', @@link_tables.keys)
+  register_subreport('digital_object_component', @@link_tables.keys)
 
-	def initialize(parent_custom_report, id)
-		super(parent_custom_report)
+  def initialize(parent_custom_report, id)
+    super(parent_custom_report)
 
-		id_type = parent_custom_report.record_type
-		record_type = if id_type.include?('agent')
-			'agent'
-		else
-			id_type
-		end
-		@link_table = @@link_tables[record_type]
-		@link_fields = @@extra_fields[record_type] || []
-		@id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
-		@id = id
-	end
+    id_type = parent_custom_report.record_type
+    record_type = if id_type.include?('agent')
+                    'agent'
+                  else
+                    id_type
+                  end
+    @link_table = @@link_tables[record_type]
+    @link_fields = @@extra_fields[record_type] || []
+    @id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
+    @id = id
+  end
 
-	def query_string
-		fields = ['digital_object_component.component_id',
-			'digital_object_component.title',
-			'digital_object.digital_object_id as root_record']
-		fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
-		"select
+  def query_string
+    fields = ['digital_object_component.component_id',
+      'digital_object_component_mlc.title as title',
+      'digital_object.digital_object_id as root_record']
+    fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
+    "select
 			#{fields.join(', ')}
 		from digital_object_component, #{@link_table}, digital_object
+		#{mlc_join('digital_object_component')}
 		where #{@link_table}.#{@id_field} = #{db.literal(@id)}
 			and #{@link_table}.digital_object_component_id
 			= digital_object_component.id
@@ -42,24 +43,24 @@ class LinkedDigitalObjectComponentSubreport < AbstractSubreport
 			and digital_object_component.repo_id = #{db.literal(@repo_id)}
 			#{suppressed_filter('digital_object_component')}
 			#{suppressed_filter('digital_object')}"
-	end
+  end
 
-	def fix_row(row)
-		@link_fields.each do |field|
-			field_name = field[:field].split(' ')[-1].to_sym
-			case field[:type]
-			when 'Enum'
-				ReportUtils.get_enum_values(row, [field_name])
-			when 'Boolean'
-				ReportUtils.fix_boolean_fields(row, [field_name])
-			when 'Decimal'
-				ReportUtils.fix_decimal_format(row, [field_name])
-			end
-		end
-	end
+  def fix_row(row)
+    @link_fields.each do |field|
+      field_name = field[:field].split(' ')[-1].to_sym
+      case field[:type]
+      when 'Enum'
+        ReportUtils.get_enum_values(row, [field_name])
+      when 'Boolean'
+        ReportUtils.fix_boolean_fields(row, [field_name])
+      when 'Decimal'
+        ReportUtils.fix_decimal_format(row, [field_name])
+      end
+    end
+  end
 
-	def self.field_name
-		'digital_object_component'
-	end
+  def self.field_name
+    'digital_object_component'
+  end
 
 end

--- a/reports/custom/linked_resource_subreport.rb
+++ b/reports/custom/linked_resource_subreport.rb
@@ -1,71 +1,72 @@
 class LinkedResourceSubreport < AbstractSubreport
 
-	@@link_tables ||= {'assessment' => 'assessment_rlshp',
-		'deaccession' => 'deaccession', 'subject' => 'subject_rlshp',
-		'classification' => 'classification_rlshp',
-		'rights_statement' => 'rights_statement', 'agent' => 'linked_agents_rlshp',
-		'event' => 'event_link_rlshp', 'accession' => 'spawned_rlshp',
-		'archival_object' => 'archival_object'
-	}
+  @@link_tables ||= {'assessment' => 'assessment_rlshp',
+    'deaccession' => 'deaccession', 'subject' => 'subject_rlshp',
+    'classification' => 'classification_rlshp',
+    'rights_statement' => 'rights_statement', 'agent' => 'linked_agents_rlshp',
+    'event' => 'event_link_rlshp', 'accession' => 'spawned_rlshp',
+    'archival_object' => 'archival_object'
+  }
 
-	@@extra_fields ||= {'agent' => [{:field => 'role_id as role',
-		:type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
-		'event' => [{:field => 'role_id as role', :type => 'Enum'}]
-	}
+  @@extra_fields ||= {'agent' => [{:field => 'role_id as role',
+    :type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
+    'event' => [{:field => 'role_id as role', :type => 'Enum'}]
+  }
 
-	register_subreport('resource', @@link_tables.keys)
+  register_subreport('resource', @@link_tables.keys)
 
-	def initialize(parent_custom_report, id)
-		super(parent_custom_report)
+  def initialize(parent_custom_report, id)
+    super(parent_custom_report)
 
-		id_type = parent_custom_report.record_type
-		record_type = if id_type.include?('agent')
-			'agent'
-		elsif id_type.include?('classification')
-			'classification'
-		else
-			id_type
-		end
-		@link_table = @@link_tables[record_type]
-		@link_fields = @@extra_fields[record_type] || []
-		@id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
-		@id = id
-		if record_type == 'archival_object'
-			@resource_id_field = 'root_record_id'
-		else
-			@resource_id_field = 'resource_id'
-		end
-	end
+    id_type = parent_custom_report.record_type
+    record_type = if id_type.include?('agent')
+                    'agent'
+                  elsif id_type.include?('classification')
+                    'classification'
+                  else
+                    id_type
+                  end
+    @link_table = @@link_tables[record_type]
+    @link_fields = @@extra_fields[record_type] || []
+    @id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
+    @id = id
+    if record_type == 'archival_object'
+      @resource_id_field = 'root_record_id'
+    else
+      @resource_id_field = 'resource_id'
+    end
+  end
 
-	def query_string
-		fields = ['resource.identifier', 'resource.title']
-		fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
-		"select
+  def query_string
+    fields = ['resource.identifier', 'resource_mlc.title as title']
+    fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
+    "select
 			#{fields.join(', ')}
-		from resource, #{@link_table}
+		from (resource, #{@link_table})
+		#{mlc_join('resource')}
 		where #{@link_table}.#{@id_field} = #{db.literal(@id)}
 		and #{@link_table}.#{@resource_id_field} = resource.id
 		and resource.repo_id = #{db.literal(@repo_id)}
 		#{suppressed_filter('resource')}"
-	end
+  end
 
-	def fix_row(row)
-		ReportUtils.fix_identifier_format(row)
-		@link_fields.each do |field|
-			field_name = field[:field].split(' ')[-1].to_sym
-			case field[:type]
-			when 'Enum'
-				ReportUtils.get_enum_values(row, [field_name])
-			when 'Boolean'
-				ReportUtils.fix_boolean_fields(row, [field_name])
-			when 'Decimal'
-				ReportUtils.fix_decimal_format(row, [field_name])
-			end
-		end
-	end
+  def fix_row(row)
+    ReportUtils.fix_identifier_format(row)
+    @link_fields.each do |field|
+      field_name = field[:field].split(' ')[-1].to_sym
+      case field[:type]
+      when 'Enum'
+        ReportUtils.get_enum_values(row, [field_name])
+      when 'Boolean'
+        ReportUtils.fix_boolean_fields(row, [field_name])
+      when 'Decimal'
+        ReportUtils.fix_decimal_format(row, [field_name])
+      end
+    end
+  end
 
-	def self.field_name
-		'resource'
-	end
+  def self.field_name
+    'resource'
+  end
 
 end

--- a/reports/custom/linked_resource_subreport.rb
+++ b/reports/custom/linked_resource_subreport.rb
@@ -1,71 +1,72 @@
 class LinkedResourceSubreport < AbstractSubreport
 
-	@@link_tables ||= {'assessment' => 'assessment_rlshp',
-		'deaccession' => 'deaccession', 'subject' => 'subject_rlshp',
-		'classification' => 'classification_rlshp',
-		'rights_statement' => 'rights_statement', 'agent' => 'linked_agents_rlshp',
-		'event' => 'event_link_rlshp', 'accession' => 'spawned_rlshp',
-		'archival_object' => 'archival_object'
-	}
+  @@link_tables ||= {'assessment' => 'assessment_rlshp',
+    'deaccession' => 'deaccession', 'subject' => 'subject_rlshp',
+    'classification' => 'classification_rlshp',
+    'rights_statement' => 'rights_statement', 'agent' => 'linked_agents_rlshp',
+    'event' => 'event_link_rlshp', 'accession' => 'spawned_rlshp',
+    'archival_object' => 'archival_object'
+  }
 
-	@@extra_fields ||= {'agent' => [{:field => 'role_id as role',
-		:type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
-		'event' => [{:field => 'role_id as role', :type => 'Enum'}]
-	}
+  @@extra_fields ||= {'agent' => [{:field => 'role_id as role',
+    :type => 'Enum'}, {:field => 'relator_id as relator', :type => 'Enum'}],
+    'event' => [{:field => 'role_id as role', :type => 'Enum'}]
+  }
 
-	register_subreport('resource', @@link_tables.keys)
+  register_subreport('resource', @@link_tables.keys)
 
-	def initialize(parent_custom_report, id)
-		super(parent_custom_report)
+  def initialize(parent_custom_report, id)
+    super(parent_custom_report)
 
-		id_type = parent_custom_report.record_type
-		record_type = if id_type.include?('agent')
-			'agent'
-		elsif id_type.include?('classification')
-			'classification'
-		else
-			id_type
-		end
-		@link_table = @@link_tables[record_type]
-		@link_fields = @@extra_fields[record_type] || []
-		@id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
-		@id = id
-		if record_type == 'archival_object'
-			@resource_id_field = 'root_record_id'
-		else
-			@resource_id_field = 'resource_id'
-		end
-	end
+    id_type = parent_custom_report.record_type
+    record_type = if id_type.include?('agent')
+                    'agent'
+                  elsif id_type.include?('classification')
+                    'classification'
+                  else
+                    id_type
+                  end
+    @link_table = @@link_tables[record_type]
+    @link_fields = @@extra_fields[record_type] || []
+    @id_field = @link_table == record_type ? 'id' : "#{id_type}_id"
+    @id = id
+    if record_type == 'archival_object'
+      @resource_id_field = 'root_record_id'
+    else
+      @resource_id_field = 'resource_id'
+    end
+  end
 
-	def query_string
-		fields = ['resource.identifier', 'resource.title']
-		fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
-		"select
+  def query_string
+    fields = ['resource.identifier', 'resource_mlc.title as title']
+    fields += @link_fields.collect {|f| "#{@link_table}.#{f[:field]}"}
+    "select
 			#{fields.join(', ')}
 		from resource, #{@link_table}
+		#{mlc_join('resource')}
 		where #{@link_table}.#{@id_field} = #{db.literal(@id)}
 		and #{@link_table}.#{@resource_id_field} = resource.id
 		and resource.repo_id = #{db.literal(@repo_id)}
 		#{suppressed_filter('resource')}"
-	end
+  end
 
-	def fix_row(row)
-		ReportUtils.fix_identifier_format(row)
-		@link_fields.each do |field|
-			field_name = field[:field].split(' ')[-1].to_sym
-			case field[:type]
-			when 'Enum'
-				ReportUtils.get_enum_values(row, [field_name])
-			when 'Boolean'
-				ReportUtils.fix_boolean_fields(row, [field_name])
-			when 'Decimal'
-				ReportUtils.fix_decimal_format(row, [field_name])
-			end
-		end
-	end
+  def fix_row(row)
+    ReportUtils.fix_identifier_format(row)
+    @link_fields.each do |field|
+      field_name = field[:field].split(' ')[-1].to_sym
+      case field[:type]
+      when 'Enum'
+        ReportUtils.get_enum_values(row, [field_name])
+      when 'Boolean'
+        ReportUtils.fix_boolean_fields(row, [field_name])
+      when 'Decimal'
+        ReportUtils.fix_decimal_format(row, [field_name])
+      end
+    end
+  end
 
-	def self.field_name
-		'resource'
-	end
+  def self.field_name
+    'resource'
+  end
 
 end

--- a/reports/digital_objects/digital_object_file_versions_list_subreport/digital_object_file_versions_list_subreport.rb
+++ b/reports/digital_objects/digital_object_file_versions_list_subreport/digital_object_file_versions_list_subreport.rb
@@ -10,12 +10,14 @@ class DigitalObjectFileVersionsListSubreport < AbstractSubreport
   def query_string
     "select
       file_uri as 'file_uri',
-      digital_object.title as 'digital_object_title',
-      digital_object_component.title as 'digital_object_component_title'
-    from file_version 
+      digital_object_mlc.title as 'digital_object_title',
+      digital_object_component_mlc.title as 'digital_object_component_title'
+    from file_version
     left outer join digital_object
       on file_version.digital_object_id = digital_object.id
     left outer join digital_object_component on file_version.digital_object_component_id = digital_object_component.id
+    #{mlc_join('digital_object')}
+    #{mlc_join('digital_object_component')}
     where (digital_object.id = #{db.literal(@digital_object_id)}
     or root_record_id = #{db.literal(@digital_object_id)})
     #{suppressed_filter('digital_object')}

--- a/reports/digital_objects/digital_object_file_versions_report/digital_object_file_versions_report.rb
+++ b/reports/digital_objects/digital_object_file_versions_report/digital_object_file_versions_report.rb
@@ -10,13 +10,14 @@ class DigitalObjectFileVersionsReport < AbstractReport
   end
 
   def query_string
-    "select 
-      digital_object.id as 'digital_object_id', 
-      digital_object.digital_object_id as 'digital_object_identifier', 
-      title as 'digital_object_title', 
-      file_uri as 'digital_object_uri' 
-      from digital_object 
-      join file_version on digital_object.id = file_version.digital_object_id 
+    "select
+      digital_object.id as 'digital_object_id',
+      digital_object.digital_object_id as 'digital_object_identifier',
+      digital_object_mlc.title as 'digital_object_title',
+      file_uri as 'digital_object_uri'
+      from digital_object
+      join file_version on digital_object.id = file_version.digital_object_id
+      #{mlc_join('digital_object')}
       where repo_id = #{db.literal(@repo_id)} and file_uri is not null#{suppressed_filter('digital_object')}"
   end
 

--- a/reports/digital_objects/digital_object_list_table_report/digital_object_list_table_report.rb
+++ b/reports/digital_objects/digital_object_list_table_report/digital_object_list_table_report.rb
@@ -7,20 +7,22 @@ class DigitalObjectListTableReport < AbstractReport
   def query_string
     "select
       digital_object.digital_object_id as identifier,
-      digital_object.title as record_title,
+      digital_object_mlc.title as record_title,
       digital_object.digital_object_type_id as object_type,
       group_concat(dates.date_expression separator ', ') as date_expression,
       group_concat(distinct resource.identifier separator ',,,') as resource_identifier
     from digital_object
 
       natural left outer join
-     
+
       (select
         digital_object_id as id,
         ifnull(expression, if(end is null, begin,
         concat(begin, ' - ', end))) as date_expression
       from date
       where not digital_object_id is null) as dates
+
+      #{mlc_join('digital_object')}
 
       left outer join instance_do_link_rlshp
         on instance_do_link_rlshp.digital_object_id = digital_object.id

--- a/reports/locations/container_resources_accessions_subreport/container_resources_accessions_subreport.rb
+++ b/reports/locations/container_resources_accessions_subreport/container_resources_accessions_subreport.rb
@@ -6,19 +6,19 @@ class ContainerResourcesAccessionsSubreport < AbstractSubreport
   end
 
   def query_string
-    "select distinct 
+    "select distinct
       'resource' as linked_record_type,
         resource.identifier as identifier,
-        resource.title as record_title 
+        resource_mlc.title as record_title
     from
       (select sub_container_id as id
-        from top_container_link_rlshp 
+        from top_container_link_rlshp
         where top_container_id = #{db.literal(@container_id)}) as sub_ids
-        
+
         join sub_container on sub_ids.id = sub_container.id
-        
+
         join instance on sub_container.instance_id = instance.id
-        
+
         left outer join archival_object
         on instance.archival_object_id = archival_object.id#{suppressed_filter('archival_object')}
 
@@ -26,16 +26,19 @@ class ContainerResourcesAccessionsSubreport < AbstractSubreport
         on (resource.id = instance.resource_id
           or resource.id = archival_object.root_record_id)#{suppressed_filter('resource')}
 
+        #{mlc_join('resource')}
+
     union
 
     select
       'accession' as linked_record_type,
       identifier as identifier,
-        title as record_title
+        accession_mlc.title as record_title
     from accession
         join instance on accession.id = accession_id
         join sub_container on instance.id = instance_id
         join top_container_link_rlshp on sub_container.id = sub_container_id
+        #{mlc_join('accession')}
     where top_container_id = #{db.literal(@container_id)}
       #{suppressed_filter('accession')}"
   end

--- a/reports/locations/location_accessions_subreport/location_accessions_subreport.rb
+++ b/reports/locations/location_accessions_subreport/location_accessions_subreport.rb
@@ -12,8 +12,8 @@ class LocationAccessionsSubreport < AbstractSubreport
     "select
       accession.id,
       accession.identifier as identifier,
-        accession.title as title
-    from 
+        accession_mlc.title as title
+    from
       (select
         top_container_id as id
       from top_container_housed_at_rlshp
@@ -29,6 +29,8 @@ class LocationAccessionsSubreport < AbstractSubreport
 
       join instance on instance.id = sub_container.instance_id
         join accession on accession.id = instance.accession_id
+
+      #{mlc_join('accession')}
 
     where accession.repo_id = #{db.literal(@repo_id)}
       #{suppressed_filter('accession')}"

--- a/reports/locations/location_resources_subreport/location_resources_subreport.rb
+++ b/reports/locations/location_resources_subreport/location_resources_subreport.rb
@@ -12,27 +12,29 @@ class LocationResourcesSubreport < AbstractSubreport
     "select distinct
       resource.id,
       resource.identifier as identifier,
-      resource.title as title
+      resource_mlc.title as title
 
     from top_container_housed_at_rlshp
 
       join top_container on top_container.id
         = top_container_housed_at_rlshp.top_container_id
 
-      join top_container_link_rlshp 
+      join top_container_link_rlshp
         on top_container_link_rlshp.top_container_id
         = top_container.id
 
       join sub_container on sub_container.id
         = top_container_link_rlshp.sub_container_id
-      
+
       join instance on instance.id = sub_container.instance_id
-      
+
       left outer join archival_object on archival_object.id
         = instance.archival_object_id#{suppressed_filter('archival_object')}
 
       join resource on resource.id = archival_object.root_record_id
         or resource.id = instance.resource_id
+
+      #{mlc_join('resource')}
 
     where top_container_housed_at_rlshp.location_id = #{db.literal(@location_id)}
       and resource.repo_id = #{db.literal(@repo_id)}

--- a/reports/resources/archival_object_instances_subreport/archival_object_instances_subreport.rb
+++ b/reports/resources/archival_object_instances_subreport/archival_object_instances_subreport.rb
@@ -55,18 +55,19 @@ class ArchivalObjectInstancesSubreport < AbstractSubreport
       where archival_object_id = #{db.literal(@archival_object_id)}) as instances
 
       left outer join sub_container on instances.id = sub_container.instance_id
-      
+
       left outer join top_container_link_rlshp
         on sub_container.id = top_container_link_rlshp.sub_container_id
-      
+
       left outer join top_container
         on top_container.id = top_container_link_rlshp.top_container_id
 
       left outer join
         (select
           instance_do_link_rlshp.instance_id,
-          group_concat(digital_object.title separator '; ') as digital_object
+          group_concat(digital_object_mlc.title separator '; ') as digital_object
         from instance_do_link_rlshp, digital_object
+          #{mlc_join('digital_object')}
         where instance_do_link_rlshp.digital_object_id = digital_object.id
           #{suppressed_filter('digital_object')}
         group by instance_do_link_rlshp.instance_id) as digital_objects

--- a/reports/resources/resource_deaccessions_list_report/resource_deaccessions_list_report.rb
+++ b/reports/resources/resource_deaccessions_list_report/resource_deaccessions_list_report.rb
@@ -18,14 +18,16 @@ class ResourceDeaccessionsListReport < AbstractReport
 
   def query_string
     "select
-      id,
-      title as record_title,
+      resource.id as id,
+      resource_mlc.title as record_title,
       identifier,
       level_id as level,
       date_expression,
       extent_number
-        
+
     from resource
+
+      #{mlc_join('resource')}
 
       natural left outer join
       (select
@@ -34,14 +36,14 @@ class ResourceDeaccessionsListReport < AbstractReport
           concat(begin, ' - ', end))) separator ', ') as date_expression
       from date
       group by resource_id) as record_date
-      
+
       natural left outer join
       (select
         resource_id as id,
         sum(number) as extent_number
       from extent
       group by resource_id) as extent_cnt
-        
+
     where repo_id = #{db.literal(@repo_id)}#{suppressed_filter('resource')}"
   end
 

--- a/reports/resources/resource_instances_list_report/resource_instances_list_report.rb
+++ b/reports/resources/resource_instances_list_report/resource_instances_list_report.rb
@@ -16,14 +16,16 @@ class ResourceInstancesListReport < AbstractReport
 
   def query_string
     "select
-      id,
-      title as record_title,
+      resource.id as id,
+      resource_mlc.title as record_title,
       identifier,
       level_id as level,
       date,
       extent_number
-        
+
     from resource
+
+      #{mlc_join('resource')}
 
       natural left outer join
       (select
@@ -32,14 +34,14 @@ class ResourceInstancesListReport < AbstractReport
           concat(begin, ' - ', end))) separator ', ') as date
       from date
       group by resource_id) as record_date
-      
+
       natural left outer join
       (select
         resource_id as id,
         sum(number) as extent_number
       from extent
       group by resource_id) as extent_cnt
-        
+
     where repo_id = #{db.literal(@repo_id)}#{suppressed_filter('resource')}"
   end
 

--- a/reports/resources/resource_instances_subreport/resource_instances_subreport.rb
+++ b/reports/resources/resource_instances_subreport/resource_instances_subreport.rb
@@ -60,18 +60,19 @@ class ResourceInstancesSubreport < AbstractSubreport
         = #{db.literal(@resource_id)}) as instances
 
       left outer join sub_container on instances.id = sub_container.instance_id
-      
+
       left outer join top_container_link_rlshp
         on sub_container.id = top_container_link_rlshp.sub_container_id
-      
+
       left outer join top_container
         on top_container.id = top_container_link_rlshp.top_container_id
 
       left outer join
         (select
           instance_do_link_rlshp.instance_id,
-          group_concat(digital_object.title separator '; ') as digital_object
+          group_concat(digital_object_mlc.title separator '; ') as digital_object
         from instance_do_link_rlshp, digital_object
+          #{mlc_join('digital_object')}
         where instance_do_link_rlshp.digital_object_id = digital_object.id
           #{suppressed_filter('digital_object')}
         group by instance_do_link_rlshp.instance_id) as digital_objects

--- a/reports/resources/resource_locations_list_report/resource_locations_list_report.rb
+++ b/reports/resources/resource_locations_list_report/resource_locations_list_report.rb
@@ -14,14 +14,16 @@ class ResourceLocationsListReport < AbstractReport
 
   def query_string
     "select
-      id,
-      title as record_title,
+      resource.id as id,
+      resource_mlc.title as record_title,
       identifier,
       level_id as level,
       dates,
       extent_number
-        
+
     from resource
+
+      #{mlc_join('resource')}
 
       natural left outer join
       (select
@@ -30,14 +32,14 @@ class ResourceLocationsListReport < AbstractReport
           concat(begin, ' - ', end))) separator ', ') as dates
       from date
       group by resource_id) as record_date
-      
+
       natural left outer join
       (select
         resource_id as id,
         sum(number) as extent_number
       from extent
       group by resource_id) as extent_cnt
-        
+
     where repo_id = #{db.literal(@repo_id)}#{suppressed_filter('resource')}"
   end
 

--- a/reports/resources/resource_restrictions_list_report/resource_restrictions_list_report.rb
+++ b/reports/resources/resource_restrictions_list_report/resource_restrictions_list_report.rb
@@ -13,14 +13,16 @@ class ResourceRestrictionsListReport < AbstractReport
 
   def query_string
     "select
-      id,
-        title as record_title,
+      resource.id as id,
+        resource_mlc.title as record_title,
         identifier,
         level_id as level,
         dates,
         extent_number
-        
+
     from resource
+
+      #{mlc_join('resource')}
 
       natural left outer join
         (select
@@ -29,14 +31,14 @@ class ResourceRestrictionsListReport < AbstractReport
           concat(begin, ' - ', end))) separator ', ') as dates
         from date
         group by resource_id) as record_date
-        
+
         natural left outer join
         (select
         resource_id as id,
             sum(number) as extent_number
         from extent
         group by resource_id) as extent_cnt
-        
+
     where resource.restrictions
       and repo_id = #{db.literal(@repo_id)}#{suppressed_filter('resource')}"
   end

--- a/reports/resources/resources_list_report/resources_list_report.rb
+++ b/reports/resources/resources_list_report/resources_list_report.rb
@@ -1,45 +1,46 @@
 class ResourcesListReport < AbstractReport
-	register_report(
-		params: [['include_suppressed', 'IncludeSuppressed', 'Include suppressed records']]
-	)
+  register_report(
+    params: [['include_suppressed', 'IncludeSuppressed', 'Include suppressed records']]
+  )
 
-	def query_string
-		"select
+  def query_string
+    "select
 			id,
-			title as record_title,
+			resource_mlc.title as record_title,
 			identifier,
 			level_id as level,
 			resource_type_id as resource_type,
 			publish,
 			restrictions
 		from resource
+			#{mlc_join('resource')}
 		where repo_id = #{db.literal(repo_id)}#{suppressed_filter('resource')}"
-	end
+  end
 
-	def fix_row(row)
-		ReportUtils.get_enum_values(row, [:level, :resource_type])
-		ReportUtils.fix_boolean_fields(row, [:publish, :restrictions])
-		ReportUtils.fix_identifier_format(row)
-		row[:date] = ResourcesListDatesSubreport.new(self, row[:id]).get_content
-		row[:extent] = ExtentSubreport.new(self, row[:id]).get_content
-		row.delete(:id)
-	end
+  def fix_row(row)
+    ReportUtils.get_enum_values(row, [:level, :resource_type])
+    ReportUtils.fix_boolean_fields(row, [:publish, :restrictions])
+    ReportUtils.fix_identifier_format(row)
+    row[:date] = ResourcesListDatesSubreport.new(self, row[:id]).get_content
+    row[:extent] = ExtentSubreport.new(self, row[:id]).get_content
+    row.delete(:id)
+  end
 
-	def record_type
-		'resource'
-	end
+  def record_type
+    'resource'
+  end
 
-	def identifier_field
-		:identifier
-	end
+  def identifier_field
+    :identifier
+  end
 
-	def special_translation(key, subreport_code)
-		if subreport_code == 'extent_subreport'
-			I18n.t("extent.#{key}", :default => nil)
-		elsif subreport_code == 'date_subreport'
-			I18n.t("date.#{key}", :default => nil)
-		elsif !subreport_code
-			I18n.t("resource.#{key}", :default => nil) unless key == 'title'
-		end
-	end
+  def special_translation(key, subreport_code)
+    if subreport_code == 'extent_subreport'
+      I18n.t("extent.#{key}", :default => nil)
+    elsif subreport_code == 'date_subreport'
+      I18n.t("date.#{key}", :default => nil)
+    elsif !subreport_code
+      I18n.t("resource.#{key}", :default => nil) unless key == 'title'
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->
[ANW-2907]

## Summary
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->
Migration 177 moved `title` and other free-text fields off the base `resource`/`accession`/`archival_object`/`digital_object`/`digital_object_component` tables and into per-language `*_mlc` tables as part of MLC support. Most report and subreport SQL under `reports/` was never updated to match, so any report touching one of those fields failed with `Unknown column` SQL errors — this surfaced as widespread backend report spec failures after [merging `master` into `ANW-2721_mlc`](https://github.com/archivesspace/archivesspace/actions/runs/30641052486/job/91191621893).

This PR makes every affected report/subreport MLC-aware:
- Adds a `ReportMlc` mixin (mirrors the existing `ReportSuppression` mixin) providing an `mlc_join` helper, included in `AbstractReport`/`AbstractSubreport`.
- Updates all affected reports, subreports, and the custom report template engine (`CustomReport`) to join the relevant `*_mlc` table and select fields from there instead of the dropped base-table columns.

As an initial MVP, I decided to have reports always render the `AppConfig` default description language/script rather than a per-request or user-selected language — report jobs run in the background with no per-request language on them, and per-run language selection is out of scope for now. This is called out in a comment on the `ReportMlc` mixin.

**Note on whitespace:** `reports/` is excluded from the project's `.rubocop.yml` `Include` list, so it's inconsistently indented (mostly tabs) compared to the rest of the codebase (spaces, rubocop-enforced). A few files in this diff show larger-than-expected whitespace diffs where an editor reformatted surrounding lines; those have been normalized back to the file's original tab convention so the diffs only reflect real changes. I'll follow up with a separate ticket to bring `reports/` into `.rubocop.yml`'s `Include` list and normalize it to the project standard in its own dedicated commit.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [x] My change requires a change to the documentation - If so elaborate: The "reports use AppConfig default language" condition - if this continues on past this initial implementation - should almost certainly be called out in post-MLC documentaiton.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and agree to the [**CONTRIBUTING** document](https://github.com/archivesspace/archivesspace/blob/master/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](https://github.com/archivesspace/archivesspace/blob/master/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why: 


[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-2907]: https://archivesspace.atlassian.net/browse/ANW-2907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ