### PR TITLE
Fix spelling errors and casing for endpoint descriptions

### DIFF
--- a/backend/app/controllers/ark_name.rb
+++ b/backend/app/controllers/ark_name.rb
@@ -24,7 +24,7 @@ class ArchivesSpaceService < Sinatra::Base
   end
 
   Endpoint.get('/repositories/:repo_id/archival_objects/:id/ark_name')
-    .description("Get the ARK name object for an ArchivalObject")
+    .description("Get the ARK name object for an Archival Object")
     .params(["id", :id],
             ["repo_id", :repo_id])
     .permissions([:administer_system])
@@ -34,7 +34,7 @@ class ArchivesSpaceService < Sinatra::Base
   end
 
   Endpoint.post('/repositories/:repo_id/archival_objects/:id/ark_name')
-    .description("Update the ARK name for an ArchivalObject")
+    .description("Update the ARK name for an Archival Object")
     .params(["id", :id],
             ["ark_name", JSONModel(:ark_name), "The updated ark_name", :body => true],
             ["repo_id", :repo_id])

--- a/backend/app/controllers/enumeration.rb
+++ b/backend/app/controllers/enumeration.rb
@@ -89,7 +89,7 @@ class ArchivesSpaceService < Sinatra::Base
 
 
   Endpoint.get('/config/enumerations/:enum_id')
-    .description("Get an Enumeration")
+    .description("Get an enumeration")
     .params(["enum_id", Integer, "The ID of the enumeration to retrieve"])
     .permissions([])
     .returns([200, "(:enumeration)"]) \
@@ -113,7 +113,7 @@ class ArchivesSpaceService < Sinatra::Base
   end
 
   Endpoint.get('/config/enumeration_values/:enum_val_id')
-    .description("Get an Enumeration Value")
+    .description("Get an enumeration value")
     .params(["enum_val_id", Integer, "The ID of the enumeration value to retrieve"])
     .permissions([])
     .returns([200, "(:enumeration_value)"]) \
@@ -133,7 +133,7 @@ class ArchivesSpaceService < Sinatra::Base
   end
 
   Endpoint.post('/config/enumeration_values/:enum_val_id/position')
-    .description("Update the position of an ennumeration value")
+    .description("Update the position of an enumeration value")
     .params(["enum_val_id", Integer, "The ID of the enumeration value to update"],
             ["position", Integer, "The target position in the value list"])
     .permissions([:update_enumeration_record])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix "ArchivalObject" to "Archival Object" in description for ARK endpoints. Fix casing and one spelling mistake for enumeration descriptions.

## Related Ticket (JIRA or GitHub Issue)
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->
N/A

## Summary
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and agree to the [**CONTRIBUTING** document](https://github.com/archivesspace/archivesspace/blob/master/CONTRIBUTING.md).
- [ ] I have authority to submit this code. - See our [licensing](https://github.com/archivesspace/archivesspace/blob/master/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:


[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ