### PR TITLE
ANW-2892 accessibility filter results input and button labels

### DIFF
--- a/public/app/views/layouts/application.html.erb
+++ b/public/app/views/layouts/application.html.erb
@@ -53,11 +53,11 @@
     <%= render partial: 'shared/navigation' %>
   </div>
 
-  <section id="content" class="container-fluid mt-2 pt-2 flex-grow-1">
+  <main id="content" class="container-fluid mt-2 pt-2 flex-grow-1">
     <a id="maincontent" tabindex="-1"></a>
     <%= flash_messages %>
     <%= yield %>
-  </section>
+  </main>
 
   <%= render partial: 'shared/footer' %>
 

--- a/public/app/views/shared/_facets.html.erb
+++ b/public/app/views/shared/_facets.html.erb
@@ -47,7 +47,8 @@
                                nil,
                                :id => 'filter_q',
                                :placeholder => t('actions.search_within'),
-                               :class=> "form-control") %>
+                               :class=> "form-control",
+                               :"aria-label" => "#{t('actions.search_within')} (#{t('search_results.filter.head')})") %>
           </div>
         <% end %>
         <% if @search.search_dates_within? %>
@@ -62,7 +63,8 @@
                                  :maxlength => 4,
                                  :class=>"form-control",
                                  :placeholder => t('search_results.filter.from_year'),
-                                 :id => 'filter_from_year') %>
+                                 :id => 'filter_from_year',
+                                 :"aria-label" => "#{t('search_results.filter.from_year')} (#{t('search_results.filter.head')})") %>
             </div>
             <div class="year_to p-0 pt-3 pt-md-0 flex-grow-1">
               <%= label_tag('filter_to_year',
@@ -74,7 +76,8 @@
                                  :maxlength => 4,
                                  :class=> "form-control",
                                  :placeholder => t('search_results.filter.to_year'),
-                                 :id => 'filter_to_year') %>
+                                 :id => 'filter_to_year',
+                                 :"aria-label" => "#{t('search_results.filter.to_year')} (#{t('search_results.filter.head')})") %>
             </div>
           </div>
         <% else %>
@@ -82,7 +85,7 @@
           <%= hidden_field_tag(:filter_to_year, @search[:filter_to_year], :id => nil) %>
         <% end %>
       <div>
-        <%= submit_tag(t('search-button.label'), :class=>'btn btn-primary', :id => nil) %>
+        <%= submit_tag(t('search-button.label'), :class=>'btn btn-primary', :id => nil, :"aria-label" => "#{t('search-button.label')} (#{t('search_results.filter.head')})") %>
       </div>
   <% end %>
  </div>

--- a/public/app/views/shared/_search.html.erb
+++ b/public/app/views/shared/_search.html.erb
@@ -19,10 +19,10 @@
       <div class="col-xl-3 col-lg-6 form-group flex-grow-1">
         <%= label_tag(:"q#{i}", t('navbar.search_placeholder'),:class => 'repeats fw-bold mb-2') %>
         <%= text_field_tag('q[]', @search[:q][i], :placeholder =>  t('navbar.search_placeholder'), :id => "q#{i}",
-                          :class=> 'form-control repeats fill-column js-search-box') %>
+                          :class=> 'form-control repeats fill-column js-search-box', :"aria-label" => "#{t('navbar.search_placeholder')} (#{t('actions.refine_search')})") %>
       </div>
       <div class="col-xl-3 col-md-6 form-group norepeat">
-        <%= label_tag(:limit, t('advanced_search.limit_label'),:class => 'fw-bold mb-2') %>
+        <%= label_tag(:advanced_search_limit, t('advanced_search.limit_label'),:class => 'fw-bold mb-2') %>
         <%
           # Determine the default limit value
           default_limit = if @search[:limit].present?
@@ -33,7 +33,7 @@
                             SearchConfigHelper.default_search_scope == 'collections_only' ? 'resource' : ''
                           end
         %>
-        <%= select_tag(:limit, options_for_select(limit_options, default_limit), :class=> 'form-select fill-column') %>
+        <%= select_tag(:limit, options_for_select(limit_options, default_limit), :id => 'advanced_search_limit', :class=> 'form-select fill-column') %>
       </div>
       <div class="col-xl-2 col-lg-4 col-md-6 form-group">
         <%= label_tag(:"field#{i}", t('search-field'),:class => 'repeats fw-bold mb-2') %>
@@ -42,12 +42,12 @@
       <div class="col-xl-1 col-lg-3 col-sm-5 form-group">
         <%= label_tag(:"from_year#{i}", "#{t('search_results.filter.from_year')}", :class => 'repeats fw-bold mb-2') %>
         <%= text_field_tag('from_year[]', @search[:from_year][i], :size => 4,:maxlength => 4, :id=>"from_year#{i}",
-                          :placeholder => t('search_results.filter.from'),:class=>'form-control repeats') %>
+                          :placeholder => t('search_results.filter.from'),:class=>'form-control repeats', :"aria-label" => "#{t('search_results.filter.from_year')} (#{t('actions.refine_search')})") %>
       </div>
       <div class="col-xl-1 col-lg-3 col-sm-5 form-group">
         <%= label_tag(:"to_year#{i}", "#{t('search_results.filter.to_year')}", :class=> 'repeats fw-bold mb-2') %>
         <%= text_field_tag('to_year[]', @search[:to_year][i], :size => 4, :maxlength => 4, :id => "to_year#{i}",
-                          :class=> 'form-control repeats', :placeholder => t('search_results.filter.to')) %>
+                          :class=> 'form-control repeats', :placeholder => t('search_results.filter.to'), :"aria-label" => "#{t('search_results.filter.to_year')} (#{t('actions.refine_search')})") %>
       </div>
       <div class="d-flex flex-column col-sm-2 form-group text-start align-self-end">
           <span class="mb-2 d-inline-block repeats plusminus_label fw-bold"><%= t('advanced_search.add_row') %></span>
@@ -64,7 +64,7 @@
   <% end %>
     <div class="row mt-3" id="submit_div">
       <div class="col-sm-3">
-        <%= submit_tag(t('search-button.label'), :class=>'btn btn-primary', :id => 'submit_search') %>
+        <%= submit_tag(t('search-button.label'), :class=>'btn btn-primary', :id => 'submit_search', :"aria-label" => "#{t('search-button.label')} (#{t('actions.refine_search')})") %>
       </div>
     </div>
   <% end %>

--- a/public/spec/features/search_spec.rb
+++ b/public/spec/features/search_spec.rb
@@ -22,8 +22,8 @@ describe 'Search', js: true do
         expect(page).to have_xpath("//label[@for='q0']")
         expect(page).to have_xpath("//input[@type='text'][@id='q0']")
 
-        expect(page).to have_xpath("//label[@for='limit']")
-        expect(page).to have_xpath("//select[@id='limit']")
+        expect(page).to have_xpath("//label[@for='advanced_search_limit']")
+        expect(page).to have_xpath("//select[@id='advanced_search_limit']")
 
         expect(page).to have_xpath("//label[@for='field0']")
         expect(page).to have_xpath("//select[@id='field0']")


### PR DESCRIPTION
## Related Ticket (JIRA or GitHub Issue)
[ANW-2892]

## Summary
This MR fixes accessibility issues on pages that render multiple search/filter forms by making control names uniquely identifiable to assistive tech and by avoiding duplicate IDs.

## Screenshots (if appropriate):
Before fix: ARC Accessibility Scan
<img width="1917" height="1170" alt="Before Accessibility scan - ARC" src="https://github.com/user-attachments/assets/c3091424-f2d5-43e2-a5e0-e714bc5e2c33" />

After fix: ARC Accessibility Scan
<img width="1503" height="903" alt="Afrer accessibility scan - arc" src="https://github.com/user-attachments/assets/935989b5-dadc-452d-b7cc-edddca42c184" />

Refine Search Aria Labels
<img width="2115" height="1316" alt="Refine Search Aria Labels" src="https://github.com/user-attachments/assets/7894d247-643c-4d73-89e3-c865106c8929" />

Filter Results Aria Labels
<img width="1508" height="543" alt="Filter Results Aria Labels" src="https://github.com/user-attachments/assets/5a10a632-4f8b-4710-b7fa-7dee02563cc5" />

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
- [X] I have read and agree to the [**CONTRIBUTING** document](https://github.com/archivesspace/archivesspace/blob/master/CONTRIBUTING.md).
- [X] I have authority to submit this code. - See our [licensing](https://github.com/archivesspace/archivesspace/blob/master/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why: Accessibility fix, no test needed


[ANW-2892]: https://archivesspace.atlassian.net/browse/ANW-2892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ