### PR TITLE
ANW-2922 Replace the remaining deprecated .panel with .card pattern in PUI digital object link partial

### DIFF
--- a/public/app/views/shared/_digital.html.erb
+++ b/public/app/views/shared/_digital.html.erb
@@ -59,13 +59,17 @@
 
           <% else %>
 
-            <div class="panel panel-default">
-              <a class="thumbnail" href="<%= d_file['out'] %>" target="new" title="<%= t('digital_object._public.link') %>">
-                <img src="<%= d_file['thumb'] %>" alt="<%= strip_mixed_content(d_file['caption'] || t('enumerations.instance_instance_type.digital_object')) %>" />
-              </a>
-              <div class="panel-heading">
-                <%= (d_file['caption'] || t('enumerations.instance_instance_type.digital_object')).html_safe %>
-              </div>
+            <div class="card">
+              <figure class="mb-0">
+                <a href="<%= d_file['out'] %>" target="new" title="<%= t('digital_object._public.link') %>">
+                  <img src="<%= d_file['thumb'] %>" alt="<%= strip_mixed_content(d_file['caption'] || t('enumerations.instance_instance_type.digital_object')) %>" />
+                </a>
+                <figcaption class="bg-lightgray rounded-bottom">
+                  <p class="mb-0">
+                    <%= (d_file['caption'] || t('enumerations.instance_instance_type.digital_object')).html_safe %>
+                  </p>
+                </figcaption>
+              </figure>
             </div>
 
           <% end %>


### PR DESCRIPTION
[ANW-2922](https://archivesspace.atlassian.net/browse/ANW-2922)

This PR replaces the one remaining deprecated Bootstrap `.panel` pattern with the current Bootstrap v5 `.card` pattern in the PUI digital object link partial.

<img width="1482" height="802" alt="ANW-2922-solution" src="https://github.com/user-attachments/assets/853dfe8b-f087-4ecb-9ebd-ab6b2c71c99a" />

[ANW-2922]: https://archivesspace.atlassian.net/browse/ANW-2922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ