### PR TITLE
Stop PUI no-results redirects from looping back on themselves

### DIFF
--- a/public/app/controllers/accessions_controller.rb
+++ b/public/app/controllers/accessions_controller.rb
@@ -41,10 +41,10 @@ class AccessionsController < ApplicationController
       set_up_and_run_search( DEFAULT_AC_TYPES, DEFAULT_AC_FACET_TYPES, search_opts, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: repository_or_root_path(@repo_id)) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: repository_or_root_path(@repo_id)) and return
     end
 
     @context = repo_context(@repo_id, 'accession')
@@ -73,10 +73,10 @@ class AccessionsController < ApplicationController
       set_up_and_run_search( DEFAULT_AC_TYPES, DEFAULT_AC_FACET_TYPES, DEFAULT_AC_SEARCH_OPTS, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: accessions_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: accessions_path) and return
     end
     @page_title = I18n.t('accession._plural')
     @results_type = @page_title

--- a/public/app/controllers/agents_controller.rb
+++ b/public/app/controllers/agents_controller.rb
@@ -40,10 +40,10 @@ class AgentsController < ApplicationController
       set_up_and_run_search( DEFAULT_AG_TYPES, default_facets, search_opts, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: repository_or_root_path(repo_id)) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/agents') and return
+      redirect_back(fallback_location: repository_or_root_path(repo_id)) and return
     end
 
     @context = repo_context(repo_id, 'agent')
@@ -74,10 +74,10 @@ class AgentsController < ApplicationController
       set_up_and_run_search( DEFAULT_AG_TYPES, DEFAULT_AG_FACET_TYPES, DEFAULT_AG_SEARCH_OPTS, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: agents_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/agents') and return
+      redirect_back(fallback_location: agents_path) and return
     end
     @page_title = I18n.t('agent._plural')
     @results_type = @page_title

--- a/public/app/controllers/application_controller.rb
+++ b/public/app/controllers/application_controller.rb
@@ -26,7 +26,11 @@ class ApplicationController < ActionController::Base
   rescue_from RequestFailedException, :with => :render_backend_failure
   rescue_from NoResultsError, :with => :render_no_results_found
 
+  # Session key marking that #redirect_back has already sent this client to its Referer once
+  REDIRECTED_BACK_KEY = 'pui_redirected_back'
+
   around_action :set_locale
+  after_action :clear_redirected_back
 
 
   # Allow overriding of templates via the local folder(s)
@@ -43,6 +47,22 @@ class ApplicationController < ActionController::Base
     ArchivesSpaceClient.instance
   end
 
+  # allow_other_host defaults to false so a Referer cannot redirect off-site.
+  # Rails 6.1 hard-codes it in the signature; on Rails 7 set
+  # config.action_controller.raise_on_open_redirects and drop the default here.
+  def redirect_back(fallback_location:, allow_other_host: false, **options)
+    fallback_location = keep_on_site(fallback_location)
+    referer = followable_referer(allow_other_host)
+    redirected_before = session[REDIRECTED_BACK_KEY]
+    session[REDIRECTED_BACK_KEY] = true
+
+    if referer.nil? || redirected_before
+      redirect_to(fallback_location, **options)
+    else
+      super(fallback_location: fallback_location, allow_other_host: allow_other_host, **options)
+    end
+  end
+
   private
 
   def render_backend_failure(exception)
@@ -53,11 +73,35 @@ class ApplicationController < ActionController::Base
   def render_no_results_found(exception)
     Rails.logger.error(exception)
     flash[:error] = I18n.t('search_results.no_results')
-    unless controller_name == 'repositories'
-      redirect_back(fallback_location: '/') and return
-    else
-      redirect_to('/')
-    end
+    redirect_back(fallback_location: root_path)
+  end
+
+  def repository_or_root_path(repo_id)
+    repo_id.present? ? PrefixHelper.app_prefix("/repositories/#{repo_id}") : root_path
+  end
+
+  def keep_on_site(location)
+    return location unless location.is_a?(String)
+    return location if location.start_with?('/') && !location.start_with?('//')
+
+    _url_host_allowed?(location) ? location : root_path
+  end
+
+  def followable_referer(allow_other_host)
+    referer = request.referer
+    return nil if referer.blank?
+    return nil if URI.join(request.original_url, referer).to_s == request.original_url
+    return nil if !allow_other_host && !_url_host_allowed?(referer)
+
+    referer
+  rescue URI::Error, ArgumentError
+    nil
+  end
+
+  def clear_redirected_back
+    return if response.redirect?
+
+    session.delete(REDIRECTED_BACK_KEY) if session.key?(REDIRECTED_BACK_KEY)
   end
 
   def process_slug_or_id(params)

--- a/public/app/controllers/classifications_controller.rb
+++ b/public/app/controllers/classifications_controller.rb
@@ -37,10 +37,10 @@ class ClassificationsController < ApplicationController
       set_up_and_run_search( DEFAULT_CL_TYPES, DEFAULT_CL_FACET_TYPES, search_opts, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: repository_or_root_path(repo_id)) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: repository_or_root_path(repo_id)) and return
     end
 
     @context = repo_context(repo_id, 'classification')
@@ -70,10 +70,10 @@ class ClassificationsController < ApplicationController
       set_up_and_run_search( DEFAULT_CL_TYPES, DEFAULT_CL_FACET_TYPES, DEFAULT_CL_SEARCH_OPTS, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: classifications_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: classifications_path) and return
     end
     @page_title = I18n.t('classification._plural')
     @results_type = @page_title

--- a/public/app/controllers/objects_controller.rb
+++ b/public/app/controllers/objects_controller.rb
@@ -35,10 +35,10 @@ class ObjectsController < ApplicationController
       set_up_and_run_search( params[:limit].split(","), DEFAULT_OBJ_FACET_TYPES, search_opts, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: repository_or_root_path(repo_id)) and return
     rescue Exception
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/objects' ) and return
+      redirect_back(fallback_location: repository_or_root_path(repo_id)) and return
     end
 
     @context = repo_context(repo_id, 'record')
@@ -66,10 +66,10 @@ class ObjectsController < ApplicationController
       set_up_and_run_search(%w(digital_object archival_object), DEFAULT_OBJ_FACET_TYPES, DEFAULT_OBJ_SEARCH_OPTS, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: objects_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/objects' ) and return
+      redirect_back(fallback_location: objects_path) and return
     end
     @page_title = I18n.t('record._plural')
     @results_type = @page_title

--- a/public/app/controllers/repositories_controller.rb
+++ b/public/app/controllers/repositories_controller.rb
@@ -50,7 +50,7 @@ class RepositoriesController < ApplicationController
 
   def search
     @repo_id = params.require(:rid)
-    @base_search = "/repositories/#{repo_id}/search?"
+    @base_search = "/repositories/#{@repo_id}/search?"
     begin
       new_search_opts = DEFAULT_REPO_SEARCH_OPTS
       new_search_opts['repo_id'] = @repo_id
@@ -59,13 +59,13 @@ class RepositoriesController < ApplicationController
     rescue Exception => error
       Rails.logger.debug( error.backtrace )
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: "/repositories/#{@repo_id}/" ) and return
+      redirect_back(fallback_location: PrefixHelper.app_prefix("/repositories/#{@repo_id}")) and return
     end
     page = Integer(params.fetch(:page, "1"))
     @results = archivesspace.advanced_search('/search', page, @criteria)
     if @results['total_hits'].blank? || @results['total_hits'] == 0
       flash[:notice] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: @base_search)
+      redirect_back(fallback_location: PrefixHelper.app_prefix("/repositories/#{@repo_id}"))
     else
       process_search_results(@base_search)
       Rails.logger.debug("@repo_id: #{@repo_id}")

--- a/public/app/controllers/requests_controller.rb
+++ b/public/app/controllers/requests_controller.rb
@@ -15,10 +15,29 @@ class RequestsController < ApplicationController
       RequestMailer.request_received_staff_email(@request).deliver
       RequestMailer.request_received_email(@request).deliver
 
-      redirect_to params.fetch('base_url', app_prefix(request[:request_uri]))
+      redirect_to params.fetch('base_url', requested_record_path)
     else
       flash[:error] = errs
-      redirect_back(fallback_location: app_prefix(request[:request_uri])) and return
+      redirect_back(fallback_location: requested_record_path) and return
     end
+  end
+
+  private
+
+  def requested_record_path
+    record = JSONModel.parse_reference(request[:request_uri].to_s)
+    return root_path unless record && requestable_type?(record[:type])
+
+    repo_id = record[:repository].to_s[%r{\A/repositories/(\d+)\z}, 1].to_i
+    return root_path if repo_id.zero?
+
+    app_prefix("/repositories/#{repo_id}/#{record[:type].to_s.pluralize}/#{record[:id].to_i}")
+  end
+
+  def requestable_type?(type)
+    permitted = ASUtils.wrap(AppConfig[:pui_requests_permitted_for_types]) +
+                AppConfig[:pui_repos].values.flat_map { |repo| ASUtils.wrap(repo[:requests_permitted_for_types]) }
+
+    permitted.map(&:to_s).include?(type.to_s)
   end
 end

--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -52,10 +52,10 @@ class ResourcesController < ApplicationController
       set_up_and_run_search(['resource'], facet_types, search_opts, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: repository_or_root_path(@repo_id)) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/' ) and return
+      redirect_back(fallback_location: repository_or_root_path(@repo_id)) and return
     end
 
     @context = repo_context(@repo_id, 'resource')
@@ -102,14 +102,14 @@ class ResourcesController < ApplicationController
       set_up_advanced_search(DEFAULT_RES_TYPES, DEFAULT_RES_FACET_TYPES, search_opts, params)
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: res_id ) and return
+      redirect_back(fallback_location: PrefixHelper.app_prefix(res_id)) and return
     end
 
     page = Integer(params.fetch(:page, "1"))
     @results = archivesspace.advanced_search('/search', page, @criteria)
     if @results['total_hits'].blank? || @results['total_hits'] == 0
       flash[:notice] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: @base_search)
+      redirect_back(fallback_location: PrefixHelper.app_prefix(res_id))
     else
       process_search_results(@base_search)
       title = ''

--- a/public/app/controllers/search_controller.rb
+++ b/public/app/controllers/search_controller.rb
@@ -48,7 +48,7 @@ class SearchController < ApplicationController
       Rails.logger.debug(error.message)
       p error
       flash[:error] = I18n.t('search_results.error')
-      redirect_back(fallback_location: root_path ) and return
+      redirect_back(fallback_location: fallback_location) and return
     end
     page = Integer(params.fetch(:page, "1"))
     Rails.logger.debug("base search: #{@base_search}")

--- a/public/app/controllers/subjects_controller.rb
+++ b/public/app/controllers/subjects_controller.rb
@@ -37,10 +37,10 @@ class SubjectsController < ApplicationController
       set_up_and_run_search(['subject'], default_facets, search_opts, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: repository_or_root_path(repo_id)) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/subjects' ) and return
+      redirect_back(fallback_location: repository_or_root_path(repo_id)) and return
     end
 
     @context = repo_context(repo_id, 'subject')
@@ -73,10 +73,10 @@ class SubjectsController < ApplicationController
       set_up_and_run_search(['subject'], DEFAULT_SUBJ_FACET_TYPES, DEFAULT_SUBJ_SEARCH_OPTS, params)
     rescue NoResultsError
       flash[:error] = I18n.t('search_results.no_results')
-      redirect_back(fallback_location: '/') and return
+      redirect_back(fallback_location: subjects_path) and return
     rescue Exception => error
       flash[:error] = I18n.t('errors.unexpected_error')
-      redirect_back(fallback_location: '/subjects' ) and return
+      redirect_back(fallback_location: subjects_path) and return
     end
     @page_title = I18n.t('subject._plural')
     @results_type = @page_title

--- a/public/spec/controllers/redirect_back_spec.rb
+++ b/public/spec/controllers/redirect_back_spec.rb
@@ -1,0 +1,134 @@
+require 'spec_helper'
+
+describe ApplicationController, type: :controller do
+  controller(ApplicationController) do
+    def empty_listing
+      redirect_back(fallback_location: '/fallback')
+    end
+
+    def other_host_allowed
+      redirect_back(fallback_location: '/fallback', allow_other_host: true)
+    end
+
+    def offsite_fallback
+      redirect_back(fallback_location: '//evil.example/phish')
+    end
+
+    def landing
+      render plain: 'landing'
+    end
+  end
+
+  before(:each) do
+    routes.draw do
+      get 'anonymous/empty_listing' => 'anonymous#empty_listing'
+      get 'anonymous/other_host_allowed' => 'anonymous#other_host_allowed'
+      get 'anonymous/offsite_fallback' => 'anonymous#offsite_fallback'
+      get 'anonymous/landing' => 'anonymous#landing'
+    end
+  end
+
+  let(:listing_url) { 'http://test.host/anonymous/empty_listing' }
+
+  describe 'a Referer that leads somewhere else' do
+    it 'sends the visitor back to it' do
+      request.env['HTTP_REFERER'] = 'http://test.host/repositories/1'
+
+      get(:empty_listing)
+
+      expect(response).to redirect_to('http://test.host/repositories/1')
+    end
+  end
+
+  describe 'a Referer naming the URL being requested' do
+    it 'uses the fallback rather than redirecting to itself' do
+      request.env['HTTP_REFERER'] = listing_url
+
+      get(:empty_listing)
+
+      expect(response.location).not_to eq(listing_url)
+      expect(response).to redirect_to('/fallback')
+    end
+
+    it 'uses the fallback when the Referer is sent as a relative path' do
+      request.env['HTTP_REFERER'] = '/anonymous/empty_listing'
+
+      get(:empty_listing)
+
+      expect(response.location).not_to eq(listing_url)
+      expect(response).to redirect_to('/fallback')
+    end
+  end
+
+  describe 'a Referer on another host' do
+    it 'uses the fallback rather than sending the visitor off-site' do
+      request.env['HTTP_REFERER'] = 'https://evil.example/phish'
+
+      get(:empty_listing)
+
+      expect(response).to redirect_to('/fallback')
+    end
+
+    it 'follows it when the caller opts in' do
+      request.env['HTTP_REFERER'] = 'https://elsewhere.example/page'
+
+      get(:other_host_allowed)
+
+      expect(response).to redirect_to('https://elsewhere.example/page')
+    end
+  end
+
+  describe 'a fallback that would leave the site' do
+    it 'redirects to the site root instead' do
+      get(:offsite_fallback)
+
+      expect(response).to redirect_to('/')
+    end
+  end
+
+  describe 'a request with no usable Referer' do
+    it 'uses the fallback when the header is absent' do
+      get(:empty_listing)
+
+      expect(response).to redirect_to('/fallback')
+    end
+
+    it 'uses the fallback when the header cannot be parsed' do
+      request.env['HTTP_REFERER'] = 'http://[not a url'
+
+      get(:empty_listing)
+
+      expect(response).to redirect_to('/fallback')
+    end
+  end
+
+  # A Referer that differs from the current URL can still lead to a page that
+  # redirects straight back, which no single request can detect. Capping the
+  # run at one bounce bounds any such cycle.
+  describe 'a second redirect with no rendered page in between' do
+    it 'uses the fallback even though the Referer leads elsewhere' do
+      request.env['HTTP_REFERER'] = 'http://test.host/repositories/1'
+      get(:empty_listing)
+      expect(response).to redirect_to('http://test.host/repositories/1')
+
+      request.env['HTTP_REFERER'] = 'http://test.host/repositories/1/resources'
+      get(:empty_listing)
+
+      expect(response).to redirect_to('/fallback')
+    end
+
+    it 'allows a bounce again once a response has rendered' do
+      request.env['HTTP_REFERER'] = 'http://test.host/repositories/1'
+      get(:empty_listing)
+      expect(session).to have_key(ApplicationController::REDIRECTED_BACK_KEY)
+
+      get(:landing)
+      expect(session).not_to have_key(ApplicationController::REDIRECTED_BACK_KEY)
+
+      request.env['HTTP_REFERER'] = 'http://test.host/repositories/2'
+      get(:empty_listing)
+
+      expect(response).to redirect_to('http://test.host/repositories/2')
+    end
+  end
+end

--- a/public/spec/controllers/requests_controller_spec.rb
+++ b/public/spec/controllers/requests_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe RequestsController, type: :controller do
+
+  describe 'the record a failed request returns to' do
+    def submit(request_uri)
+      post(:make_request, params: { request_uri: request_uri })
+    end
+
+    it 'is the requested record when the submitted URI is a record URI' do
+      submit('/repositories/2/archival_objects/5')
+
+      expect(response).to redirect_to('/repositories/2/archival_objects/5')
+    end
+
+    it 'is the site root when the submitted URI would leave the site' do
+      submit('//evil.example/phish')
+
+      expect(response).to redirect_to('/')
+    end
+
+    it 'is the site root when the submitted URI names an unrequestable type' do
+      submit('/repositories/2/not_a_record_type/5')
+
+      expect(response).to redirect_to('/')
+    end
+
+    it 'is the site root when the submitted URI is not a record URI at all' do
+      submit('https://evil.example/phish')
+
+      expect(response).to redirect_to('/')
+    end
+
+    it 'is the site root when no URI is submitted' do
+      submit(nil)
+
+      expect(response).to redirect_to('/')
+    end
+  end
+end

--- a/public/spec/controllers/resources_controller_spec.rb
+++ b/public/spec/controllers/resources_controller_spec.rb
@@ -158,6 +158,45 @@ describe ResourcesController, type: :controller do
     end
   end
 
+  describe 'index action for a repository with no published resources' do
+    before(:all) do
+      @empty_repo = create(:repo, repo_code: "resources_empty_test_#{Time.now.to_i}",
+                           publish: true)
+      run_indexers
+    end
+
+    let(:listing_url) { "http://test.host/repositories/#{@empty_repo.id}/resources" }
+
+    it 'redirects to the repository rather than back to the empty listing' do
+      request.env['HTTP_REFERER'] = listing_url
+
+      get(:index, params: { rid: @empty_repo.id })
+
+      expect(response).to have_http_status(302)
+      expect(response.location).not_to eq(listing_url)
+      expect(response).to redirect_to("/repositories/#{@empty_repo.id}")
+    end
+
+    it 'still returns a visitor to the page they arrived from' do
+      request.env['HTTP_REFERER'] = 'http://test.host/repositories'
+
+      get(:index, params: { rid: @empty_repo.id })
+
+      expect(response).to redirect_to('http://test.host/repositories')
+    end
+
+    it 'keeps the proxy prefix on the fallback when the PUI is mounted under one' do
+      allow(AppConfig).to receive(:[]).and_call_original
+      allow(AppConfig).to receive(:[]).with(:public_proxy_prefix).and_return('/aspace/')
+
+      request.env['HTTP_REFERER'] = listing_url
+
+      get(:index, params: { rid: @empty_repo.id })
+
+      expect(response).to redirect_to("/aspace/repositories/#{@empty_repo.id}")
+    end
+  end
+
   describe 'digitized action' do
     it 'displays tree breadcrumbs for digital objects linked to more than one Resource' do
       get(:digitized, params: {rid: @repo.id, id: @resource_with_rep_instance.id})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Ticket (JIRA or GitHub Issue)
[ANW-2961]
<!--- Add a link to the related Ticket (use the [ANW-1234] format for JIRA that links automatically). -->

## Summary
PUI listing and search actions redirect away rather than rendering an empty page when a search finds nothing, using `redirect_back`, which follows the Referer without checking it. When the Referer names the URL being requested the response points at itself and the client loops. A repository with no published resources triggers this on every request to its resource listing.

`redirect_back` is overridden so that:

- a Referer that resolves to the URL being requested is never followed 
- only the first redirect in an unbroken run of redirects may follow the Referer

Also removes the `unless controller_name == 'repositories'` special case in `render_no_results_found`, which only existed to keep that listing out of this loop, and fixes an unassigned local `repo_id` in `RepositoriesController#search`.

Supersedes #4261, which fixed the same loop by replacing every `redirect_back` with a fixed destination.
<!--
Summarize the context the reviewer should have in mind.
       - Avoid describing the code changes in human language.
       - Summarize the problem and the solution, refer to the Jira ticket for more details if needed.
-->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, for example API endpoint renaming)
- [ ] My change requires a change to the documentation - If so elaborate:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and agree to the [**CONTRIBUTING** document](https://github.com/archivesspace/archivesspace/blob/master/CONTRIBUTING.md).
- [ ] I have authority to submit this code. - See our [licensing](https://github.com/archivesspace/archivesspace/blob/master/contribution_files/CONTRIBUTING_README.md)
- [ ] Have you added tests to cover these changes? If not why:


[ANW-2961]: https://archivesspace.atlassian.net/browse/ANW-2961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANW-1234]: https://archivesspace.atlassian.net/browse/ANW-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ