### PR TITLE
ANW-2919 Patch Bootstrap modal aria-hidden focus warning

### DIFF
--- a/public/app/assets/javascripts/bootstrap_overrides.js
+++ b/public/app/assets/javascripts/bootstrap_overrides.js
@@ -1,0 +1,12 @@
+// Bootstrap can leave focus inside a modal while applying aria-hidden when hiding the modal,
+// causing an accessibility warning (focused element inside aria-hidden).
+// Toggle inert around the hide/show lifecycle so focus cannot remain in the modal while being hidden.
+// This issue is solved in Bootstrap v6 by using the <dialog> element :)
+// See: https://github.com/twbs/bootstrap/issues/41005
+$(document).on('hide.bs.modal', event => {
+  event.target.inert = true;
+});
+
+$(document).on('show.bs.modal', event => {
+  event.target.inert = false;
+});


### PR DESCRIPTION
[ANW-2919](https://archivesspace.atlassian.net/browse/ANW-2919)

Bootstrap can apply `aria-hidden` on a modal while focus is still inside it, which triggers Chromium's accessibility warning (see https://github.com/twbs/bootstrap/issues/41005). This commit uses the [solution](https://github.com/twbs/bootstrap/issues/41005#issuecomment-3118196916) from the linked issue, which toggles inert on hide/show events so the modal cannot retain focus while hidden.

Bootstrap v6 will fix this issue by using the `<dialog>` element for modals, at which time the new file created herein can be removed.

##  Browser-agnostic approach to manually confirm the bug and patch

Do the following to verify the bug and patch since not all browsers provide the related console warning:

1. Go to a PUI resource page to access a modal, eg the "Citation" modal
2. Paste the following script in the browser's devtools console:

```js
['show.bs.modal', 'shown.bs.modal', 'hide.bs.modal', 'hidden.bs.modal'].forEach((type) => {
  window.addEventListener(type, (event) => {
    if (event.target.id !== 'cite_modal') return;

    console.log(`[cite_modal ${type}]`, {
      inert: event.target.inert,
      ariaHidden: event.target.getAttribute('aria-hidden'),
      activeInside: event.target.contains(document.activeElement),
    });
  });
});
```

3. Click the "Citation" button to show the modal
4. Put focus inside the modal on one of the controls by clicking `TAB`, one to three times (since there are 3 buttons)
5. Now click `ESC` to hide the modal
6. Read the console log output to verify according to the following table:

| Key | Bug on `hide.bs.modal` | Patch on `hide.bs.modal` |
|---|---|---|
| `activeInside` | `true` (focus still in the modal) | `false` or soon cleared (focus not kept in the hiding modal) |
| `ariaHidden` | `"true"` (or becomes `"true"` as hide proceeds) | `"true"` (Bootstrap still sets this; the patch doesn’t remove it) |
| `inert` | `false` | `true` |

On the next `show.bs.modal` with the patch: `inert` should be `false` again so the modal is usable.

[ANW-2919]: https://archivesspace.atlassian.net/browse/ANW-2919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ