### PR TITLE
Fix redirect loop on public PUI listing/search pages with zero results

### DIFF
--- a/public/app/controllers/accessions_controller.rb
+++ b/public/app/controllers/accessions_controller.rb
@@ -41,10 +41,10 @@ class AccessionsController < ApplicationController
       set_up_and_run_search( DEFAULT_AC_TYPES, DEFAULT_AC_FACET_TYPES, search_opts, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     end
 
     @context = repo_context(@repo_id, 'accession')
@@ -73,10 +73,10 @@ class AccessionsController < ApplicationController
       set_up_and_run_search( DEFAULT_AC_TYPES, DEFAULT_AC_FACET_TYPES, DEFAULT_AC_SEARCH_OPTS, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     end
     @page_title = I18n.t('accession._plural')
     @results_type = @page_title

--- a/public/app/controllers/agents_controller.rb
+++ b/public/app/controllers/agents_controller.rb
@@ -40,10 +40,10 @@ class AgentsController < ApplicationController
       set_up_and_run_search( DEFAULT_AG_TYPES, default_facets, search_opts, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/agents') and return
+      redirect_to(agents_path) and return
     end
 
     @context = repo_context(repo_id, 'agent')
@@ -74,10 +74,10 @@ class AgentsController < ApplicationController
       set_up_and_run_search( DEFAULT_AG_TYPES, DEFAULT_AG_FACET_TYPES, DEFAULT_AG_SEARCH_OPTS, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/agents') and return
+      redirect_to(agents_path) and return
     end
     @page_title = I18n.t('agent._plural')
     @results_type = @page_title

--- a/public/app/controllers/application_controller.rb
+++ b/public/app/controllers/application_controller.rb
@@ -54,9 +54,9 @@ class ApplicationController < ActionController::Base
     Rails.logger.error(exception)
     flash[:error] = I18n.t('search_results.no_results')
     unless controller_name == 'repositories'
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     else
-      redirect_to('/')
+      redirect_to(root_path)
     end
   end
 

--- a/public/app/controllers/classifications_controller.rb
+++ b/public/app/controllers/classifications_controller.rb
@@ -37,10 +37,10 @@ class ClassificationsController < ApplicationController
       set_up_and_run_search( DEFAULT_CL_TYPES, DEFAULT_CL_FACET_TYPES, search_opts, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     end
 
     @context = repo_context(repo_id, 'classification')
@@ -70,10 +70,10 @@ class ClassificationsController < ApplicationController
       set_up_and_run_search( DEFAULT_CL_TYPES, DEFAULT_CL_FACET_TYPES, DEFAULT_CL_SEARCH_OPTS, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     end
     @page_title = I18n.t('classification._plural')
     @results_type = @page_title

--- a/public/app/controllers/objects_controller.rb
+++ b/public/app/controllers/objects_controller.rb
@@ -35,10 +35,10 @@ class ObjectsController < ApplicationController
       set_up_and_run_search( params[:limit].split(","), DEFAULT_OBJ_FACET_TYPES, search_opts, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     rescue Exception
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/objects' ) and return
+      redirect_to(objects_path) and return
     end
 
     @context = repo_context(repo_id, 'record')
@@ -66,10 +66,10 @@ class ObjectsController < ApplicationController
       set_up_and_run_search(%w(digital_object archival_object), DEFAULT_OBJ_FACET_TYPES, DEFAULT_OBJ_SEARCH_OPTS, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/objects' ) and return
+      redirect_to(objects_path) and return
     end
     @page_title = I18n.t('record._plural')
     @results_type = @page_title

--- a/public/app/controllers/repositories_controller.rb
+++ b/public/app/controllers/repositories_controller.rb
@@ -59,13 +59,13 @@ class RepositoriesController < ApplicationController
     rescue Exception => error
       Rails.logger.debug( error.backtrace )
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: "/repositories/#{@repo_id}/" ) and return
+      redirect_to("#{AppConfig[:public_proxy_prefix].sub(/\/$/, '')}/repositories/#{@repo_id}/") and return
     end
     page = Integer(params.fetch(:page, "1"))
     @results = archivesspace.advanced_search('/search', page, @criteria)
     if @results['total_hits'].blank? || @results['total_hits'] == 0
       flash[:notice] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: @base_search)
+      redirect_to("#{AppConfig[:public_proxy_prefix].sub(/\/$/, '')}/repositories/#{@repo_id}/")
     else
       process_search_results(@base_search)
       Rails.logger.debug("@repo_id: #{@repo_id}")

--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -52,10 +52,10 @@ class ResourcesController < ApplicationController
       set_up_and_run_search(['resource'], facet_types, search_opts, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(@repo_id ? "#{AppConfig[:public_proxy_prefix].sub(/\/$/, '')}/repositories/#{@repo_id}" : root_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/' ) and return
+      redirect_to(@repo_id ? "#{AppConfig[:public_proxy_prefix].sub(/\/$/, '')}/repositories/#{@repo_id}" : root_path) and return
     end
 
     @context = repo_context(@repo_id, 'resource')
@@ -102,14 +102,14 @@ class ResourcesController < ApplicationController
       set_up_advanced_search(DEFAULT_RES_TYPES, DEFAULT_RES_FACET_TYPES, search_opts, params)
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: res_id ) and return
+      redirect_to("#{AppConfig[:public_proxy_prefix].sub(/\/$/, '')}#{res_id}") and return
     end
 
     page = Integer(params.fetch(:page, "1"))
     @results = archivesspace.advanced_search('/search', page, @criteria)
     if @results['total_hits'].blank? || @results['total_hits'] == 0
       flash[:notice] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: @base_search)
+      redirect_to("#{AppConfig[:public_proxy_prefix].sub(/\/$/, '')}#{res_id}")
     else
       process_search_results(@base_search)
       title = ''

--- a/public/app/controllers/search_controller.rb
+++ b/public/app/controllers/search_controller.rb
@@ -48,7 +48,7 @@ class SearchController < ApplicationController
       Rails.logger.debug(error.message)
       p error
       flash[:error] = I18n.t('search_results.error')
-      redirect_back(fallback_location: root_path ) and return
+      redirect_to(root_path) and return
     end
     page = Integer(params.fetch(:page, "1"))
     Rails.logger.debug("base search: #{@base_search}")

--- a/public/app/controllers/subjects_controller.rb
+++ b/public/app/controllers/subjects_controller.rb
@@ -37,10 +37,10 @@ class SubjectsController < ApplicationController
       set_up_and_run_search(['subject'], default_facets, search_opts, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/subjects' ) and return
+      redirect_to(subjects_path) and return
     end
 
     @context = repo_context(repo_id, 'subject')
@@ -73,10 +73,10 @@ class SubjectsController < ApplicationController
       set_up_and_run_search(['subject'], DEFAULT_SUBJ_FACET_TYPES, DEFAULT_SUBJ_SEARCH_OPTS, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_to(root_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/subjects' ) and return
+      redirect_to(subjects_path) and return
     end
     @page_title = I18n.t('subject._plural')
     @results_type = @page_title

--- a/public/spec/controllers/resources_controller_spec.rb
+++ b/public/spec/controllers/resources_controller_spec.rb
@@ -158,6 +158,25 @@ describe ResourcesController, type: :controller do
     end
   end
 
+  describe 'index action for a repository with no published resources' do
+    before(:all) do
+      @empty_repo = create(:repo, repo_code: "resources_empty_test_#{Time.now.to_i}",
+                            publish: true)
+      run_indexers
+    end
+
+    it 'redirects to a fixed location instead of looping back to itself via referer' do
+      request.env['HTTP_REFERER'] = "/repositories/#{@empty_repo.id}/resources"
+      get(:index, params: { rid: @empty_repo.id })
+
+      expect(response).to have_http_status(302)
+      expect(response.location).not_to eq(request.env['HTTP_REFERER'])
+
+      expected_location = "#{AppConfig[:public_proxy_prefix].sub(/\/$/, '')}/repositories/#{@empty_repo.id}"
+      expect(response).to redirect_to(expected_location)
+    end
+  end
+
   describe 'digitized action' do
     it 'displays tree breadcrumbs for digital objects linked to more than one Resource' do
       get(:digitized, params: {rid: @repo.id, id: @resource_with_rep_instance.id})


### PR DESCRIPTION
This is a bigger PR than I normally do, hopefully me and Claude thought of everything that could go wrong with it. The problem was going to an ArchivesSpace site with nothing published causes a weird redirect failure. Probably not very common? So a hit to https://archives.example.com/repositories/resources fails with a bunch of redirects in different ways on different browsers if there's nothing published. I'll let Claude explain the details:

ResourcesController#index and the equivalent index/search actions in AgentsController, SubjectsController, ObjectsController, AccessionsController, ClassificationsController, RepositoriesController, SearchController, and the shared ApplicationController#render_no_results_found rescue a zero-results/error condition with redirect_back(fallback_location: ...).

redirect_back sets Location to the request's Referer header when present, with no check that it differs from the current URL. On a repository with zero published resources, every request to /repositories/resources raises NoResultsError; once a client's Referer happens to equal that same URL, the redirect points back to itself, producing an infinite 302 loop (confirmed via production nginx access logs - a real browser looping ~35 times in 5 seconds until the origin's own rate limiter cut it off with a 503).

Replace redirect_back with redirect_to using a fixed, non-referer-derived target for each rescue, matching what SearchController's zero-hits branch already does. Two zero-hit branches (ResourcesController#search, RepositoriesController#search) previously fell back to their own /search URL - self-referential regardless of referer - so those now redirect to the resource/repository show page instead, matching their sibling Exception-rescue branch.

Targets that resolve via a named route (root_path, subjects_path, agents_path, objects_path) use those helpers so they respect a public_proxy_prefix-mounted deployment. Targets built from dynamic segments with no named route (a resource or repository's own URL) manually prepend AppConfig[:public_proxy_prefix], matching how config.action_controller.relative_url_root is derived in public/config/application.rb - a bare redirect_to(string) does not consult relative_url_root (confirmed against the installed Rails actionpack redirecting.rb source).

RequestsController#make_request keeps its existing redirect_back, since it returns a user to a submitted form on validation failure - a different, legitimate use, not the self-referential listing-page loop this fixes.

Added a regression test to resources_controller_spec.rb covering a repository with zero published resources; verified it fails against the original redirect_back code and passes with this fix.

Tested locally end to end: built and ran this branch in the project's Docker dev environment (db/db-test/solr/solr-test/app via docker-compose.yml + Dev.dockerfile), migrated the dev database, and started backend/frontend/public/indexer via supervisord. Reproduced the original loop with curl (Referer equal to the request URL redirects back to itself), confirmed the fix breaks the loop (Location no longer mirrors Referer, redirect terminates in one hop), and ran the full resources_controller spec suite (14 examples, 0 failures).

<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->

## Summary
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and agree to the [**CONTRIBUTING** document](https://github.com/archivesspace/archivesspace/blob/master/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](https://github.com/archivesspace/archivesspace/blob/master/contribution_files/CONTRIBUTING_README.md)
- [x] Have you added tests to cover these changes? If not why:


[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ