### PR TITLE
ANW-2918 Reuse the PUI citation modal Bootstrap instance, and init its Clipboard only once

### DIFF
--- a/public/app/assets/javascripts/cite.js
+++ b/public/app/assets/javascripts/cite.js
@@ -1,10 +1,12 @@
 function setupCite() {
+  new Clipboard('.clip-btn');
+
   $('#cite_sub').on('submit', function (e) {
     e.preventDefault();
 
-    new Clipboard('.clip-btn');
-
-    new bootstrap.Modal(document.querySelector('#cite_modal')).show();
+    bootstrap.Modal.getOrCreateInstance(
+      document.getElementById('cite_modal')
+    ).show();
 
     return false;
   });


### PR DESCRIPTION
[ANW-2918](https://archivesspace.atlassian.net/browse/ANW-2918)

This PR brings the PUI citation modal logic inline with the request modal that was recently updated for Bootstrap 5 (see #4238), and it initializes the citation modal's `Clipboard` only once.

Before this PR, each click of the Citation page-action button created a new Modal object ; Bootstrap’s registry silently replaced the old one. That left orphaned instances in memory and was inconsistent with the request modal (request.js now uses `getOrCreateInstance`).

Also, the Clipboard was re-bound every time the modal opened. That stacked duplicate click listeners on the same buttons with no cleanup.

<img width="1491" height="800" alt="ANW-2918-example" src="https://github.com/user-attachments/assets/e4ebc1f1-b091-4721-8c78-3fafcd35a8ee" />


[ANW-2918]: https://archivesspace.atlassian.net/browse/ANW-2918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ