### PR TITLE
ANW-1960: Add specificity to event agents role tooltip

### DIFF
--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -303,8 +303,13 @@ en:
     <<: *linked_agent_attributes
 
   event_linked_agent:
-    <<: *linked_agent_attributes
-
+    role: Role
+    role_tooltip: |
+        <p>REQUIRED FIELD. An indication of what function the Agent has in regards to the action described by the event.</p>
+    ref: Agent
+    ref_tooltip: |
+        <p>REQUIRED FIELD. The person, family, corporate entity, or software that took part in the action described by the event.</p>
+ 
   resource_linked_agent:
     <<: *linked_agent_attributes
 

--- a/common/locales/en.yml
+++ b/common/locales/en.yml
@@ -306,10 +306,22 @@ en:
     role: Role
     role_tooltip: |
         <p>REQUIRED FIELD. An indication of what function the Agent has in regards to the action described by the event.</p>
+    relator: Relator
+    relator_tooltip: |
+        <p>An indication of what role the Agent has in regards to its function as indicated in how it is linked (e.g., creator, source, or subject) to a certain description record. For example, an Agent may be linked as a creator to a record, but with the more specific role of "illustrator".</p>
+        <p>See DACS 14.3, ISAAR (CPF) 6.3 and MARC Code List for Relators (https://www.loc.gov/marc/relators/).</p>
     ref: Agent
     ref_tooltip: |
         <p>REQUIRED FIELD. The person, family, corporate entity, or software that took part in the action described by the event.</p>
- 
+    terms: Terms
+    title: Title
+    title_tooltip: |
+        <p>Optional field: Record here the authoritative title of a work in order to make a Name / Title heading for an agent linked as a creator or a subject:</p>
+        <p>For example,</p>
+        <ul><li>Shakespeare, William, 1564-1616. King Lear</li><li> Pound, Ezra, 1885-1972. Cantos</li><li> Lincoln, Abraham, 1809-1865. Emancipation Proclamation</li></ul>
+    _singular: Agent Link
+    _plural: Agent Links
+
   resource_linked_agent:
     <<: *linked_agent_attributes
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->
[ANW-1960](https://archivesspace.atlassian.net/browse/ANW-1960)
## Summary

This adds more specificity to the tooltip for an agent linked to an event, rather than reusing the general linked agent tooltip. I followed the pattern from the linked agent locales. I also added a more specific tooltip for the agent linker, but note that there is a comment in line 289 that the ref tooltip for linked agents is not displaying there and it's not displaying for this new event-specific section either. (I didn't get very far in troubleshooting that.)


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and agree to the [**CONTRIBUTING** document](https://github.com/archivesspace/archivesspace/blob/master/CONTRIBUTING.md).
- [ ] I have authority to submit this code. - See our [licensing](https://github.com/archivesspace/archivesspace/blob/master/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:


[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ANW-1960]: https://archivesspace.atlassian.net/browse/ANW-1960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ