### PR TITLE
ANW-2913 Improve the PUI 'refine search' layout and styles

### DIFF
--- a/public/app/views/search/search_results.html.erb
+++ b/public/app/views/search/search_results.html.erb
@@ -23,17 +23,21 @@
   <% else %>
 
   <% unless defined?(@no_statement) %>
-    <div class="searchstatement">
-      <div class="btn btn-group float-end">
-        <%= link_to I18n.t('actions.new_search'), (defined?(@new_search) ? @new_search : root_path), :class => "btn btn-sm btn-secondary" %>
-        <button class="btn btn-sm btn-secondary" id="toggleRefineSearch" aria-expanded="false" aria-controls="refineSearchPanel"><%= I18n.t('actions.refine_search') %></button>
+    <div class="mb-3 p-3 searchstatement">
+      <div class="d-flex">
+        <% if defined?(@search) %>
+          <div class="search-summary">
+            <%= @search[:search_statement].html_safe %>
+          </div>
+        <% end %>
+
+        <div class="ms-auto p-0 align-self-start" role="group" aria-label="<%= t('search_results.refine_search_controls_aria') %>">
+          <button class="btn btn-sm btn-primary" id="toggleRefineSearch" aria-expanded="false" aria-controls="refineSearchPanel"><%= I18n.t('actions.refine_search') %></button>
+          <%= link_to I18n.t('actions.new_search'), (defined?(@new_search) ? @new_search : root_path), :class => "btn btn-sm btn-primary text-decoration-none" %>
+        </div>
       </div>
 
-      <% if defined?(@search) %>
-        <%= @search[:search_statement].html_safe %>
-      <% end %>
-
-      <div id="refineSearchPanel" class="container refinesearch" aria-hidden="true" style="display:none;">
+      <div id="refineSearchPanel" class="refinesearch" aria-hidden="true" style="display:none;">
         <%= render partial: 'shared/search', locals: {:search_url => @base_search,
                                                       :title => t('archive._plural'),
                                                       :limit_options => [["#{t('actions.search')} #{t('search-limits.all')}",''],

--- a/public/app/views/shared/_pagination.html.erb
+++ b/public/app/views/shared/_pagination.html.erb
@@ -20,8 +20,8 @@
       <% end %>
     <% end %>
     <% if pager.need_last %>
-       <li><a class="page-link" href="" style="pointer-events: none;">...</a></li>
-       <li><a class="page-link" href="<%= app_prefix(pager.link) %>&page=<%= pager.last_page %>"><%= pager.last_page %></a></li>
+       <li class="page-item"><a class="page-link" href="" style="pointer-events: none;">...</a></li>
+       <li class="page-item"><a class="page-link" href="<%= app_prefix(pager.link) %>&page=<%= pager.last_page %>"><%= pager.last_page %></a></li>
     <% end %>
     <% if pager.need_next %>
       <li class="next page-item"><a class="page-link" href="<%= app_prefix(pager.link) %>&page=<%= pager.next %>"><%= t 'actions.next' %> <span aria-hidden="true">&rarr;</span></a></li>

--- a/public/config/locales/de.yml
+++ b/public/config/locales/de.yml
@@ -152,6 +152,7 @@ de:
     in_repository: ' in <strong>%{name}</strong>'
     more_facets: Mehr
     remove_filter: Diesen Filter entfernen
+    refine_search_controls_aria: Steuerung zur Suche verfeinern
   page_actions: Seiten-Aktionen
   search-button:
     label: Suchen

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -136,6 +136,7 @@ en:
     filter_by: Filter By
     filtered_by: Filtered By
     remove_filter: Remove this filter
+    refine_search_controls_aria: Refine search controls
     more_facets: More
     fewer_facets: Less
     op:

--- a/public/config/locales/es.yml
+++ b/public/config/locales/es.yml
@@ -114,6 +114,7 @@ es:
     filter_by: Filter By
     filtered_by: Filtrado por
     remove_filter: Quitar este filtro
+    refine_search_controls_aria: Controles de refinamiento de búsqueda
     more_facets: Más
     fewer_facets: Menos
     op:

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -134,6 +134,7 @@ fr:
     filter_by: Filtrer par
     filtered_by: Filtré par
     remove_filter: Ôter ce filtre
+    refine_search_controls_aria: Contrôles d'affinement de la recherche
     more_facets: Plus
     fewer_facets: Moins
     op:

--- a/public/config/locales/it.yml
+++ b/public/config/locales/it.yml
@@ -110,6 +110,7 @@ it:
       class='searchterm'>%{kw}</span>
     no_results: Nessuna unità archivistica trovata
     remove_filter: Rimuovi questo filtro
+    refine_search_controls_aria: Controlli per raffinare la ricerca
     more_facets: Più
     op:
       NOT: e non

--- a/public/config/locales/ja.yml
+++ b/public/config/locales/ja.yml
@@ -104,6 +104,7 @@ ja:
     filter_by: フィルタリングする
     filtered_by: フィルタリングされた
     remove_filter: このフィルタを削除
+    refine_search_controls_aria: 絞り込み検索の操作
     more_facets: もっと
     fewer_facets: もっと少なく
     op:

--- a/public/config/locales/nl.yml
+++ b/public/config/locales/nl.yml
@@ -110,6 +110,7 @@ nl:
     filter_by: Filter op
     filtered_by: Gefilterd op
     remove_filter: Dit filter verwijderen
+    refine_search_controls_aria: Bediening voor zoekopdracht verfijnen
     more_facets: Meer
     fewer_facets: Minder
     op:

--- a/public/config/locales/pl.yml
+++ b/public/config/locales/pl.yml
@@ -109,6 +109,7 @@ pl:
     anything: '*'
     filtered_by: Filtrowane według
     remove_filter: Usuń ten filtr.
+    refine_search_controls_aria: Elementy sterujące sprecyzowaniem wyszukiwania
     more_facets: Więcej
     fewer_facets: Mniej
     op:

--- a/public/config/locales/pt.yml
+++ b/public/config/locales/pt.yml
@@ -85,6 +85,7 @@ pt:
     filter_by: Filtrar por
     filtered_by: Filtrado por
     remove_filter: Remova esse filtro
+    refine_search_controls_aria: Controles de refinamento da pesquisa
     more_facets: Mais
     fewer_facets: Menos
     op:

--- a/public/config/locales/uk.yml
+++ b/public/config/locales/uk.yml
@@ -155,6 +155,7 @@ uk:
       NOT: не
     search_term: Пошуковий термін
     remove_filter: Видалити цей фільтр
+    refine_search_controls_aria: Елементи керування уточненням пошуку
     creators_text_contain: <strong>творець</strong> містить <span class='searchterm'>%{кс}</span>
     subjects_text_contain: <strong> предмет</strong> містить  <span class='searchterm'>%{кс}</span>
     keyword_contain: <strong>ключове слово(a)</strong>:<span class='searchterm'>%{кс}</span>

--- a/public/spec/features/search_spec.rb
+++ b/public/spec/features/search_spec.rb
@@ -54,7 +54,7 @@ describe 'Search', js: true do
   it 'should use an asterisk for a keyword search when no inputs and search button pressed' do
     visit('/search')
     click_on('submit_search')
-    expect(page).to have_selector("div[class='searchstatement']", text: "keyword(s): *")
+    expect(page).to have_selector(".search-summary", text: "keyword(s): *")
   end
 
   it "should submit form, not delete row when search row is added and enter pressed in search field" do


### PR DESCRIPTION
[ANW-2913](https://archivesspace.atlassian.net/browse/ANW-2913)

This PR migrates the PUI "refine search" UI to Bootstrap v5, and improves the layout and styles. This includes changing the order of the "New search" and "Refine search" buttons, so that the "Refining" button is closer to the advanced search form where one actually refines the search. It also pulls the two buttons out of a `.btn-group` to make it more visually obvious that they are each actionable buttons, which is aided by the fact that they are already grouped together by virtue of being in the advanced search block. It also fixes a double-vertical-border in the pagination UI when there are enough pages to include the ellipses ('...') pagination item.

<img width="1492" height="807" alt="ANW-2913-solution" src="https://github.com/user-attachments/assets/ce9077bc-22bf-4796-b8bd-b48786821885" />


[ANW-2913]: https://archivesspace.atlassian.net/browse/ANW-2913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ