### PR TITLE
ANW-2773 Migrate existing data into language_and_script_of_description

### DIFF
--- a/common/db/migrations/177_create_lang_descriptions_and_mlc_tables.rb
+++ b/common/db/migrations/177_create_lang_descriptions_and_mlc_tables.rb
@@ -2,6 +2,17 @@ require_relative 'utils'
 
 Sequel.migration do
   up do
+    # Resolve and validate up front, before any DDL runs. Do not allow
+    # a config error to leave orphaned tables behind and break any retry
+    # with a "table already exists".
+    lang_enum   = self[:enumeration].filter(:name => 'language_iso639_2').get(:id)
+    script_enum = self[:enumeration].filter(:name => 'script_iso15924').get(:id)
+    default_language_id = self[:enumeration_value].filter(:enumeration_id => lang_enum, :value => AppConfig[:mlc_default_language]).get(:id)
+    default_script_id   = self[:enumeration_value].filter(:enumeration_id => script_enum, :value => AppConfig[:mlc_default_script]).get(:id)
+
+    raise "language_iso639_2 enum value '#{AppConfig[:mlc_default_language]}' not found" if default_language_id.nil?
+    raise "script_iso15924 enum value '#{AppConfig[:mlc_default_script]}' not found" if default_script_id.nil?
+
     create_table(:language_and_script_of_description) do
       primary_key :id
       Integer :lock_version, :default => 0, :null => false
@@ -108,11 +119,6 @@ Sequel.migration do
 
     # --- Data migration: move existing field values to _mlc tables ---
 
-    lang_enum   = self[:enumeration].filter(:name => 'language_iso639_2').get(:id)
-    script_enum = self[:enumeration].filter(:name => 'script_iso15924').get(:id)
-    language_id = self[:enumeration_value].filter(:enumeration_id => lang_enum, :value => AppConfig[:mlc_default_language]).get(:id)
-    script_id   = self[:enumeration_value].filter(:enumeration_id => script_enum, :value => AppConfig[:mlc_default_script]).get(:id)
-
     {
       :resource => %i[title finding_aid_title finding_aid_subtitle finding_aid_author
                       finding_aid_sponsor finding_aid_edition_statement
@@ -130,8 +136,8 @@ Sequel.migration do
       self[record_type].each do |row|
         self[mlc_table].insert(
           fk           => row[:id],
-          :language_id => language_id,
-          :script_id   => script_id,
+          :language_id => default_language_id,
+          :script_id   => default_script_id,
           **fields.each_with_object({}) { |f, h| h[f] = row[f] }
         )
       end

--- a/common/db/migrations/178_populate_language_and_script_of_description.rb
+++ b/common/db/migrations/178_populate_language_and_script_of_description.rb
@@ -1,0 +1,66 @@
+require_relative 'utils'
+
+Sequel.migration do
+  up do
+    lang_enum   = self[:enumeration].filter(:name => 'language_iso639_2').get(:id)
+    script_enum = self[:enumeration].filter(:name => 'script_iso15924').get(:id)
+
+    default_lang_id   = self[:enumeration_value].filter(:enumeration_id => lang_enum,   :value => AppConfig[:mlc_default_language]).get(:id)
+    default_script_id = self[:enumeration_value].filter(:enumeration_id => script_enum, :value => AppConfig[:mlc_default_script]).get(:id)
+
+    raise "language_iso639_2 enum value '#{AppConfig[:mlc_default_language]}' not found" if default_lang_id.nil?
+    raise "script_iso15924 enum value '#{AppConfig[:mlc_default_script]}' not found" if default_script_id.nil?
+
+    now = Time.now
+
+    # resource: finding_aid_language_id/finding_aid_script_id are copied as-is.
+    # These columns are never NULL due to migration 121, so AppConfig
+    # defaults are never needed here.
+    self[:resource].select(:id, :finding_aid_language_id, :finding_aid_script_id).each do |row|
+      self[:language_and_script_of_description].insert(
+        :resource_id => row[:id],
+        :language_id => row[:finding_aid_language_id],
+        :script_id   => row[:finding_aid_script_id],
+        :is_primary  => 1,
+        :json_schema_version => 1,
+        :create_time => now,
+        :system_mtime => now,
+        :user_mtime => now
+      )
+    end
+
+    # accession: language_id and script_id are independent, optional fields.
+    # Each defaults to the AppConfig value only when NULL. Existing values
+    # are never discarded.
+    self[:accession].select(:id, :language_id, :script_id).each do |row|
+      language_id = row[:language_id] || default_lang_id
+      script_id   = row[:script_id] || default_script_id
+
+      self[:language_and_script_of_description].insert(
+        :accession_id => row[:id],
+        :language_id  => language_id,
+        :script_id    => script_id,
+        :is_primary   => 1,
+        :json_schema_version => 1,
+        :create_time => now,
+        :system_mtime => now,
+        :user_mtime => now
+      )
+    end
+
+    # digital_object: no language-of-description equivalent exists,
+    # so always take the configured MLC defaults.
+    self[:digital_object].select(:id).each do |row|
+      self[:language_and_script_of_description].insert(
+        :digital_object_id => row[:id],
+        :language_id => default_lang_id,
+        :script_id   => default_script_id,
+        :is_primary  => 1,
+        :json_schema_version => 1,
+        :create_time => now,
+        :system_mtime => now,
+        :user_mtime => now
+      )
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->
[ANW-2773]

## Summary
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->
Adds migration 178, which populates `language_and_script_of_description` for all pre-existing `resource`, `accession`, and `digital_object` records. Migration 177 creates this table but leaves it empty for anything that existed before the MLC tables did; without this migration, every pre-existing record has zero primary language of description.

Also includes an in-place fix to migration 177 which has not yet been released, but is live on the MLC test server.  Testing the new migration 178 made me see the benefit of a fail fast on 177 if anything is off about the AppConfig default language and script.  We don't want to get in a state where five orphaned `_mlc` tables are left behind, but `schema_info` remains 176.  Retrying migration 177 after fixing issues with the config would fail with "table already exists" error requiring manual cleanup. A bad config value now fails before any schema change runs so the database is left untouched and a retry proceeds cleanly.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [x] My change requires a change to the documentation - If so elaborate: We should very clearly call out the importance of setting the default language and script in AppConfig BEFORE running these migrations during an upgrade flow.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and agree to the [**CONTRIBUTING** document](https://github.com/archivesspace/archivesspace/blob/master/CONTRIBUTING.md).
- [x] I have authority to submit this code. - See our [licensing](https://github.com/archivesspace/archivesspace/blob/master/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:
N/A

[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-2773]: https://archivesspace.atlassian.net/browse/ANW-2773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ