### PR TITLE
ANW-2924 Extended CSV export fix

### DIFF
--- a/backend/app/controllers/search.rb
+++ b/backend/app/controllers/search.rb
@@ -53,7 +53,15 @@ class ArchivesSpaceService < Sinatra::Base
   Endpoint.get_or_post('/repositories/:repo_id/search')
     .description("Search this repository")
     .params(["repo_id", :repo_id],
-            *BASE_SEARCH_PARAMS)
+            *BASE_SEARCH_PARAMS,
+            ["csv_export_use_solr_writer",
+                BooleanParam,
+                "If true, use the standard Solr CSV writer for this request instead of " \
+                "the extended CSV export, even if extended CSV export is enabled. Headers " \
+                "will be raw Solr field names rather than the extended export's flattened " \
+                "JSONModel property names. Used by the top container CSV export, which " \
+                "needs raw Solr field names.",
+                :optional => true])
     .paged(true)
     .permissions([:view_repository])
     .returns([200, ""]) \

--- a/backend/app/model/search.rb
+++ b/backend/app/model/search.rb
@@ -176,15 +176,14 @@ class Search
     end
   end
 
-  # A request for specific fields (e.g. the top container browse column
-  # picker) expects Solr index field names as CSV headers so the frontend can
-  # map them back to columns, See ANW-2791.
+  # csv_export_use_solr_writer=true indicates the caller wants raw Solr
+  # field names as headers (e.g. the top container browse column picker,
+  # see ANW-2791) so skip extended export.
   def self.use_extended_csv_export?(params)
     return false unless AppConfig[:extended_csv_export_enabled]
+    return false if params[:csv_export_use_solr_writer].to_s == 'true'
 
-    field_limited = !Array(params[:fields]).empty?
-
-    !field_limited
+    true
   end
 
   def self.extended_csv_export(params, repo_id)

--- a/backend/spec/model_search_spec.rb
+++ b/backend/spec/model_search_spec.rb
@@ -144,21 +144,38 @@ describe Search do
       allow(Search).to receive(:search).with(hash_including(:page => 2), repo.id).and_return(mock_empty_results)
 
       csv = ""
-      Search.search_csv({:page => 1, :page_size => 10}, repo.id).each do |chunk|
-        csv << chunk
+      Search.search_csv({:page => 1, :page_size => 10}, repo.id).each do |csv_chunk|
+        csv << csv_chunk
       end
 
       expect(csv).to include("dates::0::")
     end
 
-    it "uses the Solr CSV writer for field-limited requests even when extended export is enabled (ANW-2791)" do
+    it "uses the Solr CSV writer when csv_export_use_solr_writer is requested (ANW-2791)" do
       allow(AppConfig).to receive(:[]).and_call_original
       allow(AppConfig).to receive(:[]).with(:extended_csv_export_enabled).and_return(true)
 
       expect(Search).to receive(:search_csv_solr).with(hash_including(:fields => ['barcode_u_sstr']), repo.id)
       expect(Search).not_to receive(:extended_csv_export)
 
-      Search.search_csv({:fields => ['barcode_u_sstr'], :dt => 'csv'}, repo.id)
+      Search.search_csv({:fields => ['barcode_u_sstr'], :csv_export_use_solr_writer => 'true', :dt => 'csv'}, repo.id)
+    end
+
+    it "uses the extended CSV export for field-limited requests without csv_export_use_solr_writer (ANW-2924)" do
+      allow(AppConfig).to receive(:[]).and_call_original
+      allow(AppConfig).to receive(:[]).with(:extended_csv_export_enabled).and_return(true)
+
+      allow(Search).to receive(:search).with(hash_including(:page => 1), repo.id).and_return(mock_search_results)
+      allow(Search).to receive(:search).with(hash_including(:page => 2), repo.id).and_return(mock_empty_results)
+
+      expect(Search).not_to receive(:search_csv_solr)
+
+      csv = ""
+      Search.search_csv({:fields => ['title'], :page => 1, :page_size => 10}, repo.id).each do |csv_chunk|
+        csv << csv_chunk
+      end
+
+      expect(csv).to include("dates::0::")
     end
 
   end

--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -55,7 +55,8 @@ class TopContainersController < ApplicationController
 
         search_params = prepare_search.merge(
           'facet[]' => SearchResultData.TOP_CONTAINER_FACETS,
-          'fields[]' => csv_fields
+          'fields[]' => csv_fields,
+          'csv_export_use_solr_writer' => true
         )
 
         render plain: csv_export_with_mappings(

--- a/frontend/spec/controllers/top_containers_controller_spec.rb
+++ b/frontend/spec/controllers/top_containers_controller_spec.rb
@@ -19,6 +19,18 @@ describe TopContainersController, type: :controller do
     controller.session[:repo_id] = JSONModel.repository
   end
 
+  describe 'CSV export' do
+    it 'sends csv_export_use_solr_writer=true so it keeps using the Solr CSV writer (ANW-2924)' do
+      expect(controller).to receive(:csv_export_with_mappings)
+        .with(anything, hash_including('csv_export_use_solr_writer' => true))
+        .and_return('')
+
+      get :index, params: { q: 'Test', format: :csv }
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe 'access_top_containers' do
     it 'renders the manage_for_record partial' do
       get :access_top_containers

--- a/frontend/spec/helpers/export_helper_spec.rb
+++ b/frontend/spec/helpers/export_helper_spec.rb
@@ -27,7 +27,8 @@ describe ExportHelper do
         'fields[]' => ['type', 'indicator', 'barcode', 'ils_holding_id', 'exported_to_ils', 'internal_note'],
         'q' => '*',
         'page' => '1',
-        'filter_term[]' => [{'primary_type' => 'top_container'}.to_json]
+        'filter_term[]' => [{'primary_type' => 'top_container'}.to_json],
+        'csv_export_use_solr_writer' => true
       }
       export = csv_export_with_mappings "#{@repo.uri}/search", Search.build_filters(criteria)
       aggregate_failures do
@@ -56,7 +57,7 @@ describe ExportHelper do
 
     run_index_round
 
-    criteria = {'fields[]' => ['primary_type', 'title', 'context'], 'q' => '*', 'page' => '1'}
+    criteria = {'fields[]' => ['primary_type', 'title', 'context'], 'q' => '*', 'page' => '1', 'csv_export_use_solr_writer' => true}
     export = csv_export_with_mappings "#{@repo.uri}/search", Search.build_filters(criteria)
     expect(export).to include("accession,יחסי ציבור,")
     expect(export).to include('archival_object,ExportHelper series,ExportHelper collection')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->
[ANW-2924]

## Summary
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->
`AppConfig[:extended_csv_export_enabled]` was supposed to route CSV downloads through the extended CSV export instead of the standard Solr CSV writer, but following [ANW-2791] it no longer did for any UI-triggered download.

`Search.use_extended_csv_export?` fell back to the standard Solr writer whenever `params[:fields]` was present. That was meant to solve one specific case: the Top Container browse column picker needs raw Solr field names as CSV headers so the frontend can map columns back (ANW-2791). But every "Download CSV" link in the app sends `fields` (the currently visible browse-table columns), so extended export never fired outside of a raw API call with no `fields` param which is something the UI doesn't ever do.

This replaces the `fields`-presence heuristic with an explicit `csv_export_use_solr_writer` param instead. Only the Top Container CSV export sends it; every other CSV download (Resources, Accessions, Digital Objects, Search Results) now correctly gets the extended export when enabled, while Top Containers keeps the raw Solr field names it needs.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [x] My change requires a change to the documentation - If so elaborate: Since there is an addition to the backend search controller, this has API docs implications. I've tried to add a suitably clear docstring to the update.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and agree to the [**CONTRIBUTING** document](https://github.com/archivesspace/archivesspace/blob/master/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](https://github.com/archivesspace/archivesspace/blob/master/contribution_files/CONTRIBUTING_README.md)
- [x] Have you added tests to cover these changes? If not why:


[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-2924]: https://archivesspace.atlassian.net/browse/ANW-2924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-2791]: https://archivesspace.atlassian.net/browse/ANW-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ