### PR TITLE
ANW-2893 autocomplete attributes

### DIFF
--- a/public/app/views/shared/_facets.html.erb
+++ b/public/app/views/shared/_facets.html.erb
@@ -48,7 +48,8 @@
                                :id => 'filter_q',
                                :placeholder => t('actions.search_within'),
                                :class=> "form-control",
-                               :"aria-label" => "#{t('actions.search_within')} (#{t('search_results.filter.head')})") %>
+                               :"aria-label" => "#{t('actions.search_within')} (#{t('search_results.filter.head')})",
+                               :autocomplete => 'on') %>
           </div>
         <% end %>
         <% if @search.search_dates_within? %>
@@ -64,7 +65,8 @@
                                  :class=>"form-control",
                                  :placeholder => t('search_results.filter.from_year'),
                                  :id => 'filter_from_year',
-                                 :"aria-label" => "#{t('search_results.filter.from_year')} (#{t('search_results.filter.head')})") %>
+                                 :"aria-label" => "#{t('search_results.filter.from_year')} (#{t('search_results.filter.head')})",
+                                 :autocomplete => 'off') %>
             </div>
             <div class="year_to p-0 pt-3 pt-md-0 flex-grow-1">
               <%= label_tag('filter_to_year',
@@ -77,7 +79,8 @@
                                  :class=> "form-control",
                                  :placeholder => t('search_results.filter.to_year'),
                                  :id => 'filter_to_year',
-                                 :"aria-label" => "#{t('search_results.filter.to_year')} (#{t('search_results.filter.head')})") %>
+                                 :"aria-label" => "#{t('search_results.filter.to_year')} (#{t('search_results.filter.head')})",
+                                 :autocomplete => 'off') %>
             </div>
           </div>
         <% else %>

--- a/public/app/views/shared/_search.html.erb
+++ b/public/app/views/shared/_search.html.erb
@@ -13,13 +13,13 @@
     <div class="row search_row align-items-end pt-1 mb-3" id="search_row_<%= i %>">
       <div class="col-sm-6 col-md-4 col-xl-1 bool form-group search-operator-field">
         <%= label_tag("op#{i}", t('advanced_search.operator_label'), :class => 'fw-bold mb-2') %>
-        <%= select_tag('op[]', options_for_select(Search.get_boolean_opts, @search[:op][i]), disabled: (i == 0), :id => "op#{i}",:class=> 'form-select' + (i == 0 ? ' d-none' : '') + ' options-for-select') %>
+        <%= select_tag('op[]', options_for_select(Search.get_boolean_opts, @search[:op][i]), disabled: (i == 0), :id => "op#{i}", :class => 'form-select' + (i == 0 ? ' d-none' : '') + ' options-for-select', :autocomplete => 'off') %>
         <%= hidden_field_tag('op[]','', :id => 'op_') if i == 0 %>
       </div>
       <div class="col-xl-3 col-lg-6 form-group flex-grow-1">
         <%= label_tag(:"q#{i}", t('navbar.search_placeholder'),:class => 'repeats fw-bold mb-2') %>
         <%= text_field_tag('q[]', @search[:q][i], :placeholder =>  t('navbar.search_placeholder'), :id => "q#{i}",
-                          :class=> 'form-control repeats fill-column js-search-box', :"aria-label" => "#{t('navbar.search_placeholder')} (#{t('actions.refine_search')})") %>
+                          :class=> 'form-control repeats fill-column js-search-box', :autocomplete => 'on', :"aria-label" => "#{t('navbar.search_placeholder')} (#{t('actions.refine_search')})") %>
       </div>
       <div class="col-xl-3 col-md-6 form-group norepeat">
         <%= label_tag(:advanced_search_limit, t('advanced_search.limit_label'),:class => 'fw-bold mb-2') %>
@@ -33,21 +33,21 @@
                             SearchConfigHelper.default_search_scope == 'collections_only' ? 'resource' : ''
                           end
         %>
-        <%= select_tag(:limit, options_for_select(limit_options, default_limit), :id => 'advanced_search_limit', :class=> 'form-select fill-column') %>
+        <%= select_tag(:limit, options_for_select(limit_options, default_limit), :id => 'advanced_search_limit', :class=> 'form-select fill-column', :autocomplete => 'off') %>
       </div>
       <div class="col-xl-2 col-lg-4 col-md-6 form-group">
         <%= label_tag(:"field#{i}", t('search-field'),:class => 'repeats fw-bold mb-2') %>
-        <%= select_tag('field[]', options_for_select(field_options, @search[:field][i]), :id=> "field#{i}", :class=> 'form-select repeats') %>
+        <%= select_tag('field[]', options_for_select(field_options, @search[:field][i]), :id=> "field#{i}", :class=> 'form-select repeats', :autocomplete => 'off') %>
       </div>
       <div class="col-xl-1 col-lg-3 col-sm-5 form-group">
         <%= label_tag(:"from_year#{i}", "#{t('search_results.filter.from_year')}", :class => 'repeats fw-bold mb-2') %>
         <%= text_field_tag('from_year[]', @search[:from_year][i], :size => 4,:maxlength => 4, :id=>"from_year#{i}",
-                          :placeholder => t('search_results.filter.from'),:class=>'form-control repeats', :"aria-label" => "#{t('search_results.filter.from_year')} (#{t('actions.refine_search')})") %>
+                          :placeholder => t('search_results.filter.from'),:class=>'form-control repeats', :autocomplete => 'off', :"aria-label" => "#{t('search_results.filter.from_year')} (#{t('actions.refine_search')})") %>
       </div>
       <div class="col-xl-1 col-lg-3 col-sm-5 form-group">
         <%= label_tag(:"to_year#{i}", "#{t('search_results.filter.to_year')}", :class=> 'repeats fw-bold mb-2') %>
         <%= text_field_tag('to_year[]', @search[:to_year][i], :size => 4, :maxlength => 4, :id => "to_year#{i}",
-                          :class=> 'form-control repeats', :placeholder => t('search_results.filter.to'), :"aria-label" => "#{t('search_results.filter.to_year')} (#{t('actions.refine_search')})") %>
+                          :class=> 'form-control repeats', :placeholder => t('search_results.filter.to'), :autocomplete => 'off', :"aria-label" => "#{t('search_results.filter.to_year')} (#{t('actions.refine_search')})") %>
       </div>
       <div class="d-flex flex-column col-sm-2 form-group text-start align-self-end">
           <span class="mb-2 d-inline-block repeats plusminus_label fw-bold"><%= t('advanced_search.add_row') %></span>

--- a/public/app/views/shared/_search_collection_form.html.erb
+++ b/public/app/views/shared/_search_collection_form.html.erb
@@ -12,7 +12,8 @@
                          nil,
                          :id => 'filter_q0',
                          :placeholder => "#{action_text}",
-                         :class=> "form-control") %>
+                         :class=> "form-control",
+                         :autocomplete => 'on') %>
     </div>
 
     <div class="mb-3 d-flex gap-x-3">
@@ -31,7 +32,8 @@
                            :size => 4,
                            :maxlength => 4,
                            :placeholder => t('search_results.filter.from_year'),
-                           :class=>"form-control") %>
+                           :class=>"form-control",
+                           :autocomplete => 'off') %>
       </div>
 
       <div class="year_to p-0 flex-grow-1">
@@ -42,9 +44,10 @@
                            nil,
                            :id => 'filter_to_year',
                            :size => 4,
-                           :maxlength => 4, 
+                           :maxlength => 4,
                            :placeholder => t('search_results.filter.to_year'),
-                           :class=> "form-control") %>
+                           :class=> "form-control",
+                           :autocomplete => 'off') %>
       </div>
 
     </div>

--- a/public/app/views/shared/_sorter.html.erb
+++ b/public/app/views/shared/_sorter.html.erb
@@ -5,7 +5,7 @@
    <%= render partial: 'shared/hidden_params' %>
    <%= label_tag(:sort, "#{t('search_sorting.sort_by')}", :class=>'visually-hidden') %>
    <div class="input-group">
-      <%= select_tag(:sort, options_for_select(@sort_opts,@sort), :class=>'form-select') %>
+      <%= select_tag(:sort, options_for_select(@sort_opts,@sort), :class=>'form-select', :autocomplete => 'off') %>
       <%= submit_tag(t('search_sorting.sort'), :class=>'btn btn-primary') %>
    </div>
  <% end %>

--- a/public/spec/features/search_spec.rb
+++ b/public/spec/features/search_spec.rb
@@ -432,4 +432,70 @@ describe 'Search', js: true do
       expect(page).to have_css('.plusminus-btn[data-action="remove"]', count: 0)
     end
   end
+
+  describe 'autocomplete attributes' do
+    context 'on the search page' do
+      before do
+        visit('/search')
+      end
+
+      it 'are set and preserved on cloned rows' do
+        within 'form#advanced_search' do
+          aggregate_failures 'refine search fields row 0' do
+            expect(page).to have_css('#q0[autocomplete="on"]')
+            expect(page).to have_css('#from_year0[autocomplete="off"]')
+            expect(page).to have_css('#to_year0[autocomplete="off"]')
+            expect(page).to have_css('#advanced_search_limit[autocomplete="off"]')
+            expect(page).to have_css('#field0[autocomplete="off"]')
+            expect(page).to have_css('#op0[autocomplete="off"]', visible: false)
+          end
+
+          find('.plusminus-btn[data-action="add"]').click
+
+          aggregate_failures 'refine search fields row 1' do
+            expect(page).to have_css('#q1[autocomplete="on"]')
+            expect(page).to have_css('#from_year1[autocomplete="off"]')
+            expect(page).to have_css('#to_year1[autocomplete="off"]')
+            expect(page).to have_css('#field1[autocomplete="off"]')
+            expect(page).to have_css('#op1[autocomplete="off"]')
+          end
+        end
+      end
+    end
+
+    context 'on the collection search page' do
+      before do
+        visit('/repositories/resources')
+      end
+
+      it 'are set on the Filter Results controls' do
+        aggregate_failures do
+          expect(page).to have_css('#filter_q[autocomplete="on"]')
+          expect(page).to have_css('#filter_from_year[autocomplete="off"]')
+          expect(page).to have_css('#filter_to_year[autocomplete="off"]')
+          expect(page).to have_css('#sort[autocomplete="off"]')
+        end
+      end
+    end
+
+    context 'on the Collection Overview search form' do
+      let(:now) { Time.now.to_i }
+      let(:resource) { create(:resource, title: "Published Resource #{now}", publish: true) }
+      let(:ao) { create(:archival_object, title: "Published Archival Object #{now}", resource: { 'ref' => resource.uri }, publish: true) }
+
+      before do
+        ao
+        run_indexers
+        visit resource.uri
+      end
+
+      it 'are set on the sidebar search controls' do
+        aggregate_failures do
+          expect(page).to have_css('#filter_q0[autocomplete="on"]')
+          expect(page).to have_css('#filter_from_year[autocomplete="off"]')
+          expect(page).to have_css('#filter_to_year[autocomplete="off"]')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION

## Related Ticket (JIRA or GitHub Issue)
[ANW-2893]

## Summary
Adding autocomplete attributes to the "refine search" and search sidebar sections. For the seach term input, autocomplete="on" is added to allow users with memory retention to be able to recall previous search terms. Other fields are set to autocomplete="off" 

## Screenshots (if appropriate):
Before ARC accessibility scan
<img width="2325" height="924" alt="Before accessibility scan AS" src="https://github.com/user-attachments/assets/482ea4ad-8c73-4864-8d38-6378717d822e" />

After ARC accessibility scan
<img width="2313" height="810" alt="Afrer accessibility scan AS" src="https://github.com/user-attachments/assets/20428b5e-81d1-4e29-aed8-56709d8c0743" />

HTML changes example
<img width="2200" height="607" alt="html sample snippet" src="https://github.com/user-attachments/assets/acb0618a-c4af-4251-856f-ddc9e3dc0ef6" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read and agree to the [**CONTRIBUTING** document](https://github.com/archivesspace/archivesspace/blob/master/CONTRIBUTING.md).
- [X] I have authority to submit this code. - See our [licensing](https://github.com/archivesspace/archivesspace/blob/master/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why: accessibility fix, no test needed


[ANW-2893]: https://archivesspace.atlassian.net/browse/ANW-2893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ