### PR TITLE
Fix merge_notes dropping note text when notes share a label

### DIFF
--- a/public/app/helpers/json_helper.rb
+++ b/public/app/helpers/json_helper.rb
@@ -19,12 +19,14 @@ module JsonHelper
   end
 
   def merge_notes(note_1, note_2)
+    note_2_text = note_2['note_text']
+
     if note_1['label'].blank?
       # Our first label
       note_1['label'] = note_2['label']
     elsif note_1['label'] != note_2['label']
       # Add a secondary label as an inline label
-      note_2_text = "<span class='inline-label'>#{note_2['label']}</span> #{note_2['note_text']}"
+      note_2_text = "<span class='inline-label'>#{note_2['label']}</span> #{note_2_text}"
     end
 
     note_1['note_text'] = "#{note_1['note_text']}<br/><br/> #{note_2_text}"

--- a/public/spec/features/merge_notes_spec.rb
+++ b/public/spec/features/merge_notes_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'Merge notes', js: true do
+  before(:all) do
+    @now = Time.now.to_i
+
+    same_label_notes = [
+      build(:json_note_singlepart,
+            type: 'abstract',
+            label: 'Abstract',
+            publish: true,
+            content: ["SAME_LABEL_NOTE_ONE_#{@now}"]),
+      build(:json_note_singlepart,
+            type: 'abstract',
+            label: 'Abstract',
+            publish: true,
+            content: ["SAME_LABEL_NOTE_TWO_#{@now}"]),
+      build(:json_note_singlepart,
+            type: 'abstract',
+            label: 'Abstract',
+            publish: true,
+            content: ["SAME_LABEL_NOTE_THREE_#{@now}"])
+    ]
+
+    differing_label_notes = [
+      build(:json_note_singlepart,
+            type: 'abstract',
+            label: 'Abstract',
+            publish: true,
+            content: ["DIFFERING_LABEL_NOTE_ONE_#{@now}"]),
+      build(:json_note_singlepart,
+            type: 'abstract',
+            label: 'Summary',
+            publish: true,
+            content: ["DIFFERING_LABEL_NOTE_TWO_#{@now}"])
+    ]
+
+    @same_label_resource = create(:resource,
+                                  title: "Resource with same-label abstracts #{@now}",
+                                  publish: true,
+                                  notes: same_label_notes)
+
+    @differing_label_resource = create(:resource,
+                                       title: "Resource with differing-label abstracts #{@now}",
+                                       publish: true,
+                                       notes: differing_label_notes)
+
+    run_indexers
+  end
+
+  describe 'same-type notes with the same label' do
+    it 'are merged by concatenating their text' do
+      visit @same_label_resource.uri
+
+      within '.upper-record-details .abstract.single_note' do
+        expect(page).to have_css('h2', text: 'Abstract', count: 1)
+        expect(page).to have_content("SAME_LABEL_NOTE_ONE_#{@now}")
+        expect(page).to have_content("SAME_LABEL_NOTE_TWO_#{@now}")
+        expect(page).to have_content("SAME_LABEL_NOTE_THREE_#{@now}")
+        expect(page).not_to have_css('span.inline-label')
+      end
+    end
+  end
+
+  describe 'same-type notes with different labels' do
+    it 'are merged with non-matching labels shown inline' do
+      visit @differing_label_resource.uri
+
+      within '.upper-record-details .abstract.single_note' do
+        expect(page).to have_css('h2', text: 'Abstract', count: 1)
+        expect(page).to have_content("DIFFERING_LABEL_NOTE_ONE_#{@now}")
+        expect(page).to have_content("DIFFERING_LABEL_NOTE_TWO_#{@now}")
+        expect(page).to have_css('span.inline-label', text: 'Summary')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `merge_notes` (`public/app/helpers/json_helper.rb`) only assigned `note_2_text` inside the `elsif note_1['label'] != note_2['label']` branch, leaving it `nil` when two notes of the same type share a label.
- Symptom: a resource/etc. with 3+ notes of the same type all labeled the same (e.g. three "Abstract" notes) shows the first note's text followed by empty `<br/><br/>` pairs, with the 2nd/3rd notes' text silently dropped on the public UI.
- Fix: default `note_2_text` to `note_2['note_text']` up front, so same-label notes concatenate their text instead of being discarded, while the differing-label "inline label" behavior is unchanged.

## Test plan
- [x] Tested via a plugin override (`Module#prepend` on `JsonHelper#merge_notes`) against a live ArchivesSpace v4.2.1 instance, confirming multiple same-labeled Abstract notes now render concatenated instead of producing stray `<br>` tags with missing text.
- [ ] No automated test currently covers `merge_notes`; reviewers may want one added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)