### PR TITLE
ANW-2909 Fix PUI largetree styles by overriding Bootstrap 5 table styles

### DIFF
--- a/public/app/assets/stylesheets/application.scss
+++ b/public/app/assets/stylesheets/application.scss
@@ -36,6 +36,7 @@
 @import 'archivesspace/infinite-records';
 @import 'archivesspace/infinite-tree';
 @import 'archivesspace/largetree';
+@import 'archivesspace/largetree-bs5';
 @import 'archivesspace/mixed-content';
 @import 'archivesspace/read-more-notes';
 @import 'archivesspace/iiif';

--- a/public/app/assets/stylesheets/archivesspace/largetree-bs5.scss
+++ b/public/app/assets/stylesheets/archivesspace/largetree-bs5.scss
@@ -1,0 +1,99 @@
+// LargeTree canonical styles live in frontend/app/assets/stylesheets/archivesspace/largetree.scss
+// and are copied to public at build time. The frontend uses Bootstrap v4, but public migrated
+// to v5 (ANW-2252), so this file exists only to neutralize BS5's incompatible `.table` styles.
+// Do not fix largetree styling here unless it is BS5-specific.
+
+.largetree-container {
+  font-size: 1rem;
+
+  .table {
+    --bs-table-bg: transparent;
+    --bs-table-accent-bg: transparent;
+    --bs-table-color: inherit;
+    --bs-table-border-color: transparent;
+    --bs-table-bg-state: transparent;
+    --bs-table-bg-type: transparent;
+    --bs-table-color-state: inherit;
+    --bs-table-color-type: inherit;
+
+    margin-bottom: 0;
+
+    > :not(caption) > * > * {
+      padding: 0;
+      border-bottom-width: 0;
+      box-shadow: none;
+      color: inherit;
+    }
+  }
+
+  .table.root {
+    td,
+    .table-cell {
+      box-sizing: border-box;
+      height: calc(2rem + 1px);
+      max-height: calc(2rem + 1px);
+      line-height: 2rem;
+      padding: 0;
+      border-bottom: 1px solid #fff;
+      overflow: hidden;
+      vertical-align: middle;
+    }
+
+    td > *,
+    .table-cell > * {
+      padding: 0;
+      margin: 0;
+      line-height: 2rem;
+      vertical-align: top;
+    }
+  }
+
+  .indentor {
+    position: relative;
+    display: inline-block;
+    vertical-align: top;
+    height: 2rem;
+    line-height: 2rem;
+
+    button.expandme {
+      position: absolute;
+      top: 0;
+      right: 0;
+      width: 24px;
+      height: 2rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
+      margin: 0;
+      line-height: 1;
+      background: none;
+      border: 0;
+    }
+  }
+
+  .expandme-icon {
+    line-height: 1;
+  }
+
+  .table-row.current {
+    outline: none;
+
+    .table-cell {
+      position: relative;
+      overflow-clip-margin: 1px;
+
+      &::after {
+        content: '';
+        position: absolute;
+        z-index: 1;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: -1px;
+        border: 1px solid #0a6aa1;
+        pointer-events: none;
+      }
+    }
+  }
+}

--- a/public/app/assets/stylesheets/archivesspace/largetree-bs5.scss
+++ b/public/app/assets/stylesheets/archivesspace/largetree-bs5.scss
@@ -37,6 +37,10 @@
       border-bottom: 1px solid #fff;
       overflow: hidden;
       vertical-align: middle;
+
+      a {
+        color: $midblue;
+      }
     }
 
     td > *,
@@ -90,7 +94,7 @@
         top: 0;
         left: 0;
         right: 0;
-        bottom: -1px;
+        bottom: 0;
         border: 1px solid #0a6aa1;
         pointer-events: none;
       }


### PR DESCRIPTION
[ANW-2909](https://archivesspace.atlassian.net/browse/ANW-2909)

This PR fixes the PUI largetree styles that broke when the public app migrated to Bootstrap v5. The largetree is copied from the frontend to public at build time. The frontend assumes Bootstrap v4 which is why the largetree rendered incorrectly under Bootstrap v5.

This PR fixes this issue by neutralizing the BS5 `.table` component styles that are incompatible with the largetree. This fix does not impact the existing copying of shared resources between the frontend and public.

<img width="3024" height="2924" alt="ANW-2929-solution" src="https://github.com/user-attachments/assets/22a383bb-5184-4ca9-8ac8-9ef697d0e7ed" />


[ANW-2909]: https://archivesspace.atlassian.net/browse/ANW-2909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ