### PR TITLE
ANW-2945 PUI non-creator agent highlighting

### DIFF
--- a/public/config/locales/de.yml
+++ b/public/config/locales/de.yml
@@ -75,7 +75,7 @@ de:
       four_part_id: Kennung
       dates: Termine
       subjects_text: Fächer
-      published_agents: Agentinnen
+      agents_text: Agentinnen
       creators_text: Schöpfer
       role_enum_s: Rollen
       linked_agent_roles: Verknüpfte Agentenrollen

--- a/public/config/locales/en.yml
+++ b/public/config/locales/en.yml
@@ -106,7 +106,7 @@ en:
       four_part_id: Identifier
       dates: Dates
       subjects_text: Subjects
-      published_agents: Agents
+      agents_text: Agents
       creators_text: Creators
       role_enum_s: Roles
       linked_agent_roles: Linked Agent Roles

--- a/public/config/locales/es.yml
+++ b/public/config/locales/es.yml
@@ -87,7 +87,7 @@ es:
       four_part_id: Identificador
       dates: Fechas
       subjects_text: Sujetas
-      published_agents: Agentes
+      agents_text: Agentes
       creators_text: Creadoras
       role_enum_s: Roles
       linked_agent_roles: Roles de agente vinculada

--- a/public/config/locales/fr.yml
+++ b/public/config/locales/fr.yml
@@ -107,7 +107,7 @@ fr:
       four_part_id: Identifiant
       dates: Rendez-vous
       subjects_text: Sujettes
-      published_agents: Agentes
+      agents_text: Agentes
       creators_text: Créatrices
       role_enum_s: Les rôles
       linked_agent_roles: Rôles d'agent liés

--- a/public/config/locales/it.yml
+++ b/public/config/locales/it.yml
@@ -48,7 +48,7 @@ it:
       role_enum_s: Ruoli
       notes_published: Note
       acquisition_type: Tipo di acquisizione
-      published_agents: Agenti
+      agents_text: Agenti
       finding_aid_title: Titolo degli strumenti di ricerca
       linked_agent_roles: Ruoli dell'agente collegato
       instance_type_enum_s: Tipo di istanza

--- a/public/config/locales/ja.yml
+++ b/public/config/locales/ja.yml
@@ -77,7 +77,7 @@ ja:
       four_part_id: 識別子
       dates: 日付
       subjects_text: 科目
-      published_agents: エージェント
+      agents_text: エージェント
       creators_text: クリエイター
       role_enum_s: 役割
       linked_agent_roles: リンクされたエージェントの役割

--- a/public/config/locales/nl.yml
+++ b/public/config/locales/nl.yml
@@ -80,7 +80,7 @@ nl:
       four_part_id: Identificatiecode
       dates: Datering
       subjects_text: Onderwerpen
-      published_agents: Namen van personen, families en organisaties
+      agents_text: Namen van personen, families en organisaties
       creators_text: Archiefvormers en verzamelaars
       role_enum_s: Rollen
       linked_agent_roles: Rollen van gekoppelde namen

--- a/public/config/locales/pl.yml
+++ b/public/config/locales/pl.yml
@@ -85,7 +85,7 @@ pl:
       four_part_id: Identyfikator
       dates: Daty
       acquisition_type: Rodzaj przejęcia
-      published_agents: Agenty
+      agents_text: Agenty
       linked_agent_roles: Powiązane role agentów
       instance_type_enum_s: Typ instancji
       creators_text: Twórcy

--- a/public/config/locales/pt.yml
+++ b/public/config/locales/pt.yml
@@ -35,7 +35,7 @@ pt:
       four_part_id: Identificador
       dates: Datas
       subjects_text: Assuntos
-      published_agents: Agents
+      agents_text: Agents
       creators_text: Agentes
       role_enum_s: Funções
       linked_agent_roles: Funções de agente vinculado

--- a/public/config/locales/uk.yml
+++ b/public/config/locales/uk.yml
@@ -85,7 +85,7 @@ uk:
       four_part_id: Ідентифікатор
       dates: Дати
       subjects_text: Суб'єкти
-      published_agents: Агенти
+      agents_text: Агенти
       creators_text: Творці
       role_enum_s: Ролі
       linked_agent_roles: Ролі пов'язаних агентів

--- a/public/spec/controllers/search_controller_spec.rb
+++ b/public/spec/controllers/search_controller_spec.rb
@@ -423,6 +423,50 @@ describe SearchController, type: :controller do
       end
     end
 
+    context 'when searching for a term only matching an agent linked with a non-creator role' do
+      let(:now) { Time.now.to_i }
+      let(:search_term) { "NonCreatorAgent#{now}" }
+      let(:repository) do
+        create(
+          :repo,
+          :repo_code => "resource_search_test_non_creator_#{now}",
+          :name => "Repository Title #{now}",
+          publish: true
+        )
+      end
+
+      it 'highlights the agent name under agents_text' do
+        set_repo repository
+
+        person = JSONModel(:name_person).new(primary_name: "#{search_term} Person", name_order: 'direct')
+        linked_agent = create(:agent_person, names: [person], publish: true, dates_of_existence: [])
+
+        resource = create(:resource,
+          :title => "Resource Title #{now}",
+          :publish => true,
+          :linked_agents => [
+            { 'role' => 'subject', 'ref' => linked_agent.uri }
+          ]
+        )
+
+        run_indexers
+
+        get(:search, params: {
+          :q => [search_term],
+          :op => ['OR'],
+          :field => ['']
+        })
+
+        results = controller.instance_variable_get(:@results)
+        resource_record = results.records.find { |r| r.uri == "/repositories/#{repository.id}/resources/#{resource.id}" }
+
+        expect(resource_record).not_to be_nil
+        expect(resource_record.highlights['agents_text']).to eq(["<span class=\"searchterm\">#{search_term}</span> Person"])
+        expect(resource_record.highlights).not_to have_key('creators_text')
+        expect(resource_record.highlights).not_to have_key('subjects_text')
+      end
+    end
+
     context 'when searching for a resource repository_processing_note' do
       let(:now) { Time.now.to_i }
       let(:search_term) { SecureRandom.uuid }

--- a/public/spec/features/search_spec.rb
+++ b/public/spec/features/search_spec.rb
@@ -338,6 +338,27 @@ describe 'Search', js: true do
         end
       end
 
+      context 'when search term is only found in an agent linked with a non-creator role' do
+        let(:now) { Time.now.to_i }
+        let(:search_term) { "NonCreatorAgent#{now}" }
+
+        let(:searched_record) do
+          person = JSONModel(:name_person).new(primary_name: "#{search_term} Person", name_order: 'direct')
+          linked_agent = create(:agent_person, names: [person], publish: true, dates_of_existence: [])
+
+          create(:resource,
+                 :title => "Resource Title #{now}",
+                 :publish => true,
+                 :linked_agents => [
+                   { 'role' => 'subject', 'ref' => linked_agent.uri }
+                 ])
+        end
+
+        it 'highlights the search term in the found in agents section' do
+          expect(page).to highlight_term_found_in "Found in Agents:", search_term
+        end
+      end
+
       context 'when the search term is in a long title and a long note' do
         let(:now) { Time.now.to_i }
         let(:search_term) { "zzuniqueterm#{now}" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->
[ANW-2945]

## Summary
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->
As discussed in Slack, Solr populates a tokenized `agents_text` field that correctly captures any linked agent regardless of role, however, `agents_text` was never added to the locale files that tell the PUI results page how to label and highlight matched fields (only `creators_text` and `subjects_text` are there). What is in the highlighting block is a `published_agents` field, but it's a string-type field (not `text_general`) so it can't be highlighted.  I've swapped this `published_agents` field for the highlightable `agents_text` field.

## Screenshots (if appropriate):
Non-creator agents are now shown highlighted under "Found in Agents":
<img width="390" height="291" alt="Screenshot 2026-08-20 at 11 42 11 AM" src="https://github.com/user-attachments/assets/5576325f-aa42-4196-8a86-886b11f88e2d" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and agree to the [**CONTRIBUTING** document](https://github.com/archivesspace/archivesspace/blob/master/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](https://github.com/archivesspace/archivesspace/blob/master/contribution_files/CONTRIBUTING_README.md)
- [x] Have you added tests to cover these changes? If not why:

[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-2945]: https://archivesspace.atlassian.net/browse/ANW-2945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ