### PR TITLE
ANW-2897 collection overview accessibility

### DIFF
--- a/public/app/assets/javascripts/ReadMoreNotes.js
+++ b/public/app/assets/javascripts/ReadMoreNotes.js
@@ -21,29 +21,29 @@
      */
     listen() {
       this.state.addEventListener('change', () => {
-        this.setAriaExpanded(this.state.checked);
+        this.setLabelAriaExpanded(this.state.checked);
       });
 
       this.label.addEventListener('keydown', e => {
         if (!this.state.checked && (e.key === 'Enter' || e.key === ' ')) {
           e.preventDefault();
           this.state.checked = true;
-          this.setAriaExpanded(this.state.checked);
+          this.setLabelAriaExpanded(this.state.checked);
         } else if (this.state.checked && (e.key === 'Enter' || e.key === ' ')) {
           e.preventDefault();
           this.state.checked = false;
-          this.setAriaExpanded(this.state.checked);
+          this.setLabelAriaExpanded(this.state.checked);
         }
       });
     }
 
     /**
-     * @description - Set the aria-expanded attribute on the state element
+     * @description - Set the aria-expanded attribute on the toggle/label element
      * @param {boolean} value - The value to set the aria-expanded attribute to
      * @todo - Make this a private method once our js asset pipeline supports es6
      */
-    setAriaExpanded(value) {
-      this.state.setAttribute('aria-expanded', value);
+    setLabelAriaExpanded(value) {
+      this.label.setAttribute('aria-expanded', value);
     }
   }
 

--- a/public/app/views/shared/_note_content.html.erb
+++ b/public/app/views/shared/_note_content.html.erb
@@ -20,6 +20,8 @@
         type="checkbox"
         id="<%= state_id %>"
         class="readmore__state order-1 bottom-0 visually-hidden"
+        tabindex="-1"
+        aria-hidden="true"
       />
       <label
         for="<%= state_id %>"
@@ -27,12 +29,11 @@
         class="readmore__label order-1"
         tabindex="0"
         role="button"
-        aria-label="<%= t('readmore.see_more') %>"
         aria-expanded="false"
         aria-controls="<%= content_id %>"
       >
-        <span class="readmore__label--more"><%= t('readmore.see_more') %> <i class="fa fa-chevron-down"></i></span>
-        <span class="readmore__label--less"><%= t('readmore.see_less') %> <i class="fa fa-chevron-up"></i></span>
+        <span class="readmore__label--more"><%= t('readmore.see_more') %> <i class="fa fa-chevron-down" aria-hidden="true"></i></span>
+        <span class="readmore__label--less"><%= t('readmore.see_less') %> <i class="fa fa-chevron-up" aria-hidden="true"></i></span>
       </label>
       <section
         id="<%= content_id %>"

--- a/public/app/views/shared/_note_content.html.erb
+++ b/public/app/views/shared/_note_content.html.erb
@@ -11,24 +11,34 @@
   <% if (calling_partial != 'record_innards' || content_length <= max_chars) %>
     <%= content.html_safe %>
   <% else %>
-    <% state_id = "#{type}_readmore_#{SecureRandom.uuid}" %>
+    <% readmore_uuid = SecureRandom.uuid %>
+    <% state_id = "#{type}_readmore_#{readmore_uuid}" %>
+    <% toggle_id = "#{state_id}_toggle" %>
+    <% content_id = "#{state_id}_content" %>
     <div class="position-relative mb-3 d-flex flex-column align-items-start" data-js="readmore">
       <input
         type="checkbox"
         id="<%= state_id %>"
         class="readmore__state order-1 bottom-0 visually-hidden"
-        aria-expanded="false"
-        aria-controls="<%= type %>_readmore_content"
       />
-      <label for="<%= state_id %>" class="readmore__label order-1" tabindex="0">
+      <label
+        for="<%= state_id %>"
+        id="<%= toggle_id %>"
+        class="readmore__label order-1"
+        tabindex="0"
+        role="button"
+        aria-label="<%= t('readmore.see_more') %>"
+        aria-expanded="false"
+        aria-controls="<%= content_id %>"
+      >
         <span class="readmore__label--more"><%= t('readmore.see_more') %> <i class="fa fa-chevron-down"></i></span>
         <span class="readmore__label--less"><%= t('readmore.see_less') %> <i class="fa fa-chevron-up"></i></span>
       </label>
       <section
-        id="<%= type %>_readmore_content"
+        id="<%= content_id %>"
         class="readmore__content order-0"
         role="region"
-        aria-labelledby="<%= state_id %>"
+        aria-labelledby="<%= toggle_id %>"
       >
         <%= content.html_safe %>
       </section>

--- a/public/spec/features/read_more_notes_spec.rb
+++ b/public/spec/features/read_more_notes_spec.rb
@@ -139,22 +139,54 @@ describe 'Read More Notes', js: true do
     end
   end
 
-  it "toggles the aria-expanded attribute on the state element when state changes" do
+  it "toggles the aria-expanded attribute on the label element when state changes" do
     scope_and_contents_read_mores = all('.upper-record-details .abstract.single_note [data-js="readmore"]')
 
     within(scope_and_contents_read_mores[0]) do
-      state = find('.upper-record-details .abstract.single_note .readmore__state[aria-expanded="false"]')
+      label = find('.upper-record-details .abstract.single_note .readmore__label[aria-expanded="false"]')
       see_more = find('.upper-record-details .abstract.single_note .readmore__label--more')
       see_less = find('.upper-record-details .abstract.single_note .readmore__label--less', visible: false)
 
+      expect(label[:'aria-label']).to be_nil
+
       see_more.click
 
-      expect(state[:'aria-expanded']).to eq('true')
+      expect(label[:'aria-expanded']).to eq('true')
 
       see_less.click
 
-      expect(state[:'aria-expanded']).to eq('false')
+      expect(label[:'aria-expanded']).to eq('false')
     end
+  end
+
+  it 'gives each readmore instance unique ids and matching aria-controls' do
+    scope_and_contents_read_mores = all('.upper-record-details .abstract.single_note [data-js="readmore"]')
+    expect(scope_and_contents_read_mores.length).to eq(2)
+
+    ids = scope_and_contents_read_mores.map do |readmore|
+      within(readmore) do
+        state = find('.readmore__state', visible: :all)
+        label = find('.readmore__label')
+        content = find('.readmore__content')
+
+        expect(state[:'aria-hidden']).to eq('true')
+        expect(state[:tabindex]).to eq('-1')
+        expect(label[:'aria-controls']).to eq(content[:id])
+        expect(label[:id]).to eq(content[:'aria-labelledby'])
+        expect(label[:for]).to eq(state[:id])
+        expect(label[:role]).to eq('button')
+
+        {
+          state_id: state[:id],
+          toggle_id: label[:id],
+          content_id: content[:id]
+        }
+      end
+    end
+
+    all_ids = ids.flat_map { |id_set| id_set.values }
+    expect(all_ids).to eq(all_ids.uniq)
+    expect(ids[0][:content_id]).not_to eq(ids[1][:content_id])
   end
 
   it "does not show on second-level notes of a Resource Collection Overview when the note exceeds AppConfig[:pui_readmore_max_characters]" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-2897]

## Summary
- Updated the shared Readmore markup so the focusable toggle is explicitly announced as an interactive control (role="button" on the focusable label)
- Added accessible naming and relationships to the toggle by including aria-label, aria-expanded, and aria-controls, and by generating unique IDs (state_id, toggle_id, content_id) per instance to avoid collisions across repeated notes.
- Retained the existing click/expand behavior and visual Readmore UI (readmore__label, readmore__content, see more/see less states) while making the control semantics screen-reader and keyboard friendly.

## Screenshots (if appropriate):
<img width="1469" height="821" alt="collection overview after accessibility scan" src="https://github.com/user-attachments/assets/325a0f0e-f40c-4125-afca-1278748ec9de" />
<img width="1338" height="426" alt="see more button html fix" src="https://github.com/user-attachments/assets/c29a94be-208b-4f28-ada0-a84161300e8b" />
<img width="1467" height="526" alt="collection overview before accessibility scan" src="https://github.com/user-attachments/assets/3ed6c74e-2ed9-4107-86ba-64f60e1a1e09" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read and agree to the [**CONTRIBUTING** document](https://github.com/archivesspace/archivesspace/blob/master/CONTRIBUTING.md).
- [X] I have authority to submit this code. - See our [licensing](https://github.com/archivesspace/archivesspace/blob/master/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:


[ANW-2897]: https://archivesspace.atlassian.net/browse/ANW-2897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ