### PR TITLE
ANW-2912 Fix PUI Repositories show view large badge hover styles and the larger record-type colors system

### DIFF
--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -273,6 +273,13 @@ a img {
 
   .btn {
     --bs-btn-hover-color: #{$white};
+    --bs-btn-active-bg: color-mix(in srgb, var(--bs-btn-hover-bg) 85%, black);
+    --bs-btn-active-border-color: color-mix(
+      in srgb,
+      var(--bs-btn-hover-border-color) 85%,
+      black
+    );
+    --bs-btn-active-color: #{$white};
 
     @each $type, $color in $record-type-colors {
       &.#{$type} {
@@ -281,11 +288,16 @@ a img {
     }
 
     // Stacked FA icons use .fa-inverse (white) on a type-colored base icon.
-    // On hover the button text is white, so recolor the inverse layer to the
-    // hover fill to keep the two-tone stack.
+    // On hover/active the button text is white, so recolor the inverse layer
+    // to the fill color to keep the two-tone stack.
     &:hover .fa-inverse,
     &:focus-visible .fa-inverse {
       color: var(--bs-btn-hover-bg);
+    }
+
+    &:active .fa-inverse,
+    &.active .fa-inverse {
+      color: var(--bs-btn-active-bg);
     }
   }
 

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -271,6 +271,24 @@ a img {
 #whats-in-container {
   border: 1px solid $border;
 
+  .btn {
+    --bs-btn-hover-color: #{$white};
+
+    @each $type, $color in $record-type-colors {
+      &.#{$type} {
+        @include record-type-btn-hover($color);
+      }
+    }
+
+    // Stacked FA icons use .fa-inverse (white) on a type-colored base icon.
+    // On hover the button text is white, so recolor the inverse layer to the
+    // hover fill to keep the two-tone stack.
+    &:hover .fa-inverse,
+    &:focus-visible .fa-inverse {
+      color: var(--bs-btn-hover-bg);
+    }
+  }
+
   .btn:disabled,
   .btn.disabled {
     --bs-btn-disabled-border-color: transparent;
@@ -602,29 +620,24 @@ ul.no-bullets {
 .recordtype {
   margin-top: -0.75em;
 }
-.object {
-  color: $collection-color;
-}
-.collection,
-.resource {
-  color: $collection-color;
-}
-button.subject {
-  /* class subject also turns up in finding aid transforms */
-  color: $subject-color;
-}
-.agent {
-  color: $agent-color;
-}
 
-.person {
-  color: $agent-color;
-}
-.record {
-  color: $record-color;
-}
-.classification {
-  color: $repository-color;
+// Record-type text colors from the shared $record-type-colors map.
+// subject: button-only (class also appears in finding-aid transforms).
+// repository: scoped to .recordtype to avoid coloring unrelated .repository nodes.
+@each $type, $color in $record-type-colors {
+  @if $type == 'subject' {
+    button.subject {
+      color: $color;
+    }
+  } @else if $type == 'repository' {
+    .recordtype.repository {
+      color: $color;
+    }
+  } @else {
+    .#{$type} {
+      color: $color;
+    }
+  }
 }
 
 .page_action {
@@ -639,19 +652,6 @@ button.subject {
   color: $accent_color;
   background-color: $light-neutral;
   text-decoration: none;
-}
-
-.top_container {
-  color: $container-color;
-}
-.folder {
-  color: $folder-color;
-}
-.recordtype.repository {
-  color: $repository-color;
-}
-.recordtype.classification {
-  color: $classification-color;
 }
 .digitized {
   float: right;

--- a/public/app/assets/stylesheets/archivesspace/colors.scss
+++ b/public/app/assets/stylesheets/archivesspace/colors.scss
@@ -44,3 +44,55 @@ $accession-color: $collection-color;
 $digital-object-color: $collection-color;
 $archival-object-color: #457141;
 $folder-color: #009fcf;
+
+// Single source of DOM class name → record-type color.
+// Palette vars above remain the institutional override point; consumers
+// should read from this map (or the helpers below) instead of re-mapping.
+$record-type-colors: (
+  'resource': $collection-color,
+  'collection': $collection-color,
+  'object': $collection-color,
+  'accession': $accession-color,
+  'digital_object': $digital-object-color,
+  'archival_object': $archival-object-color,
+  'subject': $subject-color,
+  'agent': $agent-color,
+  'person': $agent-color,
+  'record': $record-color,
+  'classification': $classification-color,
+  'repository': $repository-color,
+  'top_container': $container-color,
+  'folder': $folder-color,
+);
+
+// Types that use .record-type-badge.{type} in the PUI.
+$record-type-badge-types: (
+  'resource',
+  'archival_object',
+  'agent',
+  'accession',
+  'classification',
+  'digital_object',
+  'repository',
+  'subject'
+);
+
+@function record-type-color($type) {
+  @return map-get($record-type-colors, $type);
+}
+
+@mixin record-type-color-props($color) {
+  color: $color;
+  border-color: $color;
+}
+
+@mixin record-type-btn-hover($color) {
+  --bs-btn-hover-bg: #{$color};
+  --bs-btn-hover-border-color: #{$color};
+}
+
+:root {
+  @each $type, $color in $record-type-colors {
+    --record-type-#{$type}-color: #{$color};
+  }
+}

--- a/public/app/assets/stylesheets/archivesspace/print.scss
+++ b/public/app/assets/stylesheets/archivesspace/print.scss
@@ -108,7 +108,11 @@
   .breadcrumb,
   #main-content,
   .panel-heading,
-  .panel-body {
+  .panel-body,
+  .card-body,
+  .accordion-header,
+  .accordion-button,
+  .accordion-body {
     padding-right: 0 !important;
     padding-left: 0 !important;
   }
@@ -203,15 +207,30 @@
     display: initial !important;
   }
 
-  /* Hide panel (Bootstrap v3) and card (Bootstrap v4) borders */
+  /* Hide panel (Bootstrap v3), card (Bootstrap v4), and accordion (Bootstrap v5) borders */
   .panel,
   .panel-default,
   .panel-heading,
   .panel-body,
   .card,
   .card-header,
-  .card-footer {
+  .card-body,
+  .card-footer,
+  .accordion-item,
+  .accordion-header,
+  .accordion-button,
+  .accordion-collapse,
+  .accordion-body {
     border-color: white !important;
+  }
+
+  /* BS5 accordion chrome that still prints after border-color alone */
+  .accordion-button {
+    box-shadow: none !important;
+  }
+
+  .accordion-button::after {
+    display: none !important;
   }
 
   /* Expand 'See more' sections */

--- a/public/app/assets/stylesheets/archivesspace/record-type-badge.scss
+++ b/public/app/assets/stylesheets/archivesspace/record-type-badge.scss
@@ -1,8 +1,3 @@
-@mixin record-type-badge-colored($color) {
-  color: $color;
-  border-color: $color;
-}
-
 .record-type-badge {
   padding: rem-calc(4);
   font-family: $serif-font;
@@ -18,34 +13,8 @@
   }
 }
 
-.record-type-badge.resource {
-  @include record-type-badge-colored($collection-color);
-}
-
-.record-type-badge.archival_object {
-  @include record-type-badge-colored($archival-object-color);
-}
-
-.record-type-badge.agent {
-  @include record-type-badge-colored($agent-color);
-}
-
-.record-type-badge.accession {
-  @include record-type-badge-colored($accession-color);
-}
-
-.record-type-badge.classification {
-  @include record-type-badge-colored($classification-color);
-}
-
-.record-type-badge.digital_object {
-  @include record-type-badge-colored($digital-object-color);
-}
-
-.record-type-badge.repository {
-  @include record-type-badge-colored($repository-color);
-}
-
-.record-type-badge.subject {
-  @include record-type-badge-colored($subject-color);
+@each $type in $record-type-badge-types {
+  .record-type-badge.#{$type} {
+    @include record-type-color-props(record-type-color($type));
+  }
 }


### PR DESCRIPTION
[ANW-2912](https://archivesspace.atlassian.net/browse/ANW-2912)

## Problem

On the repository show page, the large “What’s in this repository?” badge buttons no longer picked up intended hover styles under Bootstrap 5. The base `.btn:hover` depends on CSS custom properties (`--bs-btn-hover-color/bg/border-color`), and these buttons are not Bootstrap button variants, so those hover vars were never set.

Separately, record-type colors were mapped in several places (`colors.scss` palette vars, `record-type-badge.scss`, and hand-written type rules in `aspace.scss`), which made it easy for badge, text, and button hover colors to drift. One existing inconsistency was that `.classification` used `$repository-color` instead of `$classification-color`.

## Solution

- Set Bootstrap 5 hover custom properties on `#whats-in-container .btn.{type}` so repo large-badge buttons get type-colored hover fills.
- Introduce a shared $record-type-colors map (plus small helpers) in colors.scss as the single DOM class → color mapping.
- Generate from that map:
    - `.record-type-badge.{type}` styles
    - search/result type text colors
    - repo large-badge button hover vars
- Keep existing palette aliases unchanged (accession/digital object still share collection red).
- Fix classification text color to use `$classification-color`

<img width="1497" height="871" alt="ANW-2912-solution" src="https://github.com/user-attachments/assets/835bd93e-6f09-46c4-a4e3-9f24ee350d66" />

[ANW-2912]: https://archivesspace.atlassian.net/browse/ANW-2912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ