### PR TITLE
ANW-2917 Update PUI print styles for Bootstrap v5

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/print.scss
+++ b/public/app/assets/stylesheets/archivesspace/print.scss
@@ -108,7 +108,11 @@
   .breadcrumb,
   #main-content,
   .panel-heading,
-  .panel-body {
+  .panel-body,
+  .card-body,
+  .accordion-header,
+  .accordion-button,
+  .accordion-body {
     padding-right: 0 !important;
     padding-left: 0 !important;
   }
@@ -203,15 +207,30 @@
     display: initial !important;
   }
 
-  /* Hide panel (Bootstrap v3) and card (Bootstrap v4) borders */
+  /* Hide panel (Bootstrap v3), card (Bootstrap v4), and accordion (Bootstrap v5) borders */
   .panel,
   .panel-default,
   .panel-heading,
   .panel-body,
   .card,
   .card-header,
-  .card-footer {
+  .card-body,
+  .card-footer,
+  .accordion-item,
+  .accordion-header,
+  .accordion-button,
+  .accordion-collapse,
+  .accordion-body {
     border-color: white !important;
+  }
+
+  /* BS5 accordion chrome that still prints after border-color alone */
+  .accordion-button {
+    box-shadow: none !important;
+  }
+
+  .accordion-button::after {
+    display: none !important;
   }
 
   /* Expand 'See more' sections */


### PR DESCRIPTION
[ANW-2917](https://archivesspace.atlassian.net/browse/ANW-2917)

This PR updates the PUI print.css stylesheet to accommodate Bootstrap v5, mostly regarding the new `.accordion` component. Now, for example, when you print-preview a resource from its [Collection Overview page](http://localhost:3001/repositories/2/resources/16), the "Additional Description", "Related Names", "Subjects", "Finding Aid & Administrative Info", and "Repository Details" subsections no longer have a border, expand/collapse button chrome, etc.

<img width="1498" height="887" alt="ANW-2917-solution" src="https://github.com/user-attachments/assets/cdb16e86-bc93-4063-9c08-542f2c2cf06f" />

[ANW-2917]: https://archivesspace.atlassian.net/browse/ANW-2917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ