### PR TITLE
ANW-2894 additional filters aria-labelledby

### DIFF
--- a/public/app/views/shared/_only_facets.html.erb
+++ b/public/app/views/shared/_only_facets.html.erb
@@ -1,6 +1,6 @@
 <% unless @facets.blank? %>
-<h3><%= t('search_results.filter.add') %>: </h3>
-<dl id="facets">
+<h3 id="additional-filters-heading"><%= t('search_results.filter.add') %>: </h3>
+<dl id="facets" aria-labelledby="additional-filters-heading">
 
   <%
     preferred_facet_order = %w(repository primary_type agents subjects langcode)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-2894]

## Summary
When users navigate the filters using a keyboard or screen reader, the category headings/names are not read out, making the filters confusing or unusable.

Adding an id to the h3, and tying the `<dl>` to that id, the aria-labelledby tells assistive tech: “Use that heading text as this list’s accessible name.” Now, when users navigate into the filter list, the screen reader can announce the group label (localized heading text), then the list items.

## Screenshots (if appropriate):
<img width="1049" height="396" alt="aria-labelledby additional filters" src="https://github.com/user-attachments/assets/f7e0ff22-4333-48e1-ad1c-ac5276b834d3" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read and agree to the [**CONTRIBUTING** document](https://github.com/archivesspace/archivesspace/blob/master/CONTRIBUTING.md).
- [X] I have authority to submit this code. - See our [licensing](https://github.com/archivesspace/archivesspace/blob/master/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why: accessibility fix


[ANW-2894]: https://archivesspace.atlassian.net/browse/ANW-2894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ