### PR TITLE
ANW-2911, ANW-2916: Migrate PUI Request modal to Bootstrap 5 form validation; Remove usage of deprecated `.form-group` class

### DIFF
--- a/public/app/assets/javascripts/request.js
+++ b/public/app/assets/javascripts/request.js
@@ -1,48 +1,26 @@
-function setupRequest(modalId, text) {
-  $('.noscript').hide();
-  $('#request_sub').submit(function (e) {
+function setupRequest() {
+  $('#request_sub').on('submit', function () {
     request_form();
     return false;
   });
-  var $modal = $('#' + modalId);
-  $modal.find('div.modal-body').attr('id', 'requestThis');
-  var x = $modal.find('.action-btn');
-  var btn;
-  if (x.length == 1) {
-    btn = x[0];
-  } else {
-    btn = x;
-  }
-  $(btn.not('.noscript')).attr('id', 'request_btn');
-  $(btn).attr('aria-label', text);
-  $(btn).html(text);
-  $(btn).click(function (e) {
-    $('#request_form').submit();
-  });
+
+  $('#request_modal').find('div.modal-body').attr('id', 'requestThis');
+
+  // Bootstrap 5 form validation: toggle .was-validated so :invalid styles apply
+  $('#request_form')
+    .off('submit.requestValidation')
+    .on('submit.requestValidation', function (event) {
+      if (!this.checkValidity()) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+      this.classList.add('was-validated');
+    });
 }
 
 function request_form() {
-  const modal = new bootstrap.Modal(document.getElementById('request_modal'));
-  modal.show();
-  $('#user_name', this).closest('.form-group').removeClass('has-error');
-  $('#user_email', this).closest('.form-group').removeClass('has-error');
-
-  $('#request_form', '#request_modal').on('submit', function () {
-    var proceed = true;
-
-    if ($('#user_name', this).val().trim() == '') {
-      $('#user_name', this).closest('.form-group').addClass('has-error');
-      proceed = false;
-    } else {
-      $('#user_name', this).closest('.form-group').removeClass('has-error');
-    }
-    if ($('#user_email', this).val().trim() == '') {
-      $('#user_email', this).closest('.form-group').addClass('has-error');
-      proceed = false;
-    } else {
-      $('#user_email', this).closest('.form-group').removeClass('has-error');
-    }
-
-    return proceed;
-  });
+  const modalEl = document.getElementById('request_modal');
+  const form = document.getElementById('request_form');
+  form.classList.remove('was-validated');
+  bootstrap.Modal.getOrCreateInstance(modalEl).show();
 }

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -658,6 +658,18 @@ ul.no-bullets {
   line-height: inherit;
   cursor: pointer;
   border: 1px solid $light-neutral;
+
+  // Active is one step darker than hover
+  --bs-btn-active-bg: #{$shade};
+  --bs-btn-active-border-color: #{$shade};
+  --bs-btn-active-color: #{$accent-color};
+
+  // Plain .btn does not set --bs-btn-disabled-color. Without it, disabled
+  // color inherits the parent .resource/.accession/etc. record-type red/etc.
+  // (print button shows this while JS sets disabled during "Generating").
+  --bs-btn-disabled-color: #{$darkshade};
+  --bs-btn-disabled-bg: #{$light-neutral};
+  --bs-btn-disabled-border-color: #{$shade};
 }
 .page_action:hover,
 .page_action:focus {

--- a/public/app/views/objects/request_showing.html.erb
+++ b/public/app/views/objects/request_showing.html.erb
@@ -1,3 +1,0 @@
-
-<%= t('request.visit', :repo_name => @request[:repo_name], :archival_object => @request[:title]).html_safe %>
-  <%= render partial: 'shared/request_form' %>

--- a/public/app/views/shared/_cite_page_action.html.erb
+++ b/public/app/views/shared/_cite_page_action.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag app_prefix("/cite"), :id => 'cite_sub' do |f| %>
   <%= hidden_field_tag 'uri', record.uri %>
   <%= hidden_field_tag 'cite', record.cite %>
-  <button type="submit" class="btn page_action request">
+  <button type="submit" class="btn page_action cite">
     <i class="fa fa-book fa-3x"></i><br />
     <%= t('actions.cite') %>
   </button>

--- a/public/app/views/shared/_facets.html.erb
+++ b/public/app/views/shared/_facets.html.erb
@@ -53,7 +53,7 @@
           </div>
         <% end %>
         <% if @search.search_dates_within? %>
-          <div class="form-group d-flex gap-2 mb-3">
+          <div class="d-flex gap-2 mb-3">
             <div class="year_from p-0 flex-grow-1">
               <%= label_tag('filter_from_year',
                             t('search_results.filter.from_year'),

--- a/public/app/views/shared/_modal.html.erb
+++ b/public/app/views/shared/_modal.html.erb
@@ -17,8 +17,14 @@
       </div>
       <footer class="modal-footer">
         <button type="button" class="btn btn-secondary" id="<%= modal_id %>_footer_close" data-bs-dismiss="modal" aria-label="<%= I18n.t("actions.close") %>"><%= I18n.t("actions.close") %></button>
-        <% if title != t('actions.cite') %>
-          <button type="button" class="btn btn-primary action-btn"></button>
+        <% if local_assigns[:footer_submit_form_id].present? %>
+          <button
+            type="submit"
+            form="<%= footer_submit_form_id %>"
+            class="btn btn-primary"
+            <% if local_assigns[:footer_submit_id].present? %>id="<%= footer_submit_id %>"<% end %>
+            aria-label="<%= footer_submit_label %>"
+          ><%= footer_submit_label %></button>
         <% end %>
       </footer>
     </div>

--- a/public/app/views/shared/_modal_actions.html.erb
+++ b/public/app/views/shared/_modal_actions.html.erb
@@ -12,7 +12,13 @@
 
 <% if AppConfig[:pui_page_actions_request] && defined?(@request) && !@request.nil? %>
   <% req = render partial: 'shared/request_form' %>
-  <%= render partial: 'shared/modal', locals: {:modal_id => 'request_modal', :title => t('actions.request'),
-      :modal_body => req } %>
-  <script type="text/javascript">$(document).ready(function() { setupRequest("request_modal", "<%= t('actions.request') %>"); });</script>
+  <%= render partial: 'shared/modal', locals: {
+    :modal_id => 'request_modal',
+    :title => t('actions.request'),
+    :modal_body => req,
+    :footer_submit_form_id => 'request_form',
+    :footer_submit_id => 'request_btn',
+    :footer_submit_label => t('actions.request')
+  } %>
+  <script type="text/javascript">$(document).ready(function() { setupRequest(); });</script>
 <% end %>

--- a/public/app/views/shared/_request_form.html.erb
+++ b/public/app/views/shared/_request_form.html.erb
@@ -1,34 +1,31 @@
-<%= form_tag(app_prefix("fill_request"), method: 'post', :id => 'request_form') do %>
+<%= form_tag(app_prefix("fill_request"), method: 'post', :id => 'request_form', :class => 'needs-validation', :novalidate => true) do %>
   <%= render partial: 'shared/request_hiddens' %>
   <div id="request">
-    <div class="form-group required">
-      <%= label_tag(:user_name, "#{t('request.user_name')} #{t('request.required')}", :class => 'visually-hidden') %>
-      <div class="input-group mb-3">
-        <%= text_field_tag :user_name, nil, :placeholder => t('request.user_name'), :class => "form-control" %>
-        <span class="input-group-text required"><%= t('request.required') %></span>
-      </div>
+    <%= label_tag(:user_name, "#{t('request.user_name')} #{t('request.required')}", :class => 'visually-hidden') %>
+    <div class="input-group has-validation mb-3">
+      <%= text_field_tag :user_name, nil, :placeholder => t('request.user_name'), :class => 'form-control', :required => true %>
+      <span class="input-group-text required"><%= t('request.required') %></span>
+      <div class="invalid-feedback"><%= t('request.errors.name') %></div>
     </div>
-    <div class="form-group required">
-      <%= label_tag(:user_email, "#{t('request.user_email')} #{t('request.required')}", :class => 'visually-hidden') %>
-      <div class="input-group mb-3">
-        <%= text_field_tag :user_email, nil, :type => 'email', :placeholder => t('request.user_email'), :class => 'form-control' %>
-        <span class="input-group-text required"><%= t('request.required') %></span>
-      </div>
+    <%= label_tag(:user_email, "#{t('request.user_email')} #{t('request.required')}", :class => 'visually-hidden') %>
+    <div class="input-group has-validation mb-3">
+      <%= text_field_tag :user_email, nil, :type => 'email', :placeholder => t('request.user_email'), :class => 'form-control', :required => true %>
+      <span class="input-group-text required"><%= t('request.required') %></span>
+      <div class="invalid-feedback"><%= t('request.errors.email') %></div>
     </div>
-    <div class="form-group mb-3">
+    <div class="mb-3">
       <%= label_tag(:date, t('request.date'),  :class => 'visually-hidden') %>
       <%= text_field_tag :date, nil, :placeholder => t('request.date'), :class => 'form-control' %>
     </div>
-    <div class="form-group mb-3">
+    <div class="mb-3">
       <%= label_tag(:note, t('request.note'),  :class => 'visually-hidden') %>
       <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
     </div>
-    <div class="form-group honeypot">
+    <div class="honeypot">
       <span class="aria-hidden">
         <%= label_tag :comment %>
         <%= text_field_tag :comment, nil, tabindex: '-1', :class => 'form-control' %>
       </span>
     </div>
-    <button type="submit" class="btn btn-primary action-btn noscript"><%= t('request.submit') %></button>
   </div>
 <% end %>

--- a/public/app/views/shared/_search.html.erb
+++ b/public/app/views/shared/_search.html.erb
@@ -11,17 +11,17 @@
   <%= form_tag(app_prefix("#{search_url}"), method: 'get', :id => 'advanced_search') do %>
   <% (0...[1, @search.q.length].max).each do |i| %>
     <div class="row search_row align-items-end pt-1 mb-3" id="search_row_<%= i %>">
-      <div class="col-sm-6 col-md-4 col-xl-1 bool form-group search-operator-field">
+      <div class="col-sm-6 col-md-4 col-xl-1 bool search-operator-field">
         <%= label_tag("op#{i}", t('advanced_search.operator_label'), :class => 'fw-bold mb-2') %>
         <%= select_tag('op[]', options_for_select(Search.get_boolean_opts, @search[:op][i]), disabled: (i == 0), :id => "op#{i}", :class => 'form-select' + (i == 0 ? ' d-none' : '') + ' options-for-select', :autocomplete => 'off') %>
         <%= hidden_field_tag('op[]','', :id => 'op_') if i == 0 %>
       </div>
-      <div class="col-xl-3 col-lg-6 form-group flex-grow-1">
+      <div class="col-xl-3 col-lg-6 flex-grow-1">
         <%= label_tag(:"q#{i}", t('navbar.search_placeholder'),:class => 'repeats fw-bold mb-2') %>
         <%= text_field_tag('q[]', @search[:q][i], :placeholder =>  t('navbar.search_placeholder'), :id => "q#{i}",
                           :class=> 'form-control repeats fill-column js-search-box', :autocomplete => 'on', :"aria-label" => "#{t('navbar.search_placeholder')} (#{t('actions.refine_search')})") %>
       </div>
-      <div class="col-xl-3 col-md-6 form-group norepeat">
+      <div class="col-xl-3 col-md-6 norepeat">
         <%= label_tag(:advanced_search_limit, t('advanced_search.limit_label'),:class => 'fw-bold mb-2') %>
         <%
           # Determine the default limit value
@@ -35,21 +35,21 @@
         %>
         <%= select_tag(:limit, options_for_select(limit_options, default_limit), :id => 'advanced_search_limit', :class=> 'form-select fill-column', :autocomplete => 'off') %>
       </div>
-      <div class="col-xl-2 col-lg-4 col-md-6 form-group">
+      <div class="col-xl-2 col-lg-4 col-md-6">
         <%= label_tag(:"field#{i}", t('search-field'),:class => 'repeats fw-bold mb-2') %>
         <%= select_tag('field[]', options_for_select(field_options, @search[:field][i]), :id=> "field#{i}", :class=> 'form-select repeats', :autocomplete => 'off') %>
       </div>
-      <div class="col-xl-1 col-lg-3 col-sm-5 form-group">
+      <div class="col-xl-1 col-lg-3 col-sm-5">
         <%= label_tag(:"from_year#{i}", "#{t('search_results.filter.from_year')}", :class => 'repeats fw-bold mb-2') %>
         <%= text_field_tag('from_year[]', @search[:from_year][i], :size => 4,:maxlength => 4, :id=>"from_year#{i}",
                           :placeholder => t('search_results.filter.from'),:class=>'form-control repeats', :autocomplete => 'off', :"aria-label" => "#{t('search_results.filter.from_year')} (#{t('actions.refine_search')})") %>
       </div>
-      <div class="col-xl-1 col-lg-3 col-sm-5 form-group">
+      <div class="col-xl-1 col-lg-3 col-sm-5">
         <%= label_tag(:"to_year#{i}", "#{t('search_results.filter.to_year')}", :class=> 'repeats fw-bold mb-2') %>
         <%= text_field_tag('to_year[]', @search[:to_year][i], :size => 4, :maxlength => 4, :id => "to_year#{i}",
                           :class=> 'form-control repeats', :placeholder => t('search_results.filter.to'), :autocomplete => 'off', :"aria-label" => "#{t('search_results.filter.to_year')} (#{t('actions.refine_search')})") %>
       </div>
-      <div class="d-flex flex-column col-sm-2 form-group text-start align-self-end">
+      <div class="d-flex flex-column col-sm-2 text-start align-self-end">
           <span class="mb-2 d-inline-block repeats plusminus_label fw-bold"><%= t('advanced_search.add_row') %></span>
           <button type="button"
                   class="align-self-start btn btn-light border plusminus-btn"

--- a/public/spec/features/request_spec.rb
+++ b/public/spec/features/request_spec.rb
@@ -85,7 +85,7 @@ describe 'Request feature', js: true do
         within '#request_modal' do
           find('#request_modal_footer_close').click
         end
-        expect(page).to have_css('#request_modal', visible: false)
+        expect(page).to have_css('#request_modal', visible: :hidden)
 
         find('button.page_action.request').click
         wait_for_jquery

--- a/public/spec/features/request_spec.rb
+++ b/public/spec/features/request_spec.rb
@@ -30,12 +30,69 @@ describe 'Request feature', js: true do
     context 'when the Request button is clicked' do
       before :each do
         click_button 'Request'
-        wait_for_jquery
+        expect(page).to have_css('#request_modal')
       end
 
       it 'the modal becomes visible' do
+        aggregate_failures do
+          expect(page).to have_css('#request_modal', visible: true)
+          expect(page).to have_css('#request_form', visible: true)
+        end
+      end
+
+      it 'shows Bootstrap validation feedback when required fields are empty' do
+        within '#request_modal' do
+          find('#request_btn').click
+          wait_for_jquery
+
+          aggregate_failures do
+            expect(page).to have_css('#request_form.was-validated')
+            expect(page).to have_css('#user_name:invalid')
+            expect(page).to have_css('#user_email:invalid')
+            expect(page).to have_css('.invalid-feedback', text: 'Please enter your name', visible: true)
+            expect(page).to have_css('.invalid-feedback', text: 'Please enter a valid email address', visible: true)
+          end
+        end
+
         expect(page).to have_css('#request_modal', visible: true)
-        expect(page).to have_css('#request_form', visible: true)
+      end
+
+      it 'shows email validation feedback for an invalid email format' do
+        within '#request_modal' do
+          fill_in 'user_name', with: 'Test User'
+          fill_in 'user_email', with: 'not-an-email'
+          find('#request_btn').click
+          wait_for_jquery
+
+          aggregate_failures do
+            expect(page).to have_css('#request_form.was-validated')
+            expect(page).to have_css('#user_name:valid')
+            expect(page).to have_css('#user_email:invalid')
+            expect(page).to have_css('.invalid-feedback', text: 'Please enter a valid email address', visible: true)
+          end
+        end
+
+        expect(page).to have_css('#request_modal', visible: true)
+      end
+
+      it 'clears previous validation state when the modal is reopened' do
+        within '#request_modal' do
+          find('#request_btn').click
+          wait_for_jquery
+          expect(page).to have_css('#request_form.was-validated')
+        end
+
+        within '#request_modal' do
+          find('#request_modal_footer_close').click
+        end
+        expect(page).to have_css('#request_modal', visible: false)
+
+        find('button.page_action.request').click
+        wait_for_jquery
+
+        within '#request_modal' do
+          expect(page).not_to have_css('#request_form.was-validated')
+        end
       end
     end
   end


### PR DESCRIPTION
[ANW-2911](https://archivesspace.atlassian.net/browse/ANW-2911)
[ANW-2916](https://archivesspace.atlassian.net/browse/ANW-2916)

This PR addresses two tickets since removing the deprecated `.form-group` classes had implications for the request modal.

- Replace remaining .form-group/.has-error client validation in request.js with Bootstrap 5's was-validated + Constraint Validation API pattern.
- Update the request form markup with required fields, has-validation input groups, and invalid-feedback messages; remove the hidden submit button in the modal body and update the submit button in the modal footer.
- Simplify setupRequest, correct the cite page action class from request to cite, and extend request feature specs for empty/invalid fields and cleared validation on reopen.
- Fix page-action active and disabled styles; use palette neutrals for Bootstrap active/disabled vars so pressed actions darken predictably and the print button no longer turns red while showing "Generating".

This PR also removes the object `request_showing` partial which appears to be dead code.

## Screenshot showing the new Bootstrap 5 form validation UI

<img width="1486" height="802" alt="ANW-2911-solution" src="https://github.com/user-attachments/assets/c15db691-f5d3-4d2e-8dd5-37c8a181522d" />

[ANW-2911]: https://archivesspace.atlassian.net/browse/ANW-2911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-2916]: https://archivesspace.atlassian.net/browse/ANW-2916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ