### PR TITLE
ANW-2905 Do not duplicate langmat or rights note persistent ids

### DIFF
--- a/frontend/app/controllers/archival_objects_controller.rb
+++ b/frontend/app/controllers/archival_objects_controller.rb
@@ -18,11 +18,9 @@ class ArchivalObjectsController < ApplicationController
       @archival_object.ref_id = nil
       @archival_object.instances = []
       @archival_object.position = params[:position]
-      @archival_object.notes.each do |note|
-        if note.is_a?(Hash)
-          note.delete('persistent_id')
-        end
-      end
+      strip_persistent_ids(@archival_object.notes)
+      strip_persistent_ids(@archival_object.lang_materials, 'notes')
+      strip_persistent_ids(@archival_object.rights_statements, 'notes')
 
       flash[:success] = t("archival_object._frontend.messages.duplicated", archival_object_display_string: clean_mixed_content(@archival_object.display_string))
     else
@@ -374,5 +372,18 @@ class ArchivalObjectsController < ApplicationController
     render :json => list.select { |type| type != "lang_material" }.map {|type|
       [type, t("#{type == 'archival_object' ? 'resource_component' : type}._singular")]
     }
+  end
+
+  private
+
+  def strip_persistent_ids(records, nested_key = nil)
+    records.each do |record|
+      next unless record.is_a?(Hash)
+
+      notes = nested_key ? Array(record[nested_key]) : [record]
+      notes.each do |note|
+        note.delete('persistent_id') if note.is_a?(Hash)
+      end
+    end
   end
 end

--- a/frontend/app/controllers/archival_objects_controller.rb
+++ b/frontend/app/controllers/archival_objects_controller.rb
@@ -21,6 +21,7 @@ class ArchivalObjectsController < ApplicationController
       strip_persistent_ids(@archival_object.notes)
       strip_persistent_ids(@archival_object.lang_materials, 'notes')
       strip_persistent_ids(@archival_object.rights_statements, 'notes')
+      strip_persistent_ids(@archival_object.rights_statements, 'acts', 'notes')
 
       flash[:success] = t("archival_object._frontend.messages.duplicated", archival_object_display_string: clean_mixed_content(@archival_object.display_string))
     else
@@ -376,14 +377,13 @@ class ArchivalObjectsController < ApplicationController
 
   private
 
-  def strip_persistent_ids(records, nested_key = nil)
-    records.each do |record|
-      next unless record.is_a?(Hash)
+  def strip_persistent_ids(records, *nested_keys)
+    notes = nested_keys.reduce(Array(records)) do |items, key|
+      items.flat_map { |item| item.is_a?(Hash) ? Array(item[key]) : [] }
+    end
 
-      notes = nested_key ? Array(record[nested_key]) : [record]
-      notes.each do |note|
-        note.delete('persistent_id') if note.is_a?(Hash)
-      end
+    notes.each do |note|
+      note.delete('persistent_id') if note.is_a?(Hash)
     end
   end
 end

--- a/frontend/spec/controllers/archival_objects_controller_spec.rb
+++ b/frontend/spec/controllers/archival_objects_controller_spec.rb
@@ -20,6 +20,12 @@ describe ArchivalObjectsController, type: :controller do
     let (:archival_object_with_note) { create(:json_archival_object,
                                                :notes => [ build(:json_note_singlepart) ],
                                                :resource => {'ref' => resource.uri}) }
+    let (:archival_object_with_lang_material_note) { create(:json_archival_object,
+                                                             :lang_materials => [ build(:json_lang_material, :language_and_script => nil, :notes => [ build(:json_note_langmaterial) ]) ],
+                                                             :resource => {'ref' => resource.uri}) }
+    let (:archival_object_with_rights_statement_note) { create(:json_archival_object,
+                                                                :rights_statements => [ build(:json_rights_statement, :notes => [ build(:json_note_rights_statement) ]) ],
+                                                                :resource => {'ref' => resource.uri}) }
     let (:random_archival_object) { create(:json_archival_object) }
     let (:accession) { create(:json_accession) }
     let(:default_values) {
@@ -111,6 +117,30 @@ describe ArchivalObjectsController, type: :controller do
       result = Capybara.string(response.body)
 
       result.find(:css, "#archival_object_notes__0__persistent_id_") do |new_persistent_id|
+        expect(new_persistent_id.value).to eq("")
+      end
+    end
+
+    it "does not duplicate persistent id when duplicating a language of materials note" do
+      get :new, params: { resource_id: resource.id,
+                          duplicate_from_archival_object: { uri: archival_object_with_lang_material_note.uri } }
+
+      expect(response.status).to eq 200
+      result = Capybara.string(response.body)
+
+      result.find(:css, "#archival_object_lang_materials__0__notes__0__persistent_id_") do |new_persistent_id|
+        expect(new_persistent_id.value).to eq("")
+      end
+    end
+
+    it "does not duplicate persistent id when duplicating a rights statement note" do
+      get :new, params: { resource_id: resource.id,
+                          duplicate_from_archival_object: { uri: archival_object_with_rights_statement_note.uri } }
+
+      expect(response.status).to eq 200
+      result = Capybara.string(response.body)
+
+      result.find(:css, "#archival_object_rights_statements__0__notes__0__persistent_id_") do |new_persistent_id|
         expect(new_persistent_id.value).to eq("")
       end
     end

--- a/frontend/spec/controllers/archival_objects_controller_spec.rb
+++ b/frontend/spec/controllers/archival_objects_controller_spec.rb
@@ -26,6 +26,9 @@ describe ArchivalObjectsController, type: :controller do
     let (:archival_object_with_rights_statement_note) { create(:json_archival_object,
                                                                 :rights_statements => [ build(:json_rights_statement, :notes => [ build(:json_note_rights_statement) ]) ],
                                                                 :resource => {'ref' => resource.uri}) }
+    let (:archival_object_with_rights_statement_act_note) { create(:json_archival_object,
+                                                                    :rights_statements => [ build(:json_rights_statement, :acts => [ build(:json_rights_statement_act, :notes => [ build(:json_note_rights_statement_act) ]) ]) ],
+                                                                    :resource => {'ref' => resource.uri}) }
     let (:random_archival_object) { create(:json_archival_object) }
     let (:accession) { create(:json_accession) }
     let(:default_values) {
@@ -141,6 +144,18 @@ describe ArchivalObjectsController, type: :controller do
       result = Capybara.string(response.body)
 
       result.find(:css, "#archival_object_rights_statements__0__notes__0__persistent_id_") do |new_persistent_id|
+        expect(new_persistent_id.value).to eq("")
+      end
+    end
+
+    it "does not duplicate persistent id when duplicating a rights statement act note" do
+      get :new, params: { resource_id: resource.id,
+                          duplicate_from_archival_object: { uri: archival_object_with_rights_statement_act_note.uri } }
+
+      expect(response.status).to eq 200
+      result = Capybara.string(response.body)
+
+      result.find(:css, "#archival_object_rights_statements__0__acts__0__notes__0__persistent_id_") do |new_persistent_id|
         expect(new_persistent_id.value).to eq("")
       end
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->
[ANW-2905]

## Summary
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->
"Add Duplicate" on an archival object copies the record's persistent IDs for Language of Materials notes and Rights Statement notes onto the duplicate, resulting in two archival objects sharing the same persistent ID for those notes. This violates the uniqueness constraint for persistent note IDs.

[ANW-2459](https://archivesspace.atlassian.net/browse/ANW-2459) fixed this same class of bug for notes in the archival object's top-level `notes` array, by stripping `persistent_id` from each note before the duplicate form is rendered (the backend only auto-generates a `persistent_id` when one is absent, so any ID left in the payload gets saved as-is). That fix didn't reach `lang_materials` or `rights_statements`, since their notes live in separate, nested arrays rather than the flat `notes` array.

This change extends the same strip-before-render approach to `lang_materials[].notes[]` and `rights_statements[].notes[]`, and consolidates all three into a single private `strip_persistent_ids` helper on the controller.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and agree to the [**CONTRIBUTING** document](https://github.com/archivesspace/archivesspace/blob/master/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](https://github.com/archivesspace/archivesspace/blob/master/contribution_files/CONTRIBUTING_README.md)
- [x] Have you added tests to cover these changes? If not why:


[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-2905]: https://archivesspace.atlassian.net/browse/ANW-2905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-2459]: https://archivesspace.atlassian.net/browse/ANW-2459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ