### PR TITLE
add noopener & noreferrer to target = _blank links

### DIFF
--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -129,6 +129,7 @@ module ApplicationHelper
             href,
             {
               :target => "_blank",
+              :rel => "noopener noreferrer",
               :title => title,
               :class => "context-help has-tooltip #{x_padding} #{klass}",
               :style => style,

--- a/frontend/spec/features/help_tooltip_default_placement_spec.rb
+++ b/frontend/spec/features/help_tooltip_default_placement_spec.rb
@@ -7,4 +7,10 @@ describe 'Help tooltip default placement', js: true do
     visit '/resources/new'
     page.should have_css('.global-header a.context-help.has-tooltip.initialised[data-placement="auto"]')
   end
+
+  it 'should have rel="noopener noreferrer" to prevent reverse tabnabbing' do
+    login_admin
+    visit '/resources/new'
+    page.should have_css('.global-header a.context-help[target="_blank"][rel="noopener noreferrer"]')
+  end
 end


### PR DESCRIPTION
target="_blank" opens the linked page in a new tab/window, but by default that new page gets a live JS reference back to the original page via window.opener — same-origin restrictions don't apply to that reference for the basic properties it exposes (notably window.opener.location).

That enables reverse tabnabbing: the third-party page (or a malicious page in its future if it's later compromised/sold/hijacked, or an attacker-controlled destination if the link's target isn't the trusted "ArchivesSpace Help Center" wiki but something attacker-influenced) can run window.opener.location = "https://evil.example/fake-login" and silently redirect your original ArchivesSpace staff tab — the one still logged in — to a convincing fake login page while the user is looking at the new tab. If a user doesn't notice the switch and re-enters credentials there, they've handed them to the attacker. Scanner reported "It is possible to persuade a naive user to supply sensitive information such as username, password...".

rel="noopener" severs that window.opener reference entirely (the new tab gets null), and rel="noreferrer" additionally suppresses the Referer header sent to the destination. Modern browsers already default target="_blank" links to behave like noopener in some cases, but most scanners still flag the explicit absence of the attribute since it's cheap, unambiguous defense-in-depth and not all browser/version combinations apply that implicit protection consistently.
 